### PR TITLE
feat(wb): refer to `HOST` environment variable when opening browser

### DIFF
--- a/packages/wb/src/scripts/execution/baseExecutionScripts.ts
+++ b/packages/wb/src/scripts/execution/baseExecutionScripts.ts
@@ -83,6 +83,6 @@ export abstract class BaseExecutionScripts {
       project,
       argv,
       port
-    )} || wait-on http://127.0.0.1:${port} && open-cli http://localhost:${port}`;
+    )} || wait-on http://127.0.0.1:${port} && open-cli "http://\${HOST:-localhost}:${port}"`;
   }
 }


### PR DESCRIPTION
現状では、`wb start`を実行するとアプリが起動した後ブラウザで`http://localhost:{port}`が開かれます。

しかし、WillBoosterの一部のプロジェクトでは、Cookieを正しく扱うために`http://localhost:3000`でなく`http://localhost-{プロジェクトによって異なる文字列}.willbooster.net:3000`を開かねばなりません。

このPRでは、ブラウザで開かれるURLのホストを環境変数を介して指定できるようにします。

## Self Check

- [x] I've confirmed `All checks have passed` on PR page. (You may leave this box unchecked due to long workflows.)
  - PR title follows [Angular's commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
    - PR title doesn't have `WIP:`.
  - All tests are passed.
    - Test command (e.g., `yarn test`) is passed.
    - Lint command (e.g., `yarn lint`) is passed.
- [x] I've reviewed my changes on PR's diff view.

<!-- Please add screenshots if you modify the UI.
| Current                  | In coming                |
| ------------------------ | ------------------------ |
| <img src="" width="400"> | <img src="" width="400"> |
-->
