### PR TITLE
feat: support playwright passthrough args in wb test

### DIFF
--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -9,6 +9,7 @@ import { findDescendantProjects } from '../project.js';
 import { prismaScripts } from '../scripts/prismaScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
 import { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { buildShellCommand } from '../utils/shell.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
 
@@ -19,6 +20,7 @@ export const prismaCommand: CommandModule = {
   describe: 'Run prisma commands',
   builder: (yargs) => {
     return yargs
+      .parserConfiguration({ 'populate--': true })
       .command(cleanUpLitestreamCommand)
       .command(createLitestreamConfigCommand)
       .command(deployCommand)
@@ -322,6 +324,7 @@ export function extractUnknownOptions(argv: Record<string, unknown>, knownOption
     ...sharedOptionKeys,
     ...sharedOptionAliases,
     // Internal yargs properties
+    '--',
     '_',
     '$0',
   ]);
@@ -352,5 +355,6 @@ export function extractUnknownOptions(argv: Record<string, unknown>, knownOption
     }
   }
 
-  return unknownOptions.join(' ');
+  const passthroughArgs = Array.isArray(argv['--']) ? argv['--'].map(String) : [];
+  return buildShellCommand([...unknownOptions, ...passthroughArgs]);
 }

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -17,7 +17,8 @@ const builder = {} as const;
 
 export const prismaCommand: CommandModule = {
   command: 'prisma',
-  describe: 'Run prisma commands',
+  describe:
+    "Run prisma commands. Use '--' to stop wb option parsing and forward the remaining arguments to Prisma. Example: wb prisma migrate-dev -- --name init",
   builder: (yargs) => {
     return yargs
       .parserConfiguration({ 'populate--': true })
@@ -229,7 +230,7 @@ const defaultCommandBuilder = { args: { type: 'array' } } as const;
 
 const defaultCommand: CommandModule<unknown, InferredOptionTypes<typeof defaultCommandBuilder>> = {
   command: '$0 <args..>',
-  describe: 'Pass the command and arguments to prisma as is',
+  describe: "Pass the command and arguments to prisma as is. Additional Prisma flags can also be forwarded after '--'.",
   builder: defaultCommandBuilder,
   async handler(argv) {
     const allProjects = await findPrismaProjects(argv);

--- a/packages/wb/src/commands/start.ts
+++ b/packages/wb/src/commands/start.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import type { CommandModule, InferredOptionTypes } from 'yargs';
+import type { Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
 import { findDescendantProjects } from '../project.js';
 import { normalizeArgs, scriptOptionsBuilder } from '../scripts/builder.js';
@@ -27,7 +27,10 @@ const builder = {
 export const startCommand: CommandModule<unknown, InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>> = {
   command: 'start [args..]',
   describe: 'Start app',
-  builder,
+  builder: (yargs: Argv<unknown>) =>
+    yargs.parserConfiguration({ 'populate--': true }).options(builder) as Argv<
+      InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>
+    >,
   async handler(argv) {
     normalizeArgs(argv);
 

--- a/packages/wb/src/commands/start.ts
+++ b/packages/wb/src/commands/start.ts
@@ -26,7 +26,8 @@ const builder = {
 
 export const startCommand: CommandModule<unknown, InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>> = {
   command: 'start [args..]',
-  describe: 'Start app',
+  describe:
+    "Start app. Use '--' to stop wb option parsing and forward the remaining arguments to the underlying app command. Example: wb start -- --host 0.0.0.0",
   builder: (yargs: Argv<unknown>) =>
     yargs.parserConfiguration({ 'populate--': true }).options(builder) as Argv<
       InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -64,18 +64,17 @@ export type TestArgv = Partial<
   ArgumentsCamelCase<InferredOptionTypes<typeof builder & typeof scriptOptionsBuilder & typeof argumentsBuilder>>
 >;
 
-type ResolvedTestArgv = ArgumentsCamelCase<
+export type TestCommandArgv = ArgumentsCamelCase<
   InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof argumentsBuilder>
->;
-
-export type TestCommandArgv = ResolvedTestArgv & { '--'?: string[] | undefined };
+> & { '--'?: string[] };
 
 export const testCommand: CommandModule<
   unknown,
   InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof argumentsBuilder>
 > = {
   command: 'test [targets...]',
-  describe: 'Test project. If you pass no arguments, it will run all tests.',
+  describe:
+    "Test project. If you pass no arguments, it will run all tests. Use '--' to stop wb option parsing and forward the remaining flags to Playwright. Example: wb test -- --grep 'uploaded image asset'",
   builder: { ...builder, ...argumentsBuilder },
   async handler(argv) {
     await test(argv as TestCommandArgv);
@@ -239,7 +238,7 @@ async function testOnDocker(
 
 export function buildPlaywrightArgsForE2E(
   e2eTargets: string[],
-  argv: Pick<TestCommandArgv, '--'>,
+  argv: { '--'?: string[] },
   additionalArgs: string[] = []
 ): string[] {
   return ['test', ...(e2eTargets.length > 0 ? e2eTargets : ['test/e2e/']), ...(argv['--'] ?? []), ...additionalArgs];

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -10,6 +10,7 @@ import type { scriptOptionsBuilder } from '../scripts/builder.js';
 import { toDevNull } from '../scripts/builder.js';
 import { dockerScripts } from '../scripts/dockerScripts.js';
 import type { BaseScripts } from '../scripts/execution/baseScripts.js';
+import { findExplicitPlaywrightTargetIndexes } from '../scripts/execution/baseScripts.js';
 import { blitzScripts } from '../scripts/execution/blitzScripts.js';
 import { httpServerScripts } from '../scripts/execution/httpServerScripts.js';
 import { nextScripts } from '../scripts/execution/nextScripts.js';
@@ -93,13 +94,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
 
   // Get test targets from positional arguments
   const testTargets = (argv.targets ?? []) as string[];
-  const shouldRunAllTests = testTargets.length === 0;
-
-  // Detect test modes from target paths
-  const hasE2eTargets = testTargets.some((target) => target.includes('/e2e'));
-  const hasUnitTargets = testTargets.some((target) => target.includes('/unit'));
-  const shouldRunUnit = shouldRunAllTests || hasUnitTargets;
-  const shouldRunE2e = shouldRunAllTests || hasE2eTargets;
+  const forwardedPlaywrightArgs = argv['--'] ?? [];
+  const { shouldRunE2e, shouldRunUnit } = resolveTestExecutionTargets(testTargets, forwardedPlaywrightArgs);
 
   for (const project of projects.descendants) {
     const deps = project.packageJson.dependencies ?? {};
@@ -140,8 +136,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
       case 'headless': {
         await runWithSpawn(
           await scripts.testE2EProduction(project, e2eArgv, {
-            playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets),
-            forwardedPlaywrightArgs: argv['--'] ?? [],
+            playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs),
+            forwardedPlaywrightArgs,
           }),
           project,
           argv
@@ -151,8 +147,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
       case 'headless-dev': {
         await runWithSpawn(
           await scripts.testE2EDev(project, e2eArgv, {
-            playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets),
-            forwardedPlaywrightArgs: argv['--'] ?? [],
+            playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs),
+            forwardedPlaywrightArgs,
           }),
           project,
           argv
@@ -160,7 +156,13 @@ export async function test(argv: TestCommandArgv): Promise<void> {
         continue;
       }
       case 'docker': {
-        await testOnDocker(project, e2eArgv, scripts, buildPlaywrightArgsForE2E(e2eTargets), argv['--'] ?? []);
+        await testOnDocker(
+          project,
+          e2eArgv,
+          scripts,
+          buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs),
+          forwardedPlaywrightArgs
+        );
         continue;
       }
       case 'docker-debug': {
@@ -168,8 +170,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
           project,
           e2eArgv,
           scripts,
-          buildPlaywrightArgsForE2E(e2eTargets, ['--debug']),
-          argv['--'] ?? []
+          buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs, ['--debug']),
+          forwardedPlaywrightArgs
         );
         continue;
       }
@@ -179,8 +181,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
         case 'headed': {
           await runWithSpawn(
             await scripts.testE2EProduction(project, e2eArgv, {
-              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, ['--headed']),
-              forwardedPlaywrightArgs: argv['--'] ?? [],
+              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs, ['--headed']),
+              forwardedPlaywrightArgs,
             }),
             project,
             argv
@@ -190,8 +192,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
         case 'headed-dev': {
           await runWithSpawn(
             await scripts.testE2EDev(project, e2eArgv, {
-              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, ['--headed']),
-              forwardedPlaywrightArgs: argv['--'] ?? [],
+              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs, ['--headed']),
+              forwardedPlaywrightArgs,
             }),
             project,
             argv
@@ -201,8 +203,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
         case 'debug': {
           await runWithSpawn(
             await scripts.testE2EProduction(project, e2eArgv, {
-              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, ['--debug']),
-              forwardedPlaywrightArgs: argv['--'] ?? [],
+              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs, ['--debug']),
+              forwardedPlaywrightArgs,
             }),
             project,
             argv
@@ -249,6 +251,25 @@ async function testOnDocker(
   await runWithSpawn(dockerScripts.stop(project), project, argv);
 }
 
-export function buildPlaywrightArgsForE2E(e2eTargets: string[], additionalArgs: string[] = []): string[] {
-  return ['test', ...(e2eTargets.length > 0 ? [] : ['test/e2e/']), ...additionalArgs];
+export function buildPlaywrightArgsForE2E(
+  e2eTargets: string[],
+  forwardedPlaywrightArgs: string[] = [],
+  additionalArgs: string[] = []
+): string[] {
+  const hasForwardedPlaywrightTargets = findExplicitPlaywrightTargetIndexes(forwardedPlaywrightArgs).length > 0;
+  return ['test', ...(e2eTargets.length > 0 || hasForwardedPlaywrightTargets ? [] : ['test/e2e/']), ...additionalArgs];
+}
+
+export function resolveTestExecutionTargets(
+  testTargets: string[],
+  forwardedPlaywrightArgs: string[] = []
+): { shouldRunUnit: boolean; shouldRunE2e: boolean } {
+  const hasE2eTargets = testTargets.some((target) => target.includes('/e2e'));
+  const hasUnitTargets = testTargets.some((target) => target.includes('/unit'));
+  const shouldRunAllTests = testTargets.length === 0 && forwardedPlaywrightArgs.length === 0;
+
+  return {
+    shouldRunUnit: shouldRunAllTests || hasUnitTargets,
+    shouldRunE2e: shouldRunAllTests || hasE2eTargets || forwardedPlaywrightArgs.length > 0,
+  };
 }

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import chalk from 'chalk';
-import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
+import type { Argv, ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
 
 import type { Project } from '../project.js';
 import { findDescendantProjects } from '../project.js';
@@ -60,22 +60,22 @@ const argumentsBuilder = {
   },
 } as const;
 
+type TestCommandOptions = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof argumentsBuilder>;
+
 export type TestArgv = Partial<
   ArgumentsCamelCase<InferredOptionTypes<typeof builder & typeof scriptOptionsBuilder & typeof argumentsBuilder>>
 >;
 
-export type TestCommandArgv = ArgumentsCamelCase<
-  InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof argumentsBuilder>
-> & { '--'?: string[] };
+export type TestCommandArgv = ArgumentsCamelCase<TestCommandOptions> & { '--'?: string[] };
 
-export const testCommand: CommandModule<
-  unknown,
-  InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof argumentsBuilder>
-> = {
+export const testCommand: CommandModule<unknown, TestCommandOptions> = {
   command: 'test [targets...]',
   describe:
     "Test project. If you pass no arguments, it will run all tests. Use '--' to stop wb option parsing and forward the remaining flags to Playwright. Example: wb test -- --grep 'uploaded image asset'",
-  builder: { ...builder, ...argumentsBuilder },
+  builder: (yargs: Argv<unknown>): Argv<TestCommandOptions> =>
+    yargs
+      .parserConfiguration({ 'populate--': true })
+      .options({ ...builder, ...argumentsBuilder }) as Argv<TestCommandOptions>,
   async handler(argv) {
     await test(argv as TestCommandArgv);
   },

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -140,7 +140,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
       case 'headless': {
         await runWithSpawn(
           await scripts.testE2EProduction(project, e2eArgv, {
-            playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, argv),
+            playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets),
+            forwardedPlaywrightArgs: argv['--'] ?? [],
           }),
           project,
           argv
@@ -150,7 +151,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
       case 'headless-dev': {
         await runWithSpawn(
           await scripts.testE2EDev(project, e2eArgv, {
-            playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, argv),
+            playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets),
+            forwardedPlaywrightArgs: argv['--'] ?? [],
           }),
           project,
           argv
@@ -158,11 +160,17 @@ export async function test(argv: TestCommandArgv): Promise<void> {
         continue;
       }
       case 'docker': {
-        await testOnDocker(project, e2eArgv, scripts, buildPlaywrightArgsForE2E(e2eTargets, argv));
+        await testOnDocker(project, e2eArgv, scripts, buildPlaywrightArgsForE2E(e2eTargets), argv['--'] ?? []);
         continue;
       }
       case 'docker-debug': {
-        await testOnDocker(project, e2eArgv, scripts, buildPlaywrightArgsForE2E(e2eTargets, argv, ['--debug']));
+        await testOnDocker(
+          project,
+          e2eArgv,
+          scripts,
+          buildPlaywrightArgsForE2E(e2eTargets, ['--debug']),
+          argv['--'] ?? []
+        );
         continue;
       }
     }
@@ -171,7 +179,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
         case 'headed': {
           await runWithSpawn(
             await scripts.testE2EProduction(project, e2eArgv, {
-              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, argv, ['--headed']),
+              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, ['--headed']),
+              forwardedPlaywrightArgs: argv['--'] ?? [],
             }),
             project,
             argv
@@ -181,7 +190,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
         case 'headed-dev': {
           await runWithSpawn(
             await scripts.testE2EDev(project, e2eArgv, {
-              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, argv, ['--headed']),
+              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, ['--headed']),
+              forwardedPlaywrightArgs: argv['--'] ?? [],
             }),
             project,
             argv
@@ -191,7 +201,8 @@ export async function test(argv: TestCommandArgv): Promise<void> {
         case 'debug': {
           await runWithSpawn(
             await scripts.testE2EProduction(project, e2eArgv, {
-              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, argv, ['--debug']),
+              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, ['--debug']),
+              forwardedPlaywrightArgs: argv['--'] ?? [],
             }),
             project,
             argv
@@ -221,13 +232,15 @@ async function testOnDocker(
   project: Project,
   argv: ArgumentsCamelCase<InferredOptionTypes<typeof builder & typeof argumentsBuilder>>,
   scripts: BaseScripts,
-  playwrightArgs?: string[]
+  playwrightArgs?: string[],
+  forwardedPlaywrightArgs?: string[]
 ): Promise<void> {
   project.env.WB_DOCKER ||= '1';
   await runWithSpawn(`${scripts.buildDocker(project, 'test')}${toDevNull(argv)}`, project, argv);
   process.exitCode = await runWithSpawn(
     await scripts.testE2EDocker(project, argv, {
       playwrightArgs,
+      forwardedPlaywrightArgs,
     }),
     project,
     argv,
@@ -236,10 +249,6 @@ async function testOnDocker(
   await runWithSpawn(dockerScripts.stop(project), project, argv);
 }
 
-export function buildPlaywrightArgsForE2E(
-  e2eTargets: string[],
-  argv: { '--'?: string[] },
-  additionalArgs: string[] = []
-): string[] {
-  return ['test', ...(e2eTargets.length > 0 ? e2eTargets : ['test/e2e/']), ...(argv['--'] ?? []), ...additionalArgs];
+export function buildPlaywrightArgsForE2E(e2eTargets: string[], additionalArgs: string[] = []): string[] {
+  return ['test', ...(e2eTargets.length > 0 ? [] : ['test/e2e/']), ...additionalArgs];
 }

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -64,6 +64,12 @@ export type TestArgv = Partial<
   ArgumentsCamelCase<InferredOptionTypes<typeof builder & typeof scriptOptionsBuilder & typeof argumentsBuilder>>
 >;
 
+type ResolvedTestArgv = ArgumentsCamelCase<
+  InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof argumentsBuilder>
+>;
+
+export type TestCommandArgv = ResolvedTestArgv & { '--'?: string[] | undefined };
+
 export const testCommand: CommandModule<
   unknown,
   InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof argumentsBuilder>
@@ -72,13 +78,11 @@ export const testCommand: CommandModule<
   describe: 'Test project. If you pass no arguments, it will run all tests.',
   builder: { ...builder, ...argumentsBuilder },
   async handler(argv) {
-    await test(argv);
+    await test(argv as TestCommandArgv);
   },
 };
 
-export async function test(
-  argv: ArgumentsCamelCase<InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof argumentsBuilder>>
-): Promise<void> {
+export async function test(argv: TestCommandArgv): Promise<void> {
   const projects = await findDescendantProjects(argv);
   if (!projects) {
     console.error(chalk.red('No project found.'));
@@ -135,23 +139,31 @@ export async function test(
 
     switch (argv.e2e) {
       case 'headless': {
-        await runWithSpawn(await scripts.testE2EProduction(project, e2eArgv, {}), project, argv);
+        await runWithSpawn(
+          await scripts.testE2EProduction(project, e2eArgv, {
+            playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, argv),
+          }),
+          project,
+          argv
+        );
         continue;
       }
       case 'headless-dev': {
-        await runWithSpawn(await scripts.testE2EDev(project, e2eArgv, {}), project, argv);
+        await runWithSpawn(
+          await scripts.testE2EDev(project, e2eArgv, {
+            playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, argv),
+          }),
+          project,
+          argv
+        );
         continue;
       }
       case 'docker': {
-        await testOnDocker(project, e2eArgv, scripts);
+        await testOnDocker(project, e2eArgv, scripts, buildPlaywrightArgsForE2E(e2eTargets, argv));
         continue;
       }
       case 'docker-debug': {
-        await testOnDocker(project, e2eArgv, scripts, [
-          'test',
-          ...(e2eTargets.length > 0 ? e2eTargets : ['test/e2e/']),
-          '--debug',
-        ]);
+        await testOnDocker(project, e2eArgv, scripts, buildPlaywrightArgsForE2E(e2eTargets, argv, ['--debug']));
         continue;
       }
     }
@@ -160,7 +172,7 @@ export async function test(
         case 'headed': {
           await runWithSpawn(
             await scripts.testE2EProduction(project, e2eArgv, {
-              playwrightArgs: ['test', ...(e2eTargets.length > 0 ? e2eTargets : ['test/e2e/']), '--headed'],
+              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, argv, ['--headed']),
             }),
             project,
             argv
@@ -170,7 +182,7 @@ export async function test(
         case 'headed-dev': {
           await runWithSpawn(
             await scripts.testE2EDev(project, e2eArgv, {
-              playwrightArgs: ['test', ...(e2eTargets.length > 0 ? e2eTargets : ['test/e2e/']), '--headed'],
+              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, argv, ['--headed']),
             }),
             project,
             argv
@@ -180,7 +192,7 @@ export async function test(
         case 'debug': {
           await runWithSpawn(
             await scripts.testE2EProduction(project, e2eArgv, {
-              playwrightArgs: ['test', ...(e2eTargets.length > 0 ? e2eTargets : ['test/e2e/']), '--debug'],
+              playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, argv, ['--debug']),
             }),
             project,
             argv
@@ -223,4 +235,12 @@ async function testOnDocker(
     { exitIfFailed: false }
   );
   await runWithSpawn(dockerScripts.stop(project), project, argv);
+}
+
+export function buildPlaywrightArgsForE2E(
+  e2eTargets: string[],
+  argv: Pick<TestCommandArgv, '--'>,
+  additionalArgs: string[] = []
+): string[] {
+  return ['test', ...(e2eTargets.length > 0 ? e2eTargets : ['test/e2e/']), ...(argv['--'] ?? []), ...additionalArgs];
 }

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -22,7 +22,6 @@ import { sharedOptionsBuilder } from './sharedOptionsBuilder.js';
 
 await yargs(hideBin(process.argv))
   .scriptName('wb')
-  .parserConfiguration({ 'populate--': true })
   .options(sharedOptionsBuilder)
   .middleware((argv) => {
     const workingDir = argv['working-dir'];

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -22,6 +22,7 @@ import { sharedOptionsBuilder } from './sharedOptionsBuilder.js';
 
 await yargs(hideBin(process.argv))
   .scriptName('wb')
+  .parserConfiguration({ 'populate--': true })
   .options(sharedOptionsBuilder)
   .middleware((argv) => {
     const workingDir = argv['working-dir'];

--- a/packages/wb/src/scripts/builder.ts
+++ b/packages/wb/src/scripts/builder.ts
@@ -21,6 +21,7 @@ export const scriptOptionsBuilder = {
 } as const;
 
 export type ScriptArgv = Partial<ArgumentsCamelCase<InferredOptionTypes<typeof scriptOptionsBuilder>>> & {
+  '--'?: string[];
   normalizedArgsText?: string;
   normalizedDockerOptionsText?: string;
   silent?: boolean;
@@ -28,9 +29,9 @@ export type ScriptArgv = Partial<ArgumentsCamelCase<InferredOptionTypes<typeof s
 };
 
 export function normalizeArgs(
-  argv: Partial<ArgumentsCamelCase<InferredOptionTypes<typeof scriptOptionsBuilder>>>
+  argv: Partial<ArgumentsCamelCase<InferredOptionTypes<typeof scriptOptionsBuilder>>> & { '--'?: string[] }
 ): void {
-  (argv as ScriptArgv).normalizedArgsText = [...(argv.args ?? []), ...(argv._?.slice(1) ?? [])]
+  (argv as ScriptArgv).normalizedArgsText = [...(argv.args ?? []), ...(argv._?.slice(1) ?? []), ...(argv['--'] ?? [])]
     .map((arg) => shellEscapeArgument(String(arg)))
     .join(' ');
   (argv as ScriptArgv).normalizedDockerOptionsText = (argv.dockerOptions ?? [])

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -240,7 +240,7 @@ function appendPlaywrightBailOption(commandArgs: string[], bail?: boolean): stri
   return buildShellCommand([...commandArgs, '--max-failures=1']);
 }
 
-function findExplicitPlaywrightTargetIndexes(args: string[]): number[] {
+export function findExplicitPlaywrightTargetIndexes(args: string[]): number[] {
   let pendingValueMode: 'optional' | 'required' | undefined;
   const targetIndexes: number[] = [];
 

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -11,6 +11,8 @@ import { prismaScripts } from '../prismaScripts.js';
 export interface TestE2EOptions {
   /** '--e2e generate' calls 'codegen http://localhost:8080' */
   playwrightArgs?: string[];
+  /** Raw Playwright args forwarded after `wb test -- ...` */
+  forwardedPlaywrightArgs?: string[];
 }
 
 /**
@@ -127,11 +129,11 @@ export abstract class BaseScripts {
     project: Project,
     argv: TestArgv,
     startCommand: string,
-    { playwrightArgs = ['test', 'test/e2e/'] }: TestE2EOptions
+    { forwardedPlaywrightArgs = [], playwrightArgs = ['test', 'test/e2e/'] }: TestE2EOptions
   ): Promise<string> {
     const port = await checkAndKillPortProcess(project.env.PORT, project);
     const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
-    const playwrightCommand = buildPlaywrightCommand(playwrightArgs, argv.targets, argv.bail);
+    const playwrightCommand = buildPlaywrightCommand(playwrightArgs, argv.targets, argv.bail, forwardedPlaywrightArgs);
     if (project.skipLaunchingServerForPlaywright) {
       return `${playwrightCommand}${suffix}`;
     }
@@ -204,18 +206,26 @@ function findEcosystemConfigPath(project: Project): string | undefined {
   }
 }
 
-function buildPlaywrightCommand(playwrightArgs: string[], targets: TestArgv['targets'], bail?: boolean): string {
+function buildPlaywrightCommand(
+  playwrightArgs: string[],
+  targets: TestArgv['targets'],
+  bail?: boolean,
+  forwardedPlaywrightArgs: string[] = []
+): string {
   const base = ['BUN', 'playwright'];
   const normalizedTargets = targets?.map(String);
   if (playwrightArgs[0] !== 'test' || !normalizedTargets?.length) {
-    return appendPlaywrightBailOption([...base, ...playwrightArgs], bail);
+    return appendPlaywrightBailOption([...base, ...playwrightArgs, ...forwardedPlaywrightArgs], bail);
   }
 
   const rest = playwrightArgs.slice(1);
   const explicitTargetIndexes = findExplicitPlaywrightTargetIndexes(rest);
   const restWithoutExplicitTarget =
     explicitTargetIndexes.length === 0 ? rest : rest.filter((_, index) => !explicitTargetIndexes.includes(index));
-  return appendPlaywrightBailOption([...base, 'test', ...normalizedTargets, ...restWithoutExplicitTarget], bail);
+  return appendPlaywrightBailOption(
+    [...base, 'test', ...normalizedTargets, ...restWithoutExplicitTarget, ...forwardedPlaywrightArgs],
+    bail
+  );
 }
 
 function appendPlaywrightBailOption(commandArgs: string[], bail?: boolean): string {

--- a/packages/wb/test/prisma.test.ts
+++ b/packages/wb/test/prisma.test.ts
@@ -90,4 +90,16 @@ describe('prisma command unknown options', () => {
     expect(result).not.toContain('--create-only'); // false/undefined value should not be included
     expect(result).not.toContain('--verbose'); // known option should not be included
   });
+
+  it('should append arguments forwarded after --', () => {
+    const argv = {
+      '--': ['--name', 'custom migration', '--skip-generate'],
+      _: ['prisma', 'migrate-dev'],
+      $0: 'wb',
+    } as Record<string, unknown>;
+
+    const result = extractUnknownOptions(argv);
+
+    expect(result).toBe(`--name 'custom migration' --skip-generate`);
+  });
 });

--- a/packages/wb/test/prisma.test.ts
+++ b/packages/wb/test/prisma.test.ts
@@ -1,3 +1,5 @@
+import child_process from 'node:child_process';
+
 import { describe, expect, it } from 'vitest';
 import yargs from 'yargs';
 
@@ -101,5 +103,19 @@ describe('prisma command unknown options', () => {
     const result = extractUnknownOptions(argv);
 
     expect(result).toBe(`--name 'custom migration' --skip-generate`);
+  });
+
+  it('explains -- passthrough in wb prisma --help output', () => {
+    const result = child_process.spawnSync('yarn', ['workspace', '@willbooster/wb', 'start', 'prisma', '--help'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+    const normalizedStdout = result.stdout.replaceAll(/\s+/g, ' ');
+
+    expect(result.status).toBe(0);
+    expect(normalizedStdout).toContain(`Use '--' to stop wb option parsing`);
+    expect(normalizedStdout).toContain(`forward the remaining arguments to Prisma.`);
+    expect(normalizedStdout).toContain(`Example: wb prisma migrate-dev -- --name init`);
+    expect(normalizedStdout).toContain(`Additional Prisma flags can also be forwarded after '--'.`);
   });
 });

--- a/packages/wb/test/scripts/builder.test.ts
+++ b/packages/wb/test/scripts/builder.test.ts
@@ -7,12 +7,15 @@ describe('normalizeArgs', () => {
     const argv = {
       _: ['start', `semi;colon`, `quo'te`, `double"quote`],
       args: ['space value'],
+      '--': ['--host', '0.0.0.0', `quo'te`],
       dockerOptions: [`name=quo'ted`],
     } as unknown as ScriptArgv;
 
     normalizeArgs(argv);
 
-    expect(argv.normalizedArgsText).toBe(`'space value' 'semi;colon' 'quo'"'"'te' 'double"quote'`);
+    expect(argv.normalizedArgsText).toBe(
+      `'space value' 'semi;colon' 'quo'"'"'te' 'double"quote' --host 0.0.0.0 'quo'"'"'te'`
+    );
     expect(argv.normalizedDockerOptionsText).toBe(`'name=quo'"'"'ted'`);
   });
 });

--- a/packages/wb/test/scripts/execution/baseScripts.test.ts
+++ b/packages/wb/test/scripts/execution/baseScripts.test.ts
@@ -116,6 +116,15 @@ describe('BaseScripts.testE2E', () => {
     expect(command).toContain('BUN playwright test test/e2e/topPage.spec.ts --project chromium');
   });
 
+  it('preserves forwarded values when explicit targets are provided separately', async () => {
+    const command = await scripts.testE2EProduction(project, { targets: ['test/e2e/topPage.spec.ts'] } as TestArgv, {
+      playwrightArgs: ['test'],
+      forwardedPlaywrightArgs: ['--some-option', 'custom-value'],
+    });
+
+    expect(command).toContain('BUN playwright test test/e2e/topPage.spec.ts --some-option custom-value');
+  });
+
   it('preserves test list option values when replacing explicit playwright targets', async () => {
     const command = await scripts.testE2EProduction(project, { targets: ['test/e2e/topPage.spec.ts'] } as TestArgv, {
       playwrightArgs: ['test', '--test-list', 'cases.txt', '--test-list-invert', 'ignored.txt', 'test/e2e/'],

--- a/packages/wb/test/startCommand.test.ts
+++ b/packages/wb/test/startCommand.test.ts
@@ -1,0 +1,18 @@
+import child_process from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+describe('wb start --help', () => {
+  it('explains how to forward arguments after --', () => {
+    const result = child_process.spawnSync('yarn', ['workspace', '@willbooster/wb', 'start', 'start', '--help'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+    const normalizedStdout = result.stdout.replaceAll(/\s+/g, ' ');
+
+    expect(result.status).toBe(0);
+    expect(normalizedStdout).toContain(`Use '--' to stop wb option parsing`);
+    expect(normalizedStdout).toContain(`forward the remaining arguments to the underlying app command.`);
+    expect(normalizedStdout).toContain(`Example: wb start -- --host 0.0.0.0`);
+  });
+});

--- a/packages/wb/test/testCommand.test.ts
+++ b/packages/wb/test/testCommand.test.ts
@@ -1,8 +1,10 @@
 import child_process from 'node:child_process';
 
 import { describe, expect, it } from 'vitest';
+import yargs from 'yargs';
 
-import { buildPlaywrightArgsForE2E } from '../src/commands/test.js';
+import { retryCommand } from '../src/commands/retry.js';
+import { buildPlaywrightArgsForE2E, testCommand } from '../src/commands/test.js';
 
 describe('buildPlaywrightArgsForE2E', () => {
   it('uses the default e2e directory when no explicit target is provided', () => {
@@ -48,5 +50,35 @@ describe('wb test --help', () => {
     expect(normalizedStdout).toContain(`forward the remaining flags to Playwright.`);
     expect(normalizedStdout).toContain(`Example: wb test -- --grep`);
     expect(normalizedStdout).toContain(`'uploaded image asset'`);
+  });
+});
+
+describe('command-specific -- parsing', () => {
+  it('populates argv["--"] for wb test', () => {
+    const parser = (
+      typeof testCommand.builder === 'function'
+        ? testCommand.builder(yargs() as never)
+        : yargs().options(testCommand.builder ?? {})
+    ) as ReturnType<typeof yargs>;
+    const argv = parser.parseSync(['--', '--grep', 'uploaded image asset']) as {
+      '--'?: string[];
+    };
+
+    expect(argv['--']).toEqual(['--grep', 'uploaded image asset']);
+  });
+
+  it('keeps retry arguments in positional argv for wb retry -- ...', () => {
+    const parser = (
+      typeof retryCommand.builder === 'function'
+        ? retryCommand.builder(yargs() as never)
+        : yargs().options(retryCommand.builder ?? {})
+    ) as ReturnType<typeof yargs>;
+    const argv = parser.parseSync(['--', 'docker', 'build', '-t', 'img', '.']) as {
+      _: string[];
+      '--'?: string[];
+    };
+
+    expect(argv._).toEqual(['docker', 'build', '-t', 'img', '.']);
+    expect(argv['--']).toBeUndefined();
   });
 });

--- a/packages/wb/test/testCommand.test.ts
+++ b/packages/wb/test/testCommand.test.ts
@@ -8,32 +8,15 @@ import { buildPlaywrightArgsForE2E, testCommand } from '../src/commands/test.js'
 
 describe('buildPlaywrightArgsForE2E', () => {
   it('uses the default e2e directory when no explicit target is provided', () => {
-    expect(buildPlaywrightArgsForE2E([], {})).toEqual(['test', 'test/e2e/']);
+    expect(buildPlaywrightArgsForE2E([])).toEqual(['test', 'test/e2e/']);
   });
 
-  it('keeps explicit e2e targets before forwarded playwright flags', () => {
-    expect(
-      buildPlaywrightArgsForE2E(['test/e2e/phaserAssetLoading.spec.ts'], {
-        '--': ['--grep', 'uploaded image asset', '--project', 'chromium'],
-      })
-    ).toEqual([
-      'test',
-      'test/e2e/phaserAssetLoading.spec.ts',
-      '--grep',
-      'uploaded image asset',
-      '--project',
-      'chromium',
-    ]);
+  it('omits explicit e2e targets because they are provided separately to the command builder', () => {
+    expect(buildPlaywrightArgsForE2E(['test/e2e/phaserAssetLoading.spec.ts'])).toEqual(['test']);
   });
 
   it('appends wb-managed mode flags after forwarded playwright flags', () => {
-    expect(buildPlaywrightArgsForE2E([], { '--': ['--grep', 'uploaded'] }, ['--headed'])).toEqual([
-      'test',
-      'test/e2e/',
-      '--grep',
-      'uploaded',
-      '--headed',
-    ]);
+    expect(buildPlaywrightArgsForE2E([], ['--headed'])).toEqual(['test', 'test/e2e/', '--headed']);
   });
 });
 

--- a/packages/wb/test/testCommand.test.ts
+++ b/packages/wb/test/testCommand.test.ts
@@ -1,3 +1,5 @@
+import child_process from 'node:child_process';
+
 import { describe, expect, it } from 'vitest';
 
 import { buildPlaywrightArgsForE2E } from '../src/commands/test.js';
@@ -30,5 +32,21 @@ describe('buildPlaywrightArgsForE2E', () => {
       'uploaded',
       '--headed',
     ]);
+  });
+});
+
+describe('wb test --help', () => {
+  it('explains that -- forwards the remaining flags to Playwright', () => {
+    const result = child_process.spawnSync('yarn', ['workspace', '@willbooster/wb', 'start', 'test', '--help'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+    const normalizedStdout = result.stdout.replaceAll(/\s+/g, ' ');
+
+    expect(result.status).toBe(0);
+    expect(normalizedStdout).toContain(`Use '--' to stop wb option parsing`);
+    expect(normalizedStdout).toContain(`forward the remaining flags to Playwright.`);
+    expect(normalizedStdout).toContain(`Example: wb test -- --grep`);
+    expect(normalizedStdout).toContain(`'uploaded image asset'`);
   });
 });

--- a/packages/wb/test/testCommand.test.ts
+++ b/packages/wb/test/testCommand.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPlaywrightArgsForE2E } from '../src/commands/test.js';
+
+describe('buildPlaywrightArgsForE2E', () => {
+  it('uses the default e2e directory when no explicit target is provided', () => {
+    expect(buildPlaywrightArgsForE2E([], {})).toEqual(['test', 'test/e2e/']);
+  });
+
+  it('keeps explicit e2e targets before forwarded playwright flags', () => {
+    expect(
+      buildPlaywrightArgsForE2E(['test/e2e/phaserAssetLoading.spec.ts'], {
+        '--': ['--grep', 'uploaded image asset', '--project', 'chromium'],
+      })
+    ).toEqual([
+      'test',
+      'test/e2e/phaserAssetLoading.spec.ts',
+      '--grep',
+      'uploaded image asset',
+      '--project',
+      'chromium',
+    ]);
+  });
+
+  it('appends wb-managed mode flags after forwarded playwright flags', () => {
+    expect(buildPlaywrightArgsForE2E([], { '--': ['--grep', 'uploaded'] }, ['--headed'])).toEqual([
+      'test',
+      'test/e2e/',
+      '--grep',
+      'uploaded',
+      '--headed',
+    ]);
+  });
+});

--- a/packages/wb/test/testCommand.test.ts
+++ b/packages/wb/test/testCommand.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import yargs from 'yargs';
 
 import { retryCommand } from '../src/commands/retry.js';
-import { buildPlaywrightArgsForE2E, testCommand } from '../src/commands/test.js';
+import { buildPlaywrightArgsForE2E, resolveTestExecutionTargets, testCommand } from '../src/commands/test.js';
 
 describe('buildPlaywrightArgsForE2E', () => {
   it('uses the default e2e directory when no explicit target is provided', () => {
@@ -16,7 +16,11 @@ describe('buildPlaywrightArgsForE2E', () => {
   });
 
   it('appends wb-managed mode flags after forwarded playwright flags', () => {
-    expect(buildPlaywrightArgsForE2E([], ['--headed'])).toEqual(['test', 'test/e2e/', '--headed']);
+    expect(buildPlaywrightArgsForE2E([], [], ['--headed'])).toEqual(['test', 'test/e2e/', '--headed']);
+  });
+
+  it('skips the default e2e directory when forwarded args already include explicit playwright targets', () => {
+    expect(buildPlaywrightArgsForE2E([], ['test/e2e/phaserAssetLoading.spec.ts'])).toEqual(['test']);
   });
 });
 
@@ -63,5 +67,21 @@ describe('command-specific -- parsing', () => {
 
     expect(argv._).toEqual(['docker', 'build', '-t', 'img', '.']);
     expect(argv['--']).toBeUndefined();
+  });
+});
+
+describe('resolveTestExecutionTargets', () => {
+  it('runs only e2e tests when playwright args are forwarded without positional targets', () => {
+    expect(resolveTestExecutionTargets([], ['--grep', 'uploaded image asset'])).toEqual({
+      shouldRunUnit: false,
+      shouldRunE2e: true,
+    });
+  });
+
+  it('still runs unit tests when unit targets are explicitly requested', () => {
+    expect(resolveTestExecutionTargets(['test/unit/example.test.ts'], ['--grep', 'uploaded image asset'])).toEqual({
+      shouldRunUnit: true,
+      shouldRunE2e: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- allow `wb test` to forward raw Playwright flags after `--`
- merge forwarded flags with existing wb-managed e2e targets and modes
- add focused tests for the new Playwright arg builder behavior

## Verification
- yarn workspace @willbooster/wb vitest run test/testCommand.test.ts test/scripts/execution/baseScripts.test.ts
- yarn check-for-ai