### PR TITLE
fix: simplify biome lint target filtering

### DIFF
--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -136,9 +136,7 @@ export const lintCommand: CommandModule<
           const lintFilePaths = lintFilePathsByProject.get(project) ?? [];
           lintFilePaths.push(filePath);
           lintFilePathsByProject.set(project, lintFilePaths);
-          if (shouldFormatExplicitPathWithPrettier(project, extension)) {
-            prettierFilePaths.push(...buildExplicitPrettierArgs(project, filePath, fileKind, extension));
-          }
+          prettierFilePaths.push(...buildExplicitPrettierArgs(project, filePath, fileKind, extension));
         } else if (prettierExtensions.has(extension)) {
           prettierFilePaths.push(filePath);
         } else if (isPotentialLintTarget(extension) && !project.preferredLinter) {

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import chalk from 'chalk';
@@ -93,7 +94,7 @@ export const lintCommand: CommandModule<
       process.exit(1);
     }
 
-    const files = argv.files ?? [];
+    const files = getLintTargetFiles(argv);
     const lintFilePathsByProject = new Map<Project, string[]>();
     const prettierFilePaths: string[] = [];
     const packageJsonFilePaths: string[] = [];
@@ -102,7 +103,7 @@ export const lintCommand: CommandModule<
     let sortPackageJsonArgs: string[];
     if (files.length > 0) {
       for (const file of files) {
-        const filePath = path.resolve(String(file));
+        const filePath = path.resolve(file);
         if (
           filePath.endsWith('/test/fixtures') ||
           filePath.includes('/test/fixtures/') ||
@@ -112,6 +113,7 @@ export const lintCommand: CommandModule<
           continue;
         }
 
+        const fileKind = await getLintTargetFileKind(filePath);
         const extension = path.extname(filePath).slice(1);
         if (filePath.endsWith('/package.json')) {
           packageJsonFilePaths.push(filePath);
@@ -121,7 +123,7 @@ export const lintCommand: CommandModule<
         const project = findOwningProject(projects.descendants, filePath);
         if (!project) continue;
 
-        if (supportsLintingExtension(project, extension)) {
+        if (fileKind === 'directory' || supportsLintingExtension(project, extension)) {
           const lintFilePaths = lintFilePathsByProject.get(project) ?? [];
           lintFilePaths.push(filePath);
           lintFilePathsByProject.set(project, lintFilePaths);
@@ -267,6 +269,28 @@ function findOwningProject(projects: Project[], filePath: string): Project | und
     }
   }
   return owningProject;
+}
+
+export function getLintTargetFiles(
+  argv: Pick<InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>, 'files'> & {
+    _: unknown[];
+  }
+): string[] {
+  if (argv.files && argv.files.length > 0) {
+    return argv.files.map(String);
+  }
+  return argv._.slice(1).filter((value): value is string => typeof value === 'string');
+}
+
+export async function getLintTargetFileKind(filePath: string): Promise<'directory' | 'other'> {
+  try {
+    const stats = await fs.stat(filePath);
+    if (stats.isDirectory()) return 'directory';
+  } catch {
+    // Missing paths are handled by the downstream tools.
+  }
+
+  return 'other';
 }
 
 function isPotentialLintTarget(extension: string): boolean {

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -123,7 +123,11 @@ export const lintCommand: CommandModule<
         const project = findOwningProject(projects.descendants, filePath);
         if (!project) continue;
 
-        if (fileKind === 'directory' || supportsLintingExtension(project, extension)) {
+        if (
+          project.preferredLinter === 'biome' ||
+          fileKind === 'directory' ||
+          supportsLintingExtension(project, extension)
+        ) {
           const lintFilePaths = lintFilePathsByProject.get(project) ?? [];
           lintFilePaths.push(filePath);
           lintFilePathsByProject.set(project, lintFilePaths);

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -124,6 +124,7 @@ export const lintCommand: CommandModule<
           packageJsonFilePaths.push(filePath);
           continue;
         }
+        packageJsonFilePaths.push(...getExplicitPackageJsonPaths(projects.descendants, filePath, fileKind));
 
         const project = findOwningProject(projects.descendants, filePath);
         if (!project) continue;
@@ -145,7 +146,7 @@ export const lintCommand: CommandModule<
         }
       }
       prettierArgs = prettierFilePaths;
-      sortPackageJsonArgs = packageJsonFilePaths;
+      sortPackageJsonArgs = [...new Set(packageJsonFilePaths)];
     } else {
       prettierArgs = buildPrettierArgs(projects.self.dirPath, projects.descendants);
       sortPackageJsonArgs = projects.descendants.map((p) => p.packageJsonPath);
@@ -327,6 +328,21 @@ export function buildExplicitPrettierArgs(
     return [filePath];
   }
   return [];
+}
+
+export function getExplicitPackageJsonPaths(
+  projects: Pick<Project, 'dirPath' | 'packageJsonPath'>[],
+  filePath: string,
+  fileKind: 'directory' | 'other'
+): string[] {
+  if (fileKind !== 'directory') return [];
+  return projects
+    .filter(
+      (project) =>
+        project.packageJsonPath === path.join(filePath, 'package.json') ||
+        project.packageJsonPath.startsWith(`${filePath}/`)
+    )
+    .map((project) => project.packageJsonPath);
 }
 
 function isPotentialLintTarget(extension: string): boolean {

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -102,8 +102,14 @@ export const lintCommand: CommandModule<
     let prettierArgs: string[];
     let sortPackageJsonArgs: string[];
     if (files.length > 0) {
-      for (const file of files) {
-        const filePath = path.resolve(file);
+      const lintTargets = await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.resolve(file);
+          const fileKind = await getLintTargetFileKind(filePath);
+          return { fileKind, filePath };
+        })
+      );
+      for (const { fileKind, filePath } of lintTargets) {
         if (
           filePath.endsWith('/test/fixtures') ||
           filePath.includes('/test/fixtures/') ||
@@ -113,7 +119,6 @@ export const lintCommand: CommandModule<
           continue;
         }
 
-        const fileKind = await getLintTargetFileKind(filePath);
         const extension = path.extname(filePath).slice(1);
         if (filePath.endsWith('/package.json')) {
           packageJsonFilePaths.push(filePath);
@@ -280,9 +285,6 @@ export function getLintTargetFiles(
     _: unknown[];
   }
 ): string[] {
-  if (argv.files && argv.files.length > 0) {
-    return argv.files.map(String);
-  }
   return argv._.slice(1).filter((value): value is string => typeof value === 'string');
 }
 

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -137,7 +137,7 @@ export const lintCommand: CommandModule<
           lintFilePaths.push(filePath);
           lintFilePathsByProject.set(project, lintFilePaths);
           if (shouldFormatExplicitPathWithPrettier(project, extension)) {
-            prettierFilePaths.push(filePath);
+            prettierFilePaths.push(...buildExplicitPrettierArgs(project, filePath, fileKind, extension));
           }
         } else if (prettierExtensions.has(extension)) {
           prettierFilePaths.push(filePath);
@@ -314,6 +314,21 @@ export function shouldFormatExplicitPathWithPrettier(
     !supportsLintingExtension(project, extension) &&
     prettierExtensions.has(extension)
   );
+}
+
+export function buildExplicitPrettierArgs(
+  project: Pick<Project, 'preferredLinter'>,
+  filePath: string,
+  fileKind: 'directory' | 'other',
+  extension: string
+): string[] {
+  if (fileKind === 'directory' && project.preferredLinter === 'biome') {
+    return [path.join(filePath, '**/{.*/,}*.{' + [...prettierOnlyExtensions].join(',') + '}')];
+  }
+  if (shouldFormatExplicitPathWithPrettier(project, extension)) {
+    return [filePath];
+  }
+  return [];
 }
 
 function isPotentialLintTarget(extension: string): boolean {

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -126,26 +126,25 @@ export const lintCommand: CommandModule<
         }
         packageJsonFilePaths.push(...getExplicitPackageJsonPaths(projects.descendants, filePath, fileKind));
 
-        const project = findOwningProject(projects.descendants, filePath);
-        if (!project) continue;
-
-        if (
-          project.preferredLinter === 'biome' ||
-          fileKind === 'directory' ||
-          supportsLintingExtension(project, extension)
-        ) {
-          const lintFilePaths = lintFilePathsByProject.get(project) ?? [];
-          lintFilePaths.push(filePath);
-          lintFilePathsByProject.set(project, lintFilePaths);
-          prettierFilePaths.push(...buildExplicitPrettierArgs(project, filePath, fileKind, extension));
-        } else if (prettierExtensions.has(extension)) {
-          prettierFilePaths.push(filePath);
-        } else if (isPotentialLintTarget(extension) && !project.preferredLinter) {
-          console.error(chalk.red(`No linter found for ${project.name}. Install ESLint or Biome.`));
-          missingLintToolForExplicitFiles = true;
+        for (const { lintPath, project } of getExplicitLintTargets(projects.descendants, filePath, fileKind)) {
+          if (
+            project.preferredLinter === 'biome' ||
+            fileKind === 'directory' ||
+            supportsLintingExtension(project, extension)
+          ) {
+            const lintFilePaths = lintFilePathsByProject.get(project) ?? [];
+            lintFilePaths.push(lintPath);
+            lintFilePathsByProject.set(project, lintFilePaths);
+            prettierFilePaths.push(...buildExplicitPrettierArgs(project, lintPath, fileKind, extension));
+          } else if (prettierExtensions.has(extension)) {
+            prettierFilePaths.push(lintPath);
+          } else if (isPotentialLintTarget(extension) && !project.preferredLinter) {
+            console.error(chalk.red(`No linter found for ${project.name}. Install ESLint or Biome.`));
+            missingLintToolForExplicitFiles = true;
+          }
         }
       }
-      prettierArgs = prettierFilePaths;
+      prettierArgs = [...new Set(prettierFilePaths)];
       sortPackageJsonArgs = [...new Set(packageJsonFilePaths)];
     } else {
       prettierArgs = buildPrettierArgs(projects.self.dirPath, projects.descendants);
@@ -343,6 +342,24 @@ export function getExplicitPackageJsonPaths(
         project.packageJsonPath.startsWith(`${filePath}/`)
     )
     .map((project) => project.packageJsonPath);
+}
+
+export function getExplicitLintTargets(
+  projects: Project[],
+  filePath: string,
+  fileKind: 'directory' | 'other'
+): { lintPath: string; project: Project }[] {
+  if (fileKind === 'directory') {
+    const descendantProjects = projects.filter(
+      (project) => project.dirPath === filePath || project.dirPath.startsWith(`${filePath}/`)
+    );
+    if (descendantProjects.length > 0) {
+      return descendantProjects.map((project) => ({ lintPath: project.dirPath, project }));
+    }
+  }
+
+  const project = findOwningProject(projects, filePath);
+  return project ? [{ lintPath: filePath, project }] : [];
 }
 
 function isPotentialLintTarget(extension: string): boolean {

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -136,7 +136,7 @@ export const lintCommand: CommandModule<
           const lintFilePaths = lintFilePathsByProject.get(project) ?? [];
           lintFilePaths.push(filePath);
           lintFilePathsByProject.set(project, lintFilePaths);
-          if (needsPrettier(project)) {
+          if (shouldFormatExplicitPathWithPrettier(project, extension)) {
             prettierFilePaths.push(filePath);
           }
         } else if (prettierExtensions.has(extension)) {
@@ -282,10 +282,15 @@ function findOwningProject(projects: Project[], filePath: string): Project | und
 
 export function getLintTargetFiles(
   argv: Pick<InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>, 'files'> & {
+    '--'?: unknown[];
     _: unknown[];
   }
 ): string[] {
-  return argv._.slice(1).filter((value): value is string => typeof value === 'string');
+  const lintTargets = new Set<string>();
+  for (const value of [...(argv.files ?? []), ...argv._.slice(1), ...(argv['--'] ?? [])]) {
+    lintTargets.add(String(value));
+  }
+  return [...lintTargets];
 }
 
 export async function getLintTargetFileKind(filePath: string): Promise<'directory' | 'other'> {
@@ -297,6 +302,18 @@ export async function getLintTargetFileKind(filePath: string): Promise<'director
   }
 
   return 'other';
+}
+
+export function shouldFormatExplicitPathWithPrettier(
+  project: Pick<Project, 'preferredLinter'>,
+  extension: string
+): boolean {
+  if (needsPrettier(project)) return true;
+  return (
+    project.preferredLinter === 'biome' &&
+    !supportsLintingExtension(project, extension) &&
+    prettierExtensions.has(extension)
+  );
 }
 
 function isPotentialLintTarget(extension: string): boolean {

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -74,6 +74,7 @@ const prettierExtensions = new Set([
   'yml',
 ]);
 const prettierOnlyExtensions = new Set([...prettierExtensions].filter((ext) => !biomeExtensions.has(ext)));
+const prettierFixtureIgnorePattern = '!**/test{-,/}fixtures/**';
 
 export const lintCommand: CommandModule<
   unknown,
@@ -255,7 +256,7 @@ export function buildPrettierArgs(
   selfDirPath: string,
   projects: Pick<Project, 'dirPath' | 'preferredLinter'>[]
 ): string[] {
-  const args = new Set<string>([`**/{.*/,}*.{${[...prettierOnlyExtensions].join(',')}}`, '!**/test{-,/}fixtures/**']);
+  const args = new Set<string>([`**/{.*/,}*.{${[...prettierOnlyExtensions].join(',')}}`, prettierFixtureIgnorePattern]);
   for (const project of projects) {
     if (!needsPrettier(project)) continue;
 
@@ -321,7 +322,13 @@ export function buildExplicitPrettierArgs(
   extension: string
 ): string[] {
   if (fileKind === 'directory' && project.preferredLinter === 'biome') {
-    return [path.join(filePath, '**/{.*/,}*.{' + [...prettierOnlyExtensions].join(',') + '}')];
+    return [
+      path.join(filePath, '**/{.*/,}*.{' + [...prettierOnlyExtensions].join(',') + '}'),
+      prettierFixtureIgnorePattern,
+    ];
+  }
+  if (fileKind === 'directory' && needsPrettier(project)) {
+    return [filePath, prettierFixtureIgnorePattern];
   }
   if (shouldFormatExplicitPathWithPrettier(project, extension)) {
     return [filePath];

--- a/packages/wb/test/lint.test.ts
+++ b/packages/wb/test/lint.test.ts
@@ -95,12 +95,20 @@ describe('lint', () => {
   it('uses a prettier-only glob for explicit directories in biome projects', () => {
     expect(buildExplicitPrettierArgs({ preferredLinter: 'biome' }, '/tmp/example', 'directory', '')).toEqual([
       '/tmp/example/**/{.*/,}*.{java,md,scss}',
+      '!**/test{-,/}fixtures/**',
     ]);
   });
 
   it('keeps explicit files unchanged in prettier args', () => {
     expect(buildExplicitPrettierArgs({ preferredLinter: 'biome' }, '/tmp/example/README.md', 'other', 'md')).toEqual([
       '/tmp/example/README.md',
+    ]);
+  });
+
+  it('keeps fixture ignores for explicit eslint directories', () => {
+    expect(buildExplicitPrettierArgs({ preferredLinter: 'eslint' }, '/tmp/example', 'directory', '')).toEqual([
+      '/tmp/example',
+      '!**/test{-,/}fixtures/**',
     ]);
   });
 

--- a/packages/wb/test/lint.test.ts
+++ b/packages/wb/test/lint.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildExplicitPrettierArgs,
   buildLintCommand,
   buildPrettierArgs,
   getLintTargetFileKind,
@@ -87,5 +88,17 @@ describe('lint', () => {
   it('keeps prettier formatting for explicit markdown files in biome projects', () => {
     expect(shouldFormatExplicitPathWithPrettier({ preferredLinter: 'biome' }, 'md')).toBe(true);
     expect(shouldFormatExplicitPathWithPrettier({ preferredLinter: 'biome' }, 'ts')).toBe(false);
+  });
+
+  it('uses a prettier-only glob for explicit directories in biome projects', () => {
+    expect(buildExplicitPrettierArgs({ preferredLinter: 'biome' }, '/tmp/example', 'directory', '')).toEqual([
+      '/tmp/example/**/{.*/,}*.{java,md,scss}',
+    ]);
+  });
+
+  it('keeps explicit files unchanged in prettier args', () => {
+    expect(buildExplicitPrettierArgs({ preferredLinter: 'biome' }, '/tmp/example/README.md', 'other', 'md')).toEqual([
+      '/tmp/example/README.md',
+    ]);
   });
 });

--- a/packages/wb/test/lint.test.ts
+++ b/packages/wb/test/lint.test.ts
@@ -9,6 +9,7 @@ import {
   buildPrettierArgs,
   getLintTargetFileKind,
   getLintTargetFiles,
+  shouldFormatExplicitPathWithPrettier,
 } from '../src/commands/lint.js';
 
 describe('lint', () => {
@@ -58,6 +59,16 @@ describe('lint', () => {
     ).toEqual(['skills/complete-pr/SKILL.md']);
   });
 
+  it('merges positional and double-dash lint targets and preserves numeric paths', () => {
+    expect(
+      getLintTargetFiles({
+        _: ['lint', 'double-dash.ts', 123],
+        '--': ['double-dash.ts', 456],
+        files: ['positional.ts', 123],
+      })
+    ).toEqual(['positional.ts', '123', 'double-dash.ts', '456']);
+  });
+
   it('treats explicit directories as lint targets', async () => {
     const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-lint-dir-'));
 
@@ -71,5 +82,10 @@ describe('lint', () => {
     await fs.writeFile(filePath, '# test\n');
 
     await expect(getLintTargetFileKind(filePath)).resolves.toBe('other');
+  });
+
+  it('keeps prettier formatting for explicit markdown files in biome projects', () => {
+    expect(shouldFormatExplicitPathWithPrettier({ preferredLinter: 'biome' }, 'md')).toBe(true);
+    expect(shouldFormatExplicitPathWithPrettier({ preferredLinter: 'biome' }, 'ts')).toBe(false);
   });
 });

--- a/packages/wb/test/lint.test.ts
+++ b/packages/wb/test/lint.test.ts
@@ -1,6 +1,15 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
-import { buildLintCommand, buildPrettierArgs } from '../src/commands/lint.js';
+import {
+  buildLintCommand,
+  buildPrettierArgs,
+  getLintTargetFileKind,
+  getLintTargetFiles,
+} from '../src/commands/lint.js';
 
 describe('lint', () => {
   it('builds a biome command for biome projects', () => {
@@ -38,5 +47,29 @@ describe('lint', () => {
       '!**/test{-,/}fixtures/**',
       'packages/eslint-app/**/{.*/,}*.{cjs,css,cts,htm,html,java,js,json,json5,jsonc,jsx,md,mjs,mts,scss,ts,tsx,vue,yaml,yml}',
     ]);
+  });
+
+  it('accepts lint target files passed after --', () => {
+    expect(
+      getLintTargetFiles({
+        _: ['lint', 'skills/complete-pr/SKILL.md'],
+        files: undefined,
+      })
+    ).toEqual(['skills/complete-pr/SKILL.md']);
+  });
+
+  it('treats explicit directories as lint targets', async () => {
+    const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-lint-dir-'));
+
+    await expect(getLintTargetFileKind(dirPath)).resolves.toBe('directory');
+  });
+
+  it('does not treat regular files as directories', async () => {
+    const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-lint-file-'));
+    const filePath = path.join(dirPath, 'README.md');
+
+    await fs.writeFile(filePath, '# test\n');
+
+    await expect(getLintTargetFileKind(filePath)).resolves.toBe('other');
   });
 });

--- a/packages/wb/test/lint.test.ts
+++ b/packages/wb/test/lint.test.ts
@@ -10,6 +10,7 @@ import {
   buildPrettierArgs,
   getLintTargetFileKind,
   getLintTargetFiles,
+  getExplicitPackageJsonPaths,
   shouldFormatExplicitPathWithPrettier,
 } from '../src/commands/lint.js';
 
@@ -100,5 +101,19 @@ describe('lint', () => {
     expect(buildExplicitPrettierArgs({ preferredLinter: 'biome' }, '/tmp/example/README.md', 'other', 'md')).toEqual([
       '/tmp/example/README.md',
     ]);
+  });
+
+  it('collects package.json files underneath explicit directories', () => {
+    expect(
+      getExplicitPackageJsonPaths(
+        [
+          { dirPath: '/repo', packageJsonPath: '/repo/package.json' },
+          { dirPath: '/repo/packages/a', packageJsonPath: '/repo/packages/a/package.json' },
+          { dirPath: '/repo/packages/b', packageJsonPath: '/repo/packages/b/package.json' },
+        ],
+        '/repo/packages',
+        'directory'
+      )
+    ).toEqual(['/repo/packages/a/package.json', '/repo/packages/b/package.json']);
   });
 });

--- a/packages/wb/test/lint.test.ts
+++ b/packages/wb/test/lint.test.ts
@@ -8,6 +8,7 @@ import {
   buildExplicitPrettierArgs,
   buildLintCommand,
   buildPrettierArgs,
+  getExplicitLintTargets,
   getLintTargetFileKind,
   getLintTargetFiles,
   getExplicitPackageJsonPaths,
@@ -115,5 +116,22 @@ describe('lint', () => {
         'directory'
       )
     ).toEqual(['/repo/packages/a/package.json', '/repo/packages/b/package.json']);
+  });
+
+  it('fans out parent directory targets to descendant projects', () => {
+    expect(
+      getExplicitLintTargets(
+        [
+          { dirPath: '/repo', preferredLinter: 'eslint' },
+          { dirPath: '/repo/packages/a', preferredLinter: 'eslint' },
+          { dirPath: '/repo/packages/b', preferredLinter: 'biome' },
+        ] as never,
+        '/repo/packages',
+        'directory'
+      )
+    ).toEqual([
+      { lintPath: '/repo/packages/a', project: { dirPath: '/repo/packages/a', preferredLinter: 'eslint' } },
+      { lintPath: '/repo/packages/b', project: { dirPath: '/repo/packages/b', preferredLinter: 'biome' } },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- make `wb lint` treat paths passed after `--` as explicit lint targets
- preserve staged-file workflows that call `wb lint -- ...`
- add a regression test for the double-dash file path case

## Testing

- `yarn check-for-ai`

Co-authored-by: WillBooster (Codex CLI) <agent@willbooster.com>