### PR TITLE
feat: add AI check commands

### DIFF
--- a/packages/wb/src/commands/aiCheck.ts
+++ b/packages/wb/src/commands/aiCheck.ts
@@ -44,17 +44,14 @@ export const checkAllForAiCommand: CommandModule<unknown, AiCheckCommandOptions>
     }
 
     await checkForAi(projects.self, argv);
-    await runInProcessCommand('test', async () => {
-      await test({ ...argv, _: ['test'], e2e: 'headless' } as TestCommandArgv);
-      return;
-    });
+    await runProjectTest(projects.self, argv);
   },
 };
 
 async function checkForAi(project: Project, argv: AiCheckCommandArgv): Promise<void> {
-  await runPackageCommand('install', `${packageManager} install > /dev/null`, project, argv, { silent: true });
+  await runPackageCommand('install', `${packageManager} install`, project, argv, { silent: true });
   if (project.packageJson.scripts?.['gen-code']) {
-    await runPackageCommand('gen-code', `${packageManager} gen-code > /dev/null`, project, argv, {
+    await runPackageCommand('gen-code', `${packageManager} gen-code`, project, argv, {
       silent: true,
     });
   }
@@ -67,12 +64,24 @@ async function checkForAi(project: Project, argv: AiCheckCommandArgv): Promise<v
   );
 }
 
+async function runProjectTest(project: Project, argv: AiCheckCommandArgv): Promise<void> {
+  if (project.packageJson.scripts?.test?.includes('wb test')) {
+    await runInProcessCommand('test', async () => {
+      await test({ ...argv, _: ['test'], e2e: 'headless' } as TestCommandArgv);
+      return;
+    });
+    return;
+  }
+
+  await runPackageCommand('test', `${packageManager} test`, project, argv);
+}
+
 async function runInProcessCommand(
   commandName: string,
   command: () => Promise<number | undefined>,
   options: { allowFailure?: boolean } = {}
 ): Promise<number> {
-  console.info(chalk.cyan(chalk.bold('Start:'), commandName));
+  console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName));
   const exitCode = (await command()) ?? 0;
   if (exitCode === 0 || options.allowFailure) {
     console.info(chalk.green(chalk.bold('Finished:'), commandName));
@@ -90,7 +99,7 @@ async function runPackageCommand(
   argv: AiCheckCommandArgv,
   options: { allowFailure?: boolean; silent?: boolean } = {}
 ): Promise<number> {
-  console.info(chalk.cyan(chalk.bold('Start:'), commandName) + chalk.gray(` at ${project.dirPath}`));
+  console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName) + chalk.gray(` at ${project.dirPath}`));
   if (argv.verbose) {
     console.info(chalk.gray(chalk.bold('Start (raw):'), command));
   }
@@ -103,7 +112,7 @@ async function runPackageCommand(
     cwd: project.dirPath,
     env: configureEnv(project.env, { forceColor: true }),
     shell: true,
-    stdio: options.silent ? 'ignore' : 'inherit',
+    stdio: options.silent ? ['ignore', 'ignore', 'inherit'] : 'inherit',
     killOnExit: true,
     verbose: argv.verbose,
   });

--- a/packages/wb/src/commands/aiCheck.ts
+++ b/packages/wb/src/commands/aiCheck.ts
@@ -1,0 +1,97 @@
+import { spawnAsync } from '@willbooster/shared-lib-node/src';
+import chalk from 'chalk';
+import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
+
+import type { Project } from '../project.js';
+import { findRootAndSelfProjects } from '../project.js';
+import { configureEnv } from '../scripts/run.js';
+import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { packageManager, packageManagerWithRun } from '../utils/runtime.js';
+
+const builder = {} as const;
+
+type AiCheckCommandOptions = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>;
+type AiCheckCommandArgv = ArgumentsCamelCase<AiCheckCommandOptions>;
+
+export const checkForAiCommand: CommandModule<unknown, AiCheckCommandOptions> = {
+  command: 'check-for-ai',
+  describe: 'Run generated AI checks',
+  builder,
+  async handler(argv) {
+    const projects = findRootAndSelfProjects(argv, false);
+    if (!projects) {
+      console.error(chalk.red('No project found.'));
+      process.exit(1);
+    }
+
+    await checkForAi(projects.self, argv);
+  },
+};
+
+export const checkAllForAiCommand: CommandModule<unknown, AiCheckCommandOptions> = {
+  command: 'check-all-for-ai',
+  describe: 'Run generated AI checks and tests',
+  builder,
+  async handler(argv) {
+    const projects = findRootAndSelfProjects(argv, false);
+    if (!projects) {
+      console.error(chalk.red('No project found.'));
+      process.exit(1);
+    }
+
+    await checkForAi(projects.self, argv);
+    await runGeneratedCommand('test', `${packageManagerWithRun} wb test`, projects.self, argv);
+  },
+};
+
+async function checkForAi(project: Project, argv: AiCheckCommandArgv): Promise<void> {
+  await runGeneratedCommand('install', `${packageManager} install > /dev/null`, project, argv, { silent: true });
+  if (project.packageJson.scripts?.['gen-code']) {
+    await runGeneratedCommand('gen-code', `${packageManagerWithRun} gen-code > /dev/null`, project, argv, {
+      silent: true,
+    });
+  }
+  await runGeneratedCommand(
+    'format',
+    `${packageManagerWithRun} wb lint --format > /dev/null 2> /dev/null`,
+    project,
+    argv,
+    { allowFailure: true, silent: true }
+  );
+  await runGeneratedCommand('typecheck', `${packageManagerWithRun} wb typecheck`, project, argv);
+  await runGeneratedCommand('lint-fix', `${packageManagerWithRun} wb lint --fix --quiet`, project, argv);
+}
+
+async function runGeneratedCommand(
+  commandName: string,
+  command: string,
+  project: Project,
+  argv: AiCheckCommandArgv,
+  options: { allowFailure?: boolean; silent?: boolean } = {}
+): Promise<number> {
+  console.info(chalk.cyan(chalk.bold('Start:'), commandName) + chalk.gray(` at ${project.dirPath}`));
+  if (argv.verbose) {
+    console.info(chalk.gray(chalk.bold('Start (raw):'), command));
+  }
+  if (argv.dryRun) {
+    console.info(chalk.green(chalk.bold('Finished:'), commandName));
+    return 0;
+  }
+
+  const ret = await spawnAsync(command, undefined, {
+    cwd: project.dirPath,
+    env: configureEnv(project.env, { forceColor: true }),
+    shell: true,
+    stdio: options.silent ? 'ignore' : 'inherit',
+    killOnExit: true,
+    verbose: argv.verbose,
+  });
+
+  if (ret.status === 0 || options.allowFailure) {
+    console.info(chalk.green(chalk.bold('Finished:'), commandName));
+  } else {
+    console.info(chalk.red(chalk.bold(`Failed (exit code ${ret.status}):`), commandName));
+    process.exit(ret.status ?? 1);
+  }
+  return ret.status ?? 1;
+}

--- a/packages/wb/src/commands/aiCheck.ts
+++ b/packages/wb/src/commands/aiCheck.ts
@@ -45,7 +45,7 @@ export const checkAllForAiCommand: CommandModule<unknown, AiCheckCommandOptions>
 
     await checkForAi(projects.self, argv);
     await runInProcessCommand('test', async () => {
-      await test({ ...argv, _: ['test'] } as TestCommandArgv);
+      await test({ ...argv, _: ['test'], e2e: 'headless' } as TestCommandArgv);
       return;
     });
   },

--- a/packages/wb/src/commands/aiCheck.ts
+++ b/packages/wb/src/commands/aiCheck.ts
@@ -6,7 +6,11 @@ import type { Project } from '../project.js';
 import { findRootAndSelfProjects } from '../project.js';
 import { configureEnv } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
-import { packageManager, packageManagerWithRun } from '../utils/runtime.js';
+import { packageManager } from '../utils/runtime.js';
+
+import { lint, type LintCommandArgv } from './lint.js';
+import { test, type TestCommandArgv } from './test.js';
+import { typeCheck } from './typecheck.js';
 
 const builder = {} as const;
 
@@ -40,29 +44,46 @@ export const checkAllForAiCommand: CommandModule<unknown, AiCheckCommandOptions>
     }
 
     await checkForAi(projects.self, argv);
-    await runGeneratedCommand('test', `${packageManagerWithRun} wb test`, projects.self, argv);
+    await runInProcessCommand('test', async () => {
+      await test({ ...argv, _: ['test'] } as TestCommandArgv);
+      return;
+    });
   },
 };
 
 async function checkForAi(project: Project, argv: AiCheckCommandArgv): Promise<void> {
-  await runGeneratedCommand('install', `${packageManager} install > /dev/null`, project, argv, { silent: true });
+  await runPackageCommand('install', `${packageManager} install > /dev/null`, project, argv, { silent: true });
   if (project.packageJson.scripts?.['gen-code']) {
-    await runGeneratedCommand('gen-code', `${packageManagerWithRun} gen-code > /dev/null`, project, argv, {
+    await runPackageCommand('gen-code', `${packageManager} gen-code > /dev/null`, project, argv, {
       silent: true,
     });
   }
-  await runGeneratedCommand(
-    'format',
-    `${packageManagerWithRun} wb lint --format > /dev/null 2> /dev/null`,
-    project,
-    argv,
-    { allowFailure: true, silent: true }
+  await runInProcessCommand('format', () => lint({ ...argv, _: ['lint'], format: true } as LintCommandArgv), {
+    allowFailure: true,
+  });
+  await runInProcessCommand('typecheck', () => typeCheck(argv));
+  await runInProcessCommand('lint-fix', () =>
+    lint({ ...argv, _: ['lint'], fix: true, quiet: true } as LintCommandArgv)
   );
-  await runGeneratedCommand('typecheck', `${packageManagerWithRun} wb typecheck`, project, argv);
-  await runGeneratedCommand('lint-fix', `${packageManagerWithRun} wb lint --fix --quiet`, project, argv);
 }
 
-async function runGeneratedCommand(
+async function runInProcessCommand(
+  commandName: string,
+  command: () => Promise<number | undefined>,
+  options: { allowFailure?: boolean } = {}
+): Promise<number> {
+  console.info(chalk.cyan(chalk.bold('Start:'), commandName));
+  const exitCode = (await command()) ?? 0;
+  if (exitCode === 0 || options.allowFailure) {
+    console.info(chalk.green(chalk.bold('Finished:'), commandName));
+  } else {
+    console.info(chalk.red(chalk.bold(`Failed (exit code ${exitCode}):`), commandName));
+    process.exit(exitCode);
+  }
+  return exitCode;
+}
+
+async function runPackageCommand(
   commandName: string,
   command: string,
   project: Project,

--- a/packages/wb/src/commands/aiCheck.ts
+++ b/packages/wb/src/commands/aiCheck.ts
@@ -66,10 +66,9 @@ async function checkForAi(project: Project, argv: AiCheckCommandArgv): Promise<v
 
 async function runProjectTest(project: Project, argv: AiCheckCommandArgv): Promise<void> {
   if (project.packageJson.scripts?.test?.includes('wb test')) {
-    await runInProcessCommand('test', async () => {
-      await test({ ...argv, _: ['test'], e2e: 'headless' } as TestCommandArgv);
-      return;
-    });
+    console.info('\n' + chalk.cyan(chalk.bold('Start:'), 'test'));
+    await test({ ...argv, _: ['test'], e2e: 'headless' } as TestCommandArgv);
+    console.info(chalk.green(chalk.bold('Finished:'), 'test'));
     return;
   }
 

--- a/packages/wb/src/commands/aiCheck.ts
+++ b/packages/wb/src/commands/aiCheck.ts
@@ -18,8 +18,8 @@ type AiCheckCommandOptions = InferredOptionTypes<typeof builder & typeof sharedO
 type AiCheckCommandArgv = ArgumentsCamelCase<AiCheckCommandOptions>;
 
 export const checkForAiCommand: CommandModule<unknown, AiCheckCommandOptions> = {
-  command: 'check-for-ai',
-  describe: 'Run generated AI checks',
+  command: ['check', 'check-for-ai'],
+  describe: 'Run project checks',
   builder,
   async handler(argv) {
     const projects = findRootAndSelfProjects(argv, false);
@@ -33,8 +33,8 @@ export const checkForAiCommand: CommandModule<unknown, AiCheckCommandOptions> = 
 };
 
 export const checkAllForAiCommand: CommandModule<unknown, AiCheckCommandOptions> = {
-  command: 'check-all-for-ai',
-  describe: 'Run generated AI checks and tests',
+  command: ['check-all', 'check-all-for-ai'],
+  describe: 'Run project checks and tests',
   builder,
   async handler(argv) {
     const projects = findRootAndSelfProjects(argv, false);

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import chalk from 'chalk';
-import type { CommandModule, InferredOptionTypes } from 'yargs';
+import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
 
 import type { Project } from '../project.js';
 import { findDescendantProjects } from '../project.js';
@@ -31,6 +31,9 @@ const _argumentsBuilder = {
     type: 'array',
   },
 } as const;
+
+type LintCommandOptions = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>;
+export type LintCommandArgv = ArgumentsCamelCase<LintCommandOptions> & { '--'?: unknown[]; _: unknown[] };
 
 const biomeExtensions = new Set([
   'astro',
@@ -102,160 +105,164 @@ const prettierExtensions = new Set([
 const prettierOnlyExtensions = new Set([...prettierExtensions].filter((ext) => !biomeExtensions.has(ext)));
 const prettierFixtureIgnorePattern = '!**/test{-,/}fixtures/**';
 
-export const lintCommand: CommandModule<
-  unknown,
-  InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>
-> = {
+export const lintCommand: CommandModule<unknown, LintCommandOptions> = {
   command: 'lint [files...]',
   describe: 'Lint code',
   builder,
   async handler(argv) {
-    if (process.platform === 'win32') {
-      console.error(chalk.red('This command is not supported on Windows.'));
-      process.exit(1);
-    }
+    const exitCode = await lint(argv as LintCommandArgv);
+    if (exitCode) process.exit(exitCode);
+  },
+};
 
-    const projects = await findDescendantProjects(argv, false);
-    if (!projects) {
-      console.error(chalk.red('No project found.'));
-      process.exit(1);
-    }
+export async function lint(argv: LintCommandArgv): Promise<number> {
+  if (process.platform === 'win32') {
+    console.error(chalk.red('This command is not supported on Windows.'));
+    return 1;
+  }
 
-    const files = getLintTargetFiles(argv);
-    const lintFilePathsByProject = new Map<Project, string[]>();
-    const oxfmtFilePathsByProject = new Map<Project, string[]>();
-    const pythonFilePathsByProject = new Map<Project, string[]>();
-    const dartFilePathsByProject = new Map<Project, string[]>();
-    const prettierFilePaths: string[] = [];
-    const packageJsonFilePaths: string[] = [];
-    let missingLintToolForExplicitFiles = false;
-    let prettierArgs: string[];
-    let sortPackageJsonArgs: string[];
-    if (files.length > 0) {
-      const lintTargets = await Promise.all(
-        files.map(async (file) => {
-          const filePath = path.resolve(file);
-          const fileKind = await getLintTargetFileKind(filePath);
-          return { fileKind, filePath };
-        })
-      );
-      for (const { fileKind, filePath } of lintTargets) {
+  const projects = await findDescendantProjects(argv, false);
+  if (!projects) {
+    console.error(chalk.red('No project found.'));
+    return 1;
+  }
+
+  const files = getLintTargetFiles(argv);
+  const lintFilePathsByProject = new Map<Project, string[]>();
+  const oxfmtFilePathsByProject = new Map<Project, string[]>();
+  const pythonFilePathsByProject = new Map<Project, string[]>();
+  const dartFilePathsByProject = new Map<Project, string[]>();
+  const prettierFilePaths: string[] = [];
+  const packageJsonFilePaths: string[] = [];
+  let missingLintToolForExplicitFiles = false;
+  let prettierArgs: string[];
+  let sortPackageJsonArgs: string[];
+  if (files.length > 0) {
+    const lintTargets = await Promise.all(
+      files.map(async (file) => {
+        const filePath = path.resolve(file);
+        const fileKind = await getLintTargetFileKind(filePath);
+        return { fileKind, filePath };
+      })
+    );
+    for (const { fileKind, filePath } of lintTargets) {
+      if (
+        filePath.endsWith('/test/fixtures') ||
+        filePath.includes('/test/fixtures/') ||
+        filePath.endsWith('/test-fixtures') ||
+        filePath.includes('/test-fixtures/')
+      ) {
+        continue;
+      }
+
+      const extension = path.extname(filePath).slice(1);
+      if (filePath.endsWith('/package.json')) {
+        packageJsonFilePaths.push(filePath);
+        continue;
+      }
+      packageJsonFilePaths.push(...getExplicitPackageJsonPaths(projects.descendants, filePath, fileKind));
+
+      for (const { lintPath, project } of getExplicitLintTargets(projects.descendants, filePath, fileKind)) {
+        if (project.hasPoetryLock && (fileKind === 'directory' || pythonExtensions.has(extension))) {
+          const pythonFilePaths = pythonFilePathsByProject.get(project) ?? [];
+          pythonFilePaths.push(lintPath);
+          pythonFilePathsByProject.set(project, pythonFilePaths);
+          if (fileKind !== 'directory') continue;
+        }
+        if (project.hasPubspecYaml && (fileKind === 'directory' || dartExtensions.has(extension))) {
+          const dartFilePaths = dartFilePathsByProject.get(project) ?? [];
+          dartFilePaths.push(lintPath);
+          dartFilePathsByProject.set(project, dartFilePaths);
+          if (fileKind !== 'directory') continue;
+        }
         if (
-          filePath.endsWith('/test/fixtures') ||
-          filePath.includes('/test/fixtures/') ||
-          filePath.endsWith('/test-fixtures') ||
-          filePath.includes('/test-fixtures/')
+          project.preferredLinter === 'biome' ||
+          fileKind === 'directory' ||
+          supportsLintingExtension(project, extension)
         ) {
-          continue;
-        }
-
-        const extension = path.extname(filePath).slice(1);
-        if (filePath.endsWith('/package.json')) {
-          packageJsonFilePaths.push(filePath);
-          continue;
-        }
-        packageJsonFilePaths.push(...getExplicitPackageJsonPaths(projects.descendants, filePath, fileKind));
-
-        for (const { lintPath, project } of getExplicitLintTargets(projects.descendants, filePath, fileKind)) {
-          if (project.hasPoetryLock && (fileKind === 'directory' || pythonExtensions.has(extension))) {
-            const pythonFilePaths = pythonFilePathsByProject.get(project) ?? [];
-            pythonFilePaths.push(lintPath);
-            pythonFilePathsByProject.set(project, pythonFilePaths);
-            if (fileKind !== 'directory') continue;
-          }
-          if (project.hasPubspecYaml && (fileKind === 'directory' || dartExtensions.has(extension))) {
-            const dartFilePaths = dartFilePathsByProject.get(project) ?? [];
-            dartFilePaths.push(lintPath);
-            dartFilePathsByProject.set(project, dartFilePaths);
-            if (fileKind !== 'directory') continue;
-          }
-          if (
-            project.preferredLinter === 'biome' ||
-            fileKind === 'directory' ||
-            supportsLintingExtension(project, extension)
-          ) {
-            const lintFilePaths = lintFilePathsByProject.get(project) ?? [];
-            lintFilePaths.push(lintPath);
-            lintFilePathsByProject.set(project, lintFilePaths);
-            for (const formatterPath of buildExplicitFormatterArgs(project, lintPath, fileKind, extension)) {
-              if (project.hasOxfmt) {
-                const oxfmtFilePaths = oxfmtFilePathsByProject.get(project) ?? [];
-                oxfmtFilePaths.push(formatterPath);
-                oxfmtFilePathsByProject.set(project, oxfmtFilePaths);
-              } else {
-                prettierFilePaths.push(formatterPath);
-              }
-            }
-          } else if (prettierExtensions.has(extension) || oxfmtExtensions.has(extension)) {
-            if (project.hasOxfmt && oxfmtExtensions.has(extension)) {
+          const lintFilePaths = lintFilePathsByProject.get(project) ?? [];
+          lintFilePaths.push(lintPath);
+          lintFilePathsByProject.set(project, lintFilePaths);
+          for (const formatterPath of buildExplicitFormatterArgs(project, lintPath, fileKind, extension)) {
+            if (project.hasOxfmt) {
               const oxfmtFilePaths = oxfmtFilePathsByProject.get(project) ?? [];
-              oxfmtFilePaths.push(lintPath);
+              oxfmtFilePaths.push(formatterPath);
               oxfmtFilePathsByProject.set(project, oxfmtFilePaths);
-            } else if (prettierExtensions.has(extension)) {
-              prettierFilePaths.push(lintPath);
+            } else {
+              prettierFilePaths.push(formatterPath);
             }
-          } else if (isPotentialLintTarget(extension) && !project.preferredLinter) {
-            console.error(chalk.red(`No linter found for ${project.name}. Install ESLint or Biome.`));
-            missingLintToolForExplicitFiles = true;
           }
-        }
-      }
-      prettierArgs = [...new Set(prettierFilePaths)];
-      sortPackageJsonArgs = [...new Set(packageJsonFilePaths)];
-    } else {
-      prettierArgs = buildPrettierArgs(projects.self.dirPath, projects.descendants);
-      sortPackageJsonArgs = projects.descendants.map((p) => p.packageJsonPath);
-    }
-
-    const lintPromises: Promise<number>[] = [];
-    const lintRunOptions = { exitIfFailed: false, forceColor: true } as const;
-    if (files.length > 0) {
-      for (const [project, lintFilePaths] of lintFilePathsByProject) {
-        const lintCommand = buildLintCommand(project, argv, lintFilePaths);
-        if (!lintCommand) continue;
-
-        lintPromises.push(runWithSpawnInParallel(lintCommand, project, argv, lintRunOptions));
-      }
-      for (const [project, oxfmtFilePaths] of oxfmtFilePathsByProject) {
-        lintPromises.push(runWithSpawnInParallel(buildOxfmtCommand(oxfmtFilePaths), project, argv, lintRunOptions));
-      }
-      for (const [project, pythonFilePaths] of pythonFilePathsByProject) {
-        lintPromises.push(
-          runWithSpawnInParallel(buildPoetryCommand(argv, pythonFilePaths), project, argv, lintRunOptions)
-        );
-      }
-      for (const [project, dartFilePaths] of dartFilePathsByProject) {
-        lintPromises.push(runWithSpawnInParallel(buildDartCommand(argv, dartFilePaths), project, argv, lintRunOptions));
-      }
-    } else {
-      for (const project of projects.descendants) {
-        if (project.packageJson.workspaces && !project.hasSourceCode) continue;
-
-        const lintCommand = buildLintCommand(project, argv);
-        if (!lintCommand) continue;
-
-        lintPromises.push(runWithSpawnInParallel(lintCommand, project, argv, lintRunOptions));
-      }
-      for (const project of projects.descendants) {
-        if (project.hasPoetryLock) {
-          lintPromises.push(runWithSpawnInParallel(buildPoetryCommand(argv), project, argv, lintRunOptions));
-        }
-        if (project.hasPubspecYaml) {
-          lintPromises.push(runWithSpawnInParallel(buildDartCommand(argv), project, argv, lintRunOptions));
-        }
-        if (project.hasOxfmt && argv.format) {
-          lintPromises.push(runWithSpawnInParallel(buildOxfmtCommand(), project, argv, lintRunOptions));
+        } else if (prettierExtensions.has(extension) || oxfmtExtensions.has(extension)) {
+          if (project.hasOxfmt && oxfmtExtensions.has(extension)) {
+            const oxfmtFilePaths = oxfmtFilePathsByProject.get(project) ?? [];
+            oxfmtFilePaths.push(lintPath);
+            oxfmtFilePathsByProject.set(project, oxfmtFilePaths);
+          } else if (prettierExtensions.has(extension)) {
+            prettierFilePaths.push(lintPath);
+          }
+        } else if (isPotentialLintTarget(extension) && !project.preferredLinter) {
+          console.error(chalk.red(`No linter found for ${project.name}. Install ESLint or Biome.`));
+          missingLintToolForExplicitFiles = true;
         }
       }
     }
-    const lintExitCodes = await Promise.all(lintPromises);
+    prettierArgs = [...new Set(prettierFilePaths)];
+    sortPackageJsonArgs = [...new Set(packageJsonFilePaths)];
+  } else {
+    prettierArgs = buildPrettierArgs(projects.self.dirPath, projects.descendants);
+    sortPackageJsonArgs = projects.descendants.map((p) => p.packageJsonPath);
+  }
 
-    if (missingLintToolForExplicitFiles || lintExitCodes.some((exitCode) => exitCode !== 0)) {
-      process.exit(1);
+  const lintPromises: Promise<number>[] = [];
+  const lintRunOptions = { exitIfFailed: false, forceColor: true } as const;
+  if (files.length > 0) {
+    for (const [project, lintFilePaths] of lintFilePathsByProject) {
+      const lintCommand = buildLintCommand(project, argv, lintFilePaths);
+      if (!lintCommand) continue;
+
+      lintPromises.push(runWithSpawnInParallel(lintCommand, project, argv, lintRunOptions));
     }
+    for (const [project, oxfmtFilePaths] of oxfmtFilePathsByProject) {
+      lintPromises.push(runWithSpawnInParallel(buildOxfmtCommand(oxfmtFilePaths), project, argv, lintRunOptions));
+    }
+    for (const [project, pythonFilePaths] of pythonFilePathsByProject) {
+      lintPromises.push(
+        runWithSpawnInParallel(buildPoetryCommand(argv, pythonFilePaths), project, argv, lintRunOptions)
+      );
+    }
+    for (const [project, dartFilePaths] of dartFilePathsByProject) {
+      lintPromises.push(runWithSpawnInParallel(buildDartCommand(argv, dartFilePaths), project, argv, lintRunOptions));
+    }
+  } else {
+    for (const project of projects.descendants) {
+      if (project.packageJson.workspaces && !project.hasSourceCode) continue;
 
-    if (argv.format) {
-      if (prettierArgs.length > 0) {
+      const lintCommand = buildLintCommand(project, argv);
+      if (!lintCommand) continue;
+
+      lintPromises.push(runWithSpawnInParallel(lintCommand, project, argv, lintRunOptions));
+    }
+    for (const project of projects.descendants) {
+      if (project.hasPoetryLock) {
+        lintPromises.push(runWithSpawnInParallel(buildPoetryCommand(argv), project, argv, lintRunOptions));
+      }
+      if (project.hasPubspecYaml) {
+        lintPromises.push(runWithSpawnInParallel(buildDartCommand(argv), project, argv, lintRunOptions));
+      }
+      if (project.hasOxfmt && argv.format) {
+        lintPromises.push(runWithSpawnInParallel(buildOxfmtCommand(), project, argv, lintRunOptions));
+      }
+    }
+  }
+  const lintExitCodes = await Promise.all(lintPromises);
+
+  if (missingLintToolForExplicitFiles || lintExitCodes.some((exitCode) => exitCode !== 0)) {
+    return 1;
+  }
+
+  if (argv.format) {
+    if (prettierArgs.length > 0) {
+      lintExitCodes.push(
         await runWithSpawnInParallel(
           buildShellCommand([
             'YARN',
@@ -269,22 +276,24 @@ export const lintCommand: CommandModule<
           ]),
           projects.self,
           argv,
-          { forceColor: true }
-        );
-      }
-      if (sortPackageJsonArgs.length > 0) {
+          { exitIfFailed: false, forceColor: true }
+        )
+      );
+    }
+    if (sortPackageJsonArgs.length > 0) {
+      lintExitCodes.push(
         await runWithSpawnInParallel(
           buildShellCommand(['YARN', 'sort-package-json', '--', ...sortPackageJsonArgs]),
           projects.self,
           argv,
-          {
-            forceColor: true,
-          }
-        );
-      }
+          { exitIfFailed: false, forceColor: true }
+        )
+      );
     }
-  },
-};
+  }
+
+  return lintExitCodes.some((exitCode) => exitCode !== 0) ? 1 : 0;
+}
 
 export function buildLintCommand(
   project: Pick<Project, 'preferredLinter'>,

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -19,6 +19,10 @@ const builder = {
     description: 'Format the code',
     type: 'boolean',
   },
+  quiet: {
+    description: 'Report errors only',
+    type: 'boolean',
+  },
 } as const;
 
 const _argumentsBuilder = {
@@ -287,7 +291,10 @@ export function buildLintCommand(
   argv: Pick<
     InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>,
     'fix' | 'format'
-  >,
+  > &
+    Partial<
+      Pick<InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>, 'quiet'>
+    >,
   files?: string[]
 ): string | undefined {
   if (project.preferredLinter === 'biome') {
@@ -317,6 +324,7 @@ export function buildLintCommand(
       'YARN',
       'eslint',
       '--color',
+      ...(argv.quiet ? ['--quiet'] : []),
       ...(argv.fix || argv.format ? ['--fix'] : []),
       '--',
       ...(files ?? ['.']),

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -320,6 +320,7 @@ export function buildLintCommand(
       '--colors=force',
       '--no-errors-on-unmatched',
       '--files-ignore-unknown=true',
+      ...(argv.quiet ? ['--diagnostic-level=error'] : []),
       ...(files?.length ? ['--'] : []),
       ...(files ?? []),
     ]);
@@ -368,10 +369,7 @@ export function buildPoetryCommand(
 }
 
 export function buildDartCommand(
-  argv: Pick<
-    InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>,
-    'fix' | 'format'
-  >,
+  argv: Pick<LintCommandOptions, 'fix' | 'format'> & Partial<Pick<LintCommandOptions, 'quiet'>>,
   files?: string[]
 ): string {
   const targets = files && files.length > 0 ? files : ['.'];
@@ -410,12 +408,7 @@ function findOwningProject(projects: Project[], filePath: string): Project | und
   return owningProject;
 }
 
-export function getLintTargetFiles(
-  argv: Pick<InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>, 'files'> & {
-    '--'?: unknown[];
-    _: unknown[];
-  }
-): string[] {
+export function getLintTargetFiles(argv: Pick<LintCommandArgv, '--' | '_' | 'files'>): string[] {
   const lintTargets = new Set<string>();
   for (const value of [...(argv.files ?? []), ...argv._.slice(1), ...(argv['--'] ?? [])]) {
     lintTargets.add(String(value));

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -32,7 +32,9 @@ const _argumentsBuilder = {
   },
 } as const;
 
-type LintCommandOptions = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>;
+export type LintCommandOptions = InferredOptionTypes<
+  typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder
+>;
 export type LintCommandArgv = ArgumentsCamelCase<LintCommandOptions> & { '--'?: unknown[]; _: unknown[] };
 
 const biomeExtensions = new Set([
@@ -297,13 +299,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
 
 export function buildLintCommand(
   project: Pick<Project, 'preferredLinter'>,
-  argv: Pick<
-    InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>,
-    'fix' | 'format'
-  > &
-    Partial<
-      Pick<InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>, 'quiet'>
-    >,
+  argv: Pick<LintCommandOptions, 'fix' | 'format'> & Partial<Pick<LintCommandOptions, 'quiet'>>,
   files?: string[]
 ): string | undefined {
   if (project.preferredLinter === 'biome') {
@@ -340,7 +336,13 @@ export function buildLintCommand(
     ]);
   }
   if (project.preferredLinter === 'oxlint') {
-    return buildShellCommand(['YARN', 'oxlint', ...(argv.fix ? ['--fix'] : []), ...(files ?? ['.'])]);
+    return buildShellCommand([
+      'YARN',
+      'oxlint',
+      ...(argv.quiet ? ['--quiet'] : []),
+      ...(argv.fix ? ['--fix'] : []),
+      ...(files ?? ['.']),
+    ]);
   }
   return;
 }
@@ -350,10 +352,7 @@ export function buildOxfmtCommand(files?: string[]): string {
 }
 
 export function buildPoetryCommand(
-  argv: Pick<
-    InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder>,
-    'fix' | 'format'
-  >,
+  argv: Pick<LintCommandOptions, 'fix' | 'format'> & Partial<Pick<LintCommandOptions, 'quiet'>>,
   files?: string[]
 ): string {
   const targets = files && files.length > 0 ? files : ['.'];
@@ -362,9 +361,9 @@ export function buildPoetryCommand(
       ? [
           buildShellCommand(['poetry', 'run', 'isort', '--profile', 'black', '--filter-files', ...targets]),
           buildShellCommand(['poetry', 'run', 'black', ...targets]),
-          buildShellCommand(['poetry', 'run', 'flake8', ...targets]),
+          buildShellCommand(['poetry', 'run', 'flake8', ...(argv.quiet ? ['-q'] : []), ...targets]),
         ]
-      : [buildShellCommand(['poetry', 'run', 'flake8', ...targets])];
+      : [buildShellCommand(['poetry', 'run', 'flake8', ...(argv.quiet ? ['-q'] : []), ...targets])];
   return commands.join(' && ');
 }
 

--- a/packages/wb/src/commands/typecheck.ts
+++ b/packages/wb/src/commands/typecheck.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import chalk from 'chalk';
-import type { CommandModule, InferredOptionTypes } from 'yargs';
+import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
 
 import { findDescendantProjects } from '../project.js';
 import { runWithSpawnInParallel } from '../scripts/run.js';
@@ -10,80 +10,84 @@ import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
 const builder = {} as const;
 
-export const typeCheckCommand: CommandModule<
-  unknown,
-  InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>
-> = {
+type TypeCheckCommandOptions = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>;
+export type TypeCheckCommandArgv = ArgumentsCamelCase<TypeCheckCommandOptions>;
+
+export const typeCheckCommand: CommandModule<unknown, TypeCheckCommandOptions> = {
   command: 'typecheck',
   describe: 'Run type checking. .env files are ignored.',
   builder,
   async handler(argv) {
-    const projects = await findDescendantProjects(argv, false);
-    if (!projects) {
-      console.error(chalk.red('No project found.'));
-      process.exit(1);
-    }
-
-    let removedNextDir = false as boolean;
-    const promises = projects.descendants.map(async (project) => {
-      const commands: string[] = [];
-      if (!project.packageJson.workspaces) {
-        if (project.packageJson.dependencies?.typescript || project.packageJson.devDependencies?.typescript) {
-          commands.push('BUN tsc --noEmit');
-        }
-        if (project.packageJson.devDependencies?.pyright) {
-          commands.push('YARN pyright');
-        }
-      } else if (
-        project.hasSourceCode &&
-        (project.packageJson.dependencies?.typescript || project.packageJson.devDependencies?.typescript)
-      ) {
-        commands.push('BUN tsc --noEmit');
-      }
-      while (commands.length > 0) {
-        const exitCode = await runWithSpawnInParallel(commands.join(' && '), project, argv, {
-          // Disable interactive mode
-          ci: projects.descendants.length > 1,
-          exitIfFailed: false,
-          forceColor: true,
-        });
-
-        // Re-try type checking after removing `.next` directory
-        const nextDirPath = path.join(project.dirPath, '.next');
-        if (exitCode && fs.existsSync(nextDirPath)) {
-          fs.rmSync(nextDirPath, { force: true, recursive: true });
-          console.info(chalk.yellow('Removed `.next` directory. We will re-try type checking.'));
-          removedNextDir = true;
-          continue;
-        }
-
-        return exitCode;
-      }
-    });
-    const exitCodes = await Promise.all(promises);
-    let finalExitCode = 0;
-    for (const [i, exitCode] of exitCodes.entries()) {
-      if (exitCode) {
-        const deps = projects.descendants[i]?.packageJson.dependencies ?? {};
-        if (deps.blitz) {
-          console.info(chalk.yellow('Please try "yarn gen-code" if you face unknown type errors.'));
-        }
-        finalExitCode = exitCode;
-      }
-    }
-    if (!finalExitCode)
-      console.info(
-        chalk.green(
-          removedNextDir
-            ? '-----\nNo type errors found. Please ignore the previous type errors, as they were caused by outdated Next.js cache files.'
-            : 'No type errors found.'
-        )
-      );
-    process.exit(finalExitCode);
+    process.exit(await typeCheck(argv));
   },
 };
 
-export const tcCommand: CommandModule<unknown, InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>> = {
+export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
+  const projects = await findDescendantProjects(argv, false);
+  if (!projects) {
+    console.error(chalk.red('No project found.'));
+    return 1;
+  }
+
+  let removedNextDir = false as boolean;
+  const promises = projects.descendants.map(async (project) => {
+    const commands: string[] = [];
+    if (!project.packageJson.workspaces) {
+      if (project.packageJson.dependencies?.typescript || project.packageJson.devDependencies?.typescript) {
+        commands.push('BUN tsc --noEmit');
+      }
+      if (project.packageJson.devDependencies?.pyright) {
+        commands.push('YARN pyright');
+      }
+    } else if (
+      project.hasSourceCode &&
+      (project.packageJson.dependencies?.typescript || project.packageJson.devDependencies?.typescript)
+    ) {
+      commands.push('BUN tsc --noEmit');
+    }
+    while (commands.length > 0) {
+      const exitCode = await runWithSpawnInParallel(commands.join(' && '), project, argv, {
+        // Disable interactive mode
+        ci: projects.descendants.length > 1,
+        exitIfFailed: false,
+        forceColor: true,
+      });
+
+      // Re-try type checking after removing `.next` directory
+      const nextDirPath = path.join(project.dirPath, '.next');
+      if (exitCode && fs.existsSync(nextDirPath)) {
+        fs.rmSync(nextDirPath, { force: true, recursive: true });
+        console.info(chalk.yellow('Removed `.next` directory. We will re-try type checking.'));
+        removedNextDir = true;
+        continue;
+      }
+
+      return exitCode;
+    }
+  });
+  const exitCodes = await Promise.all(promises);
+  let finalExitCode = 0;
+  for (const [i, exitCode] of exitCodes.entries()) {
+    if (exitCode) {
+      const deps = projects.descendants[i]?.packageJson.dependencies ?? {};
+      if (deps.blitz) {
+        console.info(chalk.yellow('Please try "yarn gen-code" if you face unknown type errors.'));
+      }
+      finalExitCode = exitCode;
+    }
+  }
+  if (!finalExitCode)
+    console.info(
+      chalk.green(
+        removedNextDir
+          ? '-----\nNo type errors found. Please ignore the previous type errors, as they were caused by outdated Next.js cache files.'
+          : 'No type errors found.'
+      )
+    );
+  return finalExitCode;
+}
+
+export const tcCommand: CommandModule<unknown, TypeCheckCommandOptions> = {
   ...typeCheckCommand,
   command: 'tc',
 };

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -5,6 +5,7 @@ import { removeNpmAndYarnEnvironmentVariables, treeKill } from '@willbooster/sha
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
+import { checkAllForAiCommand, checkForAiCommand } from './commands/aiCheck.js';
 import { buildIfNeededCommand } from './commands/buildIfNeeded.js';
 import { concurrentlyCommand } from './commands/concurrently.js';
 import { killPortIfNonCiCommand } from './commands/killPortIfNonCi.js';
@@ -32,6 +33,8 @@ await yargs(hideBin(process.argv))
 
     removeNpmAndYarnEnvironmentVariables(process.env);
   })
+  .command(checkAllForAiCommand)
+  .command(checkForAiCommand)
   .command(buildIfNeededCommand)
   .command(concurrentlyCommand)
   .command(killPortIfNonCiCommand)


### PR DESCRIPTION
## Summary
- add built-in wb check-for-ai and check-all-for-ai commands matching wbfy-generated scripts
- allow wb lint --quiet and forward it to ESLint for lint-fix behavior

## Verification
- yarn check-for-ai
- yarn start check-for-ai --dry-run
- yarn start check-all-for-ai --dry-run