### PR TITLE
fix: format biome files with lint fixes

### DIFF
--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -305,7 +305,7 @@ export function buildLintCommand(
   if (project.preferredLinter === 'biome') {
     let biomeArgs: string[];
     if (argv.fix && argv.format) {
-      biomeArgs = ['check', '--fix'];
+      biomeArgs = ['check', '--write'];
     } else if (argv.fix) {
       biomeArgs = ['lint', '--fix'];
     } else if (argv.format) {

--- a/packages/wb/test/lint.test.ts
+++ b/packages/wb/test/lint.test.ts
@@ -21,7 +21,7 @@ import {
 describe('lint', () => {
   it('builds a biome command for biome projects', () => {
     expect(buildLintCommand({ preferredLinter: 'biome' }, { fix: true, format: true }, ['/tmp/example.ts'])).toBe(
-      'BUN biome check --fix --colors=force --no-errors-on-unmatched --files-ignore-unknown=true -- /tmp/example.ts'
+      'BUN biome check --write --colors=force --no-errors-on-unmatched --files-ignore-unknown=true -- /tmp/example.ts'
     );
   });
 


### PR DESCRIPTION
## Summary

- Change `wb lint --fix --format` for Biome projects to run `biome check --write`.
- Update the `wb` lint command-builder expectation for the combined fix-and-format mode.

## Why

- `biome check --fix` applies lint fixes but does not format JSON files such as `tsconfig.json`.
- Projects generated with `cleanup: wb lint --fix --format` expect that command to apply formatting as well as fixes.

## Testing

- `yarn workspace @willbooster/wb test test/lint.test.ts`
- `yarn check-for-ai`
- Pushed branch; pre-push `check.sh` passed.
