### PR TITLE
fix: respect Playwright webServer on CI

### DIFF
--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -7,8 +7,6 @@ import { memoizeOne } from 'at-decorators';
 import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
 
-import { isCI } from './utils/ci.js';
-
 export class Project {
   private readonly argv: EnvReaderOptions;
   private readonly loadEnv: boolean;
@@ -166,7 +164,6 @@ export class Project {
 
   @memoizeOne
   get skipLaunchingServerForPlaywright(): boolean {
-    if (isCI(this.env.CI)) return false;
     try {
       const configPath = this.findFile('playwright.config.ts');
       return /\bwebServer\b/.test(fs.readFileSync(configPath, 'utf8'));


### PR DESCRIPTION
## Summary

- Allow `wb test` to defer to Playwright's configured `webServer` even when running on CI.
- Remove the CI-only bypass that forced `wb` to generate its own e2e server startup command.

## Why

- `WillBooster/agent-workflow-queue#6` failed because `wb test` generated `wb buildIfNeeded && node dist/index.js` even though the project has a Playwright `webServer.command` for starting its Bun app directly.
- Respecting the target project's Playwright server config avoids assuming a `build` script or `dist/index.js` exists.

## Testing

- `yarn check-for-ai`
- pre-commit cleanup hook
- pre-push `check.sh` hook
