### PR TITLE
feat: add db alias for prisma command

### DIFF
--- a/packages/wb/README.md
+++ b/packages/wb/README.md
@@ -18,7 +18,7 @@ Commands:
   wb lint [files...]            Lint code
   wb optimizeForDockerBuild     Optimize configuration when building a Docker
                                 image
-  wb prisma                     Run prisma commands                [aliases: db]
+  wb prisma                     Run database commands              [aliases: db]
   wb retry [command] [args...]  Retry the given command until it succeeds
   wb setup                      Setup development environment. .env files are
                                 ignored.

--- a/packages/wb/README.md
+++ b/packages/wb/README.md
@@ -18,7 +18,7 @@ Commands:
   wb lint [files...]            Lint code
   wb optimizeForDockerBuild     Optimize configuration when building a Docker
                                 image
-  wb prisma                     Run prisma commands
+  wb prisma                     Run prisma commands                [aliases: db]
   wb retry [command] [args...]  Retry the given command until it succeeds
   wb setup                      Setup development environment. .env files are
                                 ignored.

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -4,8 +4,9 @@ import type { EnvReaderOptions } from '@willbooster/shared-lib-node/src';
 import chalk from 'chalk';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
-import type { Project } from '../project.js';
+import type { DatabaseOrm, Project } from '../project.js';
 import { findDescendantProjects } from '../project.js';
+import { drizzleScripts } from '../scripts/drizzleScripts.js';
 import { prismaScripts } from '../scripts/prismaScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
 import { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
@@ -19,7 +20,7 @@ export const prismaCommand: CommandModule = {
   command: 'prisma',
   aliases: ['db'],
   describe:
-    "Run prisma commands. Use '--' to stop wb option parsing and forward the remaining arguments to Prisma. Example: wb prisma migrate-dev -- --name init",
+    "Run database commands. Use '--' to stop wb option parsing and forward the remaining arguments to Prisma. Drizzle v1 projects use drizzle-kit. Example: wb prisma migrate-dev -- --name init",
   builder: (yargs) => {
     return yargs
       .parserConfiguration({ 'populate--': true })
@@ -48,8 +49,8 @@ const cleanUpLitestreamCommand: CommandModule<unknown, InferredOptionTypes<typeo
   describe: 'Clean up temporal Litestream files',
   builder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
-    for (const project of prepareForRunningCommand('prisma cleanup-litestream', allProjects)) {
+    const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
+    for (const { project } of prepareForRunningDatabaseOrmCommand('prisma cleanup-litestream', allProjects)) {
       await runWithSpawn(prismaScripts.cleanUpLitestream(project), project, argv);
     }
   },
@@ -60,8 +61,8 @@ const createLitestreamConfigCommand: CommandModule<unknown, InferredOptionTypes<
   describe: 'Create Litestream configuration file',
   builder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
-    for (const project of prepareForRunningCommand('prisma create-litestream-config', allProjects)) {
+    const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
+    for (const { project } of prepareForRunningDatabaseOrmCommand('prisma create-litestream-config', allProjects)) {
       createLitestreamConfig(project);
     }
   },
@@ -72,10 +73,10 @@ const deployCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>>
   describe: 'Apply migration to DB without initializing it',
   builder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
     const unknownOptions = extractUnknownOptions(argv);
-    for (const project of prepareForRunningCommand('prisma deploy', allProjects)) {
-      await runWithSpawn(prismaScripts.deploy(project, unknownOptions), project, argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db deploy', allProjects)) {
+      await runWithSpawn(getDatabaseOrmScripts(orm).deploy(project, unknownOptions), project, argv);
     }
   },
 };
@@ -85,8 +86,8 @@ const deployForceCommand: CommandModule<unknown, InferredOptionTypes<typeof buil
   describe: "Force to apply migration to DB utilizing Litestream's backup without initializing it",
   builder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
-    for (const project of prepareForRunningCommand('prisma deploy-force', allProjects)) {
+    const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
+    for (const { project } of prepareForRunningDatabaseOrmCommand('prisma deploy-force', allProjects)) {
       await runWithSpawn(prismaScripts.deployForce(project), project, argv);
     }
   },
@@ -97,8 +98,8 @@ const listBackupsCommand: CommandModule<unknown, InferredOptionTypes<typeof buil
   describe: 'List Litestream backups',
   builder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
-    for (const project of prepareForRunningCommand('prisma list-backups', allProjects)) {
+    const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
+    for (const { project } of prepareForRunningDatabaseOrmCommand('prisma list-backups', allProjects)) {
       await runWithSpawn(prismaScripts.listBackups(project), project, argv);
     }
   },
@@ -109,10 +110,10 @@ const migrateCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>
   describe: 'Apply migration to DB with initializing it',
   builder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
     const unknownOptions = extractUnknownOptions(argv);
-    for (const project of prepareForRunningCommand('prisma migrate', allProjects)) {
-      await runWithSpawn(prismaScripts.migrate(project, unknownOptions), project, argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db migrate', allProjects)) {
+      await runWithSpawn(getDatabaseOrmScripts(orm).migrate(project, unknownOptions), project, argv);
     }
   },
 };
@@ -122,10 +123,10 @@ const migrateDevCommand: CommandModule<unknown, InferredOptionTypes<typeof build
   describe: 'Create a migration file',
   builder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
     const unknownOptions = extractUnknownOptions(argv);
-    for (const project of prepareForRunningCommand('prisma migrate-dev', allProjects)) {
-      await runWithSpawn(prismaScripts.migrateDev(project, unknownOptions), project, argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db migrate-dev', allProjects)) {
+      await runWithSpawn(getDatabaseOrmScripts(orm).migrateDev(project, unknownOptions), project, argv);
     }
   },
 };
@@ -135,16 +136,19 @@ const resetCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> 
   describe: 'Reset DB',
   builder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
     const unknownOptions = extractUnknownOptions(argv);
-    for (const project of prepareForRunningCommand('prisma reset', allProjects)) {
-      await runWithSpawn(prismaScripts.reset(project, unknownOptions), project, argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db reset', allProjects)) {
+      await runWithSpawn(getDatabaseOrmScripts(orm).reset(project, unknownOptions), project, argv);
     }
     // Force to reset test database
     if (process.env.WB_ENV !== 'test') {
       process.env.WB_ENV = 'test';
-      for (const project of prepareForRunningCommand('WB_ENV=test prisma reset', await findPrismaProjects(argv))) {
-        await runWithSpawn(prismaScripts.reset(project, unknownOptions), project, argv);
+      for (const { orm, project } of prepareForRunningDatabaseOrmCommand(
+        'WB_ENV=test db reset',
+        await findDatabaseOrmProjects(argv)
+      )) {
+        await runWithSpawn(getDatabaseOrmScripts(orm).reset(project, unknownOptions), project, argv);
       }
     }
   },
@@ -163,8 +167,8 @@ const restoreCommand: CommandModule<unknown, InferredOptionTypes<typeof restoreB
   describe: "Restore DB from Litestream's backup",
   builder: restoreBuilder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
-    for (const project of prepareForRunningCommand('prisma restore', allProjects)) {
+    const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
+    for (const { project } of prepareForRunningDatabaseOrmCommand('prisma restore', allProjects)) {
       const output =
         argv.output ?? (project.packageJson.dependencies?.blitz ? 'db/restored.sqlite3' : 'prisma/restored.sqlite3');
       await runWithSpawn(prismaScripts.restore(project, output), project, argv);
@@ -186,9 +190,9 @@ const seedCommand: CommandModule<unknown, InferredOptionTypes<typeof seedBuilder
   describe: 'Populate DB with seed data',
   builder: seedBuilder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
-    for (const project of prepareForRunningCommand('prisma seed', allProjects)) {
-      await runWithSpawn(prismaScripts.seed(project, argv.file), project, argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db seed', allProjects)) {
+      await runWithSpawn(getDatabaseOrmScripts(orm).seed(project, argv.file), project, argv);
     }
   },
 };
@@ -207,22 +211,22 @@ const studioBuilder = {
 
 const studioCommand: CommandModule<unknown, InferredOptionTypes<typeof studioBuilder>> = {
   command: 'studio [db-url-or-path]',
-  describe: 'Open Prisma Studio',
+  describe: 'Open database studio',
   builder: studioBuilder,
   async handler(argv) {
     if (argv.restored && argv.dbUrlOrPath) {
       throw new Error('You cannot specify both --restored and --db-url-or-path.');
     }
 
-    const allProjects = await findPrismaProjects(argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
     const unknownOptions = extractUnknownOptions(argv, ['db-url-or-path', 'restored']);
-    for (const project of prepareForRunningCommand('prisma studio', allProjects)) {
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db studio', allProjects)) {
       const dbUrlOrPath = argv.restored
         ? project.packageJson.dependencies?.blitz
           ? 'db/restored.sqlite3'
           : 'prisma/restored.sqlite3'
         : argv.dbUrlOrPath?.toString();
-      await runWithSpawn(prismaScripts.studio(project, dbUrlOrPath, unknownOptions), project, argv);
+      await runWithSpawn(getDatabaseOrmScripts(orm).studio(project, dbUrlOrPath, unknownOptions), project, argv);
     }
   },
 };
@@ -231,15 +235,17 @@ const defaultCommandBuilder = { args: { type: 'array' } } as const;
 
 const defaultCommand: CommandModule<unknown, InferredOptionTypes<typeof defaultCommandBuilder>> = {
   command: '$0 <args..>',
-  describe: "Pass the command and arguments to prisma as is. Additional Prisma flags can also be forwarded after '--'.",
+  describe:
+    "Pass the command and arguments to the detected ORM as is. Additional Prisma flags can also be forwarded after '--'.",
   builder: defaultCommandBuilder,
   async handler(argv) {
-    const allProjects = await findPrismaProjects(argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
     const script = (argv.args?.join(' ') ?? '').trimEnd();
     const unknownOptions = extractUnknownOptions(argv, ['args']);
     const fullCommand = [script, unknownOptions].filter(Boolean).join(' ');
-    for (const project of prepareForRunningCommand(`prisma ${fullCommand}`, allProjects)) {
-      await runWithSpawn(`PRISMA ${fullCommand}`, project, argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand(`db ${fullCommand}`, allProjects)) {
+      const command = orm === 'prisma' ? `PRISMA ${fullCommand}` : `YARN drizzle-kit ${fullCommand}`;
+      await runWithSpawn(command, project, argv);
     }
   },
 };
@@ -289,25 +295,50 @@ function createLitestreamConfig(project: Project): void {
   }
 }
 
-async function findPrismaProjects(argv: EnvReaderOptions): Promise<Project[]> {
+interface DatabaseOrmProject {
+  project: Project;
+  orm: DatabaseOrm;
+}
+
+async function findDatabaseOrmProjects(argv: EnvReaderOptions, orm?: DatabaseOrm): Promise<DatabaseOrmProject[]> {
   const projects = await findDescendantProjects(argv);
   if (!projects) {
     console.error(chalk.red('No project found.'));
     process.exit(1);
   }
 
-  const filtered = projects.descendants.filter(
-    (project) => project.packageJson.dependencies?.prisma ?? project.packageJson.devDependencies?.prisma
-  );
+  const filtered = projects.descendants
+    .map((project) => (project.databaseOrm ? { project, orm: project.databaseOrm } : undefined))
+    .filter((project): project is DatabaseOrmProject => !!project && (!orm || project.orm === orm));
   if (filtered.length === 0) {
-    console.error(chalk.red('No prisma project found.'));
+    console.error(chalk.red(orm ? `No ${orm} project found.` : 'No supported database ORM project found.'));
     process.exit(1);
   }
   return filtered;
 }
 
+function getDatabaseOrmScripts(orm: DatabaseOrm): typeof prismaScripts | typeof drizzleScripts {
+  return orm === 'prisma' ? prismaScripts : drizzleScripts;
+}
+
+function* prepareForRunningDatabaseOrmCommand(
+  commandName: string,
+  projects: DatabaseOrmProject[]
+): Generator<DatabaseOrmProject, void, unknown> {
+  const ormProjectByProject = new Map(projects.map((project) => [project.project, project]));
+  for (const project of prepareForRunningCommand(
+    commandName,
+    projects.map(({ project }) => project)
+  )) {
+    const ormProject = ormProjectByProject.get(project);
+    if (!ormProject) throw new Error(`Failed to detect database ORM for ${project.name}.`);
+
+    yield ormProject;
+  }
+}
+
 /**
- * Extract unknown options from argv to pass to prisma command
+ * Extract unknown options from argv to pass to ORM commands.
  */
 export function extractUnknownOptions(argv: Record<string, unknown>, knownOptions: string[] = []): string {
   const unknownOptions: string[] = [];

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -17,6 +17,7 @@ const builder = {} as const;
 
 export const prismaCommand: CommandModule = {
   command: 'prisma',
+  aliases: ['db'],
   describe:
     "Run prisma commands. Use '--' to stop wb option parsing and forward the remaining arguments to Prisma. Example: wb prisma migrate-dev -- --name init",
   builder: (yargs) => {

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -20,7 +20,7 @@ export const prismaCommand: CommandModule = {
   command: 'prisma',
   aliases: ['db'],
   describe:
-    "Run database commands. Use '--' to stop wb option parsing and forward the remaining arguments to Prisma. Drizzle v1 projects use drizzle-kit. Example: wb prisma migrate-dev -- --name init",
+    "Run database commands. Use '--' to stop wb option parsing and forward the remaining arguments to Prisma. Drizzle projects use drizzle-kit. Example: wb prisma migrate-dev -- --name init",
   builder: (yargs) => {
     return yargs
       .parserConfiguration({ 'populate--': true })

--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -71,7 +71,10 @@ export async function testOnCi(
 
     console.info(`Running "test-on-ci" for ${project.name} ...`);
 
-    await runWithSpawnInParallel(dockerScripts.stopAll(), project, argv);
+    const hasDockerfile = project.hasDockerfile;
+    if (hasDockerfile) {
+      await runWithSpawnInParallel(dockerScripts.stopAll(), project, argv);
+    }
     if (fs.existsSync(path.join(project.dirPath, 'test', 'unit'))) {
       // CI mode disallows `only` to avoid including debug tests
       await runWithSpawnInParallel(scripts.testUnit(project, argv).replaceAll(' --allowOnly', ''), project, argv);
@@ -80,11 +83,11 @@ export async function testOnCi(
       // Avoid launching dev servers for build-only packages; only start a server when E2E needs it.
       await runWithSpawnInParallel(await scripts.testStart(project, argv), project, argv);
       await promisePool.promiseAll();
-      if (project.hasDockerfile) {
+      if (hasDockerfile) {
         project.env.WB_DOCKER ||= '1';
         await runWithSpawn(`${scripts.buildDocker(project, 'test')}${toDevNull(argv)}`, project, argv);
       }
-      const script = project.hasDockerfile
+      const script = hasDockerfile
         ? await scripts.testE2EDocker(project, argv, {})
         : await scripts.testE2EProduction(project, argv, {});
       process.exitCode = await runWithSpawn(
@@ -96,7 +99,9 @@ export async function testOnCi(
           exitIfFailed: false,
         }
       );
-      await runWithSpawn(dockerScripts.stop(project), project, argv);
+      if (hasDockerfile) {
+        await runWithSpawn(dockerScripts.stop(project), project, argv);
+      }
     }
   }
 }

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -9,6 +9,8 @@ import type { PackageJson } from 'type-fest';
 
 import { isCI } from './utils/ci.js';
 
+export type DatabaseOrm = 'prisma' | 'drizzle';
+
 export class Project {
   private readonly argv: EnvReaderOptions;
   private readonly loadEnv: boolean;
@@ -104,7 +106,23 @@ export class Project {
 
   @memoizeOne
   get hasPrisma(): boolean {
-    return !!(this.packageJson.dependencies?.prisma ?? this.packageJson.devDependencies?.prisma);
+    return !!this.getDependencyVersion('prisma');
+  }
+
+  @memoizeOne
+  get hasDrizzleV1(): boolean {
+    const drizzleOrmVersion = this.getDependencyVersion('drizzle-orm');
+    if (!drizzleOrmVersion) return false;
+
+    const versionText = drizzleOrmVersion.replace(/^npm:[^@]+@/, '').trim();
+    return versionText === 'beta' || /^[\^~>=< ]*1\./.test(versionText);
+  }
+
+  @memoizeOne
+  get databaseOrm(): DatabaseOrm | undefined {
+    if (this.hasPrisma) return 'prisma';
+    if (this.hasDrizzleV1) return 'drizzle';
+    return;
   }
 
   @memoizeOne
@@ -222,16 +240,22 @@ export class Project {
   }
 
   private hasDependency(packageName: string): boolean {
-    const hasDependencyInPackageJson = (packageJson: PackageJson | undefined): boolean =>
-      !!(
-        packageJson &&
-        (packageJson.dependencies?.[packageName] ||
-          packageJson.devDependencies?.[packageName] ||
-          packageJson.optionalDependencies?.[packageName] ||
-          packageJson.peerDependencies?.[packageName])
-      );
+    return !!this.getDependencyVersion(packageName);
+  }
 
-    return hasDependencyInPackageJson(this.packageJson) || hasDependencyInPackageJson(this.rootPackageJson);
+  private getDependencyVersion(packageName: string): string | undefined {
+    const dependencyVersionInPackageJson = (packageJson: PackageJson | undefined): string | undefined => {
+      if (!packageJson) return;
+
+      return (
+        packageJson.dependencies?.[packageName] ??
+        packageJson.devDependencies?.[packageName] ??
+        packageJson.optionalDependencies?.[packageName] ??
+        packageJson.peerDependencies?.[packageName]
+      );
+    };
+
+    return dependencyVersionInPackageJson(this.packageJson) ?? dependencyVersionInPackageJson(this.rootPackageJson);
   }
 
   @memoizeOne

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -106,22 +106,18 @@ export class Project {
 
   @memoizeOne
   get hasPrisma(): boolean {
-    return !!this.getDependencyVersion('prisma');
+    return !!this.getOwnDependencyVersion('prisma');
   }
 
   @memoizeOne
-  get hasDrizzleV1(): boolean {
-    const drizzleOrmVersion = this.getDependencyVersion('drizzle-orm');
-    if (!drizzleOrmVersion) return false;
-
-    const versionText = drizzleOrmVersion.replace(/^npm:[^@]+@/, '').trim();
-    return versionText === 'beta' || /^[\^~>=< ]*1\./.test(versionText);
+  get hasDrizzle(): boolean {
+    return !!this.getOwnDependencyVersion('drizzle-orm');
   }
 
   @memoizeOne
   get databaseOrm(): DatabaseOrm | undefined {
     if (this.hasPrisma) return 'prisma';
-    if (this.hasDrizzleV1) return 'drizzle';
+    if (this.hasDrizzle) return 'drizzle';
     return;
   }
 
@@ -240,22 +236,24 @@ export class Project {
   }
 
   private hasDependency(packageName: string): boolean {
-    return !!this.getDependencyVersion(packageName);
+    return !!(
+      this.getOwnDependencyVersion(packageName) ?? this.getDependencyVersion(this.rootPackageJson, packageName)
+    );
   }
 
-  private getDependencyVersion(packageName: string): string | undefined {
-    const dependencyVersionInPackageJson = (packageJson: PackageJson | undefined): string | undefined => {
-      if (!packageJson) return;
+  private getOwnDependencyVersion(packageName: string): string | undefined {
+    return this.getDependencyVersion(this.packageJson, packageName);
+  }
 
-      return (
-        packageJson.dependencies?.[packageName] ??
-        packageJson.devDependencies?.[packageName] ??
-        packageJson.optionalDependencies?.[packageName] ??
-        packageJson.peerDependencies?.[packageName]
-      );
-    };
+  private getDependencyVersion(packageJson: PackageJson | undefined, packageName: string): string | undefined {
+    if (!packageJson) return;
 
-    return dependencyVersionInPackageJson(this.packageJson) ?? dependencyVersionInPackageJson(this.rootPackageJson);
+    return (
+      packageJson.dependencies?.[packageName] ??
+      packageJson.devDependencies?.[packageName] ??
+      packageJson.optionalDependencies?.[packageName] ??
+      packageJson.peerDependencies?.[packageName]
+    );
   }
 
   @memoizeOne

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -1,0 +1,62 @@
+import path from 'node:path';
+
+import type { Project } from '../project.js';
+
+const FILE_SCHEMA = 'file:';
+
+class DrizzleScripts {
+  deploy(project: Project, additionalOptions = ''): string {
+    return this.migrate(project, additionalOptions);
+  }
+
+  migrate(_project: Project, additionalOptions = ''): string {
+    return `YARN drizzle-kit migrate ${additionalOptions}`;
+  }
+
+  migrateDev(_project: Project, additionalOptions = ''): string {
+    return `YARN drizzle-kit generate ${additionalOptions}`;
+  }
+
+  reset(project: Project, additionalOptions = ''): string {
+    const removeCommand = buildRemoveSqliteDbCommand(project);
+    if (!removeCommand) {
+      return "echo 'wb db reset supports Drizzle only when DATABASE_PATH or file: DATABASE_URL is set.' && exit 1";
+    }
+
+    return `${removeCommand} && ${this.migrate(project, additionalOptions)}`;
+  }
+
+  seed(project: Project, scriptPath?: string): string {
+    if (scriptPath) return `BUN build-ts run ${scriptPath}`;
+    if (project.packageJson.scripts?.seed) return 'YARN run seed';
+    return 'true';
+  }
+
+  studio(_project: Project, dbUrlOrPath?: string, additionalOptions = ''): string {
+    if (dbUrlOrPath) {
+      return "echo 'wb db studio for Drizzle does not support db-url-or-path.' && exit 1";
+    }
+
+    return `YARN drizzle-kit studio ${additionalOptions}`;
+  }
+}
+
+function buildRemoveSqliteDbCommand(project: Project): string | undefined {
+  const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
+  if (!dbPath) return;
+
+  const absolutePath = path.isAbsolute(dbPath) ? dbPath : path.resolve(project.dirPath, dbPath);
+  return `rm -f "${absolutePath}" "${absolutePath}-wal" "${absolutePath}-shm"`;
+}
+
+function getFileDatabaseUrlPath(project: Project): string | undefined {
+  const dbUrl = project.env.DATABASE_URL;
+  if (!dbUrl?.startsWith(FILE_SCHEMA)) return;
+
+  const rawDbPath = dbUrl.slice(FILE_SCHEMA.length).replace(/[?#].*$/, '');
+  if (!rawDbPath) return;
+
+  return rawDbPath;
+}
+
+export const drizzleScripts = new DrizzleScripts();

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -23,7 +23,7 @@ class DrizzleScripts {
       return "echo 'wb db reset supports Drizzle only when DATABASE_PATH or file: DATABASE_URL is set.' && exit 1";
     }
 
-    return `${removeCommand} && ${this.migrate(project, additionalOptions)}`;
+    return `${removeCommand} && ${this.migrate(project, additionalOptions)} && ${this.seed(project)}`;
   }
 
   seed(project: Project, scriptPath?: string): string {


### PR DESCRIPTION
## Summary
- add `db` as an alias for the existing `wb prisma` command
- detect supported database ORMs per package, preferring Prisma and using Drizzle when `drizzle-orm` is declared
- route Drizzle `db migrate`, `db migrate-dev`, `db reset`, `db seed`, `db studio`, and passthrough commands through `drizzle-kit`
- make Drizzle `db reset` seed after migration when a seed script exists
- document the generic database command wording in the wb README command list

## Verification
- `yarn workspace @willbooster/wb start db --help`
- `yarn workspace @willbooster/wb start prisma --help`
- `yarn workspace @willbooster/wb typecheck`
- `yarn check-for-ai`
- Drizzle dry-run fixture: `db migrate --dry-run` emits `yarn drizzle-kit migrate`
- Drizzle dry-run fixture: `db reset --dry-run` removes `DATABASE_PATH` SQLite sidecars before `yarn drizzle-kit migrate`
- Target repo verification: `BASIC_AUTH_USERNAME=test BASIC_AUTH_PASSWORD=test GH_PKG_READ_TOKEN=test NEXT_PUBLIC_BASE_URL=http://localhost yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBooster/agent-workflow-queue db migrate --dry-run` emits `yarn drizzle-kit migrate`