### PR TITLE
fix: force kill stubborn concurrent commands

### DIFF
--- a/packages/wb/src/commands/concurrently.ts
+++ b/packages/wb/src/commands/concurrently.ts
@@ -209,7 +209,7 @@ function terminateChildren(children: child_process.ChildProcess[], signal: NodeJ
 
 function signalChildren(children: child_process.ChildProcess[], signal: NodeJS.Signals): void {
   for (const child of children) {
-    if (!child.pid) continue;
+    if (!isRunningChild(child)) continue;
 
     try {
       killProcessGroup(child.pid, signal);
@@ -218,6 +218,10 @@ function signalChildren(children: child_process.ChildProcess[], signal: NodeJS.S
       console.warn('Failed to kill child process:', error);
     }
   }
+}
+
+function isRunningChild(child: child_process.ChildProcess): child is child_process.ChildProcess & { pid: number } {
+  return child.pid !== undefined && child.exitCode === null && child.signalCode === null;
 }
 
 function killProcessGroup(pid: number, signal: NodeJS.Signals): void {

--- a/packages/wb/src/commands/concurrently.ts
+++ b/packages/wb/src/commands/concurrently.ts
@@ -9,6 +9,8 @@ import { findSelfProject, type Project } from '../project.js';
 import { configureEnv, normalizeScript } from '../scripts/run.js';
 import { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
+const FORCE_KILL_DELAY_MS = 5000;
+
 const builder = {
   'kill-others': {
     description: 'Kill other commands when one command exits',
@@ -101,6 +103,7 @@ export async function runConcurrently(options: RunConcurrentlyOptions): Promise<
   let interruptedSignal: NodeJS.Signals | undefined;
   let firstResult: number | undefined;
   let stopResult: number | undefined;
+  const forceKillTimers: NodeJS.Timeout[] = [];
   const results = Array.from<number | undefined>({ length: children.length });
   const waitForExitPromises = children.map((child, index) => {
     return new Promise<void>((resolve) => {
@@ -115,7 +118,7 @@ export async function runConcurrently(options: RunConcurrentlyOptions): Promise<
         if (!stopping && shouldStopOthers(exitCode, options)) {
           stopResult = exitCode;
           stopping = true;
-          terminateChildren(children);
+          forceKillTimers.push(terminateChildren(children, 'SIGTERM'));
         }
         resolve();
       };
@@ -135,7 +138,7 @@ export async function runConcurrently(options: RunConcurrentlyOptions): Promise<
     if (stopping) return;
 
     stopping = true;
-    terminateChildren(children);
+    forceKillTimers.push(terminateChildren(children, signal));
   };
   const stopOnSigint = (): void => {
     stopAll('SIGINT');
@@ -155,6 +158,9 @@ export async function runConcurrently(options: RunConcurrentlyOptions): Promise<
     process.removeListener('SIGINT', stopOnSigint);
     process.removeListener('SIGTERM', stopOnSigterm);
     process.removeListener('SIGQUIT', stopOnSigquit);
+    for (const timer of forceKillTimers) {
+      clearTimeout(timer);
+    }
   }
 
   if (interruptedSignal) {
@@ -192,22 +198,31 @@ function shouldStopOthers(
   return options.success === 'first' || options.killOthers || (options.killOthersOnFail && exitCode !== 0);
 }
 
-function terminateChildren(children: child_process.ChildProcess[]): void {
+function terminateChildren(children: child_process.ChildProcess[], signal: NodeJS.Signals): NodeJS.Timeout {
+  signalChildren(children, signal);
+  const timer = setTimeout(() => {
+    signalChildren(children, 'SIGKILL');
+  }, FORCE_KILL_DELAY_MS);
+  timer.unref();
+  return timer;
+}
+
+function signalChildren(children: child_process.ChildProcess[], signal: NodeJS.Signals): void {
   for (const child of children) {
     if (!child.pid) continue;
 
     try {
-      killProcessGroup(child.pid);
-      treeKill(child.pid);
+      killProcessGroup(child.pid, signal);
+      treeKill(child.pid, signal);
     } catch (error) {
       console.warn('Failed to kill child process:', error);
     }
   }
 }
 
-function killProcessGroup(pid: number): void {
+function killProcessGroup(pid: number, signal: NodeJS.Signals): void {
   try {
-    process.kill(-pid, 'SIGTERM');
+    process.kill(-pid, signal);
   } catch (error) {
     if (isNoSuchProcessError(error)) {
       return;

--- a/packages/wb/src/commands/concurrently.ts
+++ b/packages/wb/src/commands/concurrently.ts
@@ -103,7 +103,7 @@ export async function runConcurrently(options: RunConcurrentlyOptions): Promise<
   let interruptedSignal: NodeJS.Signals | undefined;
   let firstResult: number | undefined;
   let stopResult: number | undefined;
-  const forceKillTimers: NodeJS.Timeout[] = [];
+  const forceKillPromises: Promise<void>[] = [];
   const results = Array.from<number | undefined>({ length: children.length });
   const waitForExitPromises = children.map((child, index) => {
     return new Promise<void>((resolve) => {
@@ -118,7 +118,7 @@ export async function runConcurrently(options: RunConcurrentlyOptions): Promise<
         if (!stopping && shouldStopOthers(exitCode, options)) {
           stopResult = exitCode;
           stopping = true;
-          forceKillTimers.push(terminateChildren(children, 'SIGTERM'));
+          forceKillPromises.push(terminateChildren(children, 'SIGTERM'));
         }
         resolve();
       };
@@ -138,7 +138,7 @@ export async function runConcurrently(options: RunConcurrentlyOptions): Promise<
     if (stopping) return;
 
     stopping = true;
-    forceKillTimers.push(terminateChildren(children, signal));
+    forceKillPromises.push(terminateChildren(children, signal));
   };
   const stopOnSigint = (): void => {
     stopAll('SIGINT');
@@ -154,13 +154,11 @@ export async function runConcurrently(options: RunConcurrentlyOptions): Promise<
   process.on('SIGQUIT', stopOnSigquit);
   try {
     await Promise.all(waitForExitPromises);
+    await Promise.all(forceKillPromises);
   } finally {
     process.removeListener('SIGINT', stopOnSigint);
     process.removeListener('SIGTERM', stopOnSigterm);
     process.removeListener('SIGQUIT', stopOnSigquit);
-    for (const timer of forceKillTimers) {
-      clearTimeout(timer);
-    }
   }
 
   if (interruptedSignal) {
@@ -198,13 +196,13 @@ function shouldStopOthers(
   return options.success === 'first' || options.killOthers || (options.killOthersOnFail && exitCode !== 0);
 }
 
-function terminateChildren(children: child_process.ChildProcess[], signal: NodeJS.Signals): NodeJS.Timeout {
+async function terminateChildren(children: child_process.ChildProcess[], signal: NodeJS.Signals): Promise<void> {
   const forceKillPids = signalPids(toChildPids(children), signal);
-  const timer = setTimeout(() => {
+  if (forceKillPids.length === 0) return;
+
+  if (await waitForForceKill(forceKillPids)) {
     signalPids(forceKillPids, 'SIGKILL');
-  }, FORCE_KILL_DELAY_MS);
-  timer.unref();
-  return timer;
+  }
 }
 
 function toChildPids(children: child_process.ChildProcess[]): number[] {
@@ -215,15 +213,41 @@ function signalPids(pids: readonly number[], signal: NodeJS.Signals): number[] {
   const signaledPids: number[] = [];
   for (const pid of pids) {
     try {
-      if (killProcessGroup(pid, signal)) {
-        signaledPids.push(pid);
-      }
+      if (!killProcessGroup(pid, signal)) continue;
+
+      signaledPids.push(pid);
       treeKill(pid, signal);
     } catch (error) {
       console.warn('Failed to kill child process:', error);
     }
   }
   return signaledPids;
+}
+
+async function waitForForceKill(pids: readonly number[]): Promise<boolean> {
+  const deadline = Date.now() + FORCE_KILL_DELAY_MS;
+  while (Date.now() < deadline) {
+    if (pids.every(isProcessGroupGone)) return false;
+
+    await sleep(Math.min(100, deadline - Date.now()));
+  }
+  return true;
+}
+
+function isProcessGroupGone(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return false;
+  } catch (error) {
+    if (isNoSuchProcessError(error)) {
+      return true;
+    }
+    return false;
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function killProcessGroup(pid: number, signal: NodeJS.Signals): boolean {

--- a/packages/wb/src/commands/concurrently.ts
+++ b/packages/wb/src/commands/concurrently.ts
@@ -199,37 +199,40 @@ function shouldStopOthers(
 }
 
 function terminateChildren(children: child_process.ChildProcess[], signal: NodeJS.Signals): NodeJS.Timeout {
-  signalChildren(children, signal);
+  const forceKillPids = signalPids(toChildPids(children), signal);
   const timer = setTimeout(() => {
-    signalChildren(children, 'SIGKILL');
+    signalPids(forceKillPids, 'SIGKILL');
   }, FORCE_KILL_DELAY_MS);
   timer.unref();
   return timer;
 }
 
-function signalChildren(children: child_process.ChildProcess[], signal: NodeJS.Signals): void {
-  for (const child of children) {
-    if (!isRunningChild(child)) continue;
+function toChildPids(children: child_process.ChildProcess[]): number[] {
+  return children.flatMap((child) => (child.pid === undefined ? [] : [child.pid]));
+}
 
+function signalPids(pids: readonly number[], signal: NodeJS.Signals): number[] {
+  const signaledPids: number[] = [];
+  for (const pid of pids) {
     try {
-      killProcessGroup(child.pid, signal);
-      treeKill(child.pid, signal);
+      if (killProcessGroup(pid, signal)) {
+        signaledPids.push(pid);
+      }
+      treeKill(pid, signal);
     } catch (error) {
       console.warn('Failed to kill child process:', error);
     }
   }
+  return signaledPids;
 }
 
-function isRunningChild(child: child_process.ChildProcess): child is child_process.ChildProcess & { pid: number } {
-  return child.pid !== undefined && child.exitCode === null && child.signalCode === null;
-}
-
-function killProcessGroup(pid: number, signal: NodeJS.Signals): void {
+function killProcessGroup(pid: number, signal: NodeJS.Signals): boolean {
   try {
     process.kill(-pid, signal);
+    return true;
   } catch (error) {
     if (isNoSuchProcessError(error)) {
-      return;
+      return false;
     }
     throw error;
   }


### PR DESCRIPTION
## Summary
- add a SIGKILL fallback when wb concurrently stops child process groups
- propagate interrupt signals to child process groups instead of always using SIGTERM

## Verification
- timeout 10s yarn workspace @willbooster/wb start concurrently --kill-others --success first 'node -e "process.on(\"SIGTERM\",()=>{}); setInterval(()=>{},1000)"' 'node -e "setTimeout(()=>process.exit(0),50)"'
- yarn check-for-ai