### PR TITLE
fix: harden wbfy generator internals

### DIFF
--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -13,7 +13,10 @@ type ParsedValue =
   | { kind: 'array'; value: ParsedValue[] }
   | { kind: 'literal'; value: string }
   | { kind: 'object'; value: ParsedObject };
-type ParsedObject = Record<string, ParsedValue>;
+interface ParsedObject {
+  extraMembers: string[];
+  properties: Record<string, ParsedValue>;
+}
 interface ExtractedObjectLiteral {
   source: ts.SourceFile;
   node: ts.ObjectLiteralExpression;
@@ -21,33 +24,39 @@ interface ExtractedObjectLiteral {
 
 const literal = (value: string): ParsedValue => ({ kind: 'literal', value });
 const asArray = (value: ParsedValue[]): ParsedValue => ({ kind: 'array', value });
-const asObject = (value: ParsedObject): ParsedValue => ({ kind: 'object', value });
+const asObject = (properties: Record<string, ParsedValue>, extraMembers: string[] = []): ParsedValue => ({
+  kind: 'object',
+  value: { extraMembers, properties },
+});
 
 const defaultConfig: ParsedObject = {
-  forbidOnly: literal('!!process.env.CI'),
-  retries: literal('process.env.PWDEBUG ? 0 : process.env.CI ? 5 : 1'),
-  use: asObject({
-    baseURL: literal('process.env.NEXT_PUBLIC_BASE_URL'),
-    trace: literal("process.env.CI ? 'on-first-retry' : 'retain-on-failure'"),
-    screenshot: literal("process.env.CI ? 'only-on-failure' : 'only-on-failure'"),
-    video: literal("process.env.CI ? 'retain-on-failure' : 'retain-on-failure'"),
-  }),
-  webServer: asObject({
-    command: literal("'yarn start-test-server'"),
-    url: literal('process.env.NEXT_PUBLIC_BASE_URL'),
-    reuseExistingServer: literal('!!process.env.CI'),
-    timeout: literal('300_000'),
-    stdout: literal("'pipe'"),
-    stderr: literal("'pipe'"),
-    env: literal(`{
+  extraMembers: [],
+  properties: {
+    forbidOnly: literal('!!process.env.CI'),
+    retries: literal('process.env.PWDEBUG ? 0 : process.env.CI ? 5 : 1'),
+    use: asObject({
+      baseURL: literal('process.env.NEXT_PUBLIC_BASE_URL'),
+      trace: literal("process.env.CI ? 'on-first-retry' : 'retain-on-failure'"),
+      screenshot: literal("process.env.CI ? 'only-on-failure' : 'only-on-failure'"),
+      video: literal("process.env.CI ? 'retain-on-failure' : 'retain-on-failure'"),
+    }),
+    webServer: asObject({
+      command: literal("'yarn start-test-server'"),
+      url: literal('process.env.NEXT_PUBLIC_BASE_URL'),
+      reuseExistingServer: literal('!!process.env.CI'),
+      timeout: literal('300_000'),
+      stdout: literal("'pipe'"),
+      stderr: literal("'pipe'"),
+      env: literal(`{
   ...process.env,
   PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION: 'true',
 }`),
-    gracefulShutdown: literal(`{
+      gracefulShutdown: literal(`{
   signal: 'SIGTERM',
   timeout: 500,
 }`),
-  }),
+    }),
+  },
 };
 
 export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> {
@@ -67,15 +76,15 @@ export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> 
     // Keep filling missing defaults, but don't overwrite local adjustments on every regeneration.
     const merged = merge.all<ParsedObject>([defaultConfig, parsed]);
     const hasStartTestServer = Boolean(config.packageJson?.scripts?.['start-test-server']);
-    const hasExistingWebServer = Boolean(parsed.webServer);
+    const hasExistingWebServer = Boolean(parsed.properties.webServer);
     // Only drop wbfy's default server command. Repos with custom Playwright
     // server setup still need it even when they do not expose start-test-server.
     if (!hasStartTestServer && !hasExistingWebServer) {
-      delete merged.webServer;
+      delete merged.properties.webServer;
     }
     setWebServerCommand(config, merged);
 
-    const newObjectLiteral = stringifyValue(asObject(merged), 0);
+    const newObjectLiteral = stringifyValue({ kind: 'object', value: merged }, 0);
     const start = extractedObjectLiteral.node.getStart(extractedObjectLiteral.source);
     const end = extractedObjectLiteral.node.getEnd();
     const newContent = `${oldContent.slice(0, start)}${newObjectLiteral}${oldContent.slice(end)}`;
@@ -106,12 +115,12 @@ async function assertNextPublicBaseUrl(dirPath: string): Promise<void> {
 }
 
 function setWebServerCommand(config: PackageConfig, object: ParsedObject): void {
-  const webServer = object.webServer;
+  const webServer = object.properties.webServer;
   if (webServer?.kind !== 'object') return;
 
   // wbfy owns the package script, so Playwright should consistently call that
   // script while preserving the rest of each repository's webServer settings.
-  webServer.value.command = literal(config.isBun ? "'bun start-test-server'" : "'yarn start-test-server'");
+  webServer.value.properties.command = literal(config.isBun ? "'bun start-test-server'" : "'yarn start-test-server'");
 }
 
 function extractDefineConfigObjectLiteral(content: string): ExtractedObjectLiteral | undefined {
@@ -139,7 +148,7 @@ function extractDefineConfigObjectLiteral(content: string): ExtractedObjectLiter
 function parseExpression(expression: ts.Expression, source: ts.SourceFile): ParsedValue | undefined {
   if (ts.isObjectLiteralExpression(expression)) {
     const parsedObject = parseObjectLiteralExpression(expression, source);
-    return parsedObject ? asObject(parsedObject) : literal(expression.getText(source));
+    return parsedObject ? { kind: 'object', value: parsedObject } : literal(expression.getText(source));
   }
   if (ts.isArrayLiteralExpression(expression)) {
     const elements = expression.elements.map((element) => parseExpression(element, source));
@@ -155,14 +164,15 @@ function parseObjectLiteralExpression(
   objectLiteral: ts.ObjectLiteralExpression,
   source: ts.SourceFile
 ): ParsedObject | undefined {
-  const parsed: ParsedObject = {};
+  const parsed: ParsedObject = { extraMembers: [], properties: {} };
   for (const property of objectLiteral.properties) {
     if (!ts.isPropertyAssignment(property) || (!ts.isIdentifier(property.name) && !ts.isStringLiteral(property.name))) {
+      parsed.extraMembers.push(property.getText(source));
       continue;
     }
     const value = parseExpression(property.initializer, source);
     if (value === undefined) return;
-    parsed[property.name.getText(source)] = value;
+    parsed.properties[property.name.getText(source)] = value;
   }
   return parsed;
 }
@@ -188,7 +198,7 @@ function stringifyValue(value: ParsedValue, level: number): string {
   if (value.kind === 'literal') return value.value;
 
   const indent = '  '.repeat(level + 1);
-  const lines = Object.entries(value.value).map(([key, item]) => {
+  const lines = Object.entries(value.value.properties).map(([key, item]) => {
     const stringified = stringifyValue(item, level + 1).split('\n');
     stringified[stringified.length - 1] = `${stringified.at(-1)},`;
     if (item.kind === 'literal') {
@@ -199,6 +209,16 @@ function stringifyValue(value: ParsedValue, level: number): string {
     stringified[0] = `${indent}${key}: ${stringified[0]}`;
     return stringified.join('\n');
   });
+  lines.push(
+    ...value.value.extraMembers.map((member) => {
+      const stringified = member.split('\n');
+      stringified[stringified.length - 1] = `${stringified.at(-1)},`;
+      for (const [index, line] of stringified.entries()) {
+        stringified[index] = `${indent}${line}`;
+      }
+      return stringified.join('\n');
+    })
+  );
   if (lines.length === 0) return `{\n${closingIndent}}`;
   return `{\n${lines.join('\n')}\n${closingIndent}}`;
 }

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -68,32 +68,6 @@ function toParsedObject(properties: Record<string, ParsedValue>, extraMembers: s
   };
 }
 
-function mergeParsedObjects(base: ParsedObject, override: ParsedObject): ParsedObject {
-  const overridePropertyKeys = new Set(
-    override.memberOrder.flatMap((member) => (member.kind === 'property' ? [member.key] : []))
-  );
-  const extraMembers = [...base.extraMembers, ...override.extraMembers];
-  const memberOrder = [
-    ...base.memberOrder.filter((member) => member.kind !== 'property' || !overridePropertyKeys.has(member.key)),
-    ...override.memberOrder.map((member): ObjectMember => {
-      if (member.kind === 'property') return member;
-      return { kind: 'extra', index: base.extraMembers.length + member.index };
-    }),
-  ];
-  const properties = { ...base.properties };
-  for (const [key, value] of Object.entries(override.properties)) {
-    properties[key] = mergeParsedValue(properties[key], value);
-  }
-  return { extraMembers, memberOrder, properties };
-}
-
-function mergeParsedValue(base: ParsedValue | undefined, override: ParsedValue): ParsedValue {
-  if (base?.kind === 'object' && override.kind === 'object') {
-    return { kind: 'object', value: mergeParsedObjects(base.value, override.value) };
-  }
-  return override;
-}
-
 export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> {
   const filePath = path.resolve(config.dirPath, `playwright.config.ts`);
   if (!fs.existsSync(filePath)) return;
@@ -126,6 +100,30 @@ export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> 
 
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
   });
+}
+
+function mergeParsedObjects(base: ParsedObject, override: ParsedObject): ParsedObject {
+  const overridePropertyKeys = new Set(Object.keys(override.properties));
+  const extraMembers = [...base.extraMembers, ...override.extraMembers];
+  const memberOrder = [
+    ...base.memberOrder.filter((member) => member.kind !== 'property' || !overridePropertyKeys.has(member.key)),
+    ...override.memberOrder.map((member): ObjectMember => {
+      if (member.kind === 'property') return member;
+      return { kind: 'extra', index: base.extraMembers.length + member.index };
+    }),
+  ];
+  const properties = { ...base.properties };
+  for (const [key, value] of Object.entries(override.properties)) {
+    properties[key] = mergeParsedValue(properties[key], value);
+  }
+  return { extraMembers, memberOrder, properties };
+}
+
+function mergeParsedValue(base: ParsedValue | undefined, override: ParsedValue): ParsedValue {
+  if (base?.kind === 'object' && override.kind === 'object') {
+    return { kind: 'object', value: mergeParsedObjects(base.value, override.value) };
+  }
+  return override;
 }
 
 async function assertNextPublicBaseUrl(dirPath: string): Promise<void> {

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -105,6 +105,7 @@ export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> 
 function mergeParsedObjects(base: ParsedObject, override: ParsedObject): ParsedObject {
   const overridePropertyKeys = new Set(Object.keys(override.properties));
   const extraMembers = [...base.extraMembers, ...override.extraMembers];
+  // Keep default-only members before parsed members so spreads and explicit local properties retain precedence.
   const memberOrder = [
     ...base.memberOrder.filter((member) => member.kind !== 'property' || !overridePropertyKeys.has(member.key)),
     ...override.memberOrder.map((member): ObjectMember => {
@@ -241,12 +242,13 @@ function stringifyValue(value: ParsedValue, level: number): string {
 
   const indent = '  '.repeat(level + 1);
   const emittedProperties = new Set<string>();
-  const lines = value.value.memberOrder.flatMap((member, index, memberOrder) => {
+  const lastPropertyIndexByKey = getLastPropertyIndexByKey(value.value.memberOrder);
+  const lines = value.value.memberOrder.flatMap((member, index) => {
     if (member.kind === 'extra') {
       return [stringifyObjectMember(value.value.extraMembers[member.index] ?? '', indent)];
     }
 
-    if (hasLaterPropertyMember(memberOrder, index, member.key)) return [];
+    if (lastPropertyIndexByKey.get(member.key) !== index) return [];
     const item = value.value.properties[member.key];
     if (!item || emittedProperties.has(member.key)) return [];
     emittedProperties.add(member.key);
@@ -261,8 +263,14 @@ function stringifyValue(value: ParsedValue, level: number): string {
   return `{\n${lines.join('\n')}\n${closingIndent}}`;
 }
 
-function hasLaterPropertyMember(memberOrder: ObjectMember[], index: number, key: string): boolean {
-  return memberOrder.slice(index + 1).some((member) => member.kind === 'property' && member.key === key);
+function getLastPropertyIndexByKey(memberOrder: ObjectMember[]): Map<string, number> {
+  const lastPropertyIndexByKey = new Map<string, number>();
+  for (const [index, member] of memberOrder.entries()) {
+    if (member.kind === 'property') {
+      lastPropertyIndexByKey.set(member.key, index);
+    }
+  }
+  return lastPropertyIndexByKey;
 }
 
 function stringifyObjectProperty(key: string, item: ParsedValue, level: number, indent: string): string {

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import merge from 'deepmerge';
 import ts from 'typescript';
 
 import { logger } from '../logger.js';
@@ -13,8 +12,10 @@ type ParsedValue =
   | { kind: 'array'; value: ParsedValue[] }
   | { kind: 'literal'; value: string }
   | { kind: 'object'; value: ParsedObject };
+type ObjectMember = { kind: 'extra'; index: number } | { kind: 'property'; key: string };
 interface ParsedObject {
   extraMembers: string[];
+  memberOrder: ObjectMember[];
   properties: Record<string, ParsedValue>;
 }
 interface ExtractedObjectLiteral {
@@ -26,38 +27,72 @@ const literal = (value: string): ParsedValue => ({ kind: 'literal', value });
 const asArray = (value: ParsedValue[]): ParsedValue => ({ kind: 'array', value });
 const asObject = (properties: Record<string, ParsedValue>, extraMembers: string[] = []): ParsedValue => ({
   kind: 'object',
-  value: { extraMembers, properties },
+  value: toParsedObject(properties, extraMembers),
 });
 
-const defaultConfig: ParsedObject = {
-  extraMembers: [],
-  properties: {
-    forbidOnly: literal('!!process.env.CI'),
-    retries: literal('process.env.PWDEBUG ? 0 : process.env.CI ? 5 : 1'),
-    use: asObject({
-      baseURL: literal('process.env.NEXT_PUBLIC_BASE_URL'),
-      trace: literal("process.env.CI ? 'on-first-retry' : 'retain-on-failure'"),
-      screenshot: literal("process.env.CI ? 'only-on-failure' : 'only-on-failure'"),
-      video: literal("process.env.CI ? 'retain-on-failure' : 'retain-on-failure'"),
-    }),
-    webServer: asObject({
-      command: literal("'yarn start-test-server'"),
-      url: literal('process.env.NEXT_PUBLIC_BASE_URL'),
-      reuseExistingServer: literal('!!process.env.CI'),
-      timeout: literal('300_000'),
-      stdout: literal("'pipe'"),
-      stderr: literal("'pipe'"),
-      env: literal(`{
+const defaultConfig = toParsedObject({
+  forbidOnly: literal('!!process.env.CI'),
+  retries: literal('process.env.PWDEBUG ? 0 : process.env.CI ? 5 : 1'),
+  use: asObject({
+    baseURL: literal('process.env.NEXT_PUBLIC_BASE_URL'),
+    trace: literal("process.env.CI ? 'on-first-retry' : 'retain-on-failure'"),
+    screenshot: literal("process.env.CI ? 'only-on-failure' : 'only-on-failure'"),
+    video: literal("process.env.CI ? 'retain-on-failure' : 'retain-on-failure'"),
+  }),
+  webServer: asObject({
+    command: literal("'yarn start-test-server'"),
+    url: literal('process.env.NEXT_PUBLIC_BASE_URL'),
+    reuseExistingServer: literal('!!process.env.CI'),
+    timeout: literal('300_000'),
+    stdout: literal("'pipe'"),
+    stderr: literal("'pipe'"),
+    env: literal(`{
   ...process.env,
   PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION: 'true',
 }`),
-      gracefulShutdown: literal(`{
+    gracefulShutdown: literal(`{
   signal: 'SIGTERM',
   timeout: 500,
 }`),
+  }),
+});
+
+function toParsedObject(properties: Record<string, ParsedValue>, extraMembers: string[] = []): ParsedObject {
+  return {
+    extraMembers,
+    memberOrder: [
+      ...Object.keys(properties).map((key): ObjectMember => ({ kind: 'property', key })),
+      ...extraMembers.map((_, index): ObjectMember => ({ kind: 'extra', index })),
+    ],
+    properties,
+  };
+}
+
+function mergeParsedObjects(base: ParsedObject, override: ParsedObject): ParsedObject {
+  const overridePropertyKeys = new Set(
+    override.memberOrder.flatMap((member) => (member.kind === 'property' ? [member.key] : []))
+  );
+  const extraMembers = [...base.extraMembers, ...override.extraMembers];
+  const memberOrder = [
+    ...base.memberOrder.filter((member) => member.kind !== 'property' || !overridePropertyKeys.has(member.key)),
+    ...override.memberOrder.map((member): ObjectMember => {
+      if (member.kind === 'property') return member;
+      return { kind: 'extra', index: base.extraMembers.length + member.index };
     }),
-  },
-};
+  ];
+  const properties = { ...base.properties };
+  for (const [key, value] of Object.entries(override.properties)) {
+    properties[key] = mergeParsedValue(properties[key], value);
+  }
+  return { extraMembers, memberOrder, properties };
+}
+
+function mergeParsedValue(base: ParsedValue | undefined, override: ParsedValue): ParsedValue {
+  if (base?.kind === 'object' && override.kind === 'object') {
+    return { kind: 'object', value: mergeParsedObjects(base.value, override.value) };
+  }
+  return override;
+}
 
 export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> {
   const filePath = path.resolve(config.dirPath, `playwright.config.ts`);
@@ -74,7 +109,7 @@ export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> 
     if (!parsed) return;
 
     // Keep filling missing defaults, but don't overwrite local adjustments on every regeneration.
-    const merged = merge.all<ParsedObject>([defaultConfig, parsed]);
+    const merged = mergeParsedObjects(defaultConfig, parsed);
     const hasStartTestServer = Boolean(config.packageJson?.scripts?.['start-test-server']);
     const hasExistingWebServer = Boolean(parsed.properties.webServer);
     // Only drop wbfy's default server command. Repos with custom Playwright
@@ -164,15 +199,24 @@ function parseObjectLiteralExpression(
   objectLiteral: ts.ObjectLiteralExpression,
   source: ts.SourceFile
 ): ParsedObject | undefined {
-  const parsed: ParsedObject = { extraMembers: [], properties: {} };
+  const parsed: ParsedObject = { extraMembers: [], memberOrder: [], properties: {} };
   for (const property of objectLiteral.properties) {
+    if (ts.isShorthandPropertyAssignment(property)) {
+      const key = property.name.getText(source);
+      parsed.properties[key] = literal(key);
+      parsed.memberOrder.push({ kind: 'property', key });
+      continue;
+    }
     if (!ts.isPropertyAssignment(property) || (!ts.isIdentifier(property.name) && !ts.isStringLiteral(property.name))) {
-      parsed.extraMembers.push(property.getText(source));
+      const index = parsed.extraMembers.push(property.getText(source)) - 1;
+      parsed.memberOrder.push({ kind: 'extra', index });
       continue;
     }
     const value = parseExpression(property.initializer, source);
     if (value === undefined) return;
-    parsed.properties[property.name.getText(source)] = value;
+    const key = property.name.getText(source);
+    parsed.properties[key] = value;
+    parsed.memberOrder.push({ kind: 'property', key });
   }
   return parsed;
 }
@@ -198,27 +242,48 @@ function stringifyValue(value: ParsedValue, level: number): string {
   if (value.kind === 'literal') return value.value;
 
   const indent = '  '.repeat(level + 1);
-  const lines = Object.entries(value.value.properties).map(([key, item]) => {
-    const stringified = stringifyValue(item, level + 1).split('\n');
-    stringified[stringified.length - 1] = `${stringified.at(-1)},`;
-    if (item.kind === 'literal') {
-      for (let index = 1; index < stringified.length; index += 1) {
-        stringified[index] = `${indent}${stringified[index]}`;
-      }
+  const emittedProperties = new Set<string>();
+  const lines = value.value.memberOrder.flatMap((member, index, memberOrder) => {
+    if (member.kind === 'extra') {
+      return [stringifyObjectMember(value.value.extraMembers[member.index] ?? '', indent)];
     }
-    stringified[0] = `${indent}${key}: ${stringified[0]}`;
-    return stringified.join('\n');
+
+    if (hasLaterPropertyMember(memberOrder, index, member.key)) return [];
+    const item = value.value.properties[member.key];
+    if (!item || emittedProperties.has(member.key)) return [];
+    emittedProperties.add(member.key);
+    return [stringifyObjectProperty(member.key, item, level, indent)];
   });
   lines.push(
-    ...value.value.extraMembers.map((member) => {
-      const stringified = member.split('\n');
-      stringified[stringified.length - 1] = `${stringified.at(-1)},`;
-      for (const [index, line] of stringified.entries()) {
-        stringified[index] = `${indent}${line}`;
-      }
-      return stringified.join('\n');
-    })
+    ...Object.entries(value.value.properties)
+      .filter(([key]) => !emittedProperties.has(key))
+      .map(([key, item]) => stringifyObjectProperty(key, item, level, indent))
   );
   if (lines.length === 0) return `{\n${closingIndent}}`;
   return `{\n${lines.join('\n')}\n${closingIndent}}`;
+}
+
+function hasLaterPropertyMember(memberOrder: ObjectMember[], index: number, key: string): boolean {
+  return memberOrder.slice(index + 1).some((member) => member.kind === 'property' && member.key === key);
+}
+
+function stringifyObjectProperty(key: string, item: ParsedValue, level: number, indent: string): string {
+  const stringified = stringifyValue(item, level + 1).split('\n');
+  stringified[stringified.length - 1] = `${stringified.at(-1)},`;
+  if (item.kind === 'literal') {
+    for (let index = 1; index < stringified.length; index += 1) {
+      stringified[index] = `${indent}${stringified[index]}`;
+    }
+  }
+  stringified[0] = `${indent}${key}: ${stringified[0]}`;
+  return stringified.join('\n');
+}
+
+function stringifyObjectMember(member: string, indent: string): string {
+  const stringified = member.split('\n');
+  stringified[stringified.length - 1] = `${stringified.at(-1)},`;
+  for (const [index, line] of stringified.entries()) {
+    stringified[index] = `${indent}${line}`;
+  }
+  return stringified.join('\n');
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -82,8 +82,8 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
   const dependencyUpdates = collectDependencyUpdates(config, rootConfig, jsonObj);
   await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
   addDependencyVersionsToPackageJson(jsonObj, dependencyUpdates);
-  removeEmptyDependencySections(jsonObj);
   await updatePrivatePackages(jsonObj);
+  removeEmptyDependencySections(jsonObj);
 
   if (config.isBun) delete jsonObj.packageManager;
   await fixScriptNames(jsonObj.scripts, config);

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -51,6 +51,17 @@ const eslintDeps: Record<EslintExtensionBase, string[]> = {
   ],
 };
 
+type WritablePackageJson = SetRequired<
+  PackageJson,
+  'scripts' | 'dependencies' | 'devDependencies' | 'peerDependencies'
+>;
+
+interface DependencyUpdates {
+  dependencies: string[];
+  devDependencies: string[];
+  poetryDevDependencies: string[];
+}
+
 export async function generatePackageJson(
   config: PackageConfig,
   rootConfig: PackageConfig,
@@ -63,53 +74,92 @@ export async function generatePackageJson(
 
 async function core(config: PackageConfig, rootConfig: PackageConfig, skipAddingDeps: boolean): Promise<void> {
   const filePath = path.resolve(config.dirPath, 'package.json');
+  const jsonObj = await readPackageJson(filePath);
+  const packageManager = config.isBun ? 'bun' : 'yarn';
+
+  await removeDeprecatedStuff(jsonObj, config.dirPath);
+  await updateScripts(config, jsonObj, packageManager);
+  const dependencyUpdates = collectDependencyUpdates(config, rootConfig, jsonObj);
+  await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
+  addDependencyVersionsToPackageJson(jsonObj, dependencyUpdates);
+  removeEmptyDependencySections(jsonObj);
+  await updatePrivatePackages(jsonObj);
+
+  if (config.isBun) delete jsonObj.packageManager;
+  await fixScriptNames(jsonObj.scripts, config);
+  await promisePool.run(() => fsUtil.generateFile(filePath, JSON.stringify(sortPackageJson(jsonObj), undefined, 2)));
+
+  if (!skipAddingDeps) {
+    installDependencyUpdates(config, jsonObj, dependencyUpdates, packageManager);
+  }
+}
+
+async function readPackageJson(filePath: string): Promise<WritablePackageJson> {
   const jsonText = await fs.promises.readFile(filePath, 'utf8');
   const jsonObj = JSON.parse(jsonText) as PackageJson;
   jsonObj.scripts = jsonObj.scripts ?? {};
   jsonObj.dependencies = jsonObj.dependencies ?? {};
   jsonObj.devDependencies = jsonObj.devDependencies ?? {};
   jsonObj.peerDependencies = jsonObj.peerDependencies ?? {};
-  const packageManager = config.isBun ? 'bun' : 'yarn';
+  return jsonObj as WritablePackageJson;
+}
 
-  await removeDeprecatedStuff(
-    jsonObj as SetRequired<PackageJson, 'scripts' | 'dependencies' | 'devDependencies'>,
-    config.dirPath
-  );
-
-  for (const [key, value] of Object.entries(jsonObj.scripts)) {
-    if (typeof value !== 'string') continue;
-    // Fresh repo still requires 'yarn install'
-    if (!value.includes('git clone')) {
-      jsonObj.scripts[key] = value.replaceAll(/yarn\s*&&\s*/gu, '').replaceAll(/yarn\s*install\s*&&\s*/gu, '');
-    }
-  }
+async function updateScripts(
+  config: PackageConfig,
+  jsonObj: WritablePackageJson,
+  packageManager: 'bun' | 'yarn'
+): Promise<void> {
+  removeLegacyInstallCommands(jsonObj.scripts);
 
   jsonObj.scripts = merge(jsonObj.scripts, generateScripts(config, jsonObj.scripts));
   addStartTestServerScriptIfNeeded(config, jsonObj);
-
-  if ('check-for-ai' in jsonObj.scripts) {
-    if ('gen-code' in jsonObj.scripts) {
-      jsonObj.scripts['check-for-ai'] = `${packageManager} gen-code > /dev/null && ${jsonObj.scripts['check-for-ai']}`;
-    }
-    jsonObj.scripts['check-for-ai'] = `${packageManager} install > /dev/null && ${jsonObj.scripts['check-for-ai']}`;
-  }
+  addInstallStepToCheckForAi(jsonObj.scripts, packageManager);
 
   if (config.isBun) {
     delete jsonObj.scripts.prettify;
   } else {
     jsonObj.scripts.prettify = (jsonObj.scripts.prettify ?? '') + (await generatePrettierSuffix(config.dirPath));
   }
+  normalizeYarnWorkspaceForeachScripts(jsonObj.scripts);
+}
+
+function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
+  for (const [key, value] of Object.entries(scripts)) {
+    if (typeof value !== 'string') continue;
+    // Fresh repo still requires 'yarn install'
+    if (!value.includes('git clone')) {
+      scripts[key] = value.replaceAll(/yarn\s*&&\s*/gu, '').replaceAll(/yarn\s*install\s*&&\s*/gu, '');
+    }
+  }
+}
+
+function addInstallStepToCheckForAi(scripts: PackageJson.Scripts, packageManager: 'bun' | 'yarn'): void {
+  if (!('check-for-ai' in scripts)) return;
+
+  if ('gen-code' in scripts) {
+    scripts['check-for-ai'] = `${packageManager} gen-code > /dev/null && ${scripts['check-for-ai']}`;
+  }
+  scripts['check-for-ai'] = `${packageManager} install > /dev/null && ${scripts['check-for-ai']}`;
+}
+
+function normalizeYarnWorkspaceForeachScripts(scripts: PackageJson.Scripts): void {
   // Deal with breaking changes in yarn berry 4.0.0-rc.49
-  for (const [key, value] of Object.entries(jsonObj.scripts)) {
+  for (const [key, value] of Object.entries(scripts)) {
     if (!value?.includes('yarn workspaces foreach')) continue;
-    jsonObj.scripts[key] = value.replaceAll(
+    scripts[key] = value.replaceAll(
       /yarn workspaces foreach(?!\s+(?:-A|-R|--(?:all|recursive|since|worktree|from|include|exclude|public|private)))/gu,
       'yarn workspaces foreach --all'
     );
   }
+}
 
-  let dependencies: string[] = [];
-  let devDependencies = ['prettier', 'sort-package-json'];
+function collectDependencyUpdates(
+  config: PackageConfig,
+  rootConfig: PackageConfig,
+  jsonObj: WritablePackageJson
+): DependencyUpdates {
+  const dependencies: string[] = [];
+  const devDependencies = ['prettier', 'sort-package-json'];
   const poetryDevDependencies: string[] = [];
 
   if (
@@ -233,10 +283,22 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
   }
 
   if (config.isWillBoosterConfigs) {
-    dependencies = dependencies.filter((dep) => !dep.includes('@willbooster/'));
-    devDependencies = devDependencies.filter((dep) => !dep.includes('@willbooster/'));
+    return {
+      dependencies: dependencies.filter((dep) => !dep.includes('@willbooster/')),
+      devDependencies: devDependencies.filter((dep) => !dep.includes('@willbooster/')),
+      poetryDevDependencies,
+    };
   }
 
+  return { dependencies, devDependencies, poetryDevDependencies };
+}
+
+async function normalizePackageMetadata(
+  config: PackageConfig,
+  rootConfig: PackageConfig,
+  jsonObj: WritablePackageJson,
+  dependencyUpdates: DependencyUpdates
+): Promise<void> {
   if (!jsonObj.name) {
     jsonObj.name = path.basename(config.dirPath);
   }
@@ -317,7 +379,7 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
           jsonObj.scripts['lint-fix'] = 'yarn lint';
         }
         jsonObj.scripts.format = (jsonObj.scripts.format ?? '') + ` && yarn format-code`;
-        poetryDevDependencies.push('black', 'isort', 'flake8');
+        dependencyUpdates.poetryDevDependencies.push('black', 'isort', 'flake8');
       }
     }
   }
@@ -343,57 +405,62 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
     // Because @types/prettier blocks prettier execution.
     delete jsonObj.devDependencies['@types/prettier'];
   }
+}
 
+function addDependencyVersionsToPackageJson(jsonObj: WritablePackageJson, dependencyUpdates: DependencyUpdates): void {
   const packageJsonDependencies = jsonObj.dependencies;
   const packageJsonDevDependencies = jsonObj.devDependencies;
-  dependencies = addPackageJsonDependencies(packageJsonDependencies, dependencies);
-  devDependencies = devDependencies.filter((dep) => !packageJsonDependencies[dep]);
-  devDependencies = addPackageJsonDependencies(packageJsonDevDependencies, devDependencies);
+  dependencyUpdates.dependencies = addPackageJsonDependencies(packageJsonDependencies, dependencyUpdates.dependencies);
+  dependencyUpdates.devDependencies = dependencyUpdates.devDependencies.filter((dep) => !packageJsonDependencies[dep]);
+  dependencyUpdates.devDependencies = addPackageJsonDependencies(
+    packageJsonDevDependencies,
+    dependencyUpdates.devDependencies
+  );
+}
 
-  if (Object.keys(jsonObj.dependencies).length === 0) {
+function removeEmptyDependencySections(jsonObj: PackageJson): void {
+  if (jsonObj.dependencies && Object.keys(jsonObj.dependencies).length === 0) {
     delete jsonObj.dependencies;
   }
-  if (Object.keys(jsonObj.devDependencies).length === 0) {
+  if (jsonObj.devDependencies && Object.keys(jsonObj.devDependencies).length === 0) {
     delete jsonObj.devDependencies;
   }
-  if (Object.keys(jsonObj.peerDependencies).length === 0) {
+  if (jsonObj.peerDependencies && Object.keys(jsonObj.peerDependencies).length === 0) {
     delete jsonObj.peerDependencies;
   }
+}
 
-  await updatePrivatePackages(jsonObj);
+function installDependencyUpdates(
+  config: PackageConfig,
+  jsonObj: PackageJson,
+  dependencyUpdates: DependencyUpdates,
+  packageManager: 'bun' | 'yarn'
+): void {
+  const dependencies = dependencyUpdates.dependencies.filter((dep) => !jsonObj.devDependencies?.[dep]);
+  installNpmDependencies(config, packageManager, dependencies, false);
 
-  if (config.isBun) delete jsonObj.packageManager;
-  await fixScriptNames(jsonObj.scripts, config);
-  await promisePool.run(() => fsUtil.generateFile(filePath, JSON.stringify(sortPackageJson(jsonObj), undefined, 2)));
+  const devDependencies = dependencyUpdates.devDependencies.filter((dep) => !jsonObj.dependencies?.[dep]);
+  installNpmDependencies(config, packageManager, devDependencies, true);
 
-  if (!skipAddingDeps) {
-    // We cannot add dependencies which are already included in devDependencies.
-    dependencies = dependencies.filter((dep) => !jsonObj.devDependencies?.[dep]);
-    if (dependencies.length > 0) {
-      const uniqueDependencies = [...new Set(dependencies)];
-      const dependencySpecifiers = uniqueDependencies.map((dependency) => getDependencySpecifier(dependency));
-      if (config.isBun) {
-        spawnSync(packageManager, ['add', '--exact', ...dependencySpecifiers], config.dirPath);
-      } else {
-        // Intentionally omit versions to update dependencies to the latest versions with Yarn.
-        spawnSync(packageManager, ['add', ...dependencySpecifiers], config.dirPath);
-      }
-    }
-    // We cannot add devDependencies which are already included in dependencies.
-    devDependencies = devDependencies.filter((dep) => !jsonObj.dependencies?.[dep]);
-    if (devDependencies.length > 0) {
-      const uniqueDevDependencies = [...new Set(devDependencies)];
-      const devDependencySpecifiers = uniqueDevDependencies.map((dependency) => getDependencySpecifier(dependency));
-      if (config.isBun) {
-        spawnSync(packageManager, ['add', '-D', '--exact', ...devDependencySpecifiers], config.dirPath);
-      } else {
-        // Intentionally omit versions to update dependencies to the latest versions with Yarn.
-        spawnSync(packageManager, ['add', '-D', ...devDependencySpecifiers], config.dirPath);
-      }
-    }
-    if (poetryDevDependencies.length > 0) {
-      spawnSync('poetry', ['add', '--group', 'dev', ...new Set(poetryDevDependencies)], config.dirPath);
-    }
+  if (dependencyUpdates.poetryDevDependencies.length > 0) {
+    spawnSync('poetry', ['add', '--group', 'dev', ...new Set(dependencyUpdates.poetryDevDependencies)], config.dirPath);
+  }
+}
+
+function installNpmDependencies(
+  config: PackageConfig,
+  packageManager: 'bun' | 'yarn',
+  dependencies: string[],
+  dev: boolean
+): void {
+  if (dependencies.length === 0) return;
+
+  const dependencySpecifiers = [...new Set(dependencies)].map((dependency) => getDependencySpecifier(dependency));
+  if (config.isBun) {
+    spawnSync(packageManager, ['add', ...(dev ? ['-D'] : []), '--exact', ...dependencySpecifiers], config.dirPath);
+  } else {
+    // Intentionally omit versions to update dependencies to the latest versions with Yarn.
+    spawnSync(packageManager, ['add', ...(dev ? ['-D'] : []), ...dependencySpecifiers], config.dirPath);
   }
 }
 
@@ -658,27 +725,28 @@ async function updatePrivatePackages(jsonObj: PackageJson): Promise<void> {
   jsonObj.dependencies = jsonObj.dependencies ?? {};
   jsonObj.devDependencies = jsonObj.devDependencies ?? {};
   const packageNames = new Set([...Object.keys(jsonObj.dependencies), ...Object.keys(jsonObj.devDependencies)]);
-  if (packageNames.has('@willbooster/auth') && !isWorkspacePackage(jsonObj, '@willbooster/auth')) {
-    delete jsonObj.devDependencies['@willbooster/auth'];
-    jsonObj.dependencies['@willbooster/auth'] = await getLatestPrivatePackageSpecifier('auth');
-  }
-  if (packageNames.has('@discord-bot/shared') && !isWorkspacePackage(jsonObj, '@discord-bot/shared')) {
-    delete jsonObj.devDependencies['@discord-bot/shared'];
-    jsonObj.dependencies['@discord-bot/shared'] = await getLatestPrivatePackageSpecifier('discord-bot');
-  }
+  const privatePackages: {
+    packageName: string;
+    repo: string;
+    target: 'dependencies' | 'devDependencies';
+  }[] = [
+    { packageName: '@willbooster/auth', repo: 'auth', target: 'dependencies' },
+    { packageName: '@discord-bot/shared', repo: 'discord-bot', target: 'dependencies' },
+    { packageName: '@willbooster/code-analyzer', repo: 'code-analyzer', target: 'devDependencies' },
+    { packageName: '@willbooster/judge', repo: 'judge', target: 'dependencies' },
+    { packageName: '@willbooster/llm-proxy', repo: 'llm-proxy', target: 'dependencies' },
+  ];
 
-  if (packageNames.has('@willbooster/code-analyzer') && !isWorkspacePackage(jsonObj, '@willbooster/code-analyzer')) {
-    delete jsonObj.dependencies['@willbooster/code-analyzer'];
-    jsonObj.devDependencies['@willbooster/code-analyzer'] = await getLatestPrivatePackageSpecifier('code-analyzer');
-  }
-  if (packageNames.has('@willbooster/judge') && !isWorkspacePackage(jsonObj, '@willbooster/judge')) {
-    delete jsonObj.devDependencies['@willbooster/judge'];
-    jsonObj.dependencies['@willbooster/judge'] = await getLatestPrivatePackageSpecifier('judge');
-  }
-  if (packageNames.has('@willbooster/llm-proxy') && !isWorkspacePackage(jsonObj, '@willbooster/llm-proxy')) {
-    delete jsonObj.devDependencies['@willbooster/llm-proxy'];
-    jsonObj.dependencies['@willbooster/llm-proxy'] = await getLatestPrivatePackageSpecifier('llm-proxy');
-  }
+  await Promise.all(
+    privatePackages.map(async ({ packageName, repo, target }) => {
+      if (!packageNames.has(packageName) || isWorkspacePackage(jsonObj, packageName)) return;
+
+      const otherTarget = target === 'dependencies' ? 'devDependencies' : 'dependencies';
+      delete jsonObj[otherTarget]?.[packageName];
+      jsonObj[target] ??= {};
+      jsonObj[target][packageName] = await getLatestPrivatePackageSpecifier(repo);
+    })
+  );
 }
 
 async function getLatestPrivatePackageSpecifier(repo: string): Promise<string> {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -126,7 +126,7 @@ async function updateScripts(
 function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
   for (const [key, value] of Object.entries(scripts)) {
     if (typeof value !== 'string') continue;
-    // Fresh repo still requires 'yarn install'
+    // Fresh repos still require standalone `yarn install`; only remove legacy install prefixes before another command.
     if (!value.includes('git clone')) {
       scripts[key] = value.replaceAll(/yarn\s*(?:install\s*)?&&\s*/gu, '');
     }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -128,7 +128,7 @@ function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
     if (typeof value !== 'string') continue;
     // Fresh repo still requires 'yarn install'
     if (!value.includes('git clone')) {
-      scripts[key] = value.replaceAll(/yarn\s*&&\s*/gu, '').replaceAll(/yarn\s*install\s*&&\s*/gu, '');
+      scripts[key] = value.replaceAll(/yarn\s*(?:install\s*)?&&\s*/gu, '');
     }
   }
 }
@@ -419,14 +419,11 @@ function addDependencyVersionsToPackageJson(jsonObj: WritablePackageJson, depend
 }
 
 function removeEmptyDependencySections(jsonObj: PackageJson): void {
-  if (jsonObj.dependencies && Object.keys(jsonObj.dependencies).length === 0) {
-    delete jsonObj.dependencies;
-  }
-  if (jsonObj.devDependencies && Object.keys(jsonObj.devDependencies).length === 0) {
-    delete jsonObj.devDependencies;
-  }
-  if (jsonObj.peerDependencies && Object.keys(jsonObj.peerDependencies).length === 0) {
-    delete jsonObj.peerDependencies;
+  for (const key of ['dependencies', 'devDependencies', 'peerDependencies'] as const) {
+    const section = jsonObj[key];
+    if (section && Object.keys(section).length === 0) {
+      Reflect.deleteProperty(jsonObj, key);
+    }
   }
 }
 
@@ -740,6 +737,7 @@ async function updatePrivatePackages(jsonObj: WritablePackageJson): Promise<void
       if (!packageNames.has(packageName) || isWorkspacePackage(jsonObj, packageName)) return;
 
       const otherTarget = target === 'dependencies' ? 'devDependencies' : 'dependencies';
+      // The lint rule disallows `delete` with computed package names; Reflect has the same deletion semantics here.
       Reflect.deleteProperty(jsonObj[otherTarget], packageName);
       jsonObj[target][packageName] = await getLatestPrivatePackageSpecifier(repo);
     })

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -111,7 +111,7 @@ async function updateScripts(
 ): Promise<void> {
   removeLegacyInstallCommands(jsonObj.scripts);
 
-  jsonObj.scripts = merge(jsonObj.scripts, generateScripts(config, jsonObj.scripts));
+  jsonObj.scripts = { ...jsonObj.scripts, ...generateScripts(config, jsonObj.scripts) };
   addStartTestServerScriptIfNeeded(config, jsonObj);
   addInstallStepToCheckForAi(jsonObj.scripts, packageManager);
 
@@ -721,9 +721,7 @@ function escapeRegExp(text: string): string {
   return text.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
 }
 
-async function updatePrivatePackages(jsonObj: PackageJson): Promise<void> {
-  jsonObj.dependencies = jsonObj.dependencies ?? {};
-  jsonObj.devDependencies = jsonObj.devDependencies ?? {};
+async function updatePrivatePackages(jsonObj: WritablePackageJson): Promise<void> {
   const packageNames = new Set([...Object.keys(jsonObj.dependencies), ...Object.keys(jsonObj.devDependencies)]);
   const privatePackages: {
     packageName: string;
@@ -742,8 +740,7 @@ async function updatePrivatePackages(jsonObj: PackageJson): Promise<void> {
       if (!packageNames.has(packageName) || isWorkspacePackage(jsonObj, packageName)) return;
 
       const otherTarget = target === 'dependencies' ? 'devDependencies' : 'dependencies';
-      delete jsonObj[otherTarget]?.[packageName];
-      jsonObj[target] ??= {};
+      Reflect.deleteProperty(jsonObj[otherTarget], packageName);
       jsonObj[target][packageName] = await getLatestPrivatePackageSpecifier(repo);
     })
   );

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -79,7 +79,7 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
 
   await removeDeprecatedStuff(jsonObj, config.dirPath);
   await updateScripts(config, jsonObj, packageManager);
-  const dependencyUpdates = collectDependencyUpdates(config, rootConfig, jsonObj);
+  const dependencyUpdates = applyPackageJsonConventions(config, rootConfig, jsonObj);
   await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
   addDependencyVersionsToPackageJson(jsonObj, dependencyUpdates);
   await updatePrivatePackages(jsonObj);
@@ -153,7 +153,7 @@ function normalizeYarnWorkspaceForeachScripts(scripts: PackageJson.Scripts): voi
   }
 }
 
-function collectDependencyUpdates(
+function applyPackageJsonConventions(
   config: PackageConfig,
   rootConfig: PackageConfig,
   jsonObj: WritablePackageJson


### PR DESCRIPTION
Fixes #629
Fixes #630

## Summary

- Split the `packageJson` generator orchestration into focused helpers for reading, script updates, convention application, metadata normalization, dependency writing, private package updates, file writing, and install side effects.
- Reused dependency install logic for dependencies and devDependencies, and parallelized private package specifier refreshes.
- Hardened Playwright config rewriting so unsupported object-literal members such as spreads and methods are preserved, shorthand properties are parsed, object member order is maintained, and duplicate-property emission uses an O(N) last-index map.
- Kept intentional behavior documented for local Playwright spreads overriding generated defaults and for preserving standalone `yarn install` in fresh repos.

## Why

- Issues #629 and #630 requested reducing the large mixed-responsibility `packageJson` core while preserving current behavior.
- The Playwright fixer needed to avoid dropping unsupported object-literal members while maintaining JavaScript object precedence semantics.

## Testing

- `yarn check-for-ai`
- pre-commit cleanup hook
- pre-push `check.sh`
- `bunx @willbooster/agent-skills@latest check-pr-ci`
- `bunx @willbooster/agent-skills@latest review --agent all`
