### PR TITLE
fix: pin libsodium for wbfy cli

### DIFF
--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -42,6 +42,7 @@
     "fast-glob": "3.3.3",
     "fastest-levenshtein": "1.0.16",
     "js-yaml": "4.1.1",
+    "libsodium": "0.8.2",
     "libsodium-wrappers": "0.8.2",
     "lodash.clonedeep": "4.5.0",
     "minimal-promise-pool": "6.0.1",

--- a/packages/wbfy/test/libsodiumCompatibility.test.ts
+++ b/packages/wbfy/test/libsodiumCompatibility.test.ts
@@ -1,0 +1,24 @@
+import child_process from 'node:child_process';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import packageJson from '../package.json' with { type: 'json' };
+
+const packageDirPath = path.resolve(import.meta.dirname, '..');
+
+test('built cli prints its version', { timeout: 60 * 1000 }, () => {
+  const buildResult = child_process.spawnSync('yarn', ['build'], {
+    cwd: packageDirPath,
+    encoding: 'utf8',
+  });
+  expect(buildResult.status).toBe(0);
+
+  const result = child_process.spawnSync(process.execPath, [path.join(packageDirPath, 'bin', 'wbfy.js'), '--version'], {
+    cwd: packageDirPath,
+    encoding: 'utf8',
+  });
+  expect(result.stderr).toBe('');
+  expect(result.status).toBe(0);
+  expect(result.stdout.trim()).toBe(packageJson.version);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6516,6 +6516,7 @@ __metadata:
     globals: "npm:17.4.0"
     js-yaml: "npm:4.1.1"
     lefthook: "npm:2.1.5"
+    libsodium: "npm:0.8.2"
     libsodium-wrappers: "npm:0.8.2"
     lodash.clonedeep: "npm:4.5.0"
     micromatch: "npm:4.0.8"
@@ -13853,7 +13854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libsodium@npm:^0.8.0":
+"libsodium@npm:0.8.2, libsodium@npm:^0.8.0":
   version: 0.8.2
   resolution: "libsodium@npm:0.8.2"
   checksum: 10c0/e943b269331670e45d63885ee32dec5471daa4c78ddfbe35e00e27a5b0ea7b51e7fa8260142ba478dcba0918e8117e9151883c11466b2fab2638ec29a1f3482b


### PR DESCRIPTION
## Summary
- pin libsodium to 0.8.2 as a direct wbfy dependency so npm does not resolve the incompatible 0.8.3 ESM package
- update the lockfile

## Verification
- yarn check-for-ai
- npm install --prefix /tmp/wbfy-npm-sim --no-package-lock --ignore-scripts @willbooster/wbfy@latest libsodium@0.8.2 && /tmp/wbfy-npm-sim/node_modules/.bin/wbfy --version