### PR TITLE
fix: remove trailing spaces from generated workflows

### DIFF
--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -524,6 +524,13 @@ function generateAutofixWorkflow(config: PackageConfig): Workflow {
 }
 
 async function writeYaml(newSettings: Workflow, filePath: string): Promise<void> {
-  const yamlText = yaml.dump(newSettings, { lineWidth: -1, noCompatMode: true, styles: { '!!null': 'empty' } });
+  const yamlText = removeTrailingSpaces(
+    yaml.dump(newSettings, { lineWidth: -1, noCompatMode: true, styles: { '!!null': 'empty' } })
+  );
   await fs.promises.writeFile(filePath, yamlText);
+}
+
+function removeTrailingSpaces(text: string): string {
+  // js-yaml emits valueless GitHub Actions events as `event: ` when using the empty null style.
+  return text.replaceAll(/[ \t]+$/gm, '');
 }


### PR DESCRIPTION
## Summary

- Strip trailing spaces from generated workflow YAML after js-yaml emits empty null values
- Preserve valueless GitHub Actions events such as `workflow_dispatch:` while keeping output clean for whitespace checks

## Why

- Applying wbfy to `moti-ai` produced `workflow_dispatch: `, which is valid YAML but fails `git diff --check`
- Centralizing this in the generator avoids target-repo hotfixes and keeps future generated workflows clean

## Testing

- `yarn check-for-ai`
- pre-push hook `check.sh`
