### PR TITLE
fix: skip dev probe for docker ci e2e

### DIFF
--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -80,8 +80,11 @@ export async function testOnCi(
       await runWithSpawnInParallel(scripts.testUnit(project, argv).replaceAll(' --allowOnly', ''), project, argv);
     }
     if (fs.existsSync(path.join(project.dirPath, 'test', 'e2e'))) {
-      // Avoid launching dev servers for build-only packages; only start a server when E2E needs it.
-      await runWithSpawnInParallel(await scripts.testStart(project, argv), project, argv);
+      // Docker E2E builds and starts the production image below. Probing a dev server first can fail on
+      // runtime-specific dev bundlers while adding no coverage for the image that Playwright will exercise.
+      if (!hasDockerfile) {
+        await runWithSpawnInParallel(await scripts.testStart(project, argv), project, argv);
+      }
       await promisePool.promiseAll();
       if (hasDockerfile) {
         project.env.WB_DOCKER ||= '1';


### PR DESCRIPTION
## Summary

- Skip the preliminary dev-server `testStart` probe in `wb test-on-ci` when a Dockerfile-backed E2E run will build and exercise the Docker image.
- Keep the existing dev-server probe for non-Docker E2E projects.

## Why

- Docker E2E already validates the production image that Playwright exercises.
- The extra dev-server probe can fail on runtime-specific dev bundlers, such as Bun with Next.js/Turbopack and Prisma external module aliases, while adding no coverage for the Docker image path.

## Testing

- `yarn check-for-ai`
- Pre-push hook check
