### PR TITLE
fix: restore e2e dev server startup

### DIFF
--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -80,11 +80,8 @@ export async function testOnCi(
       await runWithSpawnInParallel(scripts.testUnit(project, argv).replaceAll(' --allowOnly', ''), project, argv);
     }
     if (fs.existsSync(path.join(project.dirPath, 'test', 'e2e'))) {
-      // Docker E2E builds and starts the production image below. Probing a dev server first can fail on
-      // runtime-specific dev bundlers while adding no coverage for the image that Playwright will exercise.
-      if (!hasDockerfile) {
-        await runWithSpawnInParallel(await scripts.testStart(project, argv), project, argv);
-      }
+      // Avoid launching dev servers for build-only packages; only start a server when E2E needs it.
+      await runWithSpawnInParallel(await scripts.testStart(project, argv), project, argv);
       await promisePool.promiseAll();
       if (hasDockerfile) {
         project.env.WB_DOCKER ||= '1';

--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -80,7 +80,7 @@ export async function testOnCi(
       await runWithSpawnInParallel(scripts.testUnit(project, argv).replaceAll(' --allowOnly', ''), project, argv);
     }
     if (fs.existsSync(path.join(project.dirPath, 'test', 'e2e'))) {
-      // Avoid launching dev servers for build-only packages; only start a server when E2E needs it.
+      // Confirm dev server startup for consistency across projects with E2E tests.
       await runWithSpawnInParallel(await scripts.testStart(project, argv), project, argv);
       await promisePool.promiseAll();
       if (hasDockerfile) {


### PR DESCRIPTION
## Summary

- Reverts the Docker CI E2E shortcut that skipped the dev server probe.
- Restores `testOnCi` so projects with `test/e2e` always run `scripts.testStart` before Playwright/Docker E2E handling.
- Keeps the existing Docker E2E path that sets `WB_DOCKER` and runs Docker-based tests afterward.

## Why

- The previous shortcut removed the dev server startup for Dockerfile projects, which this branch intentionally reverts.
- Restoring the startup keeps the E2E setup behavior consistent across projects with E2E tests.

## Testing

- `git push origin revert` (pre-push hook ran `check.sh` successfully)
- `yarn check-for-ai`
