### PR TITLE
feat: prefer tsgo in wb typecheck

### DIFF
--- a/packages/wb/src/commands/typecheck.ts
+++ b/packages/wb/src/commands/typecheck.ts
@@ -3,8 +3,10 @@ import path from 'node:path';
 
 import chalk from 'chalk';
 import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
+import type { PackageJson } from 'type-fest';
 
 import { findDescendantProjects } from '../project.js';
+import type { Project } from '../project.js';
 import { runWithSpawnInParallel } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
@@ -33,17 +35,12 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
   const promises = projects.descendants.map(async (project) => {
     const commands: string[] = [];
     if (!project.packageJson.workspaces) {
-      if (project.packageJson.dependencies?.typescript || project.packageJson.devDependencies?.typescript) {
-        commands.push('BUN tsc --noEmit');
-      }
+      commands.push(...buildTypeScriptTypeCheckCommands(project));
       if (project.packageJson.devDependencies?.pyright) {
         commands.push('YARN pyright');
       }
-    } else if (
-      project.hasSourceCode &&
-      (project.packageJson.dependencies?.typescript || project.packageJson.devDependencies?.typescript)
-    ) {
-      commands.push('BUN tsc --noEmit');
+    } else if (project.hasSourceCode) {
+      commands.push(...buildTypeScriptTypeCheckCommands(project));
     }
     while (commands.length > 0) {
       const exitCode = await runWithSpawnInParallel(commands.join(' && '), project, argv, {
@@ -85,6 +82,25 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
       )
     );
   return finalExitCode;
+}
+
+function buildTypeScriptTypeCheckCommands(project: Project): string[] {
+  if (hasDependency(project.packageJson, '@typescript/native-preview')) {
+    return ['BUN tsgo --noEmit'];
+  }
+  if (hasDependency(project.packageJson, 'typescript')) {
+    return ['BUN tsc --noEmit'];
+  }
+  return [];
+}
+
+function hasDependency(packageJson: PackageJson, packageName: string): boolean {
+  return !!(
+    packageJson.dependencies?.[packageName] ??
+    packageJson.devDependencies?.[packageName] ??
+    packageJson.optionalDependencies?.[packageName] ??
+    packageJson.peerDependencies?.[packageName]
+  );
 }
 
 export const tcCommand: CommandModule<unknown, TypeCheckCommandOptions> = {

--- a/packages/wb/src/commands/typecheck.ts
+++ b/packages/wb/src/commands/typecheck.ts
@@ -34,13 +34,11 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
   let removedNextDir = false as boolean;
   const promises = projects.descendants.map(async (project) => {
     const commands: string[] = [];
-    if (!project.packageJson.workspaces) {
+    if (!project.packageJson.workspaces || project.hasSourceCode) {
       commands.push(...buildTypeScriptTypeCheckCommands(project));
-      if (project.packageJson.devDependencies?.pyright) {
-        commands.push('YARN pyright');
-      }
-    } else if (project.hasSourceCode) {
-      commands.push(...buildTypeScriptTypeCheckCommands(project));
+    }
+    if (!project.packageJson.workspaces && hasDependency(project.packageJson, 'pyright')) {
+      commands.push('YARN pyright');
     }
     while (commands.length > 0) {
       const exitCode = await runWithSpawnInParallel(commands.join(' && '), project, argv, {

--- a/packages/wb/src/commands/typecheck.ts
+++ b/packages/wb/src/commands/typecheck.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 
 import chalk from 'chalk';
 import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
-import type { PackageJson } from 'type-fest';
 
 import { findDescendantProjects } from '../project.js';
 import type { Project } from '../project.js';
@@ -37,7 +36,7 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
     if (!project.packageJson.workspaces || project.hasSourceCode) {
       commands.push(...buildTypeScriptTypeCheckCommands(project));
     }
-    if (!project.packageJson.workspaces && hasDependency(project.packageJson, 'pyright')) {
+    if (!project.packageJson.workspaces && project.hasOwnDependency('pyright')) {
       commands.push('YARN pyright');
     }
     while (commands.length > 0) {
@@ -83,22 +82,13 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
 }
 
 function buildTypeScriptTypeCheckCommands(project: Project): string[] {
-  if (hasDependency(project.packageJson, '@typescript/native-preview')) {
+  if (project.hasOwnDependency('@typescript/native-preview')) {
     return ['BUN tsgo --noEmit'];
   }
-  if (hasDependency(project.packageJson, 'typescript')) {
+  if (project.hasOwnDependency('typescript')) {
     return ['BUN tsc --noEmit'];
   }
   return [];
-}
-
-function hasDependency(packageJson: PackageJson, packageName: string): boolean {
-  return !!(
-    packageJson.dependencies?.[packageName] ??
-    packageJson.devDependencies?.[packageName] ??
-    packageJson.optionalDependencies?.[packageName] ??
-    packageJson.peerDependencies?.[packageName]
-  );
 }
 
 export const tcCommand: CommandModule<unknown, TypeCheckCommandOptions> = {

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -157,6 +157,10 @@ export class Project {
     return;
   }
 
+  hasOwnDependency(packageName: string): boolean {
+    return !!this.getOwnDependencyVersion(packageName);
+  }
+
   @memoizeOne
   get hasPlaywrightConfig(): boolean {
     try {


### PR DESCRIPTION
## Summary

- Add `@typescript/native-preview` detection to `wb typecheck`.
- Prefer `tsgo --noEmit` when native preview is declared.
- Keep `tsc --noEmit` as the fallback when only `typescript` is declared.

## Why

- This lets projects adopt the TypeScript native preview without losing support for existing TypeScript setups.
- The selection stays dependency-driven, so projects opt in by adding `@typescript/native-preview`.

## Testing

- `yarn workspace @willbooster/wb typecheck`
- `yarn workspace @willbooster/wb build`
- `yarn check-for-ai`
- Dry-run smoke check with a temporary fixture declaring both `@typescript/native-preview` and `typescript`, confirming `tsgo --noEmit` is selected.
- Dry-run smoke check with a temporary fixture declaring only `typescript`, confirming `tsc --noEmit` is selected.
