### PR TITLE
fix: drop baseUrl from generated tsconfig

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -64,9 +64,10 @@ function generateAgentInstruction(
 - When fixing issues, follow these rules:
   - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
   - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run \`${packageManager} check-all-for-ai\` to execute all tests (takes up to 1 hour) or \`${packageManager} check-for-ai\` for type checking and linting only (takes up to 10 minutes).
-  - If you are confident your changes will not break any tests, you may use \`check-for-ai\`.
-- Once you have verified your changes, commit and push them to the current (non-main) branch then create a PR via \`gh\`.
+- After making code changes, run \`${packageManager} check-all-for-ai\` to execute all tests (takes up to 1 hour), or \`${packageManager} check-for-ai\` for only type checking and linting (takes up to 10 minutes).
+  - If you are confident that your changes will not break any tests, you may use \`check-for-ai\`.
+  - Use \`oxlint\` ignore comments with reasons (e.g., \`// oxlint-disable-next-line no-console --- <reason>\`) if lint errors or warnings cannot be fixed.
+- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via \`gh\`.
   - Follow the conventional commits; your commit message should start with \`feat:\`, \`fix:\`, etc.
   - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.
   - Always create new commits. Avoid using \`--amend\`.

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -105,6 +105,8 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     newSettings.include?.sort();
     // Don't use old decorator
     delete newSettings.compilerOptions?.experimentalDecorators;
+    // TypeScript no longer requires baseUrl for paths, and tsgolint rejects it.
+    delete newSettings.compilerOptions?.baseUrl;
     if (config.depending.reactNative) {
       delete newSettings.compilerOptions?.verbatimModuleSyntax;
     }


### PR DESCRIPTION
## Summary
- remove legacy baseUrl from generated tsconfig files
- avoid tsgolint failures now that paths no longer require baseUrl

## Verification
- yarn check-for-ai