### PR TITLE
fix: drop tsconfig path aliases

### DIFF
--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -105,8 +105,9 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     newSettings.include?.sort();
     // Don't use old decorator
     delete newSettings.compilerOptions?.experimentalDecorators;
-    // TypeScript no longer requires baseUrl for paths, and tsgolint rejects it.
+    // Package imports should resolve through package exports instead of tsconfig aliases.
     delete newSettings.compilerOptions?.baseUrl;
+    delete newSettings.compilerOptions?.paths;
     if (config.depending.reactNative) {
       delete newSettings.compilerOptions?.verbatimModuleSyntax;
     }


### PR DESCRIPTION
Close #<IssueNumber>

## Self Check

- [ ] I've confirmed `All checks have passed` on this page.
  - PR title follows [Angular's commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
  - PR title doesn't have `WIP:`.
  - The test command (e.g., `yarn test`) passed.
  - The lint command (e.g., `yarn lint`) passed.
  - You may leave this box unchecked due to long workflows.
- [ ] I've reviewed my changes on the GitHub diff view.
- [ ] I've written the steps to test my changes.
- [ ] I've added screenshots (if the UI changed).
  - You may leave this box unchecked if you didn't modify the UI.

<!-- Please add screenshots if you modify the UI.
| Current                  | In coming                |
| ------------------------ | ------------------------ |
| <img src="" width="400"> | <img src="" width="400"> |
-->

<!-- Please add steps to test your changes.
## Steps to Test

1. Open http://localhost-exercode.willbooster.net:3000/ja-JP/courses/_example/lessons/_example_a_plus_b/problems/_example_a_plus_b after login.
2. Select the language `C`.
3. Write the following code:
   ```c
   #include <stdio.h>

   int main(void) {
     int a, b;

     scanf("%d %d", &a, &b);
     printf("%d", a + b);
     return 0;
   }
   ```
4. Push `Submit` button.
5. ...
-->
