### PR TITLE
fix: drop generated tsconfig path aliases

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -66,7 +66,7 @@ function generateAgentInstruction(
   - Fix the actual root cause instead of applying workarounds.
 - After making code changes, run \`${packageManager} check-all-for-ai\` to execute all tests (takes up to 1 hour), or \`${packageManager} check-for-ai\` for only type checking and linting (takes up to 10 minutes).
   - If you are confident that your changes will not break any tests, you may use \`check-for-ai\`.
-  - Use \`oxlint\` ignore comments with reasons (e.g., \`// oxlint-disable-next-line no-console --- <reason>\`) if lint errors or warnings cannot be fixed.
+  - Use \`oxlint\` ignore comments with reasons (e.g., \`// oxlint-disable-next-line <rule> -- <reason>\`) if lint errors or warnings cannot be fixed.
 - Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via \`gh\`.
   - Follow the conventional commits; your commit message should start with \`feat:\`, \`fix:\`, etc.
   - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -105,8 +105,9 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     newSettings.include?.sort();
     // Don't use old decorator
     delete newSettings.compilerOptions?.experimentalDecorators;
-    // TypeScript no longer requires baseUrl for paths, and tsgolint rejects it.
+    // Package imports should resolve through package exports instead of tsconfig aliases.
     delete newSettings.compilerOptions?.baseUrl;
+    delete newSettings.compilerOptions?.paths;
     if (config.depending.reactNative) {
       delete newSettings.compilerOptions?.verbatimModuleSyntax;
     }


### PR DESCRIPTION
## Summary

- Remove generated `compilerOptions.paths` alongside `baseUrl` from `wbfy` tsconfig output.
- Update the generated AGENTS oxlint ignore example to use the current `--` reason separator format.

## Why

- Package imports should resolve through package exports instead of tsconfig aliases.
- The generated oxlint guidance should match the expected ignore comment format.

## Testing

- `yarn check-for-ai`
- Pre-push hook ran `check.sh` successfully while pushing the branch.
