### PR TITLE
fix: drop legacy module resolution in wbfy

### DIFF
--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -108,7 +108,7 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     // Package imports should resolve through package exports instead of tsconfig aliases.
     delete newSettings.compilerOptions?.baseUrl;
     delete newSettings.compilerOptions?.paths;
-    deleteLegacyModuleResolution(newSettings.compilerOptions);
+    deleteLegacyModuleSettings(newSettings.compilerOptions, config);
     if (config.depending.reactNative) {
       delete newSettings.compilerOptions?.verbatimModuleSyntax;
     }
@@ -174,13 +174,22 @@ function ensureTsExtensionEmitCompatibility(compilerOptions: TsConfigJson.Compil
   compilerOptions.rewriteRelativeImportExtensions = true;
 }
 
-function deleteLegacyModuleResolution(compilerOptions: TsConfigJson.CompilerOptions | undefined): void {
+function deleteLegacyModuleSettings(
+  compilerOptions: TsConfigJson.CompilerOptions | undefined,
+  config: PackageConfig
+): void {
   if (!compilerOptions) return;
 
   // TypeScript 6 removed the old node10 resolver spelling, so inherited base configs
   // should choose the resolver unless a project already opted into a modern one.
-  if (compilerOptions.moduleResolution !== 'Node' && compilerOptions.moduleResolution !== 'node10') return;
-  delete compilerOptions.moduleResolution;
+  if (compilerOptions.moduleResolution === 'Node' || compilerOptions.moduleResolution === 'node10') {
+    delete compilerOptions.moduleResolution;
+  }
+  if (config.isBun || config.depending.reactNative || compilerOptions.module !== 'ESNext') return;
+
+  // Node base configs now pair their resolver with a matching module kind. Keeping
+  // older ESNext overrides creates invalid generated configs for TS 6.
+  delete compilerOptions.module;
 }
 
 function pickExistingEmitOptions(

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -108,6 +108,7 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     // Package imports should resolve through package exports instead of tsconfig aliases.
     delete newSettings.compilerOptions?.baseUrl;
     delete newSettings.compilerOptions?.paths;
+    deleteLegacyModuleResolution(newSettings.compilerOptions);
     if (config.depending.reactNative) {
       delete newSettings.compilerOptions?.verbatimModuleSyntax;
     }
@@ -171,6 +172,15 @@ function ensureTsExtensionEmitCompatibility(compilerOptions: TsConfigJson.Compil
   // @tsconfig/bun enables allowImportingTsExtensions, which TypeScript permits
   // during emit only when relative TS extensions are rewritten.
   compilerOptions.rewriteRelativeImportExtensions = true;
+}
+
+function deleteLegacyModuleResolution(compilerOptions: TsConfigJson.CompilerOptions | undefined): void {
+  if (!compilerOptions) return;
+
+  // TypeScript 6 removed the old node10 resolver spelling, so inherited base configs
+  // should choose the resolver unless a project already opted into a modern one.
+  if (compilerOptions.moduleResolution !== 'Node' && compilerOptions.moduleResolution !== 'node10') return;
+  delete compilerOptions.moduleResolution;
 }
 
 function pickExistingEmitOptions(

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -182,7 +182,11 @@ function deleteLegacyModuleSettings(
 
   // TypeScript 6 removed the old node10 resolver spelling, so inherited base configs
   // should choose the resolver unless a project already opted into a modern one.
-  if (compilerOptions.moduleResolution === 'Node' || compilerOptions.moduleResolution === 'node10') {
+  if (
+    compilerOptions.moduleResolution === 'node' ||
+    compilerOptions.moduleResolution === 'Node' ||
+    compilerOptions.moduleResolution === 'node10'
+  ) {
     delete compilerOptions.moduleResolution;
   }
   if (config.isBun || config.depending.reactNative || compilerOptions.module !== 'ESNext') return;


### PR DESCRIPTION
## Summary
- Drop legacy node/node10 moduleResolution values when wbfy migrates tsconfig.json
- Let modern base configs provide resolver defaults for TS 6-compatible generated configs

## Verification
- yarn check-for-ai