### PR TITLE
fix: update wbfy generated tooling config

### DIFF
--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -2,22 +2,19 @@
   "name": "@willbooster/wbfy",
   "version": "0.0.0-semantically-released",
   "description": "A tool for applying WillBooster's conventional configures to npm packages",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/wbfy"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
   "bin": "./bin/wbfy.js",
   "files": [
     "bin/",
     "dist/"
   ],
-  "type": "module",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "build-ts app",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -36,6 +33,7 @@
     "verify-code": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify-code",
     "verify-code-with-tests": "yarn verify-code && yarn test"
   },
+  "prettier": "@willbooster/prettier-config",
   "dependencies": {
     "@octokit/core": "7.0.6",
     "deepmerge": "4.3.1",
@@ -77,8 +75,10 @@
     "type-fest": "5.5.0",
     "vitest": "4.1.4"
   },
-  "prettier": "@willbooster/prettier-config",
   "engines": {
     "node": ">=24"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -22,6 +22,10 @@ import { getTsconfigBaseDependencies } from '../utils/tsconfigBase.js';
 
 const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', 'oxfmt', 'oxlint', 'oxlint-tsgolint'];
 const typescriptGoDependency = '@typescript/native-preview';
+const pinnedDependencyVersions: Record<string, string> = {
+  // oxfmt 0.45.0 raises DataCloneError when formatting JSON files.
+  oxfmt: '0.44.0',
+};
 const obsoleteLintDependencies = [
   '@biomejs/biome',
   '@eslint-react/eslint-plugin',
@@ -447,7 +451,7 @@ function installNpmDependencies(
 ): void {
   if (dependencies.length === 0) return;
 
-  const dependencySpecifiers = [...new Set(dependencies)];
+  const dependencySpecifiers = [...new Set(dependencies)].map(toInstallDependencySpecifier);
   if (config.isBun) {
     spawnSync(packageManager, ['add', ...(dev ? ['-D'] : []), '--exact', ...dependencySpecifiers], config.dirPath);
   } else {
@@ -480,7 +484,15 @@ function addPackageJsonDependencies(
   return dependenciesToInstall;
 }
 
+function toInstallDependencySpecifier(dependency: string): string {
+  const pinnedVersion = pinnedDependencyVersions[dependency];
+  return pinnedVersion ? `${dependency}@${pinnedVersion}` : dependency;
+}
+
 function getLatestDependencyVersion(dependency: string): string {
+  const pinnedVersion = pinnedDependencyVersions[dependency];
+  if (pinnedVersion) return pinnedVersion;
+
   const cachedVersion = latestDependencyVersionCache.get(dependency);
   if (cachedVersion) return cachedVersion;
 
@@ -535,7 +547,10 @@ function shouldUpdateExistingManagedDependency(dependency: string, currentVersio
   if (!currentVersion) return true;
   if (currentVersion === '*') return true;
   return (
-    dependency === '@willbooster/oxlint-config' || dependency === 'oxlint' || dependency === typescriptGoDependency
+    dependency === '@willbooster/oxlint-config' ||
+    dependency === 'oxfmt' ||
+    dependency === 'oxlint' ||
+    dependency === typescriptGoDependency
   );
 }
 

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -24,6 +24,8 @@ const rootJsonObj = {
   },
   exclude: ['packages/*/test/fixtures', 'test/fixtures'],
   include: [
+    '*.config.ts',
+    'packages/*/*.config.ts',
     'packages/*/scripts/**/*',
     'packages/*/src/**/*',
     'packages/*/test/**/*',
@@ -44,7 +46,9 @@ const subJsonObj = {
     noEmit: true,
   },
   exclude: ['test/fixtures'],
-  include: ['scripts/**/*', 'src/**/*', 'test/**/*'],
+  // wbfy generates root-level tool configs such as playwright.config.ts, and
+  // type-aware linting needs those files in the project to see Node/Bun globals.
+  include: ['*.config.ts', 'scripts/**/*', 'src/**/*', 'test/**/*'],
 };
 
 export async function generateTsconfig(config: PackageConfig): Promise<void> {

--- a/packages/wbfy/test/tsconfigGenerator.test.ts
+++ b/packages/wbfy/test/tsconfigGenerator.test.ts
@@ -39,6 +39,7 @@ test('generates explicit TS 6 types and rootDir for a root package', async () =>
   expect(tsconfig.compilerOptions.noEmit).toBe(true);
   expect(tsconfig.compilerOptions.rootDir).toBe('.');
   expect(tsconfig.compilerOptions.types).toEqual(['node', 'vitest/globals']);
+  expect(tsconfig.include).toContain('*.config.ts');
 });
 
 test('sets rootDir for monorepos without root sources', async () => {
@@ -171,6 +172,7 @@ async function readTsconfig(dirPath: string): Promise<{
     sourceMap?: boolean;
     types?: string[];
   };
+  include?: string[];
 }> {
   return JSON.parse(await fs.promises.readFile(path.join(dirPath, 'tsconfig.json'), 'utf8')) as {
     compilerOptions: {
@@ -181,6 +183,7 @@ async function readTsconfig(dirPath: string): Promise<{
       sourceMap?: boolean;
       types?: string[];
     };
+    include?: string[];
   };
 }
 


### PR DESCRIPTION
## Summary
- pin/update wbfy tooling output on this branch
- include root-level TypeScript config files in generated tsconfig include lists
- cover generated config-file inclusion in tsconfig generator tests

## Verification
- yarn check-for-ai
- yarn vitest test/tsconfigGenerator.test.ts