### PR TITLE
fix: include config files in generated tsconfig

### DIFF
--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -24,6 +24,8 @@ const rootJsonObj = {
   },
   exclude: ['packages/*/test/fixtures', 'test/fixtures'],
   include: [
+    '*.config.ts',
+    'packages/*/*.config.ts',
     'packages/*/scripts/**/*',
     'packages/*/src/**/*',
     'packages/*/test/**/*',
@@ -44,7 +46,9 @@ const subJsonObj = {
     noEmit: true,
   },
   exclude: ['test/fixtures'],
-  include: ['scripts/**/*', 'src/**/*', 'test/**/*'],
+  // wbfy generates root-level tool configs such as playwright.config.ts, and
+  // type-aware linting needs those files in the project to see Node/Bun globals.
+  include: ['*.config.ts', 'scripts/**/*', 'src/**/*', 'test/**/*'],
 };
 
 export async function generateTsconfig(config: PackageConfig): Promise<void> {

--- a/packages/wbfy/test/tsconfigGenerator.test.ts
+++ b/packages/wbfy/test/tsconfigGenerator.test.ts
@@ -39,6 +39,7 @@ test('generates explicit TS 6 types and rootDir for a root package', async () =>
   expect(tsconfig.compilerOptions.noEmit).toBe(true);
   expect(tsconfig.compilerOptions.rootDir).toBe('.');
   expect(tsconfig.compilerOptions.types).toEqual(['node', 'vitest/globals']);
+  expect(tsconfig.include).toContain('*.config.ts');
 });
 
 test('sets rootDir for monorepos without root sources', async () => {
@@ -171,6 +172,7 @@ async function readTsconfig(dirPath: string): Promise<{
     sourceMap?: boolean;
     types?: string[];
   };
+  include?: string[];
 }> {
   return JSON.parse(await fs.promises.readFile(path.join(dirPath, 'tsconfig.json'), 'utf8')) as {
     compilerOptions: {
@@ -181,6 +183,7 @@ async function readTsconfig(dirPath: string): Promise<{
       sourceMap?: boolean;
       types?: string[];
     };
+    include?: string[];
   };
 }
 


### PR DESCRIPTION
## Summary

- Include root-level `*.config.ts` files in generated tsconfig include lists.
- Include package-level `packages/*/*.config.ts` for monorepo roots.
- Add generator test coverage for the root config include.

## Why

- wbfy generates root-level tool config files such as `playwright.config.ts`.
- Type-aware linting needs those files in the TypeScript project so Node/Bun globals like `process` resolve correctly.

## Testing

- yarn check-for-ai
- yarn vitest test/tsconfigGenerator.test.ts
- pre-commit cleanup hook
- pre-push check.sh hook
