### PR TITLE
fix: skip unstable oxfmt text formats

### DIFF
--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -18,5 +18,18 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
 
 const configContent = `import config from '@willbooster/oxfmt-config';
 
-export default config;
+export default {
+  ...config,
+  ignorePatterns: [
+    ...config.ignorePatterns,
+    // oxfmt 0.45 can crash with DataCloneError on text/data parsers. Keep
+    // those formats on Prettier until oxfmt handles them reliably.
+    '**/*.html',
+    '**/*.json',
+    '**/*.jsonc',
+    '**/*.md',
+    '**/*.yaml',
+    '**/*.yml',
+  ],
+};
 `;

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -109,7 +109,10 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     newSettings.include?.sort();
     // Don't use old decorator
     delete newSettings.compilerOptions?.experimentalDecorators;
-    // Package imports should resolve through package exports instead of tsconfig aliases.
+    // Strictly ban `baseUrl` and `paths` in wbfy-generated configs. TypeScript 6
+    // tooling rejects `baseUrl`, and path aliases can hide broken package exports.
+    // Do not change wbfy to preserve or reintroduce these options; migrate imports
+    // in target repositories to relative or package-exported specifiers instead.
     delete newSettings.compilerOptions?.baseUrl;
     delete newSettings.compilerOptions?.paths;
     deleteLegacyModuleSettings(newSettings.compilerOptions, config);


### PR DESCRIPTION
## Summary

- Generate `oxfmt.config.ts` with extra ignore patterns for Markdown, JSON, YAML, and HTML files.
- Keep those formats on the existing Prettier path while `oxfmt` 0.45 crashes on them with `DataCloneError`.

## Why

- Applying `wbfy` to `gen-em` caused `bun check-for-ai` to fail during formatter cleanup.
- The formatter succeeds on TypeScript files but fails on text/data formats, so skipping those extensions keeps the generated config usable without disabling `oxfmt` for code.

## Testing

- `yarn check-for-ai` in `packages/wbfy`
- Pre-push hook checks for the shared workspace
