### PR TITLE
feat: support uv in wbfy

### DIFF
--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -69,7 +69,7 @@ packaged.yaml
 `;
     }
     // Because .venv should be ignored on root directory
-    if (config.doesContainPoetryLock) {
+    if (config.doesContainPoetryLock || config.doesContainUvLock) {
       names.push('python');
       headUserContent += `.venv/
 `;

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -187,7 +187,7 @@ function getCleanupGlobs(config: PackageConfig): string {
   if (doesContainJsOrTs(config)) {
     supportedExtensions.push(...extensions.oxfmt, ...extensions.oxlint);
   }
-  if (config.doesContainPoetryLock) {
+  if (config.doesContainPoetryLock || config.doesContainUvLock) {
     supportedExtensions.push('py');
   }
   if (config.doesContainPubspecYaml) {
@@ -219,7 +219,7 @@ ${hasJsOrTs ? String.raw`oxlint_files="$(printf '%s\n' {staged_files} | grep -E 
 ${hasJsOrTs ? String.raw`oxfmt_files="$(printf '%s\n' {staged_files} | grep -E '(${oxfmtPattern})' || true)"` : ''}
 prettier_files="$(printf '%s\n' {staged_files} | grep -E '(${prettierPattern})' || true)"
 package_json_files="$(printf '%s\n' {staged_files} | grep -E '(^|/)package\.json$' || true)"
-${config.doesContainPoetryLock ? String.raw`python_files="$(printf '%s\n' {staged_files} | grep -E '\.py$' || true)"` : ''}
+${hasPythonPackageManager(config) ? String.raw`python_files="$(printf '%s\n' {staged_files} | grep -E '\.py$' || true)"` : ''}
 ${config.doesContainPubspecYaml ? String.raw`dart_files="$(printf '%s\n' {staged_files} | grep -E '\.dart$' | grep -v 'generated' | grep -v '\.freezed\.dart$' | grep -v '\.g\.dart$' || true)"` : ''}
 
 ${
@@ -247,11 +247,11 @@ if [ -n "$package_json_files" ]; then
   node node_modules/.bin/sort-package-json -- $package_json_files
 fi
 ${
-  config.doesContainPoetryLock
+  hasPythonPackageManager(config)
     ? `if [ -n "$python_files" ]; then
-  poetry run isort --profile black --filter-files $python_files
-  poetry run black $python_files
-  poetry run flake8 $python_files
+  ${getPythonRunner(config)} isort --profile black --filter-files $python_files
+  ${getPythonRunner(config)} black $python_files
+  ${getPythonRunner(config)} flake8 $python_files
 fi`
     : ''
 }
@@ -292,6 +292,9 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
   if (config.doesContainPoetryLock) {
     postMergeCommands.push(String.raw`run_if_changed "poetry\.lock" "poetry install"`);
   }
+  if (config.doesContainUvLock) {
+    postMergeCommands.push(String.raw`run_if_changed "uv\.lock" "uv sync --frozen"`);
+  }
   if (config.depending.blitz) {
     postMergeCommands.push(
       String.raw`run_if_changed ".*\.prisma" "node node_modules/.bin/blitz prisma migrate deploy"`,
@@ -305,4 +308,12 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
     );
   }
   return postMergeCommands;
+}
+
+function hasPythonPackageManager(config: PackageConfig): boolean {
+  return config.doesContainPoetryLock || config.doesContainUvLock;
+}
+
+function getPythonRunner(config: PackageConfig): 'poetry run' | 'uv run' {
+  return config.doesContainUvLock ? 'uv run' : 'poetry run';
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -71,7 +71,7 @@ type WritablePackageJson = SetRequired<
 interface DependencyUpdates {
   dependencies: string[];
   devDependencies: string[];
-  poetryDevDependencies: string[];
+  pythonDevDependencies: string[];
 }
 
 export async function generatePackageJson(
@@ -171,7 +171,7 @@ function applyPackageJsonConventions(
 ): DependencyUpdates {
   const dependencies: string[] = [];
   const devDependencies = ['prettier', 'sort-package-json'];
-  const poetryDevDependencies: string[] = [];
+  const pythonDevDependencies: string[] = [];
 
   if (
     !fs.existsSync(path.join(rootConfig.dirPath, '.prettierrc.json')) &&
@@ -281,11 +281,11 @@ function applyPackageJsonConventions(
     return {
       dependencies: dependencies.filter((dep) => !dep.includes('@willbooster/')),
       devDependencies: devDependencies.filter((dep) => !dep.includes('@willbooster/')),
-      poetryDevDependencies,
+      pythonDevDependencies,
     };
   }
 
-  return { dependencies, devDependencies, poetryDevDependencies };
+  return { dependencies, devDependencies, pythonDevDependencies };
 }
 
 async function normalizePackageMetadata(
@@ -347,10 +347,15 @@ async function normalizePackageMetadata(
       }
     }
 
-    if (config.doesContainPoetryLock) {
+    const pythonPackageManager = getPythonPackageManager(config);
+    if (pythonPackageManager) {
       if (jsonObj.scripts.postinstall === 'poetry install') {
         delete jsonObj.scripts.postinstall;
       }
+      jsonObj.scripts['common/ci-setup'] = `yarn setup-${pythonPackageManager}`;
+      delete jsonObj.scripts[`setup-${pythonPackageManager === 'poetry' ? 'uv' : 'poetry'}`];
+      delete jsonObj.scripts['setup-poetry-asdf'];
+      jsonObj.scripts[`setup-${pythonPackageManager}`] = getPythonSetupCommand(pythonPackageManager);
       const pythonFiles = await fg.glob('**/*.py', {
         cwd: config.dirPath,
         dot: true,
@@ -365,16 +370,17 @@ async function normalizePackageMetadata(
       }
       if (dirNameSet.size > 0) {
         const dirNamesStr = [...dirNameSet].join(' ');
+        const pythonRunner = `${pythonPackageManager} run`;
         jsonObj.scripts['format-code'] =
-          `poetry run isort --profile black ${dirNamesStr} && poetry run black ${dirNamesStr}`;
+          `${pythonRunner} isort --profile black ${dirNamesStr} && ${pythonRunner} black ${dirNamesStr}`;
         if (jsonObj.scripts.lint) {
-          jsonObj.scripts.lint = `poetry run flake8 ${dirNamesStr} && ${jsonObj.scripts.lint}`;
+          jsonObj.scripts.lint = `${pythonRunner} flake8 ${dirNamesStr} && ${jsonObj.scripts.lint}`;
         } else {
-          jsonObj.scripts.lint = `poetry run flake8 ${dirNamesStr}`;
+          jsonObj.scripts.lint = `${pythonRunner} flake8 ${dirNamesStr}`;
           jsonObj.scripts['lint-fix'] = 'yarn lint';
         }
         jsonObj.scripts.format = (jsonObj.scripts.format ?? '') + ` && yarn format-code`;
-        dependencyUpdates.poetryDevDependencies.push('black', 'isort', 'flake8');
+        dependencyUpdates.pythonDevDependencies.push('black', 'isort', 'flake8');
       }
     }
   }
@@ -434,9 +440,25 @@ function installDependencyUpdates(
   const devDependencies = dependencyUpdates.devDependencies.filter((dep) => !jsonObj.dependencies?.[dep]);
   installNpmDependencies(config, packageManager, devDependencies, true);
 
-  if (dependencyUpdates.poetryDevDependencies.length > 0) {
-    spawnSync('poetry', ['add', '--group', 'dev', ...new Set(dependencyUpdates.poetryDevDependencies)], config.dirPath);
+  const pythonPackageManager = getPythonPackageManager(config);
+  if (pythonPackageManager && dependencyUpdates.pythonDevDependencies.length > 0) {
+    const dependencies = [...new Set(dependencyUpdates.pythonDevDependencies)];
+    if (pythonPackageManager === 'poetry') {
+      spawnSync('poetry', ['add', '--group', 'dev', ...dependencies], config.dirPath);
+    } else {
+      spawnSync('uv', ['add', '--dev', ...dependencies], config.dirPath);
+    }
   }
+}
+
+function getPythonPackageManager(config: PackageConfig): 'poetry' | 'uv' | undefined {
+  if (config.doesContainUvLock) return 'uv';
+  if (config.doesContainPoetryLock) return 'poetry';
+}
+
+function getPythonSetupCommand(packageManager: 'poetry' | 'uv'): string {
+  if (packageManager === 'uv') return 'uv sync --frozen';
+  return 'poetry config virtualenvs.in-project true && poetry env use $(mise current python) && poetry run pip install --upgrade pip && poetry install';
 }
 
 function installNpmDependencies(

--- a/packages/wbfy/src/generators/vscodeSettings.ts
+++ b/packages/wbfy/src/generators/vscodeSettings.ts
@@ -27,7 +27,7 @@ export async function generateVscodeSettings(config: PackageConfig): Promise<voi
       for (const excludeFilePattern of excludeFilePatterns) {
         settings = merge.all([settings, excludeSetting(excludeFilePattern)]);
       }
-      if (config.doesContainPoetryLock) {
+      if (config.doesContainPoetryLock || config.doesContainUvLock) {
         settings = merge.all([settings, excludeSetting('**/.venv/**')]);
       }
       if (config.depending.next) {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -30,6 +30,7 @@ export interface PackageConfig {
   doesContainGoMod: boolean;
   doesContainPackageJson: boolean;
   doesContainPoetryLock: boolean;
+  doesContainUvLock: boolean;
   doesContainPomXml: boolean;
   doesContainPubspecYaml: boolean;
   doesContainTemplateYaml: boolean;
@@ -183,6 +184,7 @@ export async function getPackageConfig(
       doesContainGoMod: fs.existsSync(path.resolve(dirPath, 'go.mod')),
       doesContainPackageJson: fs.existsSync(path.resolve(dirPath, 'package.json')),
       doesContainPoetryLock: fs.existsSync(path.resolve(dirPath, 'poetry.lock')),
+      doesContainUvLock: fs.existsSync(path.resolve(dirPath, 'uv.lock')),
       doesContainPomXml: fs.existsSync(path.resolve(dirPath, 'pom.xml')),
       doesContainPubspecYaml: fs.existsSync(path.resolve(dirPath, 'pubspec.yaml')),
       doesContainTemplateYaml: fs.existsSync(path.resolve(dirPath, 'template.yaml')),
@@ -228,6 +230,7 @@ export async function getPackageConfig(
       config.doesContainGoMod ||
       config.doesContainPackageJson ||
       config.doesContainPoetryLock ||
+      config.doesContainUvLock ||
       config.doesContainPomXml ||
       config.doesContainPubspecYaml ||
       config.doesContainTemplateYaml

--- a/packages/wbfy/test/lefthookGenerator.test.ts
+++ b/packages/wbfy/test/lefthookGenerator.test.ts
@@ -22,6 +22,7 @@ test('includes python files in cleanup glob when poetry is used', async () => {
       dirPath,
       doesContainPackageJson: true,
       doesContainPoetryLock: true,
+      doesContainUvLock: false,
       doesContainTypeScript: true,
     })
   );
@@ -30,7 +31,32 @@ test('includes python files in cleanup glob when poetry is used', async () => {
   expect(lefthookConfig).toContain("glob: '**/*.{");
   expect(lefthookConfig).toContain('py');
   expect(lefthookConfig).toContain('python_files=');
+  expect(lefthookConfig).toContain('poetry run isort');
   expect(lefthookConfig).not.toContain('lint-staged');
+});
+
+test('uses uv for python cleanup and install hooks when uv is used', async () => {
+  const dirPath = createTempDir();
+
+  await generateLefthookUpdatingPackageJson(
+    createConfig({
+      dirPath,
+      doesContainPackageJson: true,
+      doesContainTypeScript: true,
+      doesContainUvLock: true,
+    })
+  );
+
+  const lefthookConfig = await fs.promises.readFile(path.join(dirPath, 'lefthook.yml'), 'utf8');
+  const postMergeScript = await fs.promises.readFile(
+    path.join(dirPath, '.lefthook', 'post-merge', 'prepare.sh'),
+    'utf8'
+  );
+  expect(lefthookConfig).toContain('py');
+  expect(lefthookConfig).toContain('python_files=');
+  expect(lefthookConfig).toContain('uv run isort');
+  expect(lefthookConfig).not.toContain('poetry run');
+  expect(postMergeScript).toContain(String.raw`run_if_changed "uv\.lock" "uv sync --frozen"`);
 });
 
 test('includes dart files in cleanup glob when pubspec is present', async () => {
@@ -119,6 +145,7 @@ function createConfig(overrides: Partial<PackageConfig> = {}): PackageConfig {
     doesContainGoMod: false,
     doesContainPackageJson: false,
     doesContainPoetryLock: false,
+    doesContainUvLock: false,
     doesContainPomXml: false,
     doesContainPubspecYaml: false,
     doesContainTemplateYaml: false,

--- a/packages/wbfy/test/tsconfigGenerator.test.ts
+++ b/packages/wbfy/test/tsconfigGenerator.test.ts
@@ -205,6 +205,7 @@ function createConfig(overrides: Partial<PackageConfig> = {}): PackageConfig {
     doesContainGoMod: false,
     doesContainPackageJson: false,
     doesContainPoetryLock: false,
+    doesContainUvLock: false,
     doesContainPomXml: false,
     doesContainPubspecYaml: false,
     doesContainTemplateYaml: false,

--- a/packages/wbfy/test/willboosterConfigsUtil.test.ts
+++ b/packages/wbfy/test/willboosterConfigsUtil.test.ts
@@ -50,6 +50,7 @@ function createConfig(overrides: Partial<PackageConfig> = {}): PackageConfig {
     doesContainGoMod: false,
     doesContainPackageJson: true,
     doesContainPoetryLock: false,
+    doesContainUvLock: false,
     doesContainPomXml: false,
     doesContainPubspecYaml: false,
     doesContainTemplateYaml: false,

--- a/packages/wbfy/test/workflowGenerator.test.ts
+++ b/packages/wbfy/test/workflowGenerator.test.ts
@@ -49,6 +49,7 @@ test('skips generating workflows for reusable-workflows repository', async () =>
     doesContainGoMod: false,
     doesContainPackageJson: false,
     doesContainPoetryLock: false,
+    doesContainUvLock: false,
     doesContainPomXml: false,
     doesContainPubspecYaml: false,
     doesContainTemplateYaml: false,


### PR DESCRIPTION
## Summary

- Detect `uv.lock` in `wbfy` package configuration.
- Generate Python ignore/watch settings for both Poetry and uv projects.
- Generate `uv run` cleanup/lint commands and `uv sync --frozen` post-merge setup when uv is used.
- Use `uv add --dev` for generated Python dev tooling dependencies in uv projects.
- Add lefthook coverage for uv-backed Python cleanup hooks.

## Why

- `gen-em-web` is migrating from Poetry to uv, and the shared generator should preserve that setup instead of reintroducing Poetry commands.
- Keeping this logic in `wbfy` avoids manual target-repo patches for future managed repositories.

## Testing

- `yarn workspace @willbooster/wbfy format`
- `yarn workspace @willbooster/wbfy typecheck`
- `yarn workspace @willbooster/wbfy test lefthookGenerator`
- `yarn workspace @willbooster/wbfy check-for-ai`
- `yarn check-for-ai`
- Reran `yarn start /Users/exkazuu/ghq/github.com/WillBooster/gen-em-web` from `packages/wbfy` and confirmed it generated uv commands.