### PR TITLE
fix: preserve package-owned lint dependencies in wbfy

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -21,9 +21,10 @@ alwaysApply: true
 - When fixing issues, follow these rules:
   - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
   - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn check-all-for-ai` to execute all tests (takes up to 1 hour) or `yarn check-for-ai` for type checking and linting only (takes up to 10 minutes).
-  - If you are confident your changes will not break any tests, you may use `check-for-ai`.
-- Once you have verified your changes, commit and push them to the current (non-main) branch then create a PR via `gh`.
+- After making code changes, run `yarn check-all-for-ai` to execute all tests (takes up to 1 hour), or `yarn check-for-ai` for only type checking and linting (takes up to 10 minutes).
+  - If you are confident that your changes will not break any tests, you may use `check-for-ai`.
+  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed.
+- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Cursor) <agent@willbooster.com>`.
   - Always create new commits. Avoid using `--amend`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,10 @@
 - When fixing issues, follow these rules:
   - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
   - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn check-all-for-ai` to execute all tests (takes up to 1 hour) or `yarn check-for-ai` for type checking and linting only (takes up to 10 minutes).
-  - If you are confident your changes will not break any tests, you may use `check-for-ai`.
-- Once you have verified your changes, commit and push them to the current (non-main) branch then create a PR via `gh`.
+- After making code changes, run `yarn check-all-for-ai` to execute all tests (takes up to 1 hour), or `yarn check-for-ai` for only type checking and linting (takes up to 10 minutes).
+  - If you are confident that your changes will not break any tests, you may use `check-for-ai`.
+  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed.
+- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Codex CLI) <agent@willbooster.com>`.
   - Always create new commits. Avoid using `--amend`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,10 @@
 - When fixing issues, follow these rules:
   - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
   - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn check-all-for-ai` to execute all tests (takes up to 1 hour) or `yarn check-for-ai` for type checking and linting only (takes up to 10 minutes).
-  - If you are confident your changes will not break any tests, you may use `check-for-ai`.
-- Once you have verified your changes, commit and push them to the current (non-main) branch then create a PR via `gh`.
+- After making code changes, run `yarn check-all-for-ai` to execute all tests (takes up to 1 hour), or `yarn check-for-ai` for only type checking and linting (takes up to 10 minutes).
+  - If you are confident that your changes will not break any tests, you may use `check-for-ai`.
+  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed.
+- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>`.
   - Always create new commits. Avoid using `--amend`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,9 +15,10 @@
 - When fixing issues, follow these rules:
   - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
   - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn check-all-for-ai` to execute all tests (takes up to 1 hour) or `yarn check-for-ai` for type checking and linting only (takes up to 10 minutes).
-  - If you are confident your changes will not break any tests, you may use `check-for-ai`.
-- Once you have verified your changes, commit and push them to the current (non-main) branch then create a PR via `gh`.
+- After making code changes, run `yarn check-all-for-ai` to execute all tests (takes up to 1 hour), or `yarn check-for-ai` for only type checking and linting (takes up to 10 minutes).
+  - If you are confident that your changes will not break any tests, you may use `check-for-ai`.
+  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed.
+- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Gemini CLI) <agent@willbooster.com>`.
   - Always create new commits. Avoid using `--amend`.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260415.1",
     "@willbooster/oxfmt-config": "1.2.0",
-    "@willbooster/oxlint-config": "1.4.0",
+    "@willbooster/oxlint-config": "1.4.2",
     "@willbooster/prettier-config": "10.4.0",
     "conventional-changelog-conventionalcommits": "9.3.1",
     "lefthook": "2.1.5",

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -54,7 +54,7 @@
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260415.1",
     "@willbooster/oxfmt-config": "1.2.0",
-    "@willbooster/oxlint-config": "1.4.0",
+    "@willbooster/oxlint-config": "1.4.2",
     "@willbooster/prettier-config": "10.4.0",
     "blitz": "3.0.2",
     "build-ts": "17.1.0",

--- a/packages/shared-lib-blitz-next/tsconfig.json
+++ b/packages/shared-lib-blitz-next/tsconfig.json
@@ -8,7 +8,7 @@
     "importHelpers": false,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "noEmit": false,
+    "noEmit": true,
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "resolveJsonModule": true,
@@ -21,5 +21,5 @@
   },
   "exclude": ["test/fixtures", "test/fixtures/**/*"],
   "extends": ["@tsconfig/node-lts/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"],
-  "include": ["scripts/**/*", "src/**/*", "test/**/*"]
+  "include": ["*.config.ts", "scripts/**/*", "src/**/*", "test/**/*"]
 }

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -54,7 +54,7 @@
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260415.1",
     "@willbooster/oxfmt-config": "1.2.0",
-    "@willbooster/oxlint-config": "1.4.0",
+    "@willbooster/oxlint-config": "1.4.2",
     "@willbooster/prettier-config": "10.4.0",
     "build-ts": "17.1.0",
     "next": "16.2.3",

--- a/packages/shared-lib-next/tsconfig.json
+++ b/packages/shared-lib-next/tsconfig.json
@@ -8,7 +8,7 @@
     "importHelpers": false,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "noEmit": false,
+    "noEmit": true,
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "resolveJsonModule": true,
@@ -21,5 +21,5 @@
   },
   "exclude": ["test/fixtures", "test/fixtures/**/*"],
   "extends": ["@tsconfig/node-lts/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"],
-  "include": ["scripts/**/*", "src/**/*", "test/**/*"]
+  "include": ["*.config.ts", "scripts/**/*", "src/**/*", "test/**/*"]
 }

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -59,7 +59,7 @@
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260415.1",
     "@willbooster/oxfmt-config": "1.2.0",
-    "@willbooster/oxlint-config": "1.4.0",
+    "@willbooster/oxlint-config": "1.4.2",
     "@willbooster/prettier-config": "10.4.0",
     "build-ts": "17.1.0",
     "oxfmt": "0.45.0",

--- a/packages/shared-lib-node/tsconfig.json
+++ b/packages/shared-lib-node/tsconfig.json
@@ -21,5 +21,5 @@
   },
   "exclude": ["test/fixtures", "test/fixtures/**/*"],
   "extends": ["@tsconfig/node-lts/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"],
-  "include": ["scripts/**/*", "src/**/*", "test/**/*"]
+  "include": ["*.config.ts", "scripts/**/*", "src/**/*", "test/**/*"]
 }

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -63,7 +63,7 @@
     "@types/react-dom": "19.2.3",
     "@typescript/native-preview": "7.0.0-dev.20260415.1",
     "@willbooster/oxfmt-config": "1.2.0",
-    "@willbooster/oxlint-config": "1.4.0",
+    "@willbooster/oxlint-config": "1.4.2",
     "@willbooster/prettier-config": "10.4.0",
     "babel-loader": "10.1.1",
     "build-ts": "17.1.0",

--- a/packages/shared-lib-react/tsconfig.json
+++ b/packages/shared-lib-react/tsconfig.json
@@ -10,7 +10,7 @@
     "lib": ["DOM", "ES2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator", "ESNext.Promise"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "noEmit": false,
+    "noEmit": true,
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "resolveJsonModule": true,
@@ -23,5 +23,5 @@
   },
   "exclude": ["test/fixtures", "test/fixtures/**/*"],
   "extends": ["@tsconfig/node-lts/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"],
-  "include": ["scripts/**/*", "src/**/*", "test/**/*"]
+  "include": ["*.config.ts", "scripts/**/*", "src/**/*", "test/**/*"]
 }

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -54,7 +54,7 @@
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260415.1",
     "@willbooster/oxfmt-config": "1.2.0",
-    "@willbooster/oxlint-config": "1.4.0",
+    "@willbooster/oxlint-config": "1.4.2",
     "@willbooster/prettier-config": "10.4.0",
     "build-ts": "17.1.0",
     "oxfmt": "0.45.0",

--- a/packages/shared-lib/tsconfig.json
+++ b/packages/shared-lib/tsconfig.json
@@ -21,5 +21,5 @@
   },
   "exclude": ["test/fixtures", "test/fixtures/**/*"],
   "extends": ["@tsconfig/node-lts/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"],
-  "include": ["scripts/**/*", "src/**/*", "test/**/*"]
+  "include": ["*.config.ts", "scripts/**/*", "src/**/*", "test/**/*"]
 }

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -56,7 +56,7 @@
     "@types/yargs": "17.0.35",
     "@typescript/native-preview": "7.0.0-dev.20260415.1",
     "@willbooster/oxfmt-config": "1.2.0",
-    "@willbooster/oxlint-config": "1.4.0",
+    "@willbooster/oxlint-config": "1.4.2",
     "@willbooster/prettier-config": "10.4.0",
     "at-decorators": "7.0.2",
     "build-ts": "17.1.0",

--- a/packages/wb/tsconfig.json
+++ b/packages/wb/tsconfig.json
@@ -8,7 +8,7 @@
     "importHelpers": false,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "noEmit": false,
+    "noEmit": true,
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "resolveJsonModule": true,
@@ -21,5 +21,5 @@
   },
   "exclude": ["test/fixtures", "test/fixtures/**/*"],
   "extends": ["@tsconfig/node-lts/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"],
-  "include": ["scripts/**/*", "src/**/*", "test/**/*", "vitest.config.ts"]
+  "include": ["*.config.ts", "scripts/**/*", "src/**/*", "test/**/*", "vitest.config.ts"]
 }

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -63,7 +63,7 @@
     "@types/yargs": "17.0.35",
     "@typescript/native-preview": "7.0.0-dev.20260415.1",
     "@willbooster/oxfmt-config": "1.2.0",
-    "@willbooster/oxlint-config": "1.4.0",
+    "@willbooster/oxlint-config": "1.4.2",
     "@willbooster/prettier-config": "10.4.0",
     "@yarnpkg/core": "4.6.0",
     "build-ts": "17.1.0",

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -8,6 +8,9 @@ import { promisePool } from '../utils/promisePool.js';
 
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
+    if (isPublishedEslintConfigPackage(config)) {
+      return;
+    }
     const filePath = path.resolve(config.dirPath, 'oxlint.config.ts');
     const existingContent = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
 
@@ -31,6 +34,16 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
     }
     await Promise.all(promises);
   });
+}
+
+function isPublishedEslintConfigPackage(config: PackageConfig): boolean {
+  const packageJson = config.packageJson;
+  return (
+    typeof packageJson?.name === 'string' &&
+    packageJson.name.includes('eslint-config') &&
+    typeof packageJson.main === 'string' &&
+    /(?:^|\/)eslint\.config\.[cm]?js$/u.test(packageJson.main)
+  );
 }
 
 const configContent = `import config from '@willbooster/oxlint-config';

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -8,9 +8,7 @@ import { promisePool } from '../utils/promisePool.js';
 
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
-    if (isPublishedEslintConfigPackage(config)) {
-      return;
-    }
+    const shouldPreservePublishedEslintConfig = isWillboosterConfigsSubpackage(config);
     const filePath = path.resolve(config.dirPath, 'oxlint.config.ts');
     const existingContent = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
 
@@ -24,11 +22,15 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
       promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.json'), { force: true })),
       promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.yaml'), { force: true })),
       promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.yml'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.cjs'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.js'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.mjs'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.ts'), { force: true })),
     ];
+    if (!shouldPreservePublishedEslintConfig) {
+      promises.push(
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.cjs'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.js'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.mjs'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.ts'), { force: true }))
+      );
+    }
     if (!existingContent) {
       promises.push(promisePool.run(() => fsUtil.generateFile(filePath, configContent)));
     }
@@ -36,14 +38,12 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
   });
 }
 
-function isPublishedEslintConfigPackage(config: PackageConfig): boolean {
-  const packageJson = config.packageJson;
-  return (
-    typeof packageJson?.name === 'string' &&
-    packageJson.name.includes('eslint-config') &&
-    typeof packageJson.main === 'string' &&
-    /(?:^|\/)eslint\.config\.[cm]?js$/u.test(packageJson.main)
-  );
+function isWillboosterConfigsSubpackage(config: PackageConfig): boolean {
+  // willbooster-configs packages publish configuration files as product code.
+  // Replacing their package-local ESLint configs with oxlint configs makes the
+  // published package entry points disappear, so only this repository's
+  // subpackages opt out. Other repositories keep the normal migration.
+  return config.isWillBoosterConfigs && !config.isRoot;
 }
 
 const configContent = `import config from '@willbooster/oxlint-config';

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -249,9 +249,9 @@ function applyPackageJsonConventions(
     }
   }
 
-  // build-ts owns declaration emit for libraries. Keeping older releases can
-  // make generated .d.ts files land under dist/src while package exports point
-  // at dist, so wbfy must update existing build-ts users.
+  // build-ts owns TypeScript execution and declaration emit. wbfy must always
+  // keep existing build-ts users current because older releases can emit .d.ts
+  // files at paths that no longer match package exports.
   if (jsonObj.dependencies[buildTsDependency]) {
     dependencies.push(buildTsDependency);
   } else if (
@@ -582,8 +582,8 @@ function isPublishedLintConfigPackage(jsonObj: PackageJson): boolean {
 function shouldUpdateExistingManagedDependency(dependency: string, currentVersion: string | undefined): boolean {
   if (!currentVersion) return true;
   if (currentVersion === '*') return true;
-  // Old wb releases had Bun-only lint behavior; managed projects need the
-  // current CLI when wbfy wires hooks or scripts through wb.
+  // wbfy-managed tools must be kept current even when the package already pins
+  // a concrete version. In particular, build-ts owns declaration output paths.
   return (
     dependency === '@willbooster/wb' ||
     dependency === buildTsDependency ||

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -29,6 +29,7 @@ const obsoleteLintDependencies = [
   '@eslint/js',
   '@next/eslint-plugin-next',
   '@types/eslint',
+  '@types/micromatch',
   '@typescript-eslint/eslint-plugin',
   '@typescript-eslint/parser',
   '@willbooster/biome-config',
@@ -57,6 +58,7 @@ const obsoleteLintDependencies = [
   'eslint-plugin-unicorn',
   'eslint-plugin-unused-imports',
   'globals',
+  'micromatch',
   'typescript-eslint',
 ];
 
@@ -88,7 +90,7 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
   const jsonObj = await readPackageJson(filePath);
   const packageManager = config.isBun ? 'bun' : 'yarn';
 
-  await removeDeprecatedStuff(jsonObj, config.dirPath);
+  await removeDeprecatedStuff(config, jsonObj);
   await updateScripts(config, jsonObj, packageManager);
   const dependencyUpdates = applyPackageJsonConventions(config, rootConfig, jsonObj);
   await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
@@ -525,8 +527,8 @@ function getLatestDependencyVersion(dependency: string): string {
 
 // TODO: remove the following migration code in future
 async function removeDeprecatedStuff(
-  jsonObj: SetRequired<PackageJson, 'scripts' | 'dependencies' | 'devDependencies' | 'peerDependencies'>,
-  dirPath: string
+  config: PackageConfig,
+  jsonObj: SetRequired<PackageJson, 'scripts' | 'dependencies' | 'devDependencies' | 'peerDependencies'>
 ): Promise<void> {
   if (jsonObj.author === 'WillBooster LLC') {
     jsonObj.author = 'WillBooster Inc.';
@@ -549,13 +551,13 @@ async function removeDeprecatedStuff(
   delete jsonObj.scripts['format-python'];
   delete jsonObj.scripts.prettier;
   delete jsonObj.scripts['check-all'];
-  await promisePool.run(() => fs.promises.rm(path.resolve(dirPath, 'lerna.json'), { force: true }));
+  await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'lerna.json'), { force: true }));
 
-  // Packages that publish lint configs need their lint toolchain as package
-  // data, not just local repo tooling. Removing micromatch or ESLint peers here
-  // would break the exported config even though wbfy can lint the repo itself
-  // with oxlint.
-  if (!isPublishedLintConfigPackage(jsonObj)) {
+  // willbooster-configs subpackages publish config files as their product. Their
+  // ESLint and glob dependencies are package data, so removing them would break
+  // those published configs. Keep the migration scoped to this repository so
+  // every other repo keeps the normal obsolete-lint cleanup behavior.
+  if (!isWillboosterConfigsSubpackage(config)) {
     removeObsoleteLintDependencies(jsonObj);
   }
 }
@@ -570,13 +572,8 @@ function removeObsoleteLintDependencies(
   }
 }
 
-function isPublishedLintConfigPackage(jsonObj: PackageJson): boolean {
-  return (
-    typeof jsonObj.name === 'string' &&
-    jsonObj.name.includes('eslint-config') &&
-    typeof jsonObj.main === 'string' &&
-    /(?:^|\/)eslint\.config\.[cm]?js$/u.test(jsonObj.main)
-  );
+function isWillboosterConfigsSubpackage(config: PackageConfig): boolean {
+  return config.isWillBoosterConfigs && !config.isRoot;
 }
 
 function shouldUpdateExistingManagedDependency(dependency: string, currentVersion: string | undefined): boolean {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -61,6 +61,9 @@ const obsoleteLintDependencies = [
   'micromatch',
   'typescript-eslint',
 ];
+const micromatchPackageNames = new Set(['micromatch', '@types/micromatch']);
+const micromatchImportPattern =
+  /\bfrom\s+['"]micromatch['"]|\brequire\(\s*['"]micromatch['"]\s*\)|\bimport\(\s*['"]micromatch['"]\s*\)/u;
 
 const latestDependencyVersionCache = new Map<string, string>();
 
@@ -553,27 +556,43 @@ async function removeDeprecatedStuff(
   delete jsonObj.scripts['check-all'];
   await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'lerna.json'), { force: true }));
 
-  // willbooster-configs subpackages publish config files as their product. Their
-  // ESLint and glob dependencies are package data, so removing them would break
-  // those published configs. Keep the migration scoped to this repository so
-  // every other repo keeps the normal obsolete-lint cleanup behavior.
-  if (!isWillboosterConfigsSubpackage(config)) {
-    removeObsoleteLintDependencies(jsonObj);
-  }
+  removeObsoleteLintDependencies(jsonObj, config);
 }
 
 function removeObsoleteLintDependencies(
-  jsonObj: SetRequired<PackageJson, 'dependencies' | 'devDependencies' | 'peerDependencies'>
+  jsonObj: SetRequired<PackageJson, 'dependencies' | 'devDependencies' | 'peerDependencies'>,
+  config: PackageConfig
 ): void {
+  const preserveMicromatch = shouldPreserveMicromatch(config);
   for (const dependency of obsoleteLintDependencies) {
+    if (preserveMicromatch && micromatchPackageNames.has(dependency)) continue;
     delete jsonObj.dependencies[dependency];
     delete jsonObj.devDependencies[dependency];
     delete jsonObj.peerDependencies[dependency];
   }
 }
 
-function isWillboosterConfigsSubpackage(config: PackageConfig): boolean {
-  return config.isWillBoosterConfigs && !config.isRoot;
+function shouldPreserveMicromatch(config: PackageConfig): boolean {
+  // willbooster-configs subpackages publish config files as their product, so
+  // micromatch is package data there. Other repos keep micromatch only when
+  // product code imports it; otherwise it is treated as obsolete ESLint-era
+  // tooling.
+  return (config.isWillBoosterConfigs && !config.isRoot) || doesProductCodeImportMicromatch(config.dirPath);
+}
+
+function doesProductCodeImportMicromatch(dirPath: string): boolean {
+  const filePaths = fg.globSync('src/**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}', {
+    cwd: dirPath,
+    dot: true,
+    ignore: globIgnore,
+  });
+  return filePaths.some((filePath) => {
+    try {
+      return micromatchImportPattern.test(fs.readFileSync(path.resolve(dirPath, filePath), 'utf8'));
+    } catch {
+      return false;
+    }
+  });
 }
 
 function shouldUpdateExistingManagedDependency(dependency: string, currentVersion: string | undefined): boolean {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -22,13 +22,13 @@ import { getTsconfigBaseDependencies } from '../utils/tsconfigBase.js';
 
 const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', 'oxfmt', 'oxlint', 'oxlint-tsgolint'];
 const typescriptGoDependency = '@typescript/native-preview';
+const buildTsDependency = 'build-ts';
 const obsoleteLintDependencies = [
   '@biomejs/biome',
   '@eslint-react/eslint-plugin',
   '@eslint/js',
   '@next/eslint-plugin-next',
   '@types/eslint',
-  '@types/micromatch',
   '@typescript-eslint/eslint-plugin',
   '@typescript-eslint/parser',
   '@willbooster/biome-config',
@@ -57,7 +57,6 @@ const obsoleteLintDependencies = [
   'eslint-plugin-unicorn',
   'eslint-plugin-unused-imports',
   'globals',
-  'micromatch',
   'typescript-eslint',
 ];
 
@@ -248,6 +247,18 @@ function applyPackageJsonConventions(
       if (typeof value !== 'string') continue;
       jsonObj.scripts[key] = value.replaceAll(/wb\s+db/gu, 'wb prisma');
     }
+  }
+
+  // build-ts owns declaration emit for libraries. Keeping older releases can
+  // make generated .d.ts files land under dist/src while package exports point
+  // at dist, so wbfy must update existing build-ts users.
+  if (jsonObj.dependencies[buildTsDependency]) {
+    dependencies.push(buildTsDependency);
+  } else if (
+    jsonObj.devDependencies[buildTsDependency] ||
+    Object.values(jsonObj.scripts).some((script) => script?.includes(buildTsDependency))
+  ) {
+    devDependencies.push(buildTsDependency);
   }
 
   if (doesContainJsOrTs(config)) {
@@ -540,7 +551,13 @@ async function removeDeprecatedStuff(
   delete jsonObj.scripts['check-all'];
   await promisePool.run(() => fs.promises.rm(path.resolve(dirPath, 'lerna.json'), { force: true }));
 
-  removeObsoleteLintDependencies(jsonObj);
+  // Packages that publish lint configs need their lint toolchain as package
+  // data, not just local repo tooling. Removing micromatch or ESLint peers here
+  // would break the exported config even though wbfy can lint the repo itself
+  // with oxlint.
+  if (!isPublishedLintConfigPackage(jsonObj)) {
+    removeObsoleteLintDependencies(jsonObj);
+  }
 }
 
 function removeObsoleteLintDependencies(
@@ -553,6 +570,15 @@ function removeObsoleteLintDependencies(
   }
 }
 
+function isPublishedLintConfigPackage(jsonObj: PackageJson): boolean {
+  return (
+    typeof jsonObj.name === 'string' &&
+    jsonObj.name.includes('eslint-config') &&
+    typeof jsonObj.main === 'string' &&
+    /(?:^|\/)eslint\.config\.[cm]?js$/u.test(jsonObj.main)
+  );
+}
+
 function shouldUpdateExistingManagedDependency(dependency: string, currentVersion: string | undefined): boolean {
   if (!currentVersion) return true;
   if (currentVersion === '*') return true;
@@ -560,6 +586,7 @@ function shouldUpdateExistingManagedDependency(dependency: string, currentVersio
   // current CLI when wbfy wires hooks or scripts through wb.
   return (
     dependency === '@willbooster/wb' ||
+    dependency === buildTsDependency ||
     dependency === '@willbooster/oxlint-config' ||
     dependency === 'oxlint' ||
     dependency === typescriptGoDependency

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -113,9 +113,10 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     newSettings.include?.sort();
     // Don't use old decorator
     delete newSettings.compilerOptions?.experimentalDecorators;
-    // Package imports should resolve through package exports instead of tsconfig aliases.
+    // Package imports should resolve through package exports instead of baseUrl.
+    // paths is intentionally preserved so repo-local tooling can keep explicit
+    // aliases without relying on baseUrl's broad fallback resolution.
     delete newSettings.compilerOptions?.baseUrl;
-    delete newSettings.compilerOptions?.paths;
     deleteLegacyModuleSettings(newSettings.compilerOptions, config);
     if (config.depending.reactNative) {
       delete newSettings.compilerOptions?.verbatimModuleSyntax;

--- a/packages/wbfy/tsconfig.json
+++ b/packages/wbfy/tsconfig.json
@@ -8,7 +8,7 @@
     "importHelpers": false,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "noEmit": false,
+    "noEmit": true,
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "resolveJsonModule": true,
@@ -22,5 +22,5 @@
   },
   "exclude": ["test/fixtures", "packages/*/test/fixtures"],
   "extends": ["@tsconfig/node-lts/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"],
-  "include": ["scripts/**/*", "src/**/*", "test/**/*"]
+  "include": ["*.config.ts", "scripts/**/*", "src/**/*", "test/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "jsx": "react-jsx",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "noEmit": false,
+    "noEmit": true,
     "noUncheckedIndexedAccess": true,
     "outDir": "dist",
     "resolveJsonModule": true,
@@ -24,6 +24,8 @@
   "exclude": ["packages/*/test/fixtures", "test/fixtures", "packages/*/test/fixtures/**/*", "test/fixtures/**/*"],
   "extends": ["@tsconfig/node-lts/tsconfig.json", "@tsconfig/node-ts/tsconfig.json"],
   "include": [
+    "*.config.ts",
+    "packages/*/*.config.ts",
     "packages/*/scripts/**/*",
     "packages/*/src/**/*",
     "packages/*/test/**/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6013,13 +6013,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@willbooster/oxlint-config@npm:1.4.0":
-  version: 1.4.0
-  resolution: "@willbooster/oxlint-config@npm:1.4.0"
+"@willbooster/oxlint-config@npm:1.4.2":
+  version: 1.4.2
+  resolution: "@willbooster/oxlint-config@npm:1.4.2"
   peerDependencies:
     oxlint: ">=1.60.0"
     oxlint-tsgolint: ">=0.18.1"
-  checksum: 10c0/8b298e130818b65efcaf8058d4eba7acdcfd95834790e1fa4a6677061a26905e7c6b195ada225fb3f04814af58d041374be4b11f7c64098c5b22951e1eb0f184
+  checksum: 10c0/8f92735e41a43f55e282ddfc2f0171d68b9de0ec126fcae94c3a99648d0c33ca98d62887da6b18c360c208a30980f6f2da86331668e6b1179fdb5ce9cb601977
   languageName: node
   linkType: hard
 
@@ -6042,7 +6042,7 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260415.1"
     "@willbooster/oxfmt-config": "npm:1.2.0"
-    "@willbooster/oxlint-config": "npm:1.4.0"
+    "@willbooster/oxlint-config": "npm:1.4.2"
     "@willbooster/prettier-config": "npm:10.4.0"
     blitz: "npm:3.0.2"
     build-ts: "npm:17.1.0"
@@ -6065,7 +6065,7 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260415.1"
     "@willbooster/oxfmt-config": "npm:1.2.0"
-    "@willbooster/oxlint-config": "npm:1.4.0"
+    "@willbooster/oxlint-config": "npm:1.4.2"
     "@willbooster/prettier-config": "npm:10.4.0"
     build-ts: "npm:17.1.0"
     next: "npm:16.2.3"
@@ -6101,7 +6101,7 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260415.1"
     "@willbooster/oxfmt-config": "npm:1.2.0"
-    "@willbooster/oxlint-config": "npm:1.4.0"
+    "@willbooster/oxlint-config": "npm:1.4.2"
     "@willbooster/prettier-config": "npm:10.4.0"
     build-ts: "npm:17.1.0"
     dotenv: "npm:17.4.1"
@@ -6137,7 +6137,7 @@ __metadata:
     "@types/react-dom": "npm:19.2.3"
     "@typescript/native-preview": "npm:7.0.0-dev.20260415.1"
     "@willbooster/oxfmt-config": "npm:1.2.0"
-    "@willbooster/oxlint-config": "npm:1.4.0"
+    "@willbooster/oxlint-config": "npm:1.4.2"
     "@willbooster/prettier-config": "npm:10.4.0"
     babel-loader: "npm:10.1.1"
     build-ts: "npm:17.1.0"
@@ -6165,7 +6165,7 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260415.1"
     "@willbooster/oxfmt-config": "npm:1.2.0"
-    "@willbooster/oxlint-config": "npm:1.4.0"
+    "@willbooster/oxlint-config": "npm:1.4.2"
     "@willbooster/prettier-config": "npm:10.4.0"
     build-ts: "npm:17.1.0"
     oxfmt: "npm:0.45.0"
@@ -6193,7 +6193,7 @@ __metadata:
     "@types/yargs": "npm:17.0.35"
     "@typescript/native-preview": "npm:7.0.0-dev.20260415.1"
     "@willbooster/oxfmt-config": "npm:1.2.0"
-    "@willbooster/oxlint-config": "npm:1.4.0"
+    "@willbooster/oxlint-config": "npm:1.4.2"
     "@willbooster/prettier-config": "npm:10.4.0"
     at-decorators: "npm:7.0.2"
     build-ts: "npm:17.1.0"
@@ -6232,7 +6232,7 @@ __metadata:
     "@types/yargs": "npm:17.0.35"
     "@typescript/native-preview": "npm:7.0.0-dev.20260415.1"
     "@willbooster/oxfmt-config": "npm:1.2.0"
-    "@willbooster/oxlint-config": "npm:1.4.0"
+    "@willbooster/oxlint-config": "npm:1.4.2"
     "@willbooster/prettier-config": "npm:10.4.0"
     "@yarnpkg/core": "npm:4.6.0"
     build-ts: "npm:17.1.0"
@@ -20154,7 +20154,7 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@typescript/native-preview": "npm:7.0.0-dev.20260415.1"
     "@willbooster/oxfmt-config": "npm:1.2.0"
-    "@willbooster/oxlint-config": "npm:1.4.0"
+    "@willbooster/oxlint-config": "npm:1.4.2"
     "@willbooster/prettier-config": "npm:10.4.0"
     conventional-changelog-conventionalcommits: "npm:9.3.1"
     lefthook: "npm:2.1.5"


### PR DESCRIPTION
## Summary
- stop treating micromatch as an obsolete lint dependency
- keep published ESLint config packages from losing their exported eslint.config.js
- update existing build-ts users so declaration files emit at package export paths

## Verification
- yarn workspace @willbooster/wbfy test tsconfigGenerator.test.ts
- yarn workspace @willbooster/wbfy check-for-ai