### PR TITLE
fix: avoid updating unrelated bun dependencies in wbfy

### DIFF
--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -199,27 +199,13 @@ async function main(): Promise<void> {
 }
 
 function refreshBunLock(rootDirPath: string): void {
-  const lockFilePath = path.join(rootDirPath, 'bun.lock');
-  const backupLockFilePath = path.join(rootDirPath, '.bun.lock.wbfy-backup');
-  fs.rmSync(backupLockFilePath, { force: true });
-  if (fs.existsSync(lockFilePath)) {
-    // Regenerate from scratch, but keep the previous lockfile so a registry or
-    // resolver failure cannot leave the repository without a lockfile.
-    fs.copyFileSync(lockFilePath, backupLockFilePath);
-    fs.rmSync(lockFilePath, { force: true });
+  // wbfy should update only the packages it explicitly manages through bun add.
+  // Running bun update here refreshes unrelated application dependencies and
+  // can change product behavior, so keep the existing lock and reconcile it.
+  const status = spawnSyncAndReturnStatus('bun', ['install'], rootDirPath);
+  if (status !== 0) {
+    throw new Error(`Failed to refresh Bun lockfile: bun install exited with status ${status}`);
   }
-
-  const status = spawnSyncAndReturnStatus('bun', ['update'], rootDirPath);
-  if (status === 0 && fs.existsSync(lockFilePath)) {
-    fs.rmSync(backupLockFilePath, { force: true });
-    return;
-  }
-
-  if (fs.existsSync(backupLockFilePath)) {
-    fs.copyFileSync(backupLockFilePath, lockFilePath);
-    fs.rmSync(backupLockFilePath, { force: true });
-  }
-  throw new Error(`Failed to regenerate ${lockFilePath}: bun update exited with status ${status}`);
 }
 
 function getVersion(): string {


### PR DESCRIPTION
## Summary
- refresh Bun lockfiles with bun install instead of bun update
- avoid updating unrelated product dependencies while applying wbfy

## Verification
- yarn workspace @willbooster/wbfy test tsconfigGenerator.test.ts
- yarn workspace @willbooster/wbfy check-for-ai
- pre-push hook