### PR TITLE
fix: fail wbfy on invalid package config

### DIFF
--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -81,6 +81,7 @@ async function main(): Promise<void> {
   options.isVerbose = argv.verbose;
   options.doesUploadEnvVars = argv.env;
 
+  let hasInvalidPackageConfig = false;
   for (const rootDirPath of argv.paths as string[]) {
     const packagesDirPath = path.join(rootDirPath, 'packages');
     const dirents = (await ignoreErrorAsync(() => fs.promises.readdir(packagesDirPath, { withFileTypes: true }))) ?? [];
@@ -94,6 +95,7 @@ async function main(): Promise<void> {
     }
     if (!rootConfig) {
       console.error(`there is no valid package.json in ${rootDirPath}`);
+      hasInvalidPackageConfig = true;
       continue;
     }
     const abbreviationPromise = fixTypos(rootConfig);
@@ -195,6 +197,9 @@ async function main(): Promise<void> {
     spawnSync(packageManager, ['cleanup'], rootDirPath);
 
     await installAgentSkills(rootConfig);
+  }
+  if (hasInvalidPackageConfig) {
+    process.exitCode = 1;
   }
 }
 

--- a/packages/wbfy/test/libsodiumCompatibility.test.ts
+++ b/packages/wbfy/test/libsodiumCompatibility.test.ts
@@ -56,6 +56,45 @@ test('packed cli prints its version after npm install', { timeout: 120 * 1000 },
   }
 });
 
+test('packed cli invoked through npx fails when the target has no package config', { timeout: 120 * 1000 }, () => {
+  buildCli();
+
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-npx-invalid-target-'));
+  try {
+    const packResult = child_process.spawnSync(
+      'npm',
+      ['pack', packageDirPath, '--json', '--pack-destination', tempDirPath],
+      {
+        cwd: tempDirPath,
+        encoding: 'utf8',
+      }
+    );
+    expect(packResult.stderr).toBe('');
+    expect(packResult.status).toBe(0);
+
+    const [{ filename }] = JSON.parse(packResult.stdout) as [{ filename: string }];
+    const targetDirPath = path.join(tempDirPath, 'target');
+    fs.mkdirSync(targetDirPath);
+
+    const result = child_process.spawnSync(
+      'npx',
+      ['--yes', '--package', path.join(tempDirPath, filename), 'wbfy', '.'],
+      {
+        cwd: targetDirPath,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          npm_config_cache: path.join(tempDirPath, 'npm-cache'),
+        },
+      }
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('there is no valid package.json in .');
+  } finally {
+    fs.rmSync(tempDirPath, { force: true, recursive: true });
+  }
+});
+
 function buildCli(): void {
   const buildResult = child_process.spawnSync('yarn', ['build'], {
     cwd: packageDirPath,


### PR DESCRIPTION
## Summary

- Make wbfy exit with a non-zero status when a target path has no valid package config.
- Add a packed CLI regression test that invokes wbfy through `npx --package <tarball> wbfy .`.

## Why

- `@willbooster/wbfy@1.3.5` currently prints `there is no valid package.json in .` but exits with status `0`.
- CI scripts that run wbfy cannot detect this failure and may continue as if wbfy succeeded.

## Testing

- `yarn vitest test/libsodiumCompatibility.test.ts --run`
- Verified the new test fails before the implementation change with `expected +0 not to be +0`.
- Compared published `@willbooster/wbfy@1.3.5` with the local packed tarball:
  - published invalid target via direct npx: exit `0`
  - published invalid target via `--package`: exit `0`
  - local invalid target via direct npx: exit `1`
  - local invalid target via `--package`: exit `1`
- Verified tarball contents differ only by package version and the built `dist/index.js`; `LICENSE`, `README.md`, `bin/wbfy.js`, and file list are identical.

## Notes

- This does not change yarn/corepack behavior or package `bin` metadata.
