### PR TITLE
fix: format yarnrc without target prettier config

### DIFF
--- a/packages/wbfy/src/generators/yarnrc.ts
+++ b/packages/wbfy/src/generators/yarnrc.ts
@@ -109,8 +109,12 @@ export async function generateYarnrcYml(config: PackageConfig): Promise<void> {
 
     spawnSync('yarn', ['dlx', 'yarn-plugin-auto-install'], config.dirPath);
     // The target repo may not have prettier installed yet, and yarn-plugin-auto-install edits this file after js-yaml.
-    spawnSync('yarn', ['dlx', 'prettier', '--write', path.relative(config.dirPath, yarnrcYmlPath)], config.dirPath);
+    spawnSync('yarn', getYarnrcPrettierArgs(config.dirPath, yarnrcYmlPath), config.dirPath);
   });
+}
+
+export function getYarnrcPrettierArgs(dirPath: string, yarnrcYmlPath: string): string[] {
+  return ['dlx', 'prettier', '--no-config', '--write', path.relative(dirPath, yarnrcYmlPath)];
 }
 
 export function getLatestVersion(packageName: string, dirPath: string): string {

--- a/packages/wbfy/test/yarnrcGenerator.test.ts
+++ b/packages/wbfy/test/yarnrcGenerator.test.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { getYarnrcPrettierArgs } from '../src/generators/yarnrc.js';
+
+test('formats .yarnrc.yml without loading target prettier config', () => {
+  const dirPath = path.resolve('/tmp/project');
+  const yarnrcYmlPath = path.join(dirPath, '.yarnrc.yml');
+
+  expect(getYarnrcPrettierArgs(dirPath, yarnrcYmlPath)).toEqual([
+    'dlx',
+    'prettier',
+    '--no-config',
+    '--write',
+    '.yarnrc.yml',
+  ]);
+});


### PR DESCRIPTION
## Summary

- Add `--no-config` when wbfy formats the generated `.yarnrc.yml` with `yarn dlx prettier`.
- Add a focused test for the generated Prettier arguments.

## Why

- wbfy formats `.yarnrc.yml` before target dependencies are installed.
- Repositories such as `brand` can define `prettier: "@willbooster/prettier-config"` in `package.json`; Prettier then tries to resolve that package before it is available and logs `Cannot find package '@willbooster/prettier-config'`.
- `.yarnrc.yml` formatting does not need the target repository's Prettier config, so `--no-config` avoids the premature config resolution.

## Testing

- `yarn vitest test/yarnrcGenerator.test.ts --run`
- `yarn vitest test/yarnrcGenerator.test.ts test/libsodiumCompatibility.test.ts --run`
- Packed local wbfy and ran it via `npx` against a temporary clone of `WillBooster/brand`; confirmed the `Cannot find package '@willbooster/prettier-config'` error no longer appears.
- pre-push `check.sh` passed.
