### PR TITLE
fix: preserve config package peer dependencies

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -566,10 +566,34 @@ function removeObsoleteLintDependencies(
   const preserveMicromatch = shouldPreserveMicromatch(config);
   for (const dependency of obsoleteLintDependencies) {
     if (preserveMicromatch && micromatchPackageNames.has(dependency)) continue;
+    if (shouldPreserveConfigPackageLintDependency(jsonObj, config, dependency)) continue;
     delete jsonObj.dependencies[dependency];
     delete jsonObj.devDependencies[dependency];
     delete jsonObj.peerDependencies[dependency];
   }
+}
+
+function shouldPreserveConfigPackageLintDependency(
+  jsonObj: SetRequired<PackageJson, 'dependencies' | 'devDependencies' | 'peerDependencies'>,
+  config: PackageConfig,
+  dependency: string
+): boolean {
+  if (!isWillBoosterPublishedConfigPackage(config)) return false;
+  if (jsonObj.peerDependencies[dependency]) return true;
+
+  // Published config packages need local type-only deps to validate the
+  // package-provided config declarations under Yarn PnP.
+  return dependency === '@types/eslint' && !!jsonObj.peerDependencies.eslint;
+}
+
+function isWillBoosterPublishedConfigPackage(config: PackageConfig): boolean {
+  return (
+    config.isWillBoosterConfigs &&
+    !config.isRoot &&
+    config.packageJson?.private !== true &&
+    Array.isArray(config.packageJson?.files) &&
+    config.packageJson.files.length > 0
+  );
 }
 
 function shouldPreserveMicromatch(config: PackageConfig): boolean {

--- a/packages/wbfy/test/packageJsonGenerator.test.ts
+++ b/packages/wbfy/test/packageJsonGenerator.test.ts
@@ -1,0 +1,156 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { PackageJson } from 'type-fest';
+import { describe, expect, test } from 'vitest';
+
+import { generatePackageJson } from '../src/generators/packageJson.js';
+import type { PackageConfig } from '../src/packageConfig.js';
+import { promisePool } from '../src/utils/promisePool.js';
+
+describe('generatePackageJson', () => {
+  test('preserves lint peer dependencies for published willbooster config packages', async () => {
+    const dirPath = await createPackageDir({
+      name: '@willbooster/eslint-config-ts',
+      files: ['eslint.config.js'],
+      devDependencies: {
+        '@eslint/js': '10.0.1',
+        '@types/eslint': '9.6.1',
+        '@willbooster/prettier-config': '^10.4.0',
+        eslint: '10.2.0',
+        prettier: '3.8.1',
+        'sort-package-json': '3.6.1',
+      },
+      peerDependencies: {
+        '@eslint/js': '>=10',
+        eslint: '>=10',
+      },
+    });
+    const config = createConfig({
+      dirPath,
+      isWillBoosterConfigs: true,
+      packageJson: readPackageJson(dirPath),
+    });
+
+    await generatePackageJson(config, createRootConfig(path.dirname(dirPath)), true);
+    await promisePool.promiseAll();
+
+    const packageJson = readPackageJson(dirPath);
+    expect(packageJson.devDependencies).toMatchObject({
+      '@eslint/js': '10.0.1',
+      '@types/eslint': '9.6.1',
+      eslint: '10.2.0',
+    });
+    expect(packageJson.peerDependencies).toEqual({
+      '@eslint/js': '>=10',
+      eslint: '>=10',
+    });
+  });
+
+  test('removes obsolete lint dependencies from regular packages', async () => {
+    const dirPath = await createPackageDir({
+      name: 'regular-package',
+      devDependencies: {
+        '@eslint/js': '10.0.1',
+        '@willbooster/prettier-config': '^10.4.0',
+        eslint: '10.2.0',
+        prettier: '3.8.1',
+        'sort-package-json': '3.6.1',
+      },
+      peerDependencies: {
+        '@eslint/js': '>=10',
+        eslint: '>=10',
+      },
+    });
+    const config = createConfig({
+      dirPath,
+      packageJson: readPackageJson(dirPath),
+    });
+
+    await generatePackageJson(config, createRootConfig(path.dirname(dirPath)), true);
+    await promisePool.promiseAll();
+
+    const packageJson = readPackageJson(dirPath);
+    expect(packageJson.devDependencies).not.toHaveProperty('@eslint/js');
+    expect(packageJson.devDependencies).not.toHaveProperty('eslint');
+    expect(packageJson).not.toHaveProperty('peerDependencies');
+  });
+});
+
+async function createPackageDir(packageJson: PackageJson): Promise<string> {
+  const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
+  await fs.promises.writeFile(path.join(dirPath, 'package.json'), `${JSON.stringify(packageJson, undefined, 2)}\n`);
+  await fs.promises.writeFile(path.join(dirPath, '.prettierignore'), '');
+  return dirPath;
+}
+
+function readPackageJson(dirPath: string): PackageJson {
+  return JSON.parse(fs.readFileSync(path.join(dirPath, 'package.json'), 'utf8')) as PackageJson;
+}
+
+function createRootConfig(dirPath: string): PackageConfig {
+  return createConfig({
+    dirPath,
+    isRoot: true,
+    packageJson: {
+      name: 'root',
+      private: true,
+    },
+  });
+}
+
+function createConfig(overrides: Partial<PackageConfig> = {}): PackageConfig {
+  return {
+    dirPath: '/tmp',
+    dockerfile: '',
+    isRoot: false,
+    isPublicRepo: true,
+    isReferredByOtherRepo: false,
+    repository: 'github:WillBooster/example',
+    isWillBoosterRepo: true,
+    isBun: false,
+    isEsmPackage: false,
+    isWillBoosterConfigs: false,
+    doesContainSubPackageJsons: false,
+    doesContainDockerfile: false,
+    doesContainGemfile: false,
+    doesContainGoMod: false,
+    doesContainPackageJson: true,
+    doesContainPoetryLock: false,
+    doesContainUvLock: false,
+    doesContainPomXml: false,
+    doesContainPubspecYaml: false,
+    doesContainTemplateYaml: false,
+    doesContainVscodeSettingsJson: false,
+    doesContainJavaScript: false,
+    doesContainTypeScript: false,
+    doesContainJsxOrTsx: false,
+    doesContainJavaScriptInPackages: false,
+    doesContainTypeScriptInPackages: false,
+    doesContainJsxOrTsxInPackages: false,
+    hasStartTestServer: false,
+    depending: {
+      blitz: false,
+      firebase: false,
+      genI18nTs: false,
+      litestream: false,
+      next: false,
+      playwrightTest: false,
+      prisma: false,
+      pyright: false,
+      react: false,
+      reactNative: false,
+      semanticRelease: false,
+      storybook: false,
+      wb: false,
+    },
+    release: {
+      branches: [],
+      github: false,
+      npm: false,
+    },
+    hasVersionSettings: false,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

- Preserve lint-related peer dependencies for published `willbooster-configs` config packages during `wbfy`
- Preserve local `devDependencies` that mirror those peer dependencies so the config packages can validate themselves under Yarn PnP
- Add regression coverage for published config packages and regular packages

## Why

- `wbfy` was treating config package peer dependencies as obsolete lint tooling and deleting them
- Config packages expose those peer dependencies as part of their installation contract, so deleting them breaks consumers

## Testing

- `yarn vitest test/packageJsonGenerator.test.ts`
- `yarn check-for-ai`
- pre-push `check.sh` hook
