### PR TITLE
feat: improve lefthook generator settings

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,7 +13,8 @@ pre-commit:
   jobs:
     - name: cleanup
       glob: '**/*.{astro,cjs,css,cts,gql,graphql,hbs,htm,html,java,js,json,json5,jsonc,jsx,less,md,mdx,mjs,mts,scss,svelte,toml,ts,tsx,vue,yaml,yml}'
-      run: yarn workspace @willbooster/wb start --working-dir "$(git rev-parse --show-toplevel)" lint --fix --format -- {staged_files} && git add -- {staged_files}
+      run: yarn workspace @willbooster/wb start --working-dir "$(git rev-parse --show-toplevel)" lint --fix --format -- {staged_files}
+      stage_fixed: true
     - name: check-migrations
       glob: '**/migration.sql'
       run: |-

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,17 +1,20 @@
+glob_matcher: doublestar
 post-merge:
-  scripts:
-    prepare.sh:
+  jobs:
+    - name: prepare
+      script: prepare.sh
       runner: bash
 pre-push:
-  scripts:
-    check.sh:
+  jobs:
+    - name: check
+      script: check.sh
       runner: bash
 pre-commit:
-  commands:
-    cleanup:
+  jobs:
+    - name: cleanup
       glob: '**/*.{astro,cjs,css,cts,gql,graphql,hbs,htm,html,java,js,json,json5,jsonc,jsx,less,md,mdx,mjs,mts,scss,svelte,toml,ts,tsx,vue,yaml,yml}'
       run: yarn workspace @willbooster/wb start --working-dir "$(git rev-parse --show-toplevel)" lint --fix --format -- {staged_files} && git add -- {staged_files}
-    check-migrations:
+    - name: check-migrations
       glob: '**/migration.sql'
       run: |-
         if grep -q 'Warnings:' {staged_files}; then

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -106,7 +106,6 @@ async function core(config: PackageConfig): Promise<void> {
   const settings: Partial<LefthookSettings> = {
     ...baseSettings,
     'pre-commit': {
-      ...preCommitSettings,
       jobs: preCommitSettings.jobs.map((job) =>
         job.name === 'cleanup'
           ? {

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -32,6 +32,7 @@ interface LefthookJob {
   run?: string;
   script?: string;
   runner?: 'bash';
+  stage_fixed?: true;
 }
 
 const baseSettings: Omit<LefthookSettings, 'pre-commit'> = {
@@ -62,6 +63,7 @@ const preCommitSettings: LefthookSettings['pre-commit'] = {
       name: 'cleanup',
       glob: '',
       run: '',
+      stage_fixed: true,
     },
     {
       name: 'check-migrations',
@@ -199,14 +201,13 @@ function getCleanupGlobs(config: PackageConfig): string {
 
 function getCleanupCommand(config: PackageConfig): string {
   if (hasLocalWbWorkspace(config)) {
-    return 'yarn workspace @willbooster/wb start --working-dir "$(git rev-parse --show-toplevel)" lint --fix --format -- {staged_files} && git add -- {staged_files}';
+    return 'yarn workspace @willbooster/wb start --working-dir "$(git rev-parse --show-toplevel)" lint --fix --format -- {staged_files}';
   }
   if (config.isBun || config.depending.wb) {
     const packageManager = config.isBun ? 'bun' : 'yarn';
-    const command = config.depending.wb
+    return config.depending.wb
       ? `${config.isBun ? 'bun --bun wb' : 'yarn wb'} lint --fix --format -- {staged_files}`
       : `${packageManager} run format && ${packageManager} run lint-fix`;
-    return `${command} && git add -- {staged_files}`;
   }
 
   const oxlintPattern = extensions.oxlint.map((extension) => String.raw`\.${extension}$`).join('|');
@@ -262,7 +263,6 @@ ${
 fi`
     : ''
 }
-git add -- {staged_files}
 `.trim();
 }
 

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -14,58 +14,57 @@ import { spawnSync } from '../utils/spawnUtil.js';
 import { generateScripts } from './packageJson.js';
 
 interface LefthookSettings {
+  glob_matcher: 'doublestar';
   'post-merge': {
-    scripts: {
-      'prepare.sh': {
-        runner: 'bash';
-      };
-    };
+    jobs: LefthookJob[];
   };
   'pre-commit': {
-    commands: {
-      cleanup: {
-        glob: string;
-        run: string;
-      };
-      'check-migrations': {
-        glob: string;
-        run: string;
-      };
-    };
+    jobs: LefthookJob[];
   };
   'pre-push': {
-    scripts: {
-      'check.sh': {
-        runner: 'bash';
-      };
-    };
+    jobs: LefthookJob[];
   };
 }
 
+interface LefthookJob {
+  name: string;
+  glob?: string;
+  run?: string;
+  script?: string;
+  runner?: 'bash';
+}
+
 const baseSettings: Omit<LefthookSettings, 'pre-commit'> = {
+  glob_matcher: 'doublestar',
   'post-merge': {
-    scripts: {
-      'prepare.sh': {
+    jobs: [
+      {
+        name: 'prepare',
+        script: 'prepare.sh',
         runner: 'bash',
       },
-    },
+    ],
   },
   'pre-push': {
-    scripts: {
-      'check.sh': {
+    jobs: [
+      {
+        name: 'check',
+        script: 'check.sh',
         runner: 'bash',
       },
-    },
+    ],
   },
 };
 
 const preCommitSettings: LefthookSettings['pre-commit'] = {
-  commands: {
-    cleanup: {
+  jobs: [
+    {
+      name: 'cleanup',
       glob: '',
       run: '',
     },
-    'check-migrations': {
+    {
+      name: 'check-migrations',
       glob: '**/migration.sql',
       run: `
 if grep -q 'Warnings:' {staged_files}; then
@@ -74,7 +73,7 @@ if grep -q 'Warnings:' {staged_files}; then
 fi
 `.trim(),
     },
-  },
+  ],
 };
 
 const scripts = {
@@ -106,14 +105,15 @@ async function core(config: PackageConfig): Promise<void> {
     ...baseSettings,
     'pre-commit': {
       ...preCommitSettings,
-      commands: {
-        ...preCommitSettings.commands,
-        cleanup: {
-          ...preCommitSettings.commands.cleanup,
-          glob: getCleanupGlobs(config),
-          run: getCleanupCommand(config),
-        },
-      },
+      jobs: preCommitSettings.jobs.map((job) =>
+        job.name === 'cleanup'
+          ? {
+              ...job,
+              glob: getCleanupGlobs(config),
+              run: getCleanupCommand(config),
+            }
+          : job
+      ),
     },
   };
   if (!lint) {


### PR DESCRIPTION
## Summary

- Generate lefthook hooks with the current `jobs` syntax instead of legacy `commands` and `scripts` sections.
- Add `glob_matcher: doublestar` so generated `**/*` globs include root-level files consistently.
- Keep the existing cleanup, migration check, post-merge, and pre-push shell behavior stable.

## Why

- The latest lefthook docs recommend `jobs` as the flexible hook task format, with stable names for local overrides.
- Lefthook documents `doublestar` as the matcher that makes `**` include files in the current directory, which matches how these generated cleanup globs are intended to behave.

## Testing

- `yarn workspace @willbooster/wbfy test lefthookGenerator.test.ts`
- `yarn workspace @willbooster/wbfy typecheck`
- `yarn check-for-ai`
- `LEFTHOOK_CONFIG=<temp lefthook.yml> yarn lefthook validate`
