### PR TITLE
fix: enable sqlite foreign keys pragma

### DIFF
--- a/packages/shared-lib/src/sqlite.ts
+++ b/packages/shared-lib/src/sqlite.ts
@@ -1,7 +1,7 @@
 export function getConnectionLevelSqlitePragmas(): string {
   // cf. https://github.com/benbjohnson/litestream/issues/724#issue-3367254318
   // cf. https://github.com/benbjohnson/litestream/blob/9bd72348b7e7b1b3b8cf1e8befbee3b2c17444f7/.claude/agents/performance-optimizer.md?plain=1#L225-L232
-  return 'PRAGMA busy_timeout = 5000; PRAGMA cache_size = -16000; PRAGMA synchronous = NORMAL; PRAGMA wal_autocheckpoint = 10000;';
+  return 'PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 5000; PRAGMA cache_size = -16000; PRAGMA synchronous = NORMAL; PRAGMA wal_autocheckpoint = 10000;';
 }
 
 export function getPersistentSqlitePragmas(): string {


### PR DESCRIPTION
## Summary

- Add `PRAGMA foreign_keys = ON` to `getConnectionLevelSqlitePragmas()` in `@willbooster/shared-lib`.
- Keep the pragma in the connection-level helper because SQLite foreign key enforcement is per connection.

## Why

- Consumers using the shared SQLite pragma helper should get foreign key enforcement by default alongside busy timeout, cache, synchronous, and WAL autocheckpoint settings.
- This avoids each application needing to remember an extra `PRAGMA foreign_keys = ON` call after using the shared helper.

## Testing

- `yarn check-for-ai`
- Pre-push `check` hook
