### PR TITLE
fix: preserve willbooster config packages

### DIFF
--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -5,10 +5,13 @@ import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
+import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfigsUtil.js';
 
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
-    const shouldPreservePublishedEslintConfig = isWillboosterConfigsSubpackage(config);
+    // willbooster-configs publishes config files as product code, so migration
+    // must not remove package entrypoints listed in published package metadata.
+    const shouldPreservePublishedEslintConfig = isPublishedWillboosterConfigsPackage(config);
     const filePath = path.resolve(config.dirPath, 'oxlint.config.ts');
     const existingContent = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
 
@@ -36,14 +39,6 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
     }
     await Promise.all(promises);
   });
-}
-
-function isWillboosterConfigsSubpackage(config: PackageConfig): boolean {
-  // willbooster-configs packages publish configuration files as product code.
-  // Replacing their package-local ESLint configs with oxlint configs makes the
-  // published package entry points disappear, so only this repository's
-  // subpackages opt out. Other repositories keep the normal migration.
-  return config.isWillBoosterConfigs && !config.isRoot;
 }
 
 const configContent = `import config from '@willbooster/oxlint-config';

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -10,24 +10,23 @@ import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfig
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
     // willbooster-configs publishes config files as product code, so migration
-    // must not remove package entrypoints listed in published package metadata.
-    const shouldPreservePublishedEslintConfig = isPublishedWillboosterConfigsPackage(config);
+    // must not remove package-provided linter settings.
+    const shouldPreservePublishedLinterConfig = isPublishedWillboosterConfigsPackage(config);
     const filePath = path.resolve(config.dirPath, 'oxlint.config.ts');
     const existingContent = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
 
-    const promises = [
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.oxlintrc.json'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'biome.json'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'biome.jsonc'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.cjs'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.js'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.json'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.yaml'), { force: true })),
-      promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.yml'), { force: true })),
-    ];
-    if (!shouldPreservePublishedEslintConfig) {
+    const promises: Promise<void>[] = [];
+    if (!shouldPreservePublishedLinterConfig) {
       promises.push(
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.oxlintrc.json'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'biome.json'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'biome.jsonc'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.cjs'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.js'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.json'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.yaml'), { force: true })),
+        promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.eslintrc.yml'), { force: true })),
         promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.cjs'), { force: true })),
         promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.js'), { force: true })),
         promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.mjs'), { force: true })),

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -19,6 +19,7 @@ import { doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
 import { spawnSync, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
 import { getTsconfigBaseDependencies } from '../utils/tsconfigBase.js';
+import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfigsUtil.js';
 
 const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', 'oxfmt', 'oxlint', 'oxlint-tsgolint'];
 const typescriptGoDependency = '@typescript/native-preview';
@@ -578,22 +579,12 @@ function shouldPreserveConfigPackageLintDependency(
   config: PackageConfig,
   dependency: string
 ): boolean {
-  if (!isWillBoosterPublishedConfigPackage(config)) return false;
+  if (!isPublishedWillboosterConfigsPackage(config)) return false;
   if (jsonObj.peerDependencies[dependency]) return true;
 
   // Published config packages need local type-only deps to validate the
   // package-provided config declarations under Yarn PnP.
   return dependency === '@types/eslint' && !!jsonObj.peerDependencies.eslint;
-}
-
-function isWillBoosterPublishedConfigPackage(config: PackageConfig): boolean {
-  return (
-    config.isWillBoosterConfigs &&
-    !config.isRoot &&
-    config.packageJson?.private !== true &&
-    Array.isArray(config.packageJson?.files) &&
-    config.packageJson.files.length > 0
-  );
 }
 
 function shouldPreserveMicromatch(config: PackageConfig): boolean {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -329,6 +329,7 @@ async function normalizePackageMetadata(
   if (owner === 'WillBooster' || owner === 'WillBoosterLab') {
     jsonObj.author = 'WillBooster Inc.';
   }
+  await normalizePublishedConfigPackageMetadata(config, jsonObj);
   if (!config.isRoot && jsonObj.private && !jsonObj.main) {
     // Make VSCode possible to refactor code across subpackages.
     jsonObj.main = './src';
@@ -424,6 +425,30 @@ async function normalizePackageMetadata(
     delete jsonObj.devDependencies['@types/prettier'];
   }
 }
+
+async function normalizePublishedConfigPackageMetadata(
+  config: PackageConfig,
+  jsonObj: WritablePackageJson
+): Promise<void> {
+  if (!isPublishedWillboosterConfigsPackage(config)) return;
+
+  const configMjsPath = path.resolve(config.dirPath, 'config.mjs');
+  if (!fs.existsSync(configMjsPath)) return;
+
+  jsonObj.type = 'module';
+
+  const configDtsPath = path.resolve(config.dirPath, 'config.d.ts');
+  if (!fs.existsSync(configDtsPath)) return;
+
+  jsonObj.files = [...new Set([...(jsonObj.files ?? []), 'config.d.mts'])];
+  // NodeNext resolves a relative `./config.mjs` import to `config.d.mts`, not
+  // the package-level `types` field. Keep the published config importable from
+  // package-local TypeScript linter settings.
+  await promisePool.run(() => fsUtil.generateFile(path.resolve(config.dirPath, 'config.d.mts'), configDmtsContent));
+}
+
+const configDmtsContent = `export { default } from './config.js';
+`;
 
 function addDependencyVersionsToPackageJson(jsonObj: WritablePackageJson, dependencyUpdates: DependencyUpdates): void {
   const packageJsonDependencies = jsonObj.dependencies;

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -44,7 +44,6 @@ import { getPackageConfig } from './packageConfig.js';
 import { doesContainJsOrTs } from './utils/packageCapabilities.js';
 import { promisePool } from './utils/promisePool.js';
 import { spawnSync, spawnSyncAndReturnStatus } from './utils/spawnUtil.js';
-import { shouldSkipWillboosterConfigsPackage } from './utils/willboosterConfigsUtil.js';
 
 async function main(): Promise<void> {
   const argv = await yargs(process.argv.slice(2))
@@ -146,9 +145,6 @@ async function main(): Promise<void> {
 
     const promises: Promise<void>[] = [];
     for (const config of allPackageConfigs) {
-      if (shouldSkipWillboosterConfigsPackage(config)) {
-        continue;
-      }
       if (config.doesContainTypeScript || config.doesContainTypeScriptInPackages) {
         promises.push(fixTypeDefinitions(config, config.isRoot ? allPackageConfigs : [config]));
       }

--- a/packages/wbfy/src/utils/willboosterConfigsUtil.ts
+++ b/packages/wbfy/src/utils/willboosterConfigsUtil.ts
@@ -1,16 +1,5 @@
 import type { PackageConfig } from '../packageConfig.js';
 
-const WBFY_OWNED_CONFIG_PACKAGE_NAME_PATTERN = /^@willbooster\/[^/]+-config$/u;
-
-export function shouldSkipWillboosterConfigsPackage(config: PackageConfig): boolean {
-  const packageName = config.packageJson?.name;
-  return (
-    config.isWillBoosterConfigs &&
-    typeof packageName === 'string' &&
-    WBFY_OWNED_CONFIG_PACKAGE_NAME_PATTERN.test(packageName)
-  );
-}
-
 export function isPublishedWillboosterConfigsPackage(config: PackageConfig): boolean {
   return (
     config.isWillBoosterConfigs &&

--- a/packages/wbfy/src/utils/willboosterConfigsUtil.ts
+++ b/packages/wbfy/src/utils/willboosterConfigsUtil.ts
@@ -1,10 +1,24 @@
 import type { PackageConfig } from '../packageConfig.js';
 
-const WILLBOOSTER_CONFIG_PACKAGE_NAMES = new Set(['@willbooster/oxlint-config', '@willbooster/prettier-config']);
+const WBFY_OWNED_CONFIG_PACKAGE_NAMES = new Set([
+  '@willbooster/oxfmt-config',
+  '@willbooster/oxlint-config',
+  '@willbooster/prettier-config',
+]);
 
 export function shouldSkipWillboosterConfigsPackage(config: PackageConfig): boolean {
   const packageName = config.packageJson?.name;
   return (
-    config.isWillBoosterConfigs && typeof packageName === 'string' && WILLBOOSTER_CONFIG_PACKAGE_NAMES.has(packageName)
+    config.isWillBoosterConfigs && typeof packageName === 'string' && WBFY_OWNED_CONFIG_PACKAGE_NAMES.has(packageName)
+  );
+}
+
+export function isPublishedWillboosterConfigsPackage(config: PackageConfig): boolean {
+  return (
+    config.isWillBoosterConfigs &&
+    !config.isRoot &&
+    config.packageJson?.private !== true &&
+    Array.isArray(config.packageJson?.files) &&
+    config.packageJson.files.length > 0
   );
 }

--- a/packages/wbfy/src/utils/willboosterConfigsUtil.ts
+++ b/packages/wbfy/src/utils/willboosterConfigsUtil.ts
@@ -1,15 +1,13 @@
 import type { PackageConfig } from '../packageConfig.js';
 
-const WBFY_OWNED_CONFIG_PACKAGE_NAMES = new Set([
-  '@willbooster/oxfmt-config',
-  '@willbooster/oxlint-config',
-  '@willbooster/prettier-config',
-]);
+const WBFY_OWNED_CONFIG_PACKAGE_NAME_PATTERN = /^@willbooster\/[^/]+-config$/u;
 
 export function shouldSkipWillboosterConfigsPackage(config: PackageConfig): boolean {
   const packageName = config.packageJson?.name;
   return (
-    config.isWillBoosterConfigs && typeof packageName === 'string' && WBFY_OWNED_CONFIG_PACKAGE_NAMES.has(packageName)
+    config.isWillBoosterConfigs &&
+    typeof packageName === 'string' &&
+    WBFY_OWNED_CONFIG_PACKAGE_NAME_PATTERN.test(packageName)
   );
 }
 

--- a/packages/wbfy/test/willboosterConfigsUtil.test.ts
+++ b/packages/wbfy/test/willboosterConfigsUtil.test.ts
@@ -1,34 +1,34 @@
 import { describe, expect, test } from 'vitest';
 
 import type { PackageConfig } from '../src/packageConfig.js';
-import { shouldSkipWillboosterConfigsPackage } from '../src/utils/willboosterConfigsUtil.js';
+import { isPublishedWillboosterConfigsPackage } from '../src/utils/willboosterConfigsUtil.js';
 
-describe('shouldSkipWillboosterConfigsPackage', () => {
-  test('does not skip legacy ESLint config packages inside willbooster-configs', () => {
+describe('isPublishedWillboosterConfigsPackage', () => {
+  test('detects published config packages inside willbooster-configs', () => {
     const config = createConfig({
       isWillBoosterConfigs: true,
-      packageJson: { name: '@willbooster/eslint-config-ts' },
+      packageJson: { files: ['eslint.config.js'], name: '@willbooster/eslint-config-ts' },
     });
 
-    expect(shouldSkipWillboosterConfigsPackage(config)).toBe(false);
+    expect(isPublishedWillboosterConfigsPackage(config)).toBe(true);
   });
 
-  test('skips shared format config packages inside willbooster-configs', () => {
+  test('does not detect private helper packages', () => {
     const config = createConfig({
       isWillBoosterConfigs: true,
-      packageJson: { name: '@willbooster/prettier-config' },
+      packageJson: { name: '@willbooster/shared', private: true },
     });
 
-    expect(shouldSkipWillboosterConfigsPackage(config)).toBe(true);
+    expect(isPublishedWillboosterConfigsPackage(config)).toBe(false);
   });
 
-  test('does not skip config packages outside willbooster-configs', () => {
+  test('does not detect config packages outside willbooster-configs', () => {
     const config = createConfig({
       isWillBoosterConfigs: false,
-      packageJson: { name: '@willbooster/oxlint-config' },
+      packageJson: { files: ['config.mjs'], name: '@willbooster/oxlint-config' },
     });
 
-    expect(shouldSkipWillboosterConfigsPackage(config)).toBe(false);
+    expect(isPublishedWillboosterConfigsPackage(config)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Apply `wbfy` to every package in `willbooster-configs` instead of skipping config packages wholesale.
- Preserve published config package linter settings during oxlint migration, including ESLint, Biome, and Oxlint config files that are package product code.
- Add NodeNext metadata support for published config packages that ship `config.mjs`, including `type: module` and a generated `config.d.mts` bridge for local TypeScript linter configs.

## Why

- The generated `WillBooster/willbooster-configs#946` PR removed published ESLint config entrypoints and stripped config-package lint dependencies.
- `willbooster-configs` publishes configuration files as product code, so `wbfy` should still maintain all packages while avoiding destructive linter-config migration inside published config packages.
- Once `wbfy` applies to `@willbooster/oxlint-config`, its package-local TypeScript linter settings need ESM metadata and `.mjs` declaration resolution to pass type-aware linting.

## Testing

- `yarn workspace @willbooster/wbfy vitest test/willboosterConfigsUtil.test.ts test/packageJsonGenerator.test.ts`
- `yarn check-for-ai`
- `yarn start /Users/exkazuu/ghq/github.com/WillBooster/willbooster-configs` from `packages/wbfy`
- `yarn check-for-ai` in `/Users/exkazuu/ghq/github.com/WillBooster/willbooster-configs`
