### PR TITLE
fix: approve WillBoosterLab git repos in wbfy yarnrc

### DIFF
--- a/packages/wbfy/src/generators/yarnrc.ts
+++ b/packages/wbfy/src/generators/yarnrc.ts
@@ -12,6 +12,7 @@ import { promisePool } from '../utils/promisePool.js';
 import { spawnSync, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
 
 type Settings = {
+  approvedGitRepositories?: string[];
   defaultSemverRangePrefix: string;
   nmMode: string;
   nodeLinker: string;
@@ -68,6 +69,11 @@ export async function generateYarnrcYml(config: PackageConfig): Promise<void> {
     settings.nodeLinker = 'node-modules';
     settings.nmMode = 'hardlinks-global';
     settings.npmMinimalAgeGate = '5d';
+    settings.approvedGitRepositories = [
+      // Yarn 4.14 blocks git dependencies unless the repository URL is explicitly allowed.
+      'https://github.com/WillBoosterLab/*.git',
+      'ssh://git@github.com/WillBoosterLab/*.git',
+    ];
     settings.npmPreapprovedPackages = [
       // ---------- START: We believe our packages are safe ----------
       '@exercode/*',


### PR DESCRIPTION
## Summary
- add Yarn approvedGitRepositories entries for WillBoosterLab git dependencies generated by wbfy
- keep the allowlist scoped to WillBoosterLab GitHub repositories

## Verification
- yarn check-for-ai