### PR TITLE
fix: keep wb runtime tools in docker packages

### DIFF
--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -11,6 +11,8 @@ import { packageManager } from '../utils/runtime.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
 
+const runtimeDevDependencies = ['@willbooster/wb', 'build-ts'];
+
 const builder = {
   outside: {
     description: 'Whether the optimization is executed outside a docker container or not',
@@ -64,6 +66,7 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
 };
 
 function optimizeDevDependencies(argv: InferredOptionTypes<typeof builder>, packageJson: PackageJson): void {
+  promoteRuntimeDevDependencies(packageJson);
   if (!argv.outside) {
     delete packageJson.devDependencies;
     console.info('Removed all devDependencies.');
@@ -102,6 +105,25 @@ function optimizeDevDependencies(argv: InferredOptionTypes<typeof builder>, pack
     }
   }
   console.info('Removed devDependencies:', removedDeps.join(', ') || 'none');
+}
+
+function promoteRuntimeDevDependencies(packageJson: PackageJson): void {
+  const devDeps = packageJson.devDependencies ?? {};
+  const dependencies = packageJson.dependencies ?? {};
+  const promotedDeps: string[] = [];
+  for (const name of runtimeDevDependencies) {
+    const version = devDeps[name];
+    if (!version) continue;
+    if (!dependencies[name]) {
+      dependencies[name] = version;
+      promotedDeps.push(name);
+    }
+    delete devDeps[name];
+  }
+  if (promotedDeps.length > 0) {
+    packageJson.dependencies = dependencies;
+  }
+  console.info('Promoted runtime devDependencies:', promotedDeps.join(', ') || 'none');
 }
 
 function optimizeScripts(packageJson: PackageJson): void {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -23,6 +23,7 @@ import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfig
 
 const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', 'oxfmt', 'oxlint', 'oxlint-tsgolint'];
 const typescriptGoDependency = '@typescript/native-preview';
+const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
 const obsoleteLintDependencies = [
   '@biomejs/biome',
@@ -96,6 +97,7 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
 
   await removeDeprecatedStuff(config, jsonObj);
   await updateScripts(config, jsonObj, packageManager);
+  moveManagedToolDependenciesToDevDependencies(jsonObj);
   const dependencyUpdates = applyPackageJsonConventions(config, rootConfig, jsonObj);
   await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
   addDependencyVersionsToPackageJson(jsonObj, dependencyUpdates);
@@ -244,11 +246,7 @@ function applyPackageJsonConventions(
   }
 
   if (config.depending.wb || config.isBun) {
-    if (jsonObj.dependencies['@willbooster/wb']) {
-      dependencies.push('@willbooster/wb');
-    } else {
-      devDependencies.push('@willbooster/wb');
-    }
+    devDependencies.push(wbDependency);
     for (const [key, value] of Object.entries(jsonObj.scripts)) {
       if (typeof value !== 'string') continue;
       jsonObj.scripts[key] = value.replaceAll(/wb\s+db/gu, 'wb prisma');
@@ -258,9 +256,8 @@ function applyPackageJsonConventions(
   // build-ts owns TypeScript execution and declaration emit. wbfy must always
   // keep existing build-ts users current because older releases can emit .d.ts
   // files at paths that no longer match package exports.
-  if (jsonObj.dependencies[buildTsDependency]) {
-    dependencies.push(buildTsDependency);
-  } else if (
+  if (
+    jsonObj.dependencies[buildTsDependency] ||
     jsonObj.devDependencies[buildTsDependency] ||
     Object.values(jsonObj.scripts).some((script) => script?.includes(buildTsDependency))
   ) {
@@ -303,6 +300,14 @@ function applyPackageJsonConventions(
   }
 
   return { dependencies, devDependencies, pythonDevDependencies };
+}
+
+function moveManagedToolDependenciesToDevDependencies(jsonObj: WritablePackageJson): void {
+  for (const dependency of [wbDependency, buildTsDependency]) {
+    if (!jsonObj.dependencies[dependency]) continue;
+    jsonObj.devDependencies[dependency] ??= jsonObj.dependencies[dependency];
+    delete jsonObj.dependencies[dependency];
+  }
 }
 
 async function normalizePackageMetadata(

--- a/packages/wbfy/src/generators/yarnrc.ts
+++ b/packages/wbfy/src/generators/yarnrc.ts
@@ -12,6 +12,7 @@ import { promisePool } from '../utils/promisePool.js';
 import { spawnSync, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
 
 type Settings = {
+  approvedGitRepositories?: string[];
   defaultSemverRangePrefix: string;
   nmMode: string;
   nodeLinker: string;
@@ -68,6 +69,11 @@ export async function generateYarnrcYml(config: PackageConfig): Promise<void> {
     settings.nodeLinker = 'node-modules';
     settings.nmMode = 'hardlinks-global';
     settings.npmMinimalAgeGate = '5d';
+    settings.approvedGitRepositories = [
+      // Yarn 4.14 blocks git dependencies unless the repository URL is explicitly allowed.
+      'https://github.com/WillBoosterLab/*.git',
+      'ssh://git@github.com/WillBoosterLab/*.git',
+    ];
     settings.npmPreapprovedPackages = [
       // ---------- START: We believe our packages are safe ----------
       '@exercode/*',


### PR DESCRIPTION
## Summary

- Move wbfy-managed `@willbooster/wb` and `build-ts` from `dependencies` to `devDependencies` in source package manifests.
- Promote those two tools back into `dependencies` when `wb optimizeForDockerBuild` writes Docker package manifests, including the `--outside` path used before production installs.

## Why

- These packages are development tooling in source repos, but Docker production installs still need them available at runtime for `wb` and `build-ts` based container commands.

## Testing

- `yarn check-for-ai`
- `yarn start /Users/exkazuu/ghq/github.com/WillBoosterLab/llm-proxy` from `packages/wbfy`
- `yarn start --working-dir /Users/exkazuu/ghq/github.com/WillBoosterLab/llm-proxy optimizeForDockerBuild --outside` from `packages/wb`
- `yarn start --working-dir /Users/exkazuu/ghq/github.com/WillBoosterLab/llm-proxy optimizeForDockerBuild --dry-run` from `packages/wb`
- `bun check-for-ai` in `/Users/exkazuu/ghq/github.com/WillBoosterLab/llm-proxy`
