### PR TITLE
fix: clarify lefthook staged file expansion

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,12 +13,15 @@ pre-commit:
   jobs:
     - name: cleanup
       glob: '**/*.{astro,cjs,css,cts,gql,graphql,hbs,htm,html,java,js,json,json5,jsonc,jsx,less,md,mdx,mjs,mts,scss,svelte,toml,ts,tsx,vue,yaml,yml}'
-      run: yarn workspace @willbooster/wb start --working-dir "$(git rev-parse --show-toplevel)" lint --fix --format -- {staged_files}
+      run: |-
+        # Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
+        yarn workspace @willbooster/wb start --working-dir "$(git rev-parse --show-toplevel)" lint --fix --format -- {staged_files}
       stage_fixed: true
     - name: check-migrations
       glob: '**/migration.sql'
       run: |-
         failed=0
+        # Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
         for file in {staged_files}; do
           if grep -q 'Warnings:' "$file"; then
             echo "Migration SQL file ($file) contains warnings! Please solve the warnings and commit again."

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -70,6 +70,7 @@ const preCommitSettings: LefthookSettings['pre-commit'] = {
       glob: '**/migration.sql',
       run: `
 failed=0
+# Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
 for file in {staged_files}; do
   if grep -q 'Warnings:' "$file"; then
     echo "Migration SQL file ($file) contains warnings! Please solve the warnings and commit again."
@@ -205,12 +206,18 @@ function getCleanupGlobs(config: PackageConfig): string {
 
 function getCleanupCommand(config: PackageConfig): string {
   if (hasLocalWbWorkspace(config)) {
-    return 'yarn workspace @willbooster/wb start --working-dir "$(git rev-parse --show-toplevel)" lint --fix --format -- {staged_files}';
+    return String.raw`
+# Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
+yarn workspace @willbooster/wb start --working-dir "$(git rev-parse --show-toplevel)" lint --fix --format -- {staged_files}
+`.trim();
   }
   if (config.isBun || config.depending.wb) {
     const packageManager = config.isBun ? 'bun' : 'yarn';
     return config.depending.wb
-      ? `${config.isBun ? 'bun --bun wb' : 'yarn wb'} lint --fix --format -- {staged_files}`
+      ? `
+# Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
+${config.isBun ? 'bun --bun wb' : 'yarn wb'} lint --fix --format -- {staged_files}
+`.trim()
       : `${packageManager} run format && ${packageManager} run lint-fix`;
   }
 
@@ -220,6 +227,7 @@ function getCleanupCommand(config: PackageConfig): string {
   const hasJsOrTs = doesContainJsOrTs(config);
 
   return String.raw`
+# Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
 ${hasJsOrTs ? String.raw`oxlint_files="$(printf '%s\n' {staged_files} | grep -E '(${oxlintPattern})' || true)"` : ''}
 ${hasJsOrTs ? String.raw`oxfmt_files="$(printf '%s\n' {staged_files} | grep -E '(${oxfmtPattern})' || true)"` : ''}
 prettier_files="$(printf '%s\n' {staged_files} | grep -E '(${prettierPattern})' || true)"


### PR DESCRIPTION
## Summary

- Add comments to generated Lefthook cleanup and migration checks documenting how `{staged_files}` is expanded.
- Mirror the same comments in the checked-in root `lefthook.yml`.

## Why

- The reviewed code is valid with Lefthook 2.1.5 because `{staged_files}` is expanded as shell-escaped arguments, preserving paths that contain spaces.
- The comments make that assumption explicit at the call sites that look like shell word-splitting risks.

## Testing

- `yarn check-for-ai`
- Pre-push hook check during `git push`
- Manual Lefthook 2.1.5 reproduction with staged filenames containing spaces before applying this documentation change
