### PR TITLE
fix: write package metadata before installing deps

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -105,7 +105,10 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
   removeEmptyDependencySections(jsonObj);
 
   if (config.isBun) delete jsonObj.packageManager;
-  await promisePool.run(() => fsUtil.generateFile(filePath, JSON.stringify(sortPackageJson(jsonObj), undefined, 2)));
+  // Yarn reads package.json from disk before deciding whether `yarn add -D`
+  // conflicts with an existing regular dependency, so this write must finish
+  // before installing the managed dependency updates below.
+  await fsUtil.generateFile(filePath, JSON.stringify(sortPackageJson(jsonObj), undefined, 2));
 
   if (!skipAddingDeps) {
     installDependencyUpdates(config, jsonObj, dependencyUpdates, packageManager);


### PR DESCRIPTION
## Summary

- Write generated `package.json` synchronously before running managed dependency installs.
- Preserve the existing promise pool for other generated files whose writes do not affect immediate package-manager reads.

## Why

- `wbfy` moves managed tools such as `build-ts` from `dependencies` to `devDependencies` before running `yarn add -D`.
- The previous pooled write could still be pending when Yarn read `package.json`, so Yarn failed with `Package "build-ts" is already listed as a regular dependency` in workspaces such as `judge/packages/shared`.

## Testing

- `yarn check-for-ai`
- Pre-push hook check across shared workspaces
- Reproduced the failure against a disposable clone of `WillBoosterLab/judge`, then reran through the original failing `packages/shared` step and confirmed the `build-ts` Yarn usage error no longer occurs.
