### PR TITLE
fix: relax trusted package age gates in wbfy

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -16,6 +16,7 @@ npmPreapprovedPackages:
   - '@exercode/*'
   - '@willbooster/*'
   - agent-runtime-kit
+  - at-decorators
   - build-ts
   - one-way-git-sync
   - next

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -33,6 +33,7 @@ const minimumReleaseAgeExcludes = [
   '@willbooster/shared-lib-react',
   '@willbooster/wb',
   'agent-runtime-kit',
+  'at-decorators',
   'build-ts',
   'one-way-git-sync',
   // ---------- END: We believe our packages are safe ----------

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -22,6 +22,8 @@ const minimumReleaseAgeExcludes = [
   '@exercode/problem-utils',
   '@willbooster/agent-skills',
   '@willbooster/babel-configs',
+  '@willbooster/monaco-loader',
+  '@willbooster/monaco-react',
   '@willbooster/oxfmt-config',
   '@willbooster/oxlint-config',
   '@willbooster/prettier-config',

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -25,6 +25,7 @@ const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', '
 const typescriptGoDependency = '@typescript/native-preview';
 const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
+const atDecoratorsDependency = 'at-decorators';
 const obsoleteLintDependencies = [
   '@biomejs/biome',
   '@eslint-react/eslint-plugin',
@@ -273,6 +274,10 @@ function applyPackageJsonConventions(
     Object.values(jsonObj.scripts).some((script) => script?.includes(buildTsDependency))
   ) {
     devDependencies.push(buildTsDependency);
+  }
+  // Decorator runtimes need to stay aligned with the current Stage 3 output.
+  if (jsonObj.dependencies[atDecoratorsDependency] || jsonObj.devDependencies[atDecoratorsDependency]) {
+    devDependencies.push(atDecoratorsDependency);
   }
 
   if (doesContainJsOrTs(config)) {
@@ -659,6 +664,7 @@ function shouldUpdateExistingManagedDependency(dependency: string, currentVersio
   return (
     dependency === '@willbooster/wb' ||
     dependency === buildTsDependency ||
+    dependency === atDecoratorsDependency ||
     dependency === '@willbooster/oxlint-config' ||
     dependency === 'oxlint' ||
     dependency === typescriptGoDependency

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -25,7 +25,6 @@ const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', '
 const typescriptGoDependency = '@typescript/native-preview';
 const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
-const atDecoratorsDependency = 'at-decorators';
 const obsoleteLintDependencies = [
   '@biomejs/biome',
   '@eslint-react/eslint-plugin',
@@ -275,11 +274,6 @@ function applyPackageJsonConventions(
   ) {
     devDependencies.push(buildTsDependency);
   }
-  // Decorator runtimes need to stay aligned with the current Stage 3 output.
-  if (jsonObj.dependencies[atDecoratorsDependency] || jsonObj.devDependencies[atDecoratorsDependency]) {
-    devDependencies.push(atDecoratorsDependency);
-  }
-
   if (doesContainJsOrTs(config)) {
     devDependencies.push(...oxlintDeps);
   }
@@ -664,7 +658,6 @@ function shouldUpdateExistingManagedDependency(dependency: string, currentVersio
   return (
     dependency === '@willbooster/wb' ||
     dependency === buildTsDependency ||
-    dependency === atDecoratorsDependency ||
     dependency === '@willbooster/oxlint-config' ||
     dependency === 'oxlint' ||
     dependency === typescriptGoDependency

--- a/packages/wbfy/src/generators/yarnrc.ts
+++ b/packages/wbfy/src/generators/yarnrc.ts
@@ -79,6 +79,7 @@ export async function generateYarnrcYml(config: PackageConfig): Promise<void> {
       '@exercode/*',
       '@willbooster/*',
       'agent-runtime-kit',
+      'at-decorators',
       'build-ts',
       'one-way-git-sync',
       // ---------- END: We believe our packages are safe ----------


### PR DESCRIPTION
## Summary

- Add `at-decorators` to Yarn `npmPreapprovedPackages` generated by wbfy.
- Add `at-decorators`, `@willbooster/monaco-loader`, and `@willbooster/monaco-react` to Bun `minimumReleaseAgeExcludes` generated by wbfy.
- Update this repo's `.yarnrc.yml` so the current workspace can install a newly released `at-decorators` version.

## Why

- These trusted packages can be released and consumed immediately by WillBooster tooling, but Yarn and Bun's five-day release-age gates can block latest installs.
- Yarn already covers `@willbooster/monaco-loader` and `@willbooster/monaco-react` through the existing `@willbooster/*` preapproval. Bun needs explicit package names.
- This keeps the age gate in place globally while relaxing it only for trusted packages.

## Testing

- `yarn check-for-ai`
- Pre-push hook check
