### PR TITLE
fix: relax gen-i18n-ts package age gates

### DIFF
--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -37,6 +37,7 @@ const minimumReleaseAgeExcludes = [
   'agent-runtime-kit',
   'at-decorators',
   'build-ts',
+  'gen-i18n-ts',
   'one-way-git-sync',
   // ---------- END: We believe our packages are safe ----------
 

--- a/packages/wbfy/src/generators/yarnrc.ts
+++ b/packages/wbfy/src/generators/yarnrc.ts
@@ -81,6 +81,7 @@ export async function generateYarnrcYml(config: PackageConfig): Promise<void> {
       'agent-runtime-kit',
       'at-decorators',
       'build-ts',
+      'gen-i18n-ts',
       'one-way-git-sync',
       // ---------- END: We believe our packages are safe ----------
 


### PR DESCRIPTION
## Summary

- Add `gen-i18n-ts` to generated Bun `minimumReleaseAgeExcludes`.
- Add `gen-i18n-ts` to generated Yarn `npmPreapprovedPackages`.

## Why

- The generated Bun and Yarn settings apply age gates that can block newly published versions from being installed.
- `gen-i18n-ts` should be treated like the other trusted tooling packages so managed installs can resolve the latest release.

## Testing

- `yarn check-for-ai`
- Pre-push hook check
