### PR TITLE
fix: generate i18n types for untracked outputs

### DIFF
--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -111,15 +111,7 @@ async function core(config: PackageConfig): Promise<void> {
   const settings: Partial<LefthookSettings> = {
     ...baseSettings,
     'pre-commit': {
-      jobs: preCommitSettings.jobs.map((job) =>
-        job.name === 'cleanup'
-          ? {
-              ...job,
-              glob: getCleanupGlobs(config),
-              run: getCleanupCommand(config),
-            }
-          : job
-      ),
+      jobs: getPreCommitJobs(config),
     },
   };
   if (!lint) {
@@ -187,6 +179,27 @@ ${lintCommand}
 `.trim();
   }
   return lintCommand;
+}
+
+function getPreCommitJobs(config: PackageConfig): LefthookJob[] {
+  const jobs = preCommitSettings.jobs.map((job) =>
+    job.name === 'cleanup'
+      ? {
+          ...job,
+          glob: getCleanupGlobs(config),
+          run: getCleanupCommand(config),
+        }
+      : job
+  );
+  if (hasGenI18nTsScript(config)) {
+    // gen-i18n-ts outputs are commonly ignored, so keep local generated types fresh when resources change.
+    jobs.push({
+      name: 'gen-i18n-ts',
+      glob: 'i18n/*.json',
+      run: `${getPackageManagerRunCommand(config, 'gen-i18n-ts')} > /dev/null`,
+    });
+  }
+  return jobs;
 }
 
 function getCleanupGlobs(config: PackageConfig): string {
@@ -283,6 +296,14 @@ fi`
 `.trim();
 }
 
+function hasGenI18nTsScript(config: PackageConfig): boolean {
+  return config.depending.genI18nTs && !!config.packageJson?.scripts?.['gen-i18n-ts'];
+}
+
+function getPackageManagerRunCommand(config: PackageConfig, scriptName: string): string {
+  return config.isBun ? `bun run ${scriptName}` : `yarn ${scriptName}`;
+}
+
 function hasLocalWbWorkspace(config: PackageConfig): boolean {
   if (!config.isRoot) return false;
 
@@ -322,6 +343,11 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
     postMergeCommands.push(
       String.raw`run_if_changed ".*\.prisma" "node node_modules/.bin/dotenv -c development -- node node_modules/.bin/prisma migrate deploy"`,
       String.raw`run_if_changed ".*\.prisma" "node node_modules/.bin/dotenv -c development -- node node_modules/.bin/prisma generate"`
+    );
+  }
+  if (hasGenI18nTsScript(config)) {
+    postMergeCommands.push(
+      String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "${getPackageManagerRunCommand(config, 'gen-i18n-ts')} > /dev/null"`
     );
   }
   return postMergeCommands;

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -8,7 +8,6 @@ import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { extensions } from '../utils/extensions.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
-import { promisePool } from '../utils/promisePool.js';
 import { spawnSync } from '../utils/spawnUtil.js';
 
 import { generateScripts } from './packageJson.js';
@@ -141,19 +140,15 @@ async function core(config: PackageConfig): Promise<void> {
   if (lint) {
     const prePush = getPrePushScript(config);
     fs.mkdirSync(path.join(dirPath, 'pre-push'), { recursive: true });
-    await promisePool.run(() =>
-      fs.promises.writeFile(path.join(dirPath, 'pre-push', 'check.sh'), prePush + '\n', {
-        mode: 0o755,
-      })
-    );
+    await fs.promises.writeFile(path.join(dirPath, 'pre-push', 'check.sh'), prePush + '\n', {
+      mode: 0o755,
+    });
   }
   const postMergeCommand = `${scripts.postMerge}\n\n${generatePostMergeCommands(config).join('\n')}\n`;
   fs.mkdirSync(path.join(dirPath, 'post-merge'), { recursive: true });
-  await promisePool.run(() =>
-    fs.promises.writeFile(path.resolve(dirPath, 'post-merge', 'prepare.sh'), postMergeCommand, {
-      mode: 0o755,
-    })
-  );
+  await fs.promises.writeFile(path.resolve(dirPath, 'post-merge', 'prepare.sh'), postMergeCommand, {
+    mode: 0o755,
+  });
 }
 
 function getPrePushScript(config: PackageConfig): string {
@@ -191,14 +186,6 @@ function getPreCommitJobs(config: PackageConfig): LefthookJob[] {
         }
       : job
   );
-  if (hasGenI18nTsScript(config)) {
-    // gen-i18n-ts outputs are commonly ignored, so keep local generated types fresh when resources change.
-    jobs.push({
-      name: 'gen-i18n-ts',
-      glob: 'i18n/*.json',
-      run: `${getPackageManagerRunCommand(config, 'gen-i18n-ts')} > /dev/null`,
-    });
-  }
   return jobs;
 }
 
@@ -346,6 +333,7 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
     );
   }
   if (hasGenI18nTsScript(config)) {
+    // gen-i18n-ts outputs are commonly ignored, so post-merge regenerates them after pulled resource changes.
     postMergeCommands.push(
       String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "${getPackageManagerRunCommand(config, 'gen-i18n-ts')} > /dev/null"`
     );

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -7,6 +7,7 @@ import yaml from 'js-yaml';
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { extensions } from '../utils/extensions.js';
+import { getPackageManagerRunCommand, hasGenI18nTsScript } from '../utils/genI18nTs.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { spawnSync } from '../utils/spawnUtil.js';
 
@@ -323,21 +324,13 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
       String.raw`run_if_changed ".*\.prisma" "node node_modules/.bin/dotenv -c development -- node node_modules/.bin/prisma generate"`
     );
   }
-  if (hasGenI18nTsScript(config)) {
+  if (hasGenI18nTsScript(config, config.packageJson?.scripts)) {
     // gen-i18n-ts outputs are commonly ignored, so post-merge regenerates them after pulled resource changes.
     postMergeCommands.push(
       String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "${getPackageManagerRunCommand(config, 'gen-i18n-ts')} > /dev/null"`
     );
   }
   return postMergeCommands;
-}
-
-function hasGenI18nTsScript(config: PackageConfig): boolean {
-  return config.depending.genI18nTs && !!config.packageJson?.scripts?.['gen-i18n-ts'];
-}
-
-function getPackageManagerRunCommand(config: PackageConfig, scriptName: string): string {
-  return `${config.isBun ? 'bun' : 'yarn'} run ${scriptName}`;
 }
 
 function hasPythonPackageManager(config: PackageConfig): boolean {

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -177,7 +177,7 @@ ${lintCommand}
 }
 
 function getPreCommitJobs(config: PackageConfig): LefthookJob[] {
-  const jobs = preCommitSettings.jobs.map((job) =>
+  return preCommitSettings.jobs.map((job) =>
     job.name === 'cleanup'
       ? {
           ...job,
@@ -186,7 +186,6 @@ function getPreCommitJobs(config: PackageConfig): LefthookJob[] {
         }
       : job
   );
-  return jobs;
 }
 
 function getCleanupGlobs(config: PackageConfig): string {
@@ -283,14 +282,6 @@ fi`
 `.trim();
 }
 
-function hasGenI18nTsScript(config: PackageConfig): boolean {
-  return config.depending.genI18nTs && !!config.packageJson?.scripts?.['gen-i18n-ts'];
-}
-
-function getPackageManagerRunCommand(config: PackageConfig, scriptName: string): string {
-  return `${config.isBun ? 'bun' : 'yarn'} run ${scriptName}`;
-}
-
 function hasLocalWbWorkspace(config: PackageConfig): boolean {
   if (!config.isRoot) return false;
 
@@ -339,6 +330,14 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
     );
   }
   return postMergeCommands;
+}
+
+function hasGenI18nTsScript(config: PackageConfig): boolean {
+  return config.depending.genI18nTs && !!config.packageJson?.scripts?.['gen-i18n-ts'];
+}
+
+function getPackageManagerRunCommand(config: PackageConfig, scriptName: string): string {
+  return `${config.isBun ? 'bun' : 'yarn'} run ${scriptName}`;
 }
 
 function hasPythonPackageManager(config: PackageConfig): boolean {

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -288,7 +288,7 @@ function hasGenI18nTsScript(config: PackageConfig): boolean {
 }
 
 function getPackageManagerRunCommand(config: PackageConfig, scriptName: string): string {
-  return config.isBun ? `bun run ${scriptName}` : `yarn ${scriptName}`;
+  return `${config.isBun ? 'bun' : 'yarn'} run ${scriptName}`;
 }
 
 function hasLocalWbWorkspace(config: PackageConfig): boolean {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -459,7 +459,7 @@ function hasGenI18nTsScript(config: PackageConfig, jsonObj: WritablePackageJson)
 }
 
 function getPackageManagerRunCommand(config: PackageConfig, scriptName: string): string {
-  return config.isBun ? `bun run ${scriptName}` : `yarn ${scriptName}`;
+  return `${config.isBun ? 'bun' : 'yarn'} run ${scriptName}`;
 }
 
 async function normalizePublishedConfigPackageMetadata(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -434,11 +434,32 @@ async function normalizePackageMetadata(
   } else if (config.depending.prisma && !jsonObj.scripts['gen-code']?.startsWith('prisma generate')) {
     jsonObj.scripts['gen-code'] = 'prisma generate';
   }
+  addGenI18nTsPostinstallScript(config, jsonObj);
 
   if (!jsonObj.dependencies.prettier) {
     // Because @types/prettier blocks prettier execution.
     delete jsonObj.devDependencies['@types/prettier'];
   }
+}
+
+function addGenI18nTsPostinstallScript(config: PackageConfig, jsonObj: WritablePackageJson): void {
+  if (!hasGenI18nTsScript(config, jsonObj)) return;
+
+  const command = `${getPackageManagerRunCommand(config, 'gen-i18n-ts')} > /dev/null`;
+  const postinstall = jsonObj.scripts.postinstall;
+  if (!postinstall) {
+    jsonObj.scripts.postinstall = command;
+  } else if (!postinstall.includes(command)) {
+    jsonObj.scripts.postinstall = `${postinstall} && ${command}`;
+  }
+}
+
+function hasGenI18nTsScript(config: PackageConfig, jsonObj: WritablePackageJson): boolean {
+  return config.depending.genI18nTs && !!jsonObj.scripts['gen-i18n-ts'];
+}
+
+function getPackageManagerRunCommand(config: PackageConfig, scriptName: string): string {
+  return config.isBun ? `bun run ${scriptName}` : `yarn ${scriptName}`;
 }
 
 async function normalizePublishedConfigPackageMetadata(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -11,6 +11,7 @@ import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { extensions } from '../utils/extensions.js';
 import { fsUtil } from '../utils/fsUtil.js';
+import { getPackageManagerRunCommand, hasGenI18nTsScript } from '../utils/genI18nTs.js';
 import { gitHubUtil } from '../utils/githubUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
 import { ignoreFileUtil } from '../utils/ignoreFileUtil.js';
@@ -443,7 +444,7 @@ async function normalizePackageMetadata(
 }
 
 function addGenI18nTsPostinstallScript(config: PackageConfig, jsonObj: WritablePackageJson): void {
-  if (!hasGenI18nTsScript(config, jsonObj)) return;
+  if (!hasGenI18nTsScript(config, jsonObj.scripts)) return;
 
   const command = `${getPackageManagerRunCommand(config, 'gen-i18n-ts')} > /dev/null`;
   const postinstall = jsonObj.scripts.postinstall;
@@ -452,14 +453,6 @@ function addGenI18nTsPostinstallScript(config: PackageConfig, jsonObj: WritableP
   } else if (!postinstall.includes(command)) {
     jsonObj.scripts.postinstall = `${postinstall} && ${command}`;
   }
-}
-
-function hasGenI18nTsScript(config: PackageConfig, jsonObj: WritablePackageJson): boolean {
-  return config.depending.genI18nTs && !!jsonObj.scripts['gen-i18n-ts'];
-}
-
-function getPackageManagerRunCommand(config: PackageConfig, scriptName: string): string {
-  return `${config.isBun ? 'bun' : 'yarn'} run ${scriptName}`;
 }
 
 async function normalizePublishedConfigPackageMetadata(

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -203,7 +203,7 @@ export async function getPackageConfig(
       depending: {
         blitz: !!dependencies.blitz,
         firebase: !!devDependencies['firebase-tools'],
-        genI18nTs: !!devDependencies['gen-i18n-ts'],
+        genI18nTs: !!dependencies['gen-i18n-ts'] || !!devDependencies['gen-i18n-ts'],
         litestream: dockerfile.includes('install-litestream.sh'),
         react: !!dependencies.react,
         next: !!dependencies.next,

--- a/packages/wbfy/src/utils/genI18nTs.ts
+++ b/packages/wbfy/src/utils/genI18nTs.ts
@@ -1,0 +1,11 @@
+import type { PackageJson } from 'type-fest';
+
+import type { PackageConfig } from '../packageConfig.js';
+
+export function hasGenI18nTsScript(config: PackageConfig, scripts: PackageJson.Scripts | undefined): boolean {
+  return config.depending.genI18nTs && !!scripts?.['gen-i18n-ts'];
+}
+
+export function getPackageManagerRunCommand(config: Pick<PackageConfig, 'isBun'>, scriptName: string): string {
+  return `${config.isBun ? 'bun' : 'yarn'} run ${scriptName}`;
+}

--- a/packages/wbfy/test/lefthookGenerator.test.ts
+++ b/packages/wbfy/test/lefthookGenerator.test.ts
@@ -121,37 +121,37 @@ test('does not generate oxlint or oxfmt hooks for package-only projects', async 
   expect(lefthookConfig).not.toContain('oxlint');
 });
 
-test('runs gen-i18n-ts from lefthook when i18n resources change', async () => {
-  const dirPath = createTempDir();
+test('runs gen-i18n-ts from lefthook after pulled i18n resources change', async () => {
+  const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-lefthook-i18n-'));
 
-  await generateLefthookUpdatingPackageJson(
-    createConfig({
-      dirPath,
-      doesContainPackageJson: true,
-      doesContainTypeScript: true,
-      depending: {
-        ...createConfig().depending,
-        genI18nTs: true,
-      },
-      packageJson: {
-        scripts: {
-          'gen-i18n-ts': 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP',
+  try {
+    await generateLefthookUpdatingPackageJson(
+      createConfig({
+        dirPath,
+        doesContainPackageJson: true,
+        doesContainTypeScript: true,
+        depending: {
+          ...createConfig().depending,
+          genI18nTs: true,
         },
-      },
-    })
-  );
+        packageJson: {
+          scripts: {
+            'gen-i18n-ts': 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP',
+          },
+        },
+      })
+    );
 
-  const lefthookConfig = await fs.promises.readFile(path.join(dirPath, 'lefthook.yml'), 'utf8');
-  const postMergeScript = await fs.promises.readFile(
-    path.join(dirPath, '.lefthook', 'post-merge', 'prepare.sh'),
-    'utf8'
-  );
-  expect(lefthookConfig).toContain('name: gen-i18n-ts');
-  expect(lefthookConfig).toContain('glob: i18n/*.json');
-  expect(lefthookConfig).toContain('yarn gen-i18n-ts > /dev/null');
-  expect(postMergeScript).toContain(
-    String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "yarn gen-i18n-ts > /dev/null"`
-  );
+    const postMergeScript = await fs.promises.readFile(
+      path.join(dirPath, '.lefthook', 'post-merge', 'prepare.sh'),
+      'utf8'
+    );
+    expect(postMergeScript).toContain(
+      String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "yarn gen-i18n-ts > /dev/null"`
+    );
+  } finally {
+    await fs.promises.rm(dirPath, { force: true, recursive: true });
+  }
 });
 
 function createTempDir(): string {

--- a/packages/wbfy/test/lefthookGenerator.test.ts
+++ b/packages/wbfy/test/lefthookGenerator.test.ts
@@ -121,6 +121,39 @@ test('does not generate oxlint or oxfmt hooks for package-only projects', async 
   expect(lefthookConfig).not.toContain('oxlint');
 });
 
+test('runs gen-i18n-ts from lefthook when i18n resources change', async () => {
+  const dirPath = createTempDir();
+
+  await generateLefthookUpdatingPackageJson(
+    createConfig({
+      dirPath,
+      doesContainPackageJson: true,
+      doesContainTypeScript: true,
+      depending: {
+        ...createConfig().depending,
+        genI18nTs: true,
+      },
+      packageJson: {
+        scripts: {
+          'gen-i18n-ts': 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP',
+        },
+      },
+    })
+  );
+
+  const lefthookConfig = await fs.promises.readFile(path.join(dirPath, 'lefthook.yml'), 'utf8');
+  const postMergeScript = await fs.promises.readFile(
+    path.join(dirPath, '.lefthook', 'post-merge', 'prepare.sh'),
+    'utf8'
+  );
+  expect(lefthookConfig).toContain('name: gen-i18n-ts');
+  expect(lefthookConfig).toContain('glob: i18n/*.json');
+  expect(lefthookConfig).toContain('yarn gen-i18n-ts > /dev/null');
+  expect(postMergeScript).toContain(
+    String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "yarn gen-i18n-ts > /dev/null"`
+  );
+});
+
 function createTempDir(): string {
   const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-lefthook-'));
   tempDirs.push(dirPath);

--- a/packages/wbfy/test/lefthookGenerator.test.ts
+++ b/packages/wbfy/test/lefthookGenerator.test.ts
@@ -147,7 +147,7 @@ test('runs gen-i18n-ts from lefthook after pulled i18n resources change', async 
       'utf8'
     );
     expect(postMergeScript).toContain(
-      String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "yarn gen-i18n-ts > /dev/null"`
+      String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "yarn run gen-i18n-ts > /dev/null"`
     );
   } finally {
     await fs.promises.rm(dirPath, { force: true, recursive: true });

--- a/packages/wbfy/test/packageJsonGenerator.test.ts
+++ b/packages/wbfy/test/packageJsonGenerator.test.ts
@@ -103,7 +103,7 @@ describe('generatePackageJson', () => {
     await promisePool.promiseAll();
 
     const packageJson = readPackageJson(dirPath);
-    expect(packageJson.scripts?.postinstall).toBe('yarn gen-i18n-ts > /dev/null');
+    expect(packageJson.scripts?.postinstall).toBe('yarn run gen-i18n-ts > /dev/null');
   });
 });
 

--- a/packages/wbfy/test/packageJsonGenerator.test.ts
+++ b/packages/wbfy/test/packageJsonGenerator.test.ts
@@ -76,6 +76,35 @@ describe('generatePackageJson', () => {
     expect(packageJson.devDependencies).not.toHaveProperty('eslint');
     expect(packageJson).not.toHaveProperty('peerDependencies');
   });
+
+  test('generates i18n types after install when gen-i18n-ts is used', async () => {
+    const dirPath = await createPackageDir({
+      name: 'i18n-package',
+      private: true,
+      dependencies: {
+        'gen-i18n-ts': '4.0.6',
+      },
+      scripts: {
+        'gen-i18n-ts': 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP',
+        postinstall: 'custom-setup',
+      },
+    });
+    const config = createConfig({
+      dirPath,
+      isRoot: true,
+      depending: {
+        ...createConfig().depending,
+        genI18nTs: true,
+      },
+      packageJson: readPackageJson(dirPath),
+    });
+
+    await generatePackageJson(config, config, true);
+    await promisePool.promiseAll();
+
+    const packageJson = readPackageJson(dirPath);
+    expect(packageJson.scripts?.postinstall).toBe('yarn gen-i18n-ts > /dev/null');
+  });
 });
 
 async function createPackageDir(packageJson: PackageJson): Promise<string> {


### PR DESCRIPTION
## Summary

- Detect `gen-i18n-ts` when it is declared in either dependencies or devDependencies.
- Generate ignored i18n TypeScript outputs from package `postinstall` when a project has a `gen-i18n-ts` script.
- Regenerate i18n TypeScript outputs from lefthook `post-merge` when pulled i18n resources or package metadata change.
- Share the i18n script helper logic used by the package.json and lefthook generators.
- Make generated lefthook script writes deterministic by awaiting direct file writes.

## Why

Generated i18n TypeScript files are commonly ignored rather than committed. Projects that remove those generated outputs from Git still need them recreated after fresh installs and after pulling translation changes.

## Testing

- `yarn check-for-ai`
- `yarn vitest test/packageJsonGenerator.test.ts test/lefthookGenerator.test.ts`
- `git push` pre-push hook
- `bunx @willbooster/agent-skills@latest check-pr-ci`
