### PR TITLE
refactor: centralize i18n generation command

### DIFF
--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -7,7 +7,7 @@ import yaml from 'js-yaml';
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { extensions } from '../utils/extensions.js';
-import { getPackageManagerRunCommand, hasGenI18nTsScript } from '../utils/genI18nTs.js';
+import { getGenI18nTsCommand } from '../utils/genI18nTs.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { spawnSync } from '../utils/spawnUtil.js';
 
@@ -324,11 +324,10 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
       String.raw`run_if_changed ".*\.prisma" "node node_modules/.bin/dotenv -c development -- node node_modules/.bin/prisma generate"`
     );
   }
-  if (hasGenI18nTsScript(config, config.packageJson?.scripts)) {
+  const genI18nTsCommand = getGenI18nTsCommand(config, config.packageJson?.scripts);
+  if (genI18nTsCommand) {
     // gen-i18n-ts outputs are commonly ignored, so post-merge regenerates them after pulled resource changes.
-    postMergeCommands.push(
-      String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "${getPackageManagerRunCommand(config, 'gen-i18n-ts')} > /dev/null"`
-    );
+    postMergeCommands.push(String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "${genI18nTsCommand}"`);
   }
   return postMergeCommands;
 }

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -327,7 +327,7 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
   const genI18nTsCommand = getGenI18nTsCommand(config, config.packageJson?.scripts);
   if (genI18nTsCommand) {
     // gen-i18n-ts outputs are commonly ignored, so post-merge regenerates them after pulled resource changes.
-    postMergeCommands.push(String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "${genI18nTsCommand}"`);
+    postMergeCommands.push(String.raw`run_if_changed "(^|/)i18n/.*\.json$" "${genI18nTsCommand}"`);
   }
   return postMergeCommands;
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -11,7 +11,7 @@ import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { extensions } from '../utils/extensions.js';
 import { fsUtil } from '../utils/fsUtil.js';
-import { getPackageManagerRunCommand, hasGenI18nTsScript } from '../utils/genI18nTs.js';
+import { getGenI18nTsCommand } from '../utils/genI18nTs.js';
 import { gitHubUtil } from '../utils/githubUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
 import { ignoreFileUtil } from '../utils/ignoreFileUtil.js';
@@ -444,9 +444,9 @@ async function normalizePackageMetadata(
 }
 
 function addGenI18nTsPostinstallScript(config: PackageConfig, jsonObj: WritablePackageJson): void {
-  if (!hasGenI18nTsScript(config, jsonObj.scripts)) return;
+  const command = getGenI18nTsCommand(config, jsonObj.scripts);
+  if (!command) return;
 
-  const command = `${getPackageManagerRunCommand(config, 'gen-i18n-ts')} > /dev/null`;
   const postinstall = jsonObj.scripts.postinstall;
   if (!postinstall) {
     jsonObj.scripts.postinstall = command;

--- a/packages/wbfy/src/utils/genI18nTs.ts
+++ b/packages/wbfy/src/utils/genI18nTs.ts
@@ -2,10 +2,10 @@ import type { PackageJson } from 'type-fest';
 
 import type { PackageConfig } from '../packageConfig.js';
 
-export function hasGenI18nTsScript(config: PackageConfig, scripts: PackageJson.Scripts | undefined): boolean {
-  return config.depending.genI18nTs && !!scripts?.['gen-i18n-ts'];
-}
-
-export function getPackageManagerRunCommand(config: Pick<PackageConfig, 'isBun'>, scriptName: string): string {
-  return `${config.isBun ? 'bun' : 'yarn'} run ${scriptName}`;
+export function getGenI18nTsCommand(
+  config: Pick<PackageConfig, 'depending' | 'isBun'>,
+  scripts: PackageJson.Scripts | undefined
+): string | undefined {
+  if (!config.depending.genI18nTs || !scripts?.['gen-i18n-ts']) return undefined;
+  return `${config.isBun ? 'bun' : 'yarn'} run gen-i18n-ts > /dev/null`;
 }

--- a/packages/wbfy/test/lefthookGenerator.test.ts
+++ b/packages/wbfy/test/lefthookGenerator.test.ts
@@ -147,7 +147,7 @@ test('runs gen-i18n-ts from lefthook after pulled i18n resources change', async 
       'utf8'
     );
     expect(postMergeScript).toContain(
-      String.raw`run_if_changed "(^|/)i18n/.*\.json$|(^|/)package\.json$" "yarn run gen-i18n-ts > /dev/null"`
+      String.raw`run_if_changed "(^|/)i18n/.*\.json$" "yarn run gen-i18n-ts > /dev/null"`
     );
   } finally {
     await fs.promises.rm(dirPath, { force: true, recursive: true });


### PR DESCRIPTION
## Summary

- Replace separate gen-i18n-ts capability and command helpers with a single shared quiet-command helper.
- Reuse the helper from both package.json and lefthook generation.
- Narrow the post-merge i18n trigger to i18n JSON resources; package metadata changes already run install, which triggers postinstall generation.

## Why

This follows up on the review finding about duplicated i18n generation logic by centralizing the remaining shared command assembly and avoiding duplicate generation after package installs.

## Testing

- yarn check-for-ai
- yarn vitest test/packageJsonGenerator.test.ts test/lefthookGenerator.test.ts
- git push pre-push hook