### PR TITLE
fix: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
   "name": "willbooster-shared",
   "version": "0.0.0-semantically-released",
   "private": true,
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
   "workspaces": [
     "packages/*"
   ],
-  "type": "module",
   "scripts": {
     "build": "yarn workspaces foreach --all --parallel --verbose run build",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -33,19 +33,19 @@
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
-    "@typescript/native-preview": "7.0.0-dev.20260417.1",
+    "@typescript/native-preview": "7.0.0-dev.20260418.1",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "conventional-changelog-conventionalcommits": "9.3.1",
     "lefthook": "2.1.5",
     "oxfmt": "0.45.0",
     "oxlint": "1.60.0",
-    "oxlint-tsgolint": "0.21.0",
+    "oxlint-tsgolint": "0.21.1",
     "semantic-release": "25.0.3",
     "sort-package-json": "3.6.1"
   },
+  "packageManager": "yarn@4.14.1",
   "engines": {
     "node": ">= 22.18.0"
-  },
-  "packageManager": "yarn@4.14.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
   "name": "willbooster-shared",
   "version": "0.0.0-semantically-released",
   "private": true,
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "type": "module",
   "workspaces": [
     "packages/*"
   ],
+  "type": "module",
   "scripts": {
     "build": "yarn workspaces foreach --all --parallel --verbose run build",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -44,8 +44,8 @@
     "semantic-release": "25.0.3",
     "sort-package-json": "3.6.1"
   },
-  "packageManager": "yarn@4.14.1",
   "engines": {
     "node": ">= 22.18.0"
-  }
+  },
+  "packageManager": "yarn@4.14.1"
 }

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -2,15 +2,22 @@
   "name": "@willbooster/shared-lib-blitz-next",
   "version": "0.0.0-semantically-released",
   "description": "Shared library for WillBooster Blitz.js projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/shared-lib-blitz-next"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "sideEffects": false,
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "type": "module",
+  "sideEffects": false,
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -23,13 +30,9 @@
       "import": "./src/index.ts"
     }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "bin/",
-    "dist/"
-  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "build-ts lib",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -58,8 +61,5 @@
     "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -2,22 +2,15 @@
   "name": "@willbooster/shared-lib-blitz-next",
   "version": "0.0.0-semantically-released",
   "description": "Shared library for WillBooster Blitz.js projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/shared-lib-blitz-next"
   },
-  "files": [
-    "bin/",
-    "dist/"
-  ],
-  "type": "module",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "sideEffects": false,
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -30,9 +23,13 @@
       "import": "./src/index.ts"
     }
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "scripts": {
     "build": "build-ts lib",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -51,15 +48,18 @@
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
-    "@typescript/native-preview": "7.0.0-dev.20260417.1",
+    "@typescript/native-preview": "7.0.0-dev.20260418.1",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "blitz": "3.0.2",
-    "build-ts": "17.1.2",
+    "build-ts": "17.1.6",
     "oxfmt": "0.45.0",
     "oxlint": "1.60.0",
-    "oxlint-tsgolint": "0.21.0",
+    "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -2,15 +2,22 @@
   "name": "@willbooster/shared-lib-next",
   "version": "0.0.0-semantically-released",
   "description": "Shared library for WillBooster Next.js projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/shared-lib-next"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "sideEffects": false,
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "type": "module",
+  "sideEffects": false,
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -23,13 +30,9 @@
       "import": "./src/index.ts"
     }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "bin/",
-    "dist/"
-  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "build-ts lib",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -61,8 +64,5 @@
   },
   "peerDependencies": {
     "next": "*"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -2,22 +2,15 @@
   "name": "@willbooster/shared-lib-next",
   "version": "0.0.0-semantically-released",
   "description": "Shared library for WillBooster Next.js projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/shared-lib-next"
   },
-  "files": [
-    "bin/",
-    "dist/"
-  ],
-  "type": "module",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "sideEffects": false,
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -30,9 +23,13 @@
       "import": "./src/index.ts"
     }
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "scripts": {
     "build": "build-ts lib",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -51,18 +48,21 @@
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
-    "@typescript/native-preview": "7.0.0-dev.20260417.1",
+    "@typescript/native-preview": "7.0.0-dev.20260418.1",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
-    "build-ts": "17.1.2",
+    "build-ts": "17.1.6",
     "next": "16.2.4",
     "oxfmt": "0.45.0",
     "oxlint": "1.60.0",
-    "oxlint-tsgolint": "0.21.0",
+    "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"
   },
   "peerDependencies": {
     "next": "*"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -2,15 +2,22 @@
   "name": "@willbooster/shared-lib-node",
   "version": "0.0.0-semantically-released",
   "description": "Shared library for WillBooster Node.js projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/shared-lib-node"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "sideEffects": false,
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "type": "module",
+  "sideEffects": false,
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -23,13 +30,9 @@
       "import": "./src/index.ts"
     }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "bin/",
-    "dist/"
-  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "build-ts lib",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -62,8 +65,5 @@
     "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -2,22 +2,15 @@
   "name": "@willbooster/shared-lib-node",
   "version": "0.0.0-semantically-released",
   "description": "Shared library for WillBooster Node.js projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/shared-lib-node"
   },
-  "files": [
-    "bin/",
-    "dist/"
-  ],
-  "type": "module",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "sideEffects": false,
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -30,9 +23,13 @@
       "import": "./src/index.ts"
     }
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "scripts": {
     "build": "build-ts lib",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -56,14 +53,17 @@
     "@tsconfig/node-ts": "23.6.4",
     "@types/bun": "1.3.12",
     "@types/node": "25.6.0",
-    "@typescript/native-preview": "7.0.0-dev.20260417.1",
+    "@typescript/native-preview": "7.0.0-dev.20260418.1",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
-    "build-ts": "17.1.2",
+    "build-ts": "17.1.6",
     "oxfmt": "0.45.0",
     "oxlint": "1.60.0",
-    "oxlint-tsgolint": "0.21.0",
+    "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -2,15 +2,22 @@
   "name": "@willbooster/shared-lib-react",
   "version": "0.0.0-semantically-released",
   "description": "Shared library for WillBooster React projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/shared-lib-react"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "sideEffects": false,
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "type": "module",
+  "sideEffects": false,
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -18,13 +25,9 @@
       "import": "./dist/index.js"
     }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "bin/",
-    "dist/"
-  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "build-ts lib",
     "build-storybook": "build-storybook",
@@ -73,8 +76,5 @@
   "peerDependencies": {
     "react": "~19.2.0",
     "react-dom": "~19.2.0"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -2,22 +2,15 @@
   "name": "@willbooster/shared-lib-react",
   "version": "0.0.0-semantically-released",
   "description": "Shared library for WillBooster React projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/shared-lib-react"
   },
-  "files": [
-    "bin/",
-    "dist/"
-  ],
-  "type": "module",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "sideEffects": false,
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -25,9 +18,13 @@
       "import": "./dist/index.js"
     }
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "scripts": {
     "build": "build-ts lib",
     "build-storybook": "build-storybook",
@@ -60,14 +57,14 @@
     "@types/node": "25.6.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "@typescript/native-preview": "7.0.0-dev.20260417.1",
+    "@typescript/native-preview": "7.0.0-dev.20260418.1",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "babel-loader": "10.1.1",
-    "build-ts": "17.1.2",
+    "build-ts": "17.1.6",
     "oxfmt": "0.45.0",
     "oxlint": "1.60.0",
-    "oxlint-tsgolint": "0.21.0",
+    "oxlint-tsgolint": "0.21.1",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "sort-package-json": "3.6.1",
@@ -76,5 +73,8 @@
   "peerDependencies": {
     "react": "~19.2.0",
     "react-dom": "~19.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -2,22 +2,15 @@
   "name": "@willbooster/shared-lib",
   "version": "0.0.0-semantically-released",
   "description": "Shared library for WillBooster projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/shared-lib"
   },
-  "files": [
-    "bin/",
-    "dist/"
-  ],
-  "type": "module",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "sideEffects": false,
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -30,9 +23,13 @@
       "import": "./src/index.ts"
     }
   },
-  "publishConfig": {
-    "access": "public"
-  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "scripts": {
     "build": "build-ts lib",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -51,14 +48,17 @@
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
-    "@typescript/native-preview": "7.0.0-dev.20260417.1",
+    "@typescript/native-preview": "7.0.0-dev.20260418.1",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
-    "build-ts": "17.1.2",
+    "build-ts": "17.1.6",
     "oxfmt": "0.45.0",
     "oxlint": "1.60.0",
-    "oxlint-tsgolint": "0.21.0",
+    "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -2,15 +2,22 @@
   "name": "@willbooster/shared-lib",
   "version": "0.0.0-semantically-released",
   "description": "Shared library for WillBooster projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/shared-lib"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "sideEffects": false,
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "type": "module",
+  "sideEffects": false,
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -23,13 +30,9 @@
       "import": "./src/index.ts"
     }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "bin/",
-    "dist/"
-  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "build-ts lib",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -57,8 +60,5 @@
     "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -2,22 +2,19 @@
   "name": "@willbooster/wb",
   "version": "0.0.0-semantically-released",
   "description": "CLI tool for WillBooster projects",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/wb"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
   "bin": "bin/index.js",
   "files": [
     "bin/",
     "dist/"
   ],
-  "type": "module",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "yarn start buildIfNeeded --command 'yarn build-ts app'",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -53,14 +50,14 @@
     "@types/kill-port": "2.0.3",
     "@types/node": "25.6.0",
     "@types/yargs": "17.0.35",
-    "@typescript/native-preview": "7.0.0-dev.20260417.1",
+    "@typescript/native-preview": "7.0.0-dev.20260418.1",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
-    "at-decorators": "7.0.2",
-    "build-ts": "17.1.2",
+    "at-decorators": "7.1.0",
+    "build-ts": "17.1.6",
     "oxfmt": "0.45.0",
     "oxlint": "1.60.0",
-    "oxlint-tsgolint": "0.21.0",
+    "oxlint-tsgolint": "0.21.1",
     "rolldown": "1.0.0-rc.15",
     "sort-package-json": "3.6.1",
     "type-fest": "5.5.0",
@@ -68,5 +65,8 @@
   },
   "engines": {
     "node": ">= 22.18.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -2,19 +2,22 @@
   "name": "@willbooster/wb",
   "version": "0.0.0-semantically-released",
   "description": "CLI tool for WillBooster projects",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/wb"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "type": "module",
   "bin": "bin/index.js",
   "files": [
     "bin/",
     "dist/"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "yarn start buildIfNeeded --command 'yarn build-ts app'",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -65,8 +68,5 @@
   },
   "engines": {
     "node": ">= 22.18.0"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -2,19 +2,22 @@
   "name": "@willbooster/wbfy",
   "version": "0.0.0-semantically-released",
   "description": "A tool for applying WillBooster's conventional configures to npm packages",
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/wbfy"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "type": "module",
   "bin": "./bin/wbfy.js",
   "files": [
     "bin/",
     "dist/"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "build-ts app",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -72,8 +75,5 @@
   },
   "engines": {
     "node": ">=24"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -2,22 +2,19 @@
   "name": "@willbooster/wbfy",
   "version": "0.0.0-semantically-released",
   "description": "A tool for applying WillBooster's conventional configures to npm packages",
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/shared.git",
     "directory": "packages/wbfy"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
   "bin": "./bin/wbfy.js",
   "files": [
     "bin/",
     "dist/"
   ],
-  "type": "module",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "build-ts app",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -60,20 +57,23 @@
     "@types/node": "25.6.0",
     "@types/semver": "7.7.1",
     "@types/yargs": "17.0.35",
-    "@typescript/native-preview": "7.0.0-dev.20260417.1",
+    "@typescript/native-preview": "7.0.0-dev.20260418.1",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "@yarnpkg/core": "4.6.0",
-    "build-ts": "17.1.2",
+    "build-ts": "17.1.6",
     "lefthook": "2.1.5",
     "oxfmt": "0.45.0",
     "oxlint": "1.60.0",
-    "oxlint-tsgolint": "0.21.0",
+    "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "type-fest": "5.5.0",
     "vitest": "4.1.4"
   },
   "engines": {
     "node": ">=24"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3177,44 +3177,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxlint-tsgolint/darwin-arm64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@oxlint-tsgolint/darwin-arm64@npm:0.21.0"
+"@oxlint-tsgolint/darwin-arm64@npm:0.21.1":
+  version: 0.21.1
+  resolution: "@oxlint-tsgolint/darwin-arm64@npm:0.21.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxlint-tsgolint/darwin-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@oxlint-tsgolint/darwin-x64@npm:0.21.0"
+"@oxlint-tsgolint/darwin-x64@npm:0.21.1":
+  version: 0.21.1
+  resolution: "@oxlint-tsgolint/darwin-x64@npm:0.21.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxlint-tsgolint/linux-arm64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@oxlint-tsgolint/linux-arm64@npm:0.21.0"
+"@oxlint-tsgolint/linux-arm64@npm:0.21.1":
+  version: 0.21.1
+  resolution: "@oxlint-tsgolint/linux-arm64@npm:0.21.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxlint-tsgolint/linux-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@oxlint-tsgolint/linux-x64@npm:0.21.0"
+"@oxlint-tsgolint/linux-x64@npm:0.21.1":
+  version: 0.21.1
+  resolution: "@oxlint-tsgolint/linux-x64@npm:0.21.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxlint-tsgolint/win32-arm64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@oxlint-tsgolint/win32-arm64@npm:0.21.0"
+"@oxlint-tsgolint/win32-arm64@npm:0.21.1":
+  version: 0.21.1
+  resolution: "@oxlint-tsgolint/win32-arm64@npm:0.21.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxlint-tsgolint/win32-x64@npm:0.21.0":
-  version: 0.21.0
-  resolution: "@oxlint-tsgolint/win32-x64@npm:0.21.0"
+"@oxlint-tsgolint/win32-x64@npm:0.21.1":
+  version: 0.21.1
+  resolution: "@oxlint-tsgolint/win32-x64@npm:0.21.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5452,115 +5452,115 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260412.1":
-  version: 7.0.0-dev.20260412.1
-  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260412.1"
+"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260413.1":
+  version: 7.0.0-dev.20260413.1
+  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260413.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260417.1":
-  version: 7.0.0-dev.20260417.1
-  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260417.1"
+"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260418.1":
+  version: 7.0.0-dev.20260418.1
+  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260418.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260412.1":
-  version: 7.0.0-dev.20260412.1
-  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260412.1"
+"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260413.1":
+  version: 7.0.0-dev.20260413.1
+  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260413.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260417.1":
-  version: 7.0.0-dev.20260417.1
-  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260417.1"
+"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260418.1":
+  version: 7.0.0-dev.20260418.1
+  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260418.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260412.1":
-  version: 7.0.0-dev.20260412.1
-  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260412.1"
+"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260413.1":
+  version: 7.0.0-dev.20260413.1
+  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260413.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260417.1":
-  version: 7.0.0-dev.20260417.1
-  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260417.1"
+"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260418.1":
+  version: 7.0.0-dev.20260418.1
+  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260418.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260412.1":
-  version: 7.0.0-dev.20260412.1
-  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260412.1"
+"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260413.1":
+  version: 7.0.0-dev.20260413.1
+  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260413.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260417.1":
-  version: 7.0.0-dev.20260417.1
-  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260417.1"
+"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260418.1":
+  version: 7.0.0-dev.20260418.1
+  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260418.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260412.1":
-  version: 7.0.0-dev.20260412.1
-  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260412.1"
+"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260413.1":
+  version: 7.0.0-dev.20260413.1
+  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260413.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260417.1":
-  version: 7.0.0-dev.20260417.1
-  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260417.1"
+"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260418.1":
+  version: 7.0.0-dev.20260418.1
+  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260418.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260412.1":
-  version: 7.0.0-dev.20260412.1
-  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260412.1"
+"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260413.1":
+  version: 7.0.0-dev.20260413.1
+  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260413.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260417.1":
-  version: 7.0.0-dev.20260417.1
-  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260417.1"
+"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260418.1":
+  version: 7.0.0-dev.20260418.1
+  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260418.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260412.1":
-  version: 7.0.0-dev.20260412.1
-  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260412.1"
+"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260413.1":
+  version: 7.0.0-dev.20260413.1
+  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260413.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260417.1":
-  version: 7.0.0-dev.20260417.1
-  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260417.1"
+"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260418.1":
+  version: 7.0.0-dev.20260418.1
+  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260418.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@typescript/native-preview@npm:7.0.0-dev.20260412.1":
-  version: 7.0.0-dev.20260412.1
-  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260412.1"
+"@typescript/native-preview@npm:7.0.0-dev.20260413.1":
+  version: 7.0.0-dev.20260413.1
+  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260413.1"
   dependencies:
-    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260412.1"
-    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260412.1"
-    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260412.1"
-    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260412.1"
-    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260412.1"
-    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260412.1"
-    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260412.1"
+    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260413.1"
+    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260413.1"
+    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260413.1"
+    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260413.1"
+    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260413.1"
+    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260413.1"
+    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260413.1"
   dependenciesMeta:
     "@typescript/native-preview-darwin-arm64":
       optional: true
@@ -5578,21 +5578,21 @@ __metadata:
       optional: true
   bin:
     tsgo: bin/tsgo.js
-  checksum: 10c0/e60bee05becc1f93c64d8e2f32421de61ded31bdc5a8cbfa3a08972e059bd13294ef951375ad103a4fc04be343e55292a6c687e68ef5e35e19ca11c57b57fae6
+  checksum: 10c0/572b2aa8e07e0716e4a35ffe772d88db757d251ea2f9bb1b5ecdd8efba7de90671e0ac09277ab74aee7e647fa52d25ae23066c6c6e4a69ead885a698bf406f4c
   languageName: node
   linkType: hard
 
-"@typescript/native-preview@npm:7.0.0-dev.20260417.1":
-  version: 7.0.0-dev.20260417.1
-  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260417.1"
+"@typescript/native-preview@npm:7.0.0-dev.20260418.1":
+  version: 7.0.0-dev.20260418.1
+  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260418.1"
   dependencies:
-    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260417.1"
-    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260417.1"
-    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260417.1"
-    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260417.1"
-    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260417.1"
-    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260417.1"
-    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260417.1"
+    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260418.1"
+    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260418.1"
+    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260418.1"
+    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260418.1"
+    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260418.1"
+    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260418.1"
+    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260418.1"
   dependenciesMeta:
     "@typescript/native-preview-darwin-arm64":
       optional: true
@@ -5610,7 +5610,7 @@ __metadata:
       optional: true
   bin:
     tsgo: bin/tsgo.js
-  checksum: 10c0/a6ab152d4aa5ac2033e053240658d15da1bda2acb9ef87f0250b5c78526a1e7ce59449c80ba46fed62382aed13b30ae0cc892bcf7ccaf7115321131e34e4cc82
+  checksum: 10c0/a97d905a15648fbc01d40ec57fa6d00a4fbcdd3565c36b0673915c686278a0c6227cd1b8a8ff0ab9ccf274a7ec7c45fc7261649e2e9cff5c334e6a6b4b28326f
   languageName: node
   linkType: hard
 
@@ -5988,14 +5988,14 @@ __metadata:
     "@tsconfig/node-lts": "npm:24.0.0"
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260417.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260418.1"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     blitz: "npm:3.0.2"
-    build-ts: "npm:17.1.2"
+    build-ts: "npm:17.1.6"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.60.0"
-    oxlint-tsgolint: "npm:0.21.0"
+    oxlint-tsgolint: "npm:0.21.1"
     sort-package-json: "npm:3.6.1"
     vitest: "npm:4.1.4"
   languageName: unknown
@@ -6008,14 +6008,14 @@ __metadata:
     "@tsconfig/node-lts": "npm:24.0.0"
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260417.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260418.1"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
-    build-ts: "npm:17.1.2"
+    build-ts: "npm:17.1.6"
     next: "npm:16.2.4"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.60.0"
-    oxlint-tsgolint: "npm:0.21.0"
+    oxlint-tsgolint: "npm:0.21.1"
     sort-package-json: "npm:3.6.1"
     vitest: "npm:4.1.4"
   peerDependencies:
@@ -6023,13 +6023,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@willbooster/shared-lib-node@npm:8.5.4":
-  version: 8.5.4
-  resolution: "@willbooster/shared-lib-node@npm:8.5.4"
+"@willbooster/shared-lib-node@npm:8.5.5":
+  version: 8.5.5
+  resolution: "@willbooster/shared-lib-node@npm:8.5.5"
   dependencies:
     dotenv: "npm:17.4.2"
     dotenv-expand: "npm:12.0.3"
-  checksum: 10c0/4626fbbdee08ed2ebba531c160485e09f1440abebb156fe928d88923ec8264abf1f73773052e7a45af0aa44199a3e2bc22cf76eab8c064452827cc89c1abf18b
+  checksum: 10c0/2dfff0dde7c87f0d916e34b772ce053cc6dddf56e874215b2f56d7bbf146b41b803d6a5a03f57bd56fc55d787c5004606418987ccabf8ab53989a3d26ec82449
   languageName: node
   linkType: hard
 
@@ -6041,15 +6041,15 @@ __metadata:
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/bun": "npm:1.3.12"
     "@types/node": "npm:25.6.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260417.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260418.1"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
-    build-ts: "npm:17.1.2"
+    build-ts: "npm:17.1.6"
     dotenv: "npm:17.4.2"
     dotenv-expand: "npm:12.0.3"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.60.0"
-    oxlint-tsgolint: "npm:0.21.0"
+    oxlint-tsgolint: "npm:0.21.1"
     sort-package-json: "npm:3.6.1"
     vitest: "npm:4.1.4"
   languageName: unknown
@@ -6074,14 +6074,14 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@types/react": "npm:19.2.14"
     "@types/react-dom": "npm:19.2.3"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260417.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260418.1"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     babel-loader: "npm:10.1.1"
-    build-ts: "npm:17.1.2"
+    build-ts: "npm:17.1.6"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.60.0"
-    oxlint-tsgolint: "npm:0.21.0"
+    oxlint-tsgolint: "npm:0.21.1"
     react: "npm:19.2.5"
     react-dom: "npm:19.2.5"
     sort-package-json: "npm:3.6.1"
@@ -6099,13 +6099,13 @@ __metadata:
     "@tsconfig/node-lts": "npm:24.0.0"
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260417.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260418.1"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
-    build-ts: "npm:17.1.2"
+    build-ts: "npm:17.1.6"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.60.0"
-    oxlint-tsgolint: "npm:0.21.0"
+    oxlint-tsgolint: "npm:0.21.1"
     sort-package-json: "npm:3.6.1"
     vitest: "npm:4.1.4"
   languageName: unknown
@@ -6124,11 +6124,11 @@ __metadata:
     "@types/kill-port": "npm:2.0.3"
     "@types/node": "npm:25.6.0"
     "@types/yargs": "npm:17.0.35"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260417.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260418.1"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
-    at-decorators: "npm:7.0.2"
-    build-ts: "npm:17.1.2"
+    at-decorators: "npm:7.1.0"
+    build-ts: "npm:17.1.6"
     chalk: "npm:5.6.2"
     dotenv: "npm:17.4.2"
     dotenv-expand: "npm:12.0.3"
@@ -6137,7 +6137,7 @@ __metadata:
     minimal-promise-pool: "npm:6.0.1"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.60.0"
-    oxlint-tsgolint: "npm:0.21.0"
+    oxlint-tsgolint: "npm:0.21.1"
     rolldown: "npm:1.0.0-rc.15"
     sort-package-json: "npm:3.6.1"
     type-fest: "npm:5.5.0"
@@ -6160,11 +6160,11 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@types/semver": "npm:7.7.1"
     "@types/yargs": "npm:17.0.35"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260417.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260418.1"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     "@yarnpkg/core": "npm:4.6.0"
-    build-ts: "npm:17.1.2"
+    build-ts: "npm:17.1.6"
     deepmerge: "npm:4.3.1"
     dotenv: "npm:17.4.2"
     fast-glob: "npm:3.3.3"
@@ -6176,7 +6176,7 @@ __metadata:
     minimal-promise-pool: "npm:6.0.1"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.60.0"
-    oxlint-tsgolint: "npm:0.21.0"
+    oxlint-tsgolint: "npm:0.21.1"
     semver: "npm:7.7.4"
     simple-git: "npm:3.36.0"
     smol-toml: "npm:1.6.1"
@@ -6899,10 +6899,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"at-decorators@npm:7.0.2":
-  version: 7.0.2
-  resolution: "at-decorators@npm:7.0.2"
-  checksum: 10c0/196d4358542df9a36257f9b853a8e2ebf450af209ad2062a699f08635f64820d04196fd9ac6c6eb58e1f2158290496cce2884ffbdc8074454c6e7a46c0cb4823
+"at-decorators@npm:7.1.0":
+  version: 7.1.0
+  resolution: "at-decorators@npm:7.1.0"
+  checksum: 10c0/8f732efe3d5026a83a19b99d056201f1707c0b7bf53aa87103a8023d12fa4996055013385a1517ae7d61163f8ccf6968f8dcc441bf81a098a42b9a13af5a268c
   languageName: node
   linkType: hard
 
@@ -7519,9 +7519,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"build-ts@npm:17.1.2":
-  version: 17.1.2
-  resolution: "build-ts@npm:17.1.2"
+"build-ts@npm:17.1.6":
+  version: 17.1.6
+  resolution: "build-ts@npm:17.1.6"
   dependencies:
     "@babel/core": "npm:7.29.0"
     "@babel/plugin-proposal-decorators": "npm:7.29.0"
@@ -7538,8 +7538,8 @@ __metadata:
     "@rollup/plugin-replace": "npm:6.0.3"
     "@rollup/plugin-terser": "npm:1.0.0"
     "@rollup/pluginutils": "npm:5.3.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260412.1"
-    "@willbooster/shared-lib-node": "npm:8.5.4"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260413.1"
+    "@willbooster/shared-lib-node": "npm:8.5.5"
     babel-plugin-polyfill-corejs3: "npm:0.14.2"
     babel-plugin-transform-remove-console: "npm:6.9.4"
     chalk: "npm:5.6.2"
@@ -7550,7 +7550,7 @@ __metadata:
     rollup: "npm:4.60.1"
     rollup-plugin-analyzer: "npm:4.0.0"
     rollup-plugin-keep-import: "npm:1.0.3"
-    rollup-plugin-node-externals: "npm:8.1.2"
+    rollup-plugin-node-externals: "npm:9.0.0"
     rollup-plugin-preserve-directives: "npm:0.4.0"
     rollup-plugin-string: "npm:3.0.0"
     signal-exit: "npm:4.1.0"
@@ -7558,7 +7558,7 @@ __metadata:
     yargs: "npm:18.0.0"
   bin:
     build-ts: bin/index.js
-  checksum: 10c0/b73c08772f1881c7bc75ea6dd57ad26f0ed0204cabdaaafe8658eae326f0e9fd16b75e02327b87a04c93d4c0c0c24a754b7947522c718cb8c7182dce79e5eebc
+  checksum: 10c0/13fc6a574f4170481c1e64283f4b7fe796e3952098adedec5896c96fd01d5a396f16e07185dd02f5f3ac7e8917f0b4234852e3bf42a825e2dc7f1bee0d3f8e19
   languageName: node
   linkType: hard
 
@@ -14977,16 +14977,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oxlint-tsgolint@npm:0.21.0":
-  version: 0.21.0
-  resolution: "oxlint-tsgolint@npm:0.21.0"
+"oxlint-tsgolint@npm:0.21.1":
+  version: 0.21.1
+  resolution: "oxlint-tsgolint@npm:0.21.1"
   dependencies:
-    "@oxlint-tsgolint/darwin-arm64": "npm:0.21.0"
-    "@oxlint-tsgolint/darwin-x64": "npm:0.21.0"
-    "@oxlint-tsgolint/linux-arm64": "npm:0.21.0"
-    "@oxlint-tsgolint/linux-x64": "npm:0.21.0"
-    "@oxlint-tsgolint/win32-arm64": "npm:0.21.0"
-    "@oxlint-tsgolint/win32-x64": "npm:0.21.0"
+    "@oxlint-tsgolint/darwin-arm64": "npm:0.21.1"
+    "@oxlint-tsgolint/darwin-x64": "npm:0.21.1"
+    "@oxlint-tsgolint/linux-arm64": "npm:0.21.1"
+    "@oxlint-tsgolint/linux-x64": "npm:0.21.1"
+    "@oxlint-tsgolint/win32-arm64": "npm:0.21.1"
+    "@oxlint-tsgolint/win32-x64": "npm:0.21.1"
   dependenciesMeta:
     "@oxlint-tsgolint/darwin-arm64":
       optional: true
@@ -15002,7 +15002,7 @@ __metadata:
       optional: true
   bin:
     tsgolint: bin/tsgolint.js
-  checksum: 10c0/f1025d3707f3f68390c27f92ba9a18384401854d8b1e72d8ad2a3d1a1ccd1d533499e9e50d5e0c23a0ecf4edeb9589cca83f4951e6f451b8f45651f6e69de35c
+  checksum: 10c0/7f175543d5d7adf6b5df16735de9105aec6c882e71ccd1b6f337d6bccb681ae3099020992ca0482d8ce0b2e6d0d43ba4201d10e299ba292a468cfdfb24ccaa11
   languageName: node
   linkType: hard
 
@@ -16831,12 +16831,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-node-externals@npm:8.1.2":
-  version: 8.1.2
-  resolution: "rollup-plugin-node-externals@npm:8.1.2"
+"rollup-plugin-node-externals@npm:9.0.0":
+  version: 9.0.0
+  resolution: "rollup-plugin-node-externals@npm:9.0.0"
   peerDependencies:
     rollup: ^4.0.0
-  checksum: 10c0/ea37fb84e562c311b473f354e7ff98f8d19caf7c57b526ef6a29f1fab05880d291d2edd3c482dfedd27150a4133ebe914723ac9dc3165ce679ec00146a97df06
+    vite: ">=5.0.0"
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/041175999540985dcda9b3f0ad4d073b889d266e3dac4a0a825d5d7acb9b77c60bf3bf6ee0e22ec313af9f85a98f657652a3818d96ee8e4cc4f64c848b504ea1
   languageName: node
   linkType: hard
 
@@ -20009,14 +20015,14 @@ __metadata:
     "@tsconfig/node-lts": "npm:24.0.0"
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260417.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260418.1"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     conventional-changelog-conventionalcommits: "npm:9.3.1"
     lefthook: "npm:2.1.5"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.60.0"
-    oxlint-tsgolint: "npm:0.21.0"
+    oxlint-tsgolint: "npm:0.21.1"
     semantic-release: "npm:25.0.3"
     sort-package-json: "npm:3.6.1"
   languageName: unknown


### PR DESCRIPTION
## Summary

- Update dependency versions across the workspace package manifests.
- Refresh `yarn.lock` to match the updated dependency graph.
- Keep the scope limited to dependency metadata and lockfile changes.

## Why

- Keeps the shared packages aligned with current dependency releases.
- Uses the existing package manager lockfile update so installs resolve consistently.

## Testing

- `yarn check-for-ai`
- `git push` pre-push hook ran `check` successfully
