### PR TITLE
fix: skip prettier lint when unavailable

### DIFF
--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -247,7 +247,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
   }
 
   if (argv.format) {
-    if (prettierArgs.length > 0) {
+    if (prettierArgs.length > 0 && projects.self.hasPrettier) {
       lintExitCodes.push(
         await runWithSpawnInParallel(
           buildShellCommand([

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -137,6 +137,11 @@ export class Project {
   }
 
   @memoizeOne
+  get hasPrettier(): boolean {
+    return this.hasDependency('prettier');
+  }
+
+  @memoizeOne
   get hasPoetryLock(): boolean {
     return (
       fs.existsSync(path.join(this.dirPath, 'poetry.lock')) || fs.existsSync(path.join(this.rootDirPath, 'poetry.lock'))

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -190,8 +190,8 @@ function getPreCommitJobs(config: PackageConfig): LefthookJob[] {
 }
 
 function getCleanupGlobs(config: PackageConfig): string {
-  // `wb lint --format` can format prettier-only files directly; include them
-  // so adding the first Java file still triggers the cleanup hook.
+  // Let `wb lint --format` decide whether Prettier is available; the hook
+  // still needs to trigger when adding the first prettier-only file.
   const supportedExtensions =
     config.isBun || config.depending.wb || doesContainJava(config) ? [...extensions.prettierOnly] : [];
   if (doesContainJsOrTs(config)) {

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -190,7 +190,10 @@ function getPreCommitJobs(config: PackageConfig): LefthookJob[] {
 }
 
 function getCleanupGlobs(config: PackageConfig): string {
-  const supportedExtensions = doesContainJava(config) ? [...extensions.prettierOnly] : [];
+  // `wb lint --format` can format prettier-only files directly; include them
+  // so adding the first Java file still triggers the cleanup hook.
+  const supportedExtensions =
+    config.isBun || config.depending.wb || doesContainJava(config) ? [...extensions.prettierOnly] : [];
   if (doesContainJsOrTs(config)) {
     supportedExtensions.push(...extensions.oxfmt, ...extensions.oxlint);
   }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -195,7 +195,9 @@ function applyPackageJsonConventions(
     jsonObj.prettier = '@willbooster/prettier-config';
     devDependencies.push('prettier-plugin-java', '@willbooster/prettier-config');
   }
-  if (hasJava) {
+  // Bun projects use `wb lint --format`, and wb still invokes Prettier for
+  // prettier-only extensions even when the repository has no matching files.
+  if (hasJava || config.isBun) {
     devDependencies.push('prettier');
   } else {
     removePrettierArtifacts(jsonObj);

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -195,9 +195,7 @@ function applyPackageJsonConventions(
     jsonObj.prettier = '@willbooster/prettier-config';
     devDependencies.push('prettier-plugin-java', '@willbooster/prettier-config');
   }
-  // Bun projects use `wb lint --format`, and wb still invokes Prettier for
-  // prettier-only extensions even when the repository has no matching files.
-  if (hasJava || config.isBun) {
+  if (hasJava) {
     devDependencies.push('prettier');
   } else {
     removePrettierArtifacts(jsonObj);


### PR DESCRIPTION
## Summary

- Make `wb lint --format` skip the Prettier formatting phase when the current project cannot resolve a `prettier` dependency.
- Add `Project.hasPrettier` alongside the existing formatter capability checks.
- Keep Java/prettier-only files in generated cleanup hook globs, but stop forcing `prettier` into every Bun project through `wbfy`.

## Why

- `wb lint --format` can generate Prettier args for prettier-only extensions even when a repository has no Prettier installed.
- Clean installs should not fail with `Script not found "prettier"` when the project does not use Prettier.
- Projects that actually contain Java still get `prettier` from `wbfy`; projects without it simply skip that formatter phase.

## Testing

- `yarn check-for-ai`
- Pre-push hook checks across the shared workspace
