### PR TITLE
fix: suppress oxlint warning details on push

### DIFF
--- a/.lefthook/pre-push/check.sh
+++ b/.lefthook/pre-push/check.sh
@@ -1,1 +1,1 @@
-yarn run lint
+yarn run lint --quiet

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -159,6 +159,7 @@ function getPrePushScript(config: PackageConfig): string {
   } else {
     lintCommand = config.depending.wb ? 'yarn wb lint' : 'yarn run lint';
   }
+  const quietLintCommand = `${lintCommand} --quiet`;
   // No separate typecheck step needed — the lint command already includes typechecking.
   if (config.repository?.startsWith('github:WillBoosterLab/')) {
     return `
@@ -171,10 +172,10 @@ if [ $(git branch --show-current) = "main" ] && [ $(git config user.email) != "e
   exit 1
 fi
 
-${lintCommand}
+${quietLintCommand}
 `.trim();
   }
-  return lintCommand;
+  return quietLintCommand;
 }
 
 function getPreCommitJobs(config: PackageConfig): LefthookJob[] {

--- a/packages/wbfy/test/lefthookGenerator.test.ts
+++ b/packages/wbfy/test/lefthookGenerator.test.ts
@@ -121,6 +121,40 @@ test('does not generate oxlint or oxfmt hooks for package-only projects', async 
   expect(lefthookConfig).not.toContain('oxlint');
 });
 
+test('uses quiet lint in pre-push hooks for wb projects', async () => {
+  const dirPath = createTempDir();
+
+  await generateLefthookUpdatingPackageJson(
+    createConfig({
+      dirPath,
+      doesContainPackageJson: true,
+      doesContainTypeScript: true,
+      depending: {
+        ...createConfig().depending,
+        wb: true,
+      },
+    })
+  );
+
+  const prePushScript = await fs.promises.readFile(path.join(dirPath, '.lefthook', 'pre-push', 'check.sh'), 'utf8');
+  expect(prePushScript).toContain('yarn wb lint --quiet');
+});
+
+test('uses quiet lint in pre-push hooks for plain oxlint projects', async () => {
+  const dirPath = createTempDir();
+
+  await generateLefthookUpdatingPackageJson(
+    createConfig({
+      dirPath,
+      doesContainPackageJson: true,
+      doesContainTypeScript: true,
+    })
+  );
+
+  const prePushScript = await fs.promises.readFile(path.join(dirPath, '.lefthook', 'pre-push', 'check.sh'), 'utf8');
+  expect(prePushScript).toContain('yarn run lint --quiet');
+});
+
 test('runs gen-i18n-ts from lefthook after pulled i18n resources change', async () => {
   const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-lefthook-i18n-'));
 


### PR DESCRIPTION
## Summary
- run generated pre-push lint hooks in quiet mode so oxlint warning details are not printed during push
- update the tracked hook script in this repo to match the generated behavior
- add generator coverage for both wb-based and plain oxlint projects

## Verification
- yarn check-for-ai
- yarn workspace @willbooster/wbfy test packages/wbfy/test/lefthookGenerator.test.ts