### PR TITLE
fix: clarify generated agent ordering guidance

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -105,8 +105,9 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
 - Design each module with high cohesion, grouping related functionality together.
   - Refactor existing large modules into smaller, focused modules when necessary.
   - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions in the file above the functions they call to maintain a clear top-down order.
-  - e.g. \`function caller() { callee(); } function callee() { ... }\`
+- Place calling functions above the functions they call to maintain a clear top-down order.
+  - e.g., \`function caller() { callee(); } function callee() { ... }\`
+  - Unlike functions, place variable and type declarations ABOVE their usage.
 - Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
 - Prefer \`undefined\` over \`null\` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of \`join()\` with an array of strings.


### PR DESCRIPTION
## Summary

- clarify the generated coding-style guidance for top-down ordering in agent instruction files
- keep the ordering rule scoped to functions and add an explicit rule that variables and type declarations must appear before use
- tighten the example wording to reduce ambiguity in generated AGENTS-style documentation

## Why

- the previous wording could be read as a broader declaration-order rule even though the surrounding implementation comment already intended this guidance to apply only to functions
- making the distinction explicit reduces the risk of generating misleading instructions for code that depends on non-hoisted declarations

## Testing

- `yarn check-for-ai`
