### PR TITLE
fix: scope sqlite connection_limit to prisma repos

### DIFF
--- a/packages/wbfy/src/fixers/prisma.ts
+++ b/packages/wbfy/src/fixers/prisma.ts
@@ -35,12 +35,13 @@ function shouldAddSqliteConnectionLimit(config: PackageConfig): boolean {
 
   // `connection_limit=1` only applies to Prisma's SQLite datasource handling.
   // Repos that opt into non-pure SQLite adapters should keep their URL as-is.
-  return !dependencies['@prisma/adapter-better-sqlite3'] &&
-    !dependencies['@prisma/adapter-libsql'];
+  return !dependencies['@prisma/adapter-better-sqlite3'] && !dependencies['@prisma/adapter-libsql'];
 }
 
 function normalizeSqliteDatabaseUrl(url: string, shouldAddConnectionLimit: boolean): string {
-  const [pathPart, queryPart] = url.split('?', 2);
+  const queryStart = url.indexOf('?');
+  const pathPart = queryStart !== -1 ? url.slice(0, queryStart) : url;
+  const queryPart = queryStart !== -1 ? url.slice(queryStart + 1) : '';
   const params = new URLSearchParams(queryPart);
 
   params.delete('connection_limit');

--- a/packages/wbfy/src/fixers/prisma.ts
+++ b/packages/wbfy/src/fixers/prisma.ts
@@ -20,7 +20,9 @@ export async function fixPrismaEnvFiles(config: PackageConfig): Promise<void> {
           return `DATABASE_URL="${normalizeSqliteDatabaseUrl(url, shouldAddConnectionLimit)}"`;
         }
       );
-      await fs.writeFile(envFilePath, newContent);
+      if (newContent !== content) {
+        await fs.writeFile(envFilePath, newContent);
+      }
     }
   });
 }

--- a/packages/wbfy/src/fixers/prisma.ts
+++ b/packages/wbfy/src/fixers/prisma.ts
@@ -36,9 +36,7 @@ function shouldAddSqliteConnectionLimit(config: PackageConfig): boolean {
   // `connection_limit=1` only applies to Prisma's SQLite datasource handling.
   // Repos that opt into non-pure SQLite adapters should keep their URL as-is.
   return !dependencies['@prisma/adapter-better-sqlite3'] &&
-    !dependencies['@prisma/adapter-libsql'] &&
-    !dependencies['better-sqlite3'] &&
-    !dependencies['@libsql/client'];
+    !dependencies['@prisma/adapter-libsql'];
 }
 
 function normalizeSqliteDatabaseUrl(url: string, shouldAddConnectionLimit: boolean): string {

--- a/packages/wbfy/src/fixers/prisma.ts
+++ b/packages/wbfy/src/fixers/prisma.ts
@@ -9,6 +9,7 @@ import { globIgnore } from '../utils/globUtil.js';
 
 export async function fixPrismaEnvFiles(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('fixPrismaEnvFiles', async () => {
+    const shouldAddConnectionLimit = shouldAddSqliteConnectionLimit(config);
     const envFiles = await fg.glob(['*.env', '*.env.*'], { dot: true, cwd: config.dirPath, ignore: globIgnore });
     for (const envFile of envFiles) {
       const envFilePath = path.resolve(config.dirPath, envFile);
@@ -16,12 +17,29 @@ export async function fixPrismaEnvFiles(config: PackageConfig): Promise<void> {
       const newContent = content.replaceAll(
         /DATABASE_URL\s*=\s*"?([^"#\n]+?\.sqlite3[^"#\n]*)"?/g,
         (match, url: string) => {
-          if (url.includes('connection_limit=1')) return match;
-          const separator = url.includes('?') ? '&' : '?';
-          return `DATABASE_URL="${url}${separator}connection_limit=1"`;
+          return `DATABASE_URL="${normalizeSqliteDatabaseUrl(url, shouldAddConnectionLimit)}"`;
         }
       );
       await fs.writeFile(envFilePath, newContent);
     }
   });
+}
+
+function shouldAddSqliteConnectionLimit(config: PackageConfig): boolean {
+  // `connection_limit=1` is a Prisma-specific SQLite datasource tweak.
+  // Non-Prisma projects should keep their DATABASE_URL untouched.
+  return config.depending.prisma;
+}
+
+function normalizeSqliteDatabaseUrl(url: string, shouldAddConnectionLimit: boolean): string {
+  const [pathPart, queryPart] = url.split('?', 2);
+  const params = new URLSearchParams(queryPart);
+
+  params.delete('connection_limit');
+  if (shouldAddConnectionLimit) {
+    params.set('connection_limit', '1');
+  }
+
+  const normalizedQuery = params.toString();
+  return normalizedQuery ? `${pathPart}?${normalizedQuery}` : pathPart;
 }

--- a/packages/wbfy/src/fixers/prisma.ts
+++ b/packages/wbfy/src/fixers/prisma.ts
@@ -26,9 +26,19 @@ export async function fixPrismaEnvFiles(config: PackageConfig): Promise<void> {
 }
 
 function shouldAddSqliteConnectionLimit(config: PackageConfig): boolean {
-  // `connection_limit=1` is a Prisma-specific SQLite datasource tweak.
-  // Non-Prisma projects should keep their DATABASE_URL untouched.
-  return config.depending.prisma;
+  if (!config.depending.prisma) return false;
+
+  const dependencies = {
+    ...config.packageJson?.dependencies,
+    ...config.packageJson?.devDependencies,
+  };
+
+  // `connection_limit=1` only applies to Prisma's SQLite datasource handling.
+  // Repos that opt into non-pure SQLite adapters should keep their URL as-is.
+  return !dependencies['@prisma/adapter-better-sqlite3'] &&
+    !dependencies['@prisma/adapter-libsql'] &&
+    !dependencies['better-sqlite3'] &&
+    !dependencies['@libsql/client'];
 }
 
 function normalizeSqliteDatabaseUrl(url: string, shouldAddConnectionLimit: boolean): string {


### PR DESCRIPTION
## Summary

- Restrict the SQLite `DATABASE_URL` `connection_limit=1` rewrite to repositories that use Prisma without Prisma SQLite adapter packages
- Normalize SQLite URLs safely by splitting on the first `?` and preserving the rest of the query string
- Avoid rewriting env files when normalization produces no content change

## Why

- `connection_limit=1` only applies to pure Prisma SQLite handling and should not be injected into adapter-based or non-Prisma setups
- The URL normalization needs to be safe for URLs with no query string or with additional `?` characters inside query values
- Rerunning `wbfy` should not churn env file mtimes when nothing changes

## Testing

- `yarn workspace @willbooster/wbfy cleanup`
- `yarn start /Users/exkazuu/ghq/github.com/WillBooster/agent-challenges`
- `bun check-for-ai` in `/Users/exkazuu/ghq/github.com/WillBooster/agent-challenges`
- PR CI

## Notes

- Verified rerunning `wbfy` keeps `agent-challenges` `.env` files at `file:./drizzle/mount/dev.sqlite3` with no `?connection_limit=1`
