### PR TITLE
fix: use TypeScript 7 beta in wbfy

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
-    "@typescript/native-preview": "7.0.0-dev.20260419.1",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "conventional-changelog-conventionalcommits": "9.3.1",

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -51,7 +51,7 @@
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
-    "@typescript/native-preview": "7.0.0-dev.20260419.1",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "blitz": "3.0.2",

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -51,7 +51,7 @@
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
-    "@typescript/native-preview": "7.0.0-dev.20260419.1",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "build-ts": "17.1.6",

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -56,7 +56,7 @@
     "@tsconfig/node-ts": "23.6.4",
     "@types/bun": "1.3.12",
     "@types/node": "25.6.0",
-    "@typescript/native-preview": "7.0.0-dev.20260419.1",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "build-ts": "17.1.6",

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -60,7 +60,7 @@
     "@types/node": "25.6.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "@typescript/native-preview": "7.0.0-dev.20260419.1",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "babel-loader": "10.1.1",

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -51,7 +51,7 @@
     "@tsconfig/node-lts": "24.0.0",
     "@tsconfig/node-ts": "23.6.4",
     "@types/node": "25.6.0",
-    "@typescript/native-preview": "7.0.0-dev.20260419.1",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "build-ts": "17.1.6",

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -53,7 +53,7 @@
     "@types/kill-port": "2.0.3",
     "@types/node": "25.6.0",
     "@types/yargs": "17.0.35",
-    "@typescript/native-preview": "7.0.0-dev.20260419.1",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "at-decorators": "7.1.0",

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -60,7 +60,7 @@
     "@types/node": "25.6.0",
     "@types/semver": "7.7.1",
     "@types/yargs": "17.0.35",
-    "@typescript/native-preview": "7.0.0-dev.20260419.1",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "@yarnpkg/core": "4.6.0",

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -605,10 +605,16 @@ function getLatestDependencyVersion(dependency: string): string {
   const cachedVersion = latestDependencyVersionCache.get(dependency);
   if (cachedVersion) return cachedVersion;
 
-  const version =
-    spawnSyncAndReturnStdout('npm', ['show', dependency, 'version', '--workspaces=false'], process.cwd()) || '*';
+  const version = getDependencyVersionFromNpm(dependency);
   latestDependencyVersionCache.set(dependency, version);
   return version;
+}
+
+function getDependencyVersionFromNpm(dependency: string): string {
+  // npm's latest dist-tag still tracks TS7 dev snapshots; wbfy should follow
+  // the public beta channel until the stable TS7 package layout is finalized.
+  const specifier = dependency === typescriptGoDependency ? `${dependency}@beta` : dependency;
+  return spawnSyncAndReturnStdout('npm', ['show', specifier, 'version', '--workspaces=false'], process.cwd()) || '*';
 }
 
 // TODO: remove the following migration code in future

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -549,7 +549,7 @@ function installNpmDependencies(
 ): void {
   if (dependencies.length === 0) return;
 
-  const dependencySpecifiers = [...new Set(dependencies)];
+  const dependencySpecifiers = [...new Set(dependencies.map(getDependencySpecifier))];
   if (config.isBun) {
     spawnSync(packageManager, ['add', ...(dev ? ['-D'] : []), '--exact', ...dependencySpecifiers], config.dirPath);
   } else {
@@ -613,8 +613,17 @@ function getLatestDependencyVersion(dependency: string): string {
 function getDependencyVersionFromNpm(dependency: string): string {
   // npm's latest dist-tag still tracks TS7 dev snapshots; wbfy should follow
   // the public beta channel until the stable TS7 package layout is finalized.
-  const specifier = dependency === typescriptGoDependency ? `${dependency}@beta` : dependency;
-  return spawnSyncAndReturnStdout('npm', ['show', specifier, 'version', '--workspaces=false'], process.cwd()) || '*';
+  return (
+    spawnSyncAndReturnStdout(
+      'npm',
+      ['show', getDependencySpecifier(dependency), 'version', '--workspaces=false'],
+      process.cwd()
+    ) || '*'
+  );
+}
+
+function getDependencySpecifier(dependency: string): string {
+  return dependency === typescriptGoDependency ? `${dependency}@beta` : dependency;
 }
 
 // TODO: remove the following migration code in future

--- a/yarn.lock
+++ b/yarn.lock
@@ -5459,9 +5459,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260419.1":
-  version: 7.0.0-dev.20260419.1
-  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260419.1"
+"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260421.2":
+  version: 7.0.0-dev.20260421.2
+  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260421.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -5473,9 +5473,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260419.1":
-  version: 7.0.0-dev.20260419.1
-  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260419.1"
+"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260421.2":
+  version: 7.0.0-dev.20260421.2
+  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260421.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -5487,9 +5487,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260419.1":
-  version: 7.0.0-dev.20260419.1
-  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260419.1"
+"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260421.2":
+  version: 7.0.0-dev.20260421.2
+  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260421.2"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -5501,9 +5501,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260419.1":
-  version: 7.0.0-dev.20260419.1
-  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260419.1"
+"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260421.2":
+  version: 7.0.0-dev.20260421.2
+  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260421.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -5515,9 +5515,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260419.1":
-  version: 7.0.0-dev.20260419.1
-  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260419.1"
+"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260421.2":
+  version: 7.0.0-dev.20260421.2
+  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260421.2"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -5529,9 +5529,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260419.1":
-  version: 7.0.0-dev.20260419.1
-  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260419.1"
+"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260421.2":
+  version: 7.0.0-dev.20260421.2
+  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260421.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -5543,9 +5543,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260419.1":
-  version: 7.0.0-dev.20260419.1
-  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260419.1"
+"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260421.2":
+  version: 7.0.0-dev.20260421.2
+  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260421.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5582,17 +5582,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview@npm:7.0.0-dev.20260419.1":
-  version: 7.0.0-dev.20260419.1
-  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260419.1"
+"@typescript/native-preview@npm:7.0.0-dev.20260421.2":
+  version: 7.0.0-dev.20260421.2
+  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260421.2"
   dependencies:
-    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260419.1"
-    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260419.1"
-    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260419.1"
-    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260419.1"
-    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260419.1"
-    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260419.1"
-    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260421.2"
+    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260421.2"
+    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260421.2"
+    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260421.2"
+    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260421.2"
+    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260421.2"
+    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260421.2"
   dependenciesMeta:
     "@typescript/native-preview-darwin-arm64":
       optional: true
@@ -5610,7 +5610,7 @@ __metadata:
       optional: true
   bin:
     tsgo: bin/tsgo.js
-  checksum: 10c0/68f367136e33ab14980444e227dadc26e842019a3eb87fcc45d36c40efe86c8baacee6b0023ab7ba0427b0b869683e662f7711dec3e064166c192f35bd82eafb
+  checksum: 10c0/79dbb7e5204c5906bcb3a2946209162efbaac9c8fa78ffeccb8b6718661a5b40f988d60b27350ad538cc1a4143524e5fc97b04fa4767bd42a036000f226438db
   languageName: node
   linkType: hard
 
@@ -5988,7 +5988,7 @@ __metadata:
     "@tsconfig/node-lts": "npm:24.0.0"
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     blitz: "npm:3.0.2"
@@ -6008,7 +6008,7 @@ __metadata:
     "@tsconfig/node-lts": "npm:24.0.0"
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     build-ts: "npm:17.1.6"
@@ -6041,7 +6041,7 @@ __metadata:
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/bun": "npm:1.3.12"
     "@types/node": "npm:25.6.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     build-ts: "npm:17.1.6"
@@ -6074,7 +6074,7 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@types/react": "npm:19.2.14"
     "@types/react-dom": "npm:19.2.3"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     babel-loader: "npm:10.1.1"
@@ -6099,7 +6099,7 @@ __metadata:
     "@tsconfig/node-lts": "npm:24.0.0"
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     build-ts: "npm:17.1.6"
@@ -6124,7 +6124,7 @@ __metadata:
     "@types/kill-port": "npm:2.0.3"
     "@types/node": "npm:25.6.0"
     "@types/yargs": "npm:17.0.35"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     at-decorators: "npm:7.1.0"
@@ -6160,7 +6160,7 @@ __metadata:
     "@types/node": "npm:25.6.0"
     "@types/semver": "npm:7.7.1"
     "@types/yargs": "npm:17.0.35"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     "@yarnpkg/core": "npm:4.6.0"
@@ -20015,7 +20015,7 @@ __metadata:
     "@tsconfig/node-lts": "npm:24.0.0"
     "@tsconfig/node-ts": "npm:23.6.4"
     "@types/node": "npm:25.6.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     conventional-changelog-conventionalcommits: "npm:9.3.1"


### PR DESCRIPTION
## Summary
- make wbfy resolve `@typescript/native-preview` from the `beta` dist-tag instead of npm `latest`
- refresh this repo's managed TypeScript native preview dependency pins and lockfile to the beta-tagged build

## Verification
- yarn check-for-ai