### PR TITLE
fix: correct wbfy playwright recording defaults

### DIFF
--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -36,8 +36,8 @@ const defaultConfig = toParsedObject({
   use: asObject({
     baseURL: literal('process.env.NEXT_PUBLIC_BASE_URL'),
     trace: literal("process.env.CI ? 'on-first-retry' : 'retain-on-failure'"),
-    screenshot: literal("process.env.CI ? 'only-on-failure' : 'only-on-failure'"),
-    video: literal("process.env.CI ? 'retain-on-failure' : 'retain-on-failure'"),
+    screenshot: literal("process.env.CI ? 'only-on-failure' : 'on'"),
+    video: literal("process.env.CI ? 'on-first-retry' : 'retain-on-failure'"),
   }),
   webServer: asObject({
     command: literal("'yarn start-test-server'"),


### PR DESCRIPTION
## Summary
- make the generated Playwright screenshot setting differ between CI and local runs
- align generated video defaults with the existing trace policy by using lighter CI recording and richer local failure artifacts

## Verification
- yarn check-for-ai