### PR TITLE
fix: correct generated start-test-server command

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -76,7 +76,7 @@ function generateAgentInstruction(
 - Always use heredoc syntax when passing multi-line content to any command.
 ${
   allConfigs.some((c) => c.hasStartTestServer)
-    ? `- Use \`${packageManager} run start-test-server\` to launch a web server for debugging or testing.`
+    ? `- Use \`${packageManager} start-test-server\` to launch a web server for debugging or testing.`
     : ''
 }
 


### PR DESCRIPTION
## Summary

- update generated agent instructions in `wbfy` to use `yarn start-test-server`
- remove the unnecessary `run` subcommand from the documented debug/test server command
- keep the change scoped to the generated instruction text only

## Why

- generated instructions should match the package script invocation style used in this repository
- this avoids telling agents to run a command variant that is unnecessary and can be inconsistent with the rest of the guidance

## Testing

- `yarn check-for-ai`

