### PR TITLE
fix: preserve typescript for next.js repos

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -651,7 +651,7 @@ async function removeDeprecatedStuff(
   // Next.js still requires the `typescript` package at build/dev time for
   // TypeScript projects even when repos use tsgo for explicit typechecking.
   if (!config.depending.next) {
-    delete jsonObj.devDependencies.typescript;
+    delete jsonObj.devDependencies[typescriptDependency];
   }
   delete jsonObj.devDependencies.lerna;
   // To install the latest pinst

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -24,6 +24,7 @@ import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfig
 
 const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', 'oxfmt', 'oxlint', 'oxlint-tsgolint'];
 const typescriptGoDependency = '@typescript/native-preview';
+const typescriptDependency = 'typescript';
 const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
 const obsoleteLintDependencies = [
@@ -294,6 +295,11 @@ function applyPackageJsonConventions(
 
   if (config.doesContainTypeScript || config.doesContainTypeScriptInPackages) {
     devDependencies.push(typescriptGoDependency);
+    if (config.depending.next) {
+      // Next.js still uses the `typescript` package during dev/build startup for
+      // TypeScript apps even when repositories delegate explicit typechecking to tsgo.
+      devDependencies.push(typescriptDependency);
+    }
     if (config.isBun) {
       devDependencies.push('@types/bun');
     } else if (!config.depending.reactNative) {
@@ -642,7 +648,11 @@ async function removeDeprecatedStuff(
   delete jsonObj.dependencies.tslib;
   delete jsonObj.devDependencies['@willbooster/renovate-config'];
   delete jsonObj.devDependencies['@willbooster/tsconfig'];
-  delete jsonObj.devDependencies.typescript;
+  // Next.js still requires the `typescript` package at build/dev time for
+  // TypeScript projects even when repos use tsgo for explicit typechecking.
+  if (!config.depending.next) {
+    delete jsonObj.devDependencies.typescript;
+  }
   delete jsonObj.devDependencies.lerna;
   // To install the latest pinst
   delete jsonObj.devDependencies.pinst;

--- a/packages/wbfy/test/packageJsonGenerator.test.ts
+++ b/packages/wbfy/test/packageJsonGenerator.test.ts
@@ -1,9 +1,10 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import childProcess from 'node:child_process';
 
 import type { PackageJson } from 'type-fest';
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { generatePackageJson } from '../src/generators/packageJson.js';
 import type { PackageConfig } from '../src/packageConfig.js';
@@ -11,6 +12,10 @@ import { promisePool } from '../src/utils/promisePool.js';
 import { createConfig } from './testConfig.js';
 
 describe('generatePackageJson', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test('preserves lint peer dependencies for published willbooster config packages', async () => {
     const dirPath = await createPackageDir({
       name: '@willbooster/eslint-config-ts',
@@ -133,6 +138,20 @@ describe('generatePackageJson', () => {
   });
 
   test('adds typescript for next.js packages that use tsgo', { timeout: 30_000 }, async () => {
+    vi.spyOn(childProcess, 'spawnSync').mockImplementation((command, args = []) => {
+      const dependency = args[1];
+      if (command === 'npm' && args[0] === 'show') {
+        if (dependency === '@typescript/native-preview@beta') {
+          return { output: [], pid: 1, signal: null, status: 0, stdout: '7.0.0-beta.1', stderr: '' };
+        }
+        if (dependency === 'typescript') {
+          return { output: [], pid: 1, signal: null, status: 0, stdout: '6.0.3', stderr: '' };
+        }
+        return { output: [], pid: 1, signal: null, status: 0, stdout: '1.0.0', stderr: '' };
+      }
+      throw new Error(`Unexpected spawnSync call: ${String(command)} ${args.join(' ')}`);
+    });
+
     const dirPath = await createPackageDir({
       name: 'next-package',
       private: true,
@@ -154,7 +173,7 @@ describe('generatePackageJson', () => {
     await generatePackageJson(config, createRootConfig(path.dirname(dirPath)), true);
 
     const packageJson = readPackageJson(dirPath);
-    expect(packageJson.devDependencies?.typescript).toMatch(/^6\./u);
+    expect(packageJson.devDependencies?.typescript).toMatch(/^\d+\.\d+\.\d+/u);
     expect(packageJson.devDependencies?.['@typescript/native-preview']).toBeDefined();
   });
 });

--- a/packages/wbfy/test/packageJsonGenerator.test.ts
+++ b/packages/wbfy/test/packageJsonGenerator.test.ts
@@ -101,10 +101,61 @@ describe('generatePackageJson', () => {
     });
 
     await generatePackageJson(config, config, true);
-    await promisePool.promiseAll();
 
     const packageJson = readPackageJson(dirPath);
     expect(packageJson.scripts?.postinstall).toBe('yarn run gen-i18n-ts > /dev/null');
+  });
+
+  test('keeps typescript for next.js packages', async () => {
+    const dirPath = await createPackageDir({
+      name: 'next-package',
+      private: true,
+      dependencies: {
+        next: '16.1.6',
+      },
+      devDependencies: {
+        typescript: '6.0.3',
+      },
+    });
+    const config = createConfig({
+      dirPath,
+      depending: {
+        ...createConfig().depending,
+        next: true,
+      },
+      packageJson: readPackageJson(dirPath),
+    });
+
+    await generatePackageJson(config, createRootConfig(path.dirname(dirPath)), true);
+
+    const packageJson = readPackageJson(dirPath);
+    expect(packageJson.devDependencies?.typescript).toBe('6.0.3');
+  });
+
+  test('adds typescript for next.js packages that use tsgo', { timeout: 30_000 }, async () => {
+    const dirPath = await createPackageDir({
+      name: 'next-package',
+      private: true,
+      dependencies: {
+        next: '16.1.6',
+      },
+      devDependencies: {},
+    });
+    const config = createConfig({
+      dirPath,
+      doesContainTypeScript: true,
+      depending: {
+        ...createConfig().depending,
+        next: true,
+      },
+      packageJson: readPackageJson(dirPath),
+    });
+
+    await generatePackageJson(config, createRootConfig(path.dirname(dirPath)), true);
+
+    const packageJson = readPackageJson(dirPath);
+    expect(packageJson.devDependencies?.typescript).toMatch(/^6\./u);
+    expect(packageJson.devDependencies?.['@typescript/native-preview']).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Keep `typescript` in `wbfy`-managed Next.js repositories instead of removing it unconditionally.
- Continue adding `typescript` for Next.js TypeScript repos that use `tsgo`.
- Fold in review follow-ups by using the shared TypeScript dependency constant and making the regression test deterministic and version-agnostic.

## Why

- Next.js still requires the `typescript` package during dev/build startup for TypeScript apps.
- Repositories can still use `tsgo` for explicit typechecking, but removing `typescript` from Next.js repos breaks the framework path and forces repo-specific workarounds.
- The follow-up test changes keep the regression coverage fast and stable as TypeScript versions move forward.

## Testing

- `yarn workspace @willbooster/wbfy test test/packageJsonGenerator.test.ts`
- `yarn check-for-ai`
