### PR TITLE
fix: clarify generated agent guidance and refresh oxlint

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -18,6 +18,8 @@ alwaysApply: true
   - Continue modifying the tests and code until all tests pass.
   - Ensure tests reset any related persistent data, as our test infrastructure does not clear it automatically.
   - Prefer actual API calls over mocks. Use mocks when actual calls are impractical, have unintended side effects, or are explicitly requested.
+  - Always investigate the root cause of a test failure before fixing it.
+  - Avoid adding wait functions in E2E tests unless you are confident they are necessary.
 - When fixing issues, follow these rules:
   - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
   - Fix the actual root cause instead of applying workarounds.
@@ -28,6 +30,7 @@ alwaysApply: true
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Cursor) <agent@willbooster.com>`.
   - Always create new commits. Avoid using `--amend`.
+- Always use heredoc syntax when passing multi-line content to any command.
 
 ## Coding Style
 
@@ -36,9 +39,11 @@ alwaysApply: true
 - Design each module with high cohesion, grouping related functionality together.
   - Refactor existing large modules into smaller, focused modules when necessary.
   - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions in the file above the functions they call to maintain a clear top-down order.
-  - e.g. `function caller() { callee(); } function callee() { ... }`
-- Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
+- Place calling functions above the functions they call to maintain a clear top-down order.
+  - e.g., `function caller() { callee(); } function callee() { ... }`
+  - Unlike functions, place variable and type declarations ABOVE their usage.
+- Write comments that explain "why" and use JSDoc to explain "what".
+  - Avoid stating what can be easily understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
 - Use `project.env` instead of `process.env` on `wb` package.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -7,9 +7,11 @@ Review in English based on the following coding standards.
 - Design each module with high cohesion, grouping related functionality together.
   - Refactor existing large modules into smaller, focused modules when necessary.
   - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions in the file above the functions they call to maintain a clear top-down order.
-  - e.g. `function caller() { callee(); } function callee() { ... }`
-- Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
+- Place calling functions above the functions they call to maintain a clear top-down order.
+  - e.g., `function caller() { callee(); } function callee() { ... }`
+  - Unlike functions, place variable and type declarations ABOVE their usage.
+- Write comments that explain "why" and use JSDoc to explain "what".
+  - Avoid stating what can be easily understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
 - Use `project.env` instead of `process.env` on `wb` package.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@
   - Continue modifying the tests and code until all tests pass.
   - Ensure tests reset any related persistent data, as our test infrastructure does not clear it automatically.
   - Prefer actual API calls over mocks. Use mocks when actual calls are impractical, have unintended side effects, or are explicitly requested.
+  - Always investigate the root cause of a test failure before fixing it.
+  - Avoid adding wait functions in E2E tests unless you are confident they are necessary.
 - When fixing issues, follow these rules:
   - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
   - Fix the actual root cause instead of applying workarounds.
@@ -22,6 +24,7 @@
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Codex CLI) <agent@willbooster.com>`.
   - Always create new commits. Avoid using `--amend`.
+- Always use heredoc syntax when passing multi-line content to any command.
 
 ## Coding Style
 
@@ -30,9 +33,11 @@
 - Design each module with high cohesion, grouping related functionality together.
   - Refactor existing large modules into smaller, focused modules when necessary.
   - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions in the file above the functions they call to maintain a clear top-down order.
-  - e.g. `function caller() { callee(); } function callee() { ... }`
-- Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
+- Place calling functions above the functions they call to maintain a clear top-down order.
+  - e.g., `function caller() { callee(); } function callee() { ... }`
+  - Unlike functions, place variable and type declarations ABOVE their usage.
+- Write comments that explain "why" and use JSDoc to explain "what".
+  - Avoid stating what can be easily understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
 - Use `project.env` instead of `process.env` on `wb` package.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@
   - Continue modifying the tests and code until all tests pass.
   - Ensure tests reset any related persistent data, as our test infrastructure does not clear it automatically.
   - Prefer actual API calls over mocks. Use mocks when actual calls are impractical, have unintended side effects, or are explicitly requested.
+  - Always investigate the root cause of a test failure before fixing it.
+  - Avoid adding wait functions in E2E tests unless you are confident they are necessary.
 - When fixing issues, follow these rules:
   - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
   - Fix the actual root cause instead of applying workarounds.
@@ -22,6 +24,7 @@
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>`.
   - Always create new commits. Avoid using `--amend`.
+- Always use heredoc syntax when passing multi-line content to any command.
 
 ## Coding Style
 
@@ -30,9 +33,11 @@
 - Design each module with high cohesion, grouping related functionality together.
   - Refactor existing large modules into smaller, focused modules when necessary.
   - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions in the file above the functions they call to maintain a clear top-down order.
-  - e.g. `function caller() { callee(); } function callee() { ... }`
-- Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
+- Place calling functions above the functions they call to maintain a clear top-down order.
+  - e.g., `function caller() { callee(); } function callee() { ... }`
+  - Unlike functions, place variable and type declarations ABOVE their usage.
+- Write comments that explain "why" and use JSDoc to explain "what".
+  - Avoid stating what can be easily understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
 - Use `project.env` instead of `process.env` on `wb` package.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -12,6 +12,8 @@
   - Continue modifying the tests and code until all tests pass.
   - Ensure tests reset any related persistent data, as our test infrastructure does not clear it automatically.
   - Prefer actual API calls over mocks. Use mocks when actual calls are impractical, have unintended side effects, or are explicitly requested.
+  - Always investigate the root cause of a test failure before fixing it.
+  - Avoid adding wait functions in E2E tests unless you are confident they are necessary.
 - When fixing issues, follow these rules:
   - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
   - Fix the actual root cause instead of applying workarounds.
@@ -22,6 +24,7 @@
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Gemini CLI) <agent@willbooster.com>`.
   - Always create new commits. Avoid using `--amend`.
+- Always use heredoc syntax when passing multi-line content to any command.
 
 ## Coding Style
 
@@ -30,9 +33,11 @@
 - Design each module with high cohesion, grouping related functionality together.
   - Refactor existing large modules into smaller, focused modules when necessary.
   - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions in the file above the functions they call to maintain a clear top-down order.
-  - e.g. `function caller() { callee(); } function callee() { ... }`
-- Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
+- Place calling functions above the functions they call to maintain a clear top-down order.
+  - e.g., `function caller() { callee(); } function callee() { ... }`
+  - Unlike functions, place variable and type declarations ABOVE their usage.
+- Write comments that explain "why" and use JSDoc to explain "what".
+  - Avoid stating what can be easily understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
 - Use `project.env` instead of `process.env` on `wb` package.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "conventional-changelog-conventionalcommits": "9.3.1",
     "lefthook": "2.1.5",
     "oxfmt": "0.45.0",
-    "oxlint": "1.60.0",
+    "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",
     "semantic-release": "25.0.3",
     "sort-package-json": "3.6.1"

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -57,7 +57,7 @@
     "blitz": "3.0.2",
     "build-ts": "17.1.6",
     "oxfmt": "0.45.0",
-    "oxlint": "1.60.0",
+    "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -57,7 +57,7 @@
     "build-ts": "17.1.6",
     "next": "16.2.4",
     "oxfmt": "0.45.0",
-    "oxlint": "1.60.0",
+    "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -61,7 +61,7 @@
     "@willbooster/oxlint-config": "1.4.4",
     "build-ts": "17.1.6",
     "oxfmt": "0.45.0",
-    "oxlint": "1.60.0",
+    "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -66,7 +66,7 @@
     "babel-loader": "10.1.1",
     "build-ts": "17.1.6",
     "oxfmt": "0.45.0",
-    "oxlint": "1.60.0",
+    "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -56,7 +56,7 @@
     "@willbooster/oxlint-config": "1.4.4",
     "build-ts": "17.1.6",
     "oxfmt": "0.45.0",
-    "oxlint": "1.60.0",
+    "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -59,7 +59,7 @@
     "at-decorators": "7.1.0",
     "build-ts": "17.1.6",
     "oxfmt": "0.45.0",
-    "oxlint": "1.60.0",
+    "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",
     "rolldown": "1.0.0-rc.15",
     "sort-package-json": "3.6.1",

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -67,7 +67,7 @@
     "build-ts": "17.1.6",
     "lefthook": "2.1.5",
     "oxfmt": "0.45.0",
-    "oxlint": "1.60.0",
+    "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",
     "sort-package-json": "3.6.1",
     "type-fest": "5.5.0",

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -108,7 +108,8 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
 - Place calling functions above the functions they call to maintain a clear top-down order.
   - e.g., \`function caller() { callee(); } function callee() { ... }\`
   - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
+- Write comments that explain "why" and use JSDoc to explain "what".
+  - Avoid stating what can be easily understood from the code itself.
 - Prefer \`undefined\` over \`null\` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of \`join()\` with an array of strings.
 ${

--- a/yarn.lock
+++ b/yarn.lock
@@ -3219,135 +3219,135 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxlint/binding-android-arm-eabi@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-android-arm-eabi@npm:1.60.0"
+"@oxlint/binding-android-arm-eabi@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-android-arm-eabi@npm:1.61.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxlint/binding-android-arm64@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-android-arm64@npm:1.60.0"
+"@oxlint/binding-android-arm64@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-android-arm64@npm:1.61.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxlint/binding-darwin-arm64@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-darwin-arm64@npm:1.60.0"
+"@oxlint/binding-darwin-arm64@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-darwin-arm64@npm:1.61.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxlint/binding-darwin-x64@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-darwin-x64@npm:1.60.0"
+"@oxlint/binding-darwin-x64@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-darwin-x64@npm:1.61.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxlint/binding-freebsd-x64@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-freebsd-x64@npm:1.60.0"
+"@oxlint/binding-freebsd-x64@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-freebsd-x64@npm:1.61.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@oxlint/binding-linux-arm-gnueabihf@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-linux-arm-gnueabihf@npm:1.60.0"
+"@oxlint/binding-linux-arm-gnueabihf@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-linux-arm-gnueabihf@npm:1.61.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxlint/binding-linux-arm-musleabihf@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-linux-arm-musleabihf@npm:1.60.0"
+"@oxlint/binding-linux-arm-musleabihf@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-linux-arm-musleabihf@npm:1.61.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@oxlint/binding-linux-arm64-gnu@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-linux-arm64-gnu@npm:1.60.0"
+"@oxlint/binding-linux-arm64-gnu@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-linux-arm64-gnu@npm:1.61.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxlint/binding-linux-arm64-musl@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-linux-arm64-musl@npm:1.60.0"
+"@oxlint/binding-linux-arm64-musl@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-linux-arm64-musl@npm:1.61.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxlint/binding-linux-ppc64-gnu@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-linux-ppc64-gnu@npm:1.60.0"
+"@oxlint/binding-linux-ppc64-gnu@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-linux-ppc64-gnu@npm:1.61.0"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxlint/binding-linux-riscv64-gnu@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-linux-riscv64-gnu@npm:1.60.0"
+"@oxlint/binding-linux-riscv64-gnu@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-linux-riscv64-gnu@npm:1.61.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxlint/binding-linux-riscv64-musl@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-linux-riscv64-musl@npm:1.60.0"
+"@oxlint/binding-linux-riscv64-musl@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-linux-riscv64-musl@npm:1.61.0"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxlint/binding-linux-s390x-gnu@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-linux-s390x-gnu@npm:1.60.0"
+"@oxlint/binding-linux-s390x-gnu@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-linux-s390x-gnu@npm:1.61.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxlint/binding-linux-x64-gnu@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-linux-x64-gnu@npm:1.60.0"
+"@oxlint/binding-linux-x64-gnu@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-linux-x64-gnu@npm:1.61.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@oxlint/binding-linux-x64-musl@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-linux-x64-musl@npm:1.60.0"
+"@oxlint/binding-linux-x64-musl@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-linux-x64-musl@npm:1.61.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@oxlint/binding-openharmony-arm64@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-openharmony-arm64@npm:1.60.0"
+"@oxlint/binding-openharmony-arm64@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-openharmony-arm64@npm:1.61.0"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxlint/binding-win32-arm64-msvc@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-win32-arm64-msvc@npm:1.60.0"
+"@oxlint/binding-win32-arm64-msvc@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-win32-arm64-msvc@npm:1.61.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@oxlint/binding-win32-ia32-msvc@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-win32-ia32-msvc@npm:1.60.0"
+"@oxlint/binding-win32-ia32-msvc@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-win32-ia32-msvc@npm:1.61.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@oxlint/binding-win32-x64-msvc@npm:1.60.0":
-  version: 1.60.0
-  resolution: "@oxlint/binding-win32-x64-msvc@npm:1.60.0"
+"@oxlint/binding-win32-x64-msvc@npm:1.61.0":
+  version: 1.61.0
+  resolution: "@oxlint/binding-win32-x64-msvc@npm:1.61.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5994,7 +5994,7 @@ __metadata:
     blitz: "npm:3.0.2"
     build-ts: "npm:17.1.6"
     oxfmt: "npm:0.45.0"
-    oxlint: "npm:1.60.0"
+    oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
     sort-package-json: "npm:3.6.1"
     vitest: "npm:4.1.4"
@@ -6014,7 +6014,7 @@ __metadata:
     build-ts: "npm:17.1.6"
     next: "npm:16.2.4"
     oxfmt: "npm:0.45.0"
-    oxlint: "npm:1.60.0"
+    oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
     sort-package-json: "npm:3.6.1"
     vitest: "npm:4.1.4"
@@ -6048,7 +6048,7 @@ __metadata:
     dotenv: "npm:17.4.2"
     dotenv-expand: "npm:12.0.3"
     oxfmt: "npm:0.45.0"
-    oxlint: "npm:1.60.0"
+    oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
     sort-package-json: "npm:3.6.1"
     vitest: "npm:4.1.4"
@@ -6080,7 +6080,7 @@ __metadata:
     babel-loader: "npm:10.1.1"
     build-ts: "npm:17.1.6"
     oxfmt: "npm:0.45.0"
-    oxlint: "npm:1.60.0"
+    oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
     react: "npm:19.2.5"
     react-dom: "npm:19.2.5"
@@ -6104,7 +6104,7 @@ __metadata:
     "@willbooster/oxlint-config": "npm:1.4.4"
     build-ts: "npm:17.1.6"
     oxfmt: "npm:0.45.0"
-    oxlint: "npm:1.60.0"
+    oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
     sort-package-json: "npm:3.6.1"
     vitest: "npm:4.1.4"
@@ -6136,7 +6136,7 @@ __metadata:
     kill-port: "npm:2.0.1"
     minimal-promise-pool: "npm:6.0.1"
     oxfmt: "npm:0.45.0"
-    oxlint: "npm:1.60.0"
+    oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
     rolldown: "npm:1.0.0-rc.15"
     sort-package-json: "npm:3.6.1"
@@ -6175,7 +6175,7 @@ __metadata:
     libsodium-wrappers: "npm:0.8.3"
     minimal-promise-pool: "npm:6.0.1"
     oxfmt: "npm:0.45.0"
-    oxlint: "npm:1.60.0"
+    oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
     semver: "npm:7.7.4"
     simple-git: "npm:3.36.0"
@@ -15006,29 +15006,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"oxlint@npm:1.60.0":
-  version: 1.60.0
-  resolution: "oxlint@npm:1.60.0"
+"oxlint@npm:1.61.0":
+  version: 1.61.0
+  resolution: "oxlint@npm:1.61.0"
   dependencies:
-    "@oxlint/binding-android-arm-eabi": "npm:1.60.0"
-    "@oxlint/binding-android-arm64": "npm:1.60.0"
-    "@oxlint/binding-darwin-arm64": "npm:1.60.0"
-    "@oxlint/binding-darwin-x64": "npm:1.60.0"
-    "@oxlint/binding-freebsd-x64": "npm:1.60.0"
-    "@oxlint/binding-linux-arm-gnueabihf": "npm:1.60.0"
-    "@oxlint/binding-linux-arm-musleabihf": "npm:1.60.0"
-    "@oxlint/binding-linux-arm64-gnu": "npm:1.60.0"
-    "@oxlint/binding-linux-arm64-musl": "npm:1.60.0"
-    "@oxlint/binding-linux-ppc64-gnu": "npm:1.60.0"
-    "@oxlint/binding-linux-riscv64-gnu": "npm:1.60.0"
-    "@oxlint/binding-linux-riscv64-musl": "npm:1.60.0"
-    "@oxlint/binding-linux-s390x-gnu": "npm:1.60.0"
-    "@oxlint/binding-linux-x64-gnu": "npm:1.60.0"
-    "@oxlint/binding-linux-x64-musl": "npm:1.60.0"
-    "@oxlint/binding-openharmony-arm64": "npm:1.60.0"
-    "@oxlint/binding-win32-arm64-msvc": "npm:1.60.0"
-    "@oxlint/binding-win32-ia32-msvc": "npm:1.60.0"
-    "@oxlint/binding-win32-x64-msvc": "npm:1.60.0"
+    "@oxlint/binding-android-arm-eabi": "npm:1.61.0"
+    "@oxlint/binding-android-arm64": "npm:1.61.0"
+    "@oxlint/binding-darwin-arm64": "npm:1.61.0"
+    "@oxlint/binding-darwin-x64": "npm:1.61.0"
+    "@oxlint/binding-freebsd-x64": "npm:1.61.0"
+    "@oxlint/binding-linux-arm-gnueabihf": "npm:1.61.0"
+    "@oxlint/binding-linux-arm-musleabihf": "npm:1.61.0"
+    "@oxlint/binding-linux-arm64-gnu": "npm:1.61.0"
+    "@oxlint/binding-linux-arm64-musl": "npm:1.61.0"
+    "@oxlint/binding-linux-ppc64-gnu": "npm:1.61.0"
+    "@oxlint/binding-linux-riscv64-gnu": "npm:1.61.0"
+    "@oxlint/binding-linux-riscv64-musl": "npm:1.61.0"
+    "@oxlint/binding-linux-s390x-gnu": "npm:1.61.0"
+    "@oxlint/binding-linux-x64-gnu": "npm:1.61.0"
+    "@oxlint/binding-linux-x64-musl": "npm:1.61.0"
+    "@oxlint/binding-openharmony-arm64": "npm:1.61.0"
+    "@oxlint/binding-win32-arm64-msvc": "npm:1.61.0"
+    "@oxlint/binding-win32-ia32-msvc": "npm:1.61.0"
+    "@oxlint/binding-win32-x64-msvc": "npm:1.61.0"
   peerDependencies:
     oxlint-tsgolint: ">=0.18.0"
   dependenciesMeta:
@@ -15075,7 +15075,7 @@ __metadata:
       optional: true
   bin:
     oxlint: bin/oxlint
-  checksum: 10c0/d12a2f4a6aeba5263e37b28e565b04ba8707eaec7cae53a43f3976771ec019f341fdd0f7fbd089e02c6c135d12a149a07b7162f96c2b3fa702b0642c93aff72f
+  checksum: 10c0/9f041882e722479a1f1a2f9da57279b9a9f67d45c6ce45a9984bf4134f68ff01d5a0b91162f73968444c84ea4a2627094a26da392455f141e26b74c34ec895d4
   languageName: node
   linkType: hard
 
@@ -20021,7 +20021,7 @@ __metadata:
     conventional-changelog-conventionalcommits: "npm:9.3.1"
     lefthook: "npm:2.1.5"
     oxfmt: "npm:0.45.0"
-    oxlint: "npm:1.60.0"
+    oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
     semantic-release: "npm:25.0.3"
     sort-package-json: "npm:3.6.1"


### PR DESCRIPTION
## Summary

- update the wbfy agent-instruction generator so generated guidance distinguishes comment intent from JSDoc intent
- regenerate the repository AI instruction files from that updated template
- refresh `oxlint` from `1.60.0` to `1.61.0` across the workspace and update `yarn.lock`

## Why

- the previous generated guidance said comments should avoid describing "what", which was too broad once JSDoc is part of the expected documentation style
- applying `wbfy` keeps this repository aligned with the current generated standards and dependency versions managed by the generator

## Testing

- `yarn check-for-ai`
- `yarn start /Users/exkazuu/ghq/github.com/WillBooster/shared` in `packages/wbfy`
- `yarn check-for-ai`

## Notes

- both `check-for-ai` runs completed with 3 existing `@willbooster/wbfy` warnings and no errors
