### PR TITLE
fix: silence dotenv output

### DIFF
--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -135,7 +135,7 @@ function readEnvFile(filePath: string): Record<string, string> {
   const cached = cachedEnvVars.get(filePath);
   if (cached) return cached;
 
-  const parsed = config({ path: path.resolve(filePath), processEnv: {} }).parsed ?? {};
+  const parsed = config({ path: path.resolve(filePath), processEnv: {}, quiet: true }).parsed ?? {};
   cachedEnvVars.set(filePath, parsed);
   return parsed;
 }

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -18,7 +18,7 @@ export async function setupSecrets(config: PackageConfig): Promise<void> {
     if (!owner || !repo || owner !== 'WillBoosterLab') return;
     if (!hasGitHubToken(owner) || !options.doesUploadEnvVars) return;
 
-    const parsed = dotenv.config({ path: path.resolve(config.dirPath, '.env') }).parsed ?? {};
+    const parsed = dotenv.config({ path: path.resolve(config.dirPath, '.env'), quiet: true }).parsed ?? {};
     if (Object.keys(parsed).length === 0) return;
 
     const octokit = getOctokit(owner);


### PR DESCRIPTION
## Summary

- Add `quiet: true` to dotenv reads in `shared-lib-node` environment loading and `wbfy` GitHub secret setup
- Keep parsed `.env` behavior unchanged while suppressing dotenv console output

## Why

- Dotenv output can add noise when these helpers read environment files
- The dotenv option is the narrowest change because it only affects logging from config loading

## Testing

- `yarn check-for-ai`
