### PR TITLE
fix: add React component style guidance

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -119,7 +119,8 @@ ${
 }
 ${
   allConfigs.some((c) => c.depending.react || c.depending.next)
-    ? `- Prefer \`useImmer\` for storing an array or an object to \`useState\`.`
+    ? `- Prefer lambda over \`function\` for React components, e.g., \`const Button: React.FC = () => {\`.
+- Prefer \`useImmer\` for storing an array or an object to \`useState\`.`
     : ''
 }
 ${


### PR DESCRIPTION
## Summary
- add React-only agent guidance to prefer lambda component declarations over `function`

## Verification
- `yarn check-for-ai`
