### PR TITLE
chore: apply wbfy

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -46,5 +46,7 @@ alwaysApply: true
   - Avoid stating what can be easily understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
+- Assume that all environment variables are properly defined.
+  - If validation is required, use `assert` to fail fast (e.g., during startup).
 - Use `project.env` instead of `process.env` on `wb` package.
 - Always drop any Windows support.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -14,5 +14,7 @@ Review in English based on the following coding standards.
   - Avoid stating what can be easily understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
+- Assume that all environment variables are properly defined.
+  - If validation is required, use `assert` to fail fast (e.g., during startup).
 - Use `project.env` instead of `process.env` on `wb` package.
 - Always drop any Windows support.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,5 +40,7 @@
   - Avoid stating what can be easily understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
+- Assume that all environment variables are properly defined.
+  - If validation is required, use `assert` to fail fast (e.g., during startup).
 - Use `project.env` instead of `process.env` on `wb` package.
 - Always drop any Windows support.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,5 +40,7 @@
   - Avoid stating what can be easily understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
+- Assume that all environment variables are properly defined.
+  - If validation is required, use `assert` to fail fast (e.g., during startup).
 - Use `project.env` instead of `process.env` on `wb` package.
 - Always drop any Windows support.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -40,5 +40,7 @@
   - Avoid stating what can be easily understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
+- Assume that all environment variables are properly defined.
+  - If validation is required, use `assert` to fail fast (e.g., during startup).
 - Use `project.env` instead of `process.env` on `wb` package.
 - Always drop any Windows support.

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -55,7 +55,7 @@
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "blitz": "3.0.2",
-    "build-ts": "17.1.6",
+    "build-ts": "17.1.7",
     "oxfmt": "0.45.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -54,7 +54,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
-    "build-ts": "17.1.6",
+    "build-ts": "17.1.7",
     "next": "16.2.4",
     "oxfmt": "0.45.0",
     "oxlint": "1.61.0",

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -59,7 +59,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
-    "build-ts": "17.1.6",
+    "build-ts": "17.1.7",
     "oxfmt": "0.45.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -64,7 +64,7 @@
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "babel-loader": "10.1.1",
-    "build-ts": "17.1.6",
+    "build-ts": "17.1.7",
     "oxfmt": "0.45.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -54,7 +54,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
-    "build-ts": "17.1.6",
+    "build-ts": "17.1.7",
     "oxfmt": "0.45.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -57,7 +57,7 @@
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "at-decorators": "7.1.0",
-    "build-ts": "17.1.6",
+    "build-ts": "17.1.7",
     "oxfmt": "0.45.0",
     "oxlint": "1.61.0",
     "oxlint-tsgolint": "0.21.1",

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -64,7 +64,7 @@
     "@willbooster/oxfmt-config": "1.2.1",
     "@willbooster/oxlint-config": "1.4.4",
     "@yarnpkg/core": "4.6.0",
-    "build-ts": "17.1.6",
+    "build-ts": "17.1.7",
     "lefthook": "2.1.5",
     "oxfmt": "0.45.0",
     "oxlint": "1.61.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3635,177 +3635,177 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.1"
+"@rollup/rollup-android-arm-eabi@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.2"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-android-arm64@npm:4.60.1"
+"@rollup/rollup-android-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-android-arm64@npm:4.60.2"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.1"
+"@rollup/rollup-darwin-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-darwin-x64@npm:4.60.1"
+"@rollup/rollup-darwin-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-darwin-x64@npm:4.60.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.1"
+"@rollup/rollup-freebsd-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.2"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-x64@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.1"
+"@rollup/rollup-freebsd-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.1"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.2"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.1"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.2"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.1"
+"@rollup/rollup-linux-arm64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.1"
+"@rollup/rollup-linux-arm64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loong64-gnu@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.1"
+"@rollup/rollup-linux-loong64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.2"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loong64-musl@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.1"
+"@rollup/rollup-linux-loong64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.2"
   conditions: os=linux & cpu=loong64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-ppc64-gnu@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.1"
+"@rollup/rollup-linux-ppc64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.2"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-ppc64-musl@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.1"
+"@rollup/rollup-linux-ppc64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.2"
   conditions: os=linux & cpu=ppc64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.1"
+"@rollup/rollup-linux-riscv64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.2"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-musl@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.1"
+"@rollup/rollup-linux-riscv64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.2"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.1"
+"@rollup/rollup-linux-s390x-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.2"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.1"
+"@rollup/rollup-linux-x64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.1"
+"@rollup/rollup-linux-x64-musl@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.2"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-openbsd-x64@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.1"
+"@rollup/rollup-openbsd-x64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.2"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-openharmony-arm64@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.1"
+"@rollup/rollup-openharmony-arm64@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.2"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.1"
+"@rollup/rollup-win32-arm64-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.1"
+"@rollup/rollup-win32-ia32-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.2"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-gnu@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.1"
+"@rollup/rollup-win32-x64-gnu@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.60.1":
-  version: 4.60.1
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.1"
+"@rollup/rollup-win32-x64-msvc@npm:4.60.2":
+  version: 4.60.2
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5452,9 +5452,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260413.1":
-  version: 7.0.0-dev.20260413.1
-  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260413.1"
+"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260419.1":
+  version: 7.0.0-dev.20260419.1
+  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260419.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -5466,9 +5466,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260413.1":
-  version: 7.0.0-dev.20260413.1
-  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260413.1"
+"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260419.1":
+  version: 7.0.0-dev.20260419.1
+  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260419.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -5480,9 +5480,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260413.1":
-  version: 7.0.0-dev.20260413.1
-  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260413.1"
+"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260419.1":
+  version: 7.0.0-dev.20260419.1
+  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260419.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -5494,9 +5494,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260413.1":
-  version: 7.0.0-dev.20260413.1
-  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260413.1"
+"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260419.1":
+  version: 7.0.0-dev.20260419.1
+  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260419.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -5508,9 +5508,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260413.1":
-  version: 7.0.0-dev.20260413.1
-  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260413.1"
+"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260419.1":
+  version: 7.0.0-dev.20260419.1
+  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260419.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -5522,9 +5522,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260413.1":
-  version: 7.0.0-dev.20260413.1
-  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260413.1"
+"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260419.1":
+  version: 7.0.0-dev.20260419.1
+  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260419.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -5536,9 +5536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260413.1":
-  version: 7.0.0-dev.20260413.1
-  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260413.1"
+"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260419.1":
+  version: 7.0.0-dev.20260419.1
+  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260419.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5550,17 +5550,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/native-preview@npm:7.0.0-dev.20260413.1":
-  version: 7.0.0-dev.20260413.1
-  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260413.1"
+"@typescript/native-preview@npm:7.0.0-dev.20260419.1":
+  version: 7.0.0-dev.20260419.1
+  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260419.1"
   dependencies:
-    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260413.1"
-    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260413.1"
-    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260413.1"
-    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260413.1"
-    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260413.1"
-    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260413.1"
-    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260413.1"
+    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260419.1"
+    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260419.1"
   dependenciesMeta:
     "@typescript/native-preview-darwin-arm64":
       optional: true
@@ -5578,7 +5578,7 @@ __metadata:
       optional: true
   bin:
     tsgo: bin/tsgo.js
-  checksum: 10c0/572b2aa8e07e0716e4a35ffe772d88db757d251ea2f9bb1b5ecdd8efba7de90671e0ac09277ab74aee7e647fa52d25ae23066c6c6e4a69ead885a698bf406f4c
+  checksum: 10c0/68f367136e33ab14980444e227dadc26e842019a3eb87fcc45d36c40efe86c8baacee6b0023ab7ba0427b0b869683e662f7711dec3e064166c192f35bd82eafb
   languageName: node
   linkType: hard
 
@@ -5992,7 +5992,7 @@ __metadata:
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     blitz: "npm:3.0.2"
-    build-ts: "npm:17.1.6"
+    build-ts: "npm:17.1.7"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
@@ -6011,7 +6011,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
-    build-ts: "npm:17.1.6"
+    build-ts: "npm:17.1.7"
     next: "npm:16.2.4"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.61.0"
@@ -6023,13 +6023,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@willbooster/shared-lib-node@npm:8.5.5":
-  version: 8.5.5
-  resolution: "@willbooster/shared-lib-node@npm:8.5.5"
+"@willbooster/shared-lib-node@npm:8.5.9":
+  version: 8.5.9
+  resolution: "@willbooster/shared-lib-node@npm:8.5.9"
   dependencies:
     dotenv: "npm:17.4.2"
     dotenv-expand: "npm:12.0.3"
-  checksum: 10c0/2dfff0dde7c87f0d916e34b772ce053cc6dddf56e874215b2f56d7bbf146b41b803d6a5a03f57bd56fc55d787c5004606418987ccabf8ab53989a3d26ec82449
+  checksum: 10c0/086f447bd058575734be525afb6fe156d6966f6c78bcb29ee05531a293e193b5571601b8cad48d94f55801b5ccf95d2bf101a5c4d7c24bfd556a9eaecb07742b
   languageName: node
   linkType: hard
 
@@ -6044,7 +6044,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
-    build-ts: "npm:17.1.6"
+    build-ts: "npm:17.1.7"
     dotenv: "npm:17.4.2"
     dotenv-expand: "npm:12.0.3"
     oxfmt: "npm:0.45.0"
@@ -6078,7 +6078,7 @@ __metadata:
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     babel-loader: "npm:10.1.1"
-    build-ts: "npm:17.1.6"
+    build-ts: "npm:17.1.7"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
@@ -6102,7 +6102,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260421.2"
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
-    build-ts: "npm:17.1.6"
+    build-ts: "npm:17.1.7"
     oxfmt: "npm:0.45.0"
     oxlint: "npm:1.61.0"
     oxlint-tsgolint: "npm:0.21.1"
@@ -6128,7 +6128,7 @@ __metadata:
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     at-decorators: "npm:7.1.0"
-    build-ts: "npm:17.1.6"
+    build-ts: "npm:17.1.7"
     chalk: "npm:5.6.2"
     dotenv: "npm:17.4.2"
     dotenv-expand: "npm:12.0.3"
@@ -6164,7 +6164,7 @@ __metadata:
     "@willbooster/oxfmt-config": "npm:1.2.1"
     "@willbooster/oxlint-config": "npm:1.4.4"
     "@yarnpkg/core": "npm:4.6.0"
-    build-ts: "npm:17.1.6"
+    build-ts: "npm:17.1.7"
     deepmerge: "npm:4.3.1"
     dotenv: "npm:17.4.2"
     fast-glob: "npm:3.3.3"
@@ -7519,9 +7519,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"build-ts@npm:17.1.6":
-  version: 17.1.6
-  resolution: "build-ts@npm:17.1.6"
+"build-ts@npm:17.1.7":
+  version: 17.1.7
+  resolution: "build-ts@npm:17.1.7"
   dependencies:
     "@babel/core": "npm:7.29.0"
     "@babel/plugin-proposal-decorators": "npm:7.29.0"
@@ -7538,8 +7538,8 @@ __metadata:
     "@rollup/plugin-replace": "npm:6.0.3"
     "@rollup/plugin-terser": "npm:1.0.0"
     "@rollup/pluginutils": "npm:5.3.0"
-    "@typescript/native-preview": "npm:7.0.0-dev.20260413.1"
-    "@willbooster/shared-lib-node": "npm:8.5.5"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260419.1"
+    "@willbooster/shared-lib-node": "npm:8.5.9"
     babel-plugin-polyfill-corejs3: "npm:0.14.2"
     babel-plugin-transform-remove-console: "npm:6.9.4"
     chalk: "npm:5.6.2"
@@ -7547,10 +7547,10 @@ __metadata:
     core-js-pure: "npm:3.49.0"
     date-time: "npm:4.0.0"
     pretty-ms: "npm:9.3.0"
-    rollup: "npm:4.60.1"
+    rollup: "npm:4.60.2"
     rollup-plugin-analyzer: "npm:4.0.0"
     rollup-plugin-keep-import: "npm:1.0.3"
-    rollup-plugin-node-externals: "npm:9.0.0"
+    rollup-plugin-node-externals: "npm:9.0.1"
     rollup-plugin-preserve-directives: "npm:0.4.0"
     rollup-plugin-string: "npm:3.0.0"
     signal-exit: "npm:4.1.0"
@@ -7558,7 +7558,7 @@ __metadata:
     yargs: "npm:18.0.0"
   bin:
     build-ts: bin/index.js
-  checksum: 10c0/13fc6a574f4170481c1e64283f4b7fe796e3952098adedec5896c96fd01d5a396f16e07185dd02f5f3ac7e8917f0b4234852e3bf42a825e2dc7f1bee0d3f8e19
+  checksum: 10c0/0afd60fb0d0908d8eb5442a2e43facc84e9cd1dfe4c3612f84540f480fcd3e33ecee949d8ce9ca1d2d3bea66de8ed97574fbe94d45875b0a51388fe98c7b4a43
   languageName: node
   linkType: hard
 
@@ -16831,9 +16831,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-node-externals@npm:9.0.0":
-  version: 9.0.0
-  resolution: "rollup-plugin-node-externals@npm:9.0.0"
+"rollup-plugin-node-externals@npm:9.0.1":
+  version: 9.0.1
+  resolution: "rollup-plugin-node-externals@npm:9.0.1"
   peerDependencies:
     rollup: ^4.0.0
     vite: ">=5.0.0"
@@ -16842,7 +16842,7 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: 10c0/041175999540985dcda9b3f0ad4d073b889d266e3dac4a0a825d5d7acb9b77c60bf3bf6ee0e22ec313af9f85a98f657652a3818d96ee8e4cc4f64c848b504ea1
+  checksum: 10c0/0d57f267cf7356aecd3ec08fa031cccfb4e621b1d0f83216240bcf647ab439b083340a1d927bb8dab3a20fe21b47fd4929a99086bfb3d08c7ad740f191d3bf9d
   languageName: node
   linkType: hard
 
@@ -16876,35 +16876,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:4.60.1":
-  version: 4.60.1
-  resolution: "rollup@npm:4.60.1"
+"rollup@npm:4.60.2":
+  version: 4.60.2
+  resolution: "rollup@npm:4.60.2"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.60.1"
-    "@rollup/rollup-android-arm64": "npm:4.60.1"
-    "@rollup/rollup-darwin-arm64": "npm:4.60.1"
-    "@rollup/rollup-darwin-x64": "npm:4.60.1"
-    "@rollup/rollup-freebsd-arm64": "npm:4.60.1"
-    "@rollup/rollup-freebsd-x64": "npm:4.60.1"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.60.1"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.60.1"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.60.1"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.60.1"
-    "@rollup/rollup-linux-loong64-gnu": "npm:4.60.1"
-    "@rollup/rollup-linux-loong64-musl": "npm:4.60.1"
-    "@rollup/rollup-linux-ppc64-gnu": "npm:4.60.1"
-    "@rollup/rollup-linux-ppc64-musl": "npm:4.60.1"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.60.1"
-    "@rollup/rollup-linux-riscv64-musl": "npm:4.60.1"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.60.1"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.60.1"
-    "@rollup/rollup-linux-x64-musl": "npm:4.60.1"
-    "@rollup/rollup-openbsd-x64": "npm:4.60.1"
-    "@rollup/rollup-openharmony-arm64": "npm:4.60.1"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.60.1"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.60.1"
-    "@rollup/rollup-win32-x64-gnu": "npm:4.60.1"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.60.1"
+    "@rollup/rollup-android-arm-eabi": "npm:4.60.2"
+    "@rollup/rollup-android-arm64": "npm:4.60.2"
+    "@rollup/rollup-darwin-arm64": "npm:4.60.2"
+    "@rollup/rollup-darwin-x64": "npm:4.60.2"
+    "@rollup/rollup-freebsd-arm64": "npm:4.60.2"
+    "@rollup/rollup-freebsd-x64": "npm:4.60.2"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.60.2"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.60.2"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.60.2"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.60.2"
+    "@rollup/rollup-linux-x64-musl": "npm:4.60.2"
+    "@rollup/rollup-openbsd-x64": "npm:4.60.2"
+    "@rollup/rollup-openharmony-arm64": "npm:4.60.2"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.60.2"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.60.2"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.60.2"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.60.2"
     "@types/estree": "npm:1.0.8"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
@@ -16962,7 +16962,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10c0/48d3f2216b5533639b007e6756e2275c7f594e45adee21ce03674aa2e004406c661f8b86c7a0b471c9e889c6a9efbb29240ca0b7673c50e391406c490c309833
+  checksum: 10c0/f67d6156fc5b895f33b929a4762392906d00fa5550f0a1f5e66519ab1c05d835aec5f201b4e748c29d1c87f024d3d9c4b0a2d1285668456db661d82b961d379c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Apply the latest `wbfy` generated repository guidance updates.
- Bump `build-ts` from `17.1.6` to `17.1.7` across workspaces.
- Refresh `yarn.lock` for the generated dependency updates.

## Why

- Keeps this repository aligned with the current shared `wbfy` automation output.

## Testing

- `yarn check-for-ai`

## Notes

- `yarn check-for-ai` passed with three existing non-fatal `no-null` warnings in `packages/wbfy/test/packageJsonGenerator.test.ts`.
