### PR TITLE
fix: remove config workspace edges in wbfy

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -703,12 +703,13 @@ function removeWillBoosterConfigsManagedDependencies(
 ): void {
   if (!config.isWillBoosterConfigs) return;
 
+  const sections = getDependencySections(jsonObj);
   for (const dependency of oxlintDeps) {
     if (!dependency.startsWith('@willbooster/')) continue;
     // willbooster-configs publishes these managed config packages from the same
     // monorepo. Keeping them in subpackage metadata creates local workspace
     // graph edges that multi-semantic-release sorts as release dependencies.
-    for (const section of getDependencySections(jsonObj)) {
+    for (const section of sections) {
       Reflect.deleteProperty(section, dependency);
     }
   }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -27,6 +27,11 @@ const typescriptGoDependency = '@typescript/native-preview';
 const typescriptDependency = 'typescript';
 const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
+const willBoosterConfigsManagedDependencies = [
+  '@willbooster/prettier-config',
+  wbDependency,
+  ...oxlintDeps.filter((dependency) => dependency.startsWith('@willbooster/')),
+];
 const obsoleteLintDependencies = [
   '@biomejs/biome',
   '@eslint-react/eslint-plugin',
@@ -704,8 +709,7 @@ function removeWillBoosterConfigsManagedDependencies(
   if (!config.isWillBoosterConfigs) return;
 
   const sections = getDependencySections(jsonObj);
-  for (const dependency of oxlintDeps) {
-    if (!dependency.startsWith('@willbooster/')) continue;
+  for (const dependency of willBoosterConfigsManagedDependencies) {
     // willbooster-configs publishes these managed config packages from the same
     // monorepo. Keeping them in subpackage metadata creates local workspace
     // graph edges that multi-semantic-release sorts as release dependencies.

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -663,6 +663,7 @@ async function removeDeprecatedStuff(
   delete jsonObj.scripts['check-all'];
   await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'lerna.json'), { force: true }));
 
+  removeWillBoosterConfigsManagedDependencies(config, jsonObj);
   removeObsoleteLintDependencies(jsonObj, config);
 }
 
@@ -692,6 +693,23 @@ function replaceWillBoosterConfigsWorkspaceDependencyRanges(config: PackageConfi
       // The final `yarn install --no-immutable` syncs the lockfile after this
       // migration, even when the dependency is not part of wbfy's managed list.
       section[dependency] = getLatestDependencyVersion(dependency);
+    }
+  }
+}
+
+function removeWillBoosterConfigsManagedDependencies(
+  config: PackageConfig,
+  jsonObj: SetRequired<PackageJson, 'dependencies' | 'devDependencies' | 'peerDependencies'>
+): void {
+  if (!config.isWillBoosterConfigs) return;
+
+  for (const dependency of oxlintDeps) {
+    if (!dependency.startsWith('@willbooster/')) continue;
+    // willbooster-configs publishes these managed config packages from the same
+    // monorepo. Keeping them in subpackage metadata creates local workspace
+    // graph edges that multi-semantic-release sorts as release dependencies.
+    for (const section of getDependencySections(jsonObj)) {
+      Reflect.deleteProperty(section, dependency);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Update `wbfy` so `willbooster-configs` removes stale managed `@willbooster/*` dependencies from package metadata.
- Cover managed config/tool packages including `@willbooster/oxfmt-config`, `@willbooster/oxlint-config`, `@willbooster/prettier-config`, and `@willbooster/wb`.
- Avoid repeated dependency-section lookup while deleting stale entries.

## Why

- The failed `willbooster-configs` release job hit a `multi-semantic-release` loop involving config packages.
- The root cause was stale managed `@willbooster/*` dependency entries that create local workspace graph edges in a monorepo whose config packages are released independently.

## Testing

- `yarn check-for-ai` in `packages/wbfy`
- Applied this local `wbfy` change to `~/ghq/github.com/WillBooster/willbooster-configs`
- PR CI passed
- Resolved Gemini review threads and requested follow-up Gemini reviews
