### PR TITLE
fix: avoid unused wbfy tsconfig dependencies

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -741,14 +741,15 @@ async function removeUnusedTsconfigBaseDependencies(
     if (usedDependencySet.has(dependency) || existingTsconfigBaseDependencies.has(dependency)) continue;
     // wbfy owns these base-config packages. Remove stale variants when repo
     // capabilities change, such as Next.js taking ownership of tsconfig.json.
-    delete jsonObj.dependencies[dependency];
-    delete jsonObj.devDependencies[dependency];
+    for (const section of getDependencySections(jsonObj)) {
+      Reflect.deleteProperty(section, dependency);
+    }
   }
 }
 
 async function getExistingTsconfigBaseDependencies(config: PackageConfig): Promise<Set<string>> {
   const existingTsconfigBaseDependencies = new Set<string>();
-  const filePaths = fg.globSync('**/tsconfig*.json', {
+  const filePaths = await fg.glob('**/tsconfig*.json', {
     cwd: config.dirPath,
     dot: true,
     ignore: globIgnore,

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -61,7 +61,9 @@ const obsoleteLintDependencies = [
   'eslint-plugin-import-x',
   'eslint-plugin-perfectionist',
   'eslint-plugin-prettier',
+  'eslint-plugin-react',
   'eslint-plugin-react-compiler',
+  'eslint-plugin-react-hooks',
   'eslint-plugin-sort-class-members',
   'eslint-plugin-sort-destructure-keys',
   'eslint-plugin-storybook',
@@ -1049,6 +1051,7 @@ function removePrettierArtifacts(jsonObj: WritablePackageJson): void {
     if (!section) continue;
     delete section.prettier;
     delete section['prettier-plugin-java'];
+    delete section['prettier-plugin-prisma'];
     delete section['@willbooster/prettier-config'];
     delete section['@types/prettier'];
   }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -110,7 +110,7 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
   await removeDeprecatedStuff(config, jsonObj);
   await updateScripts(config, jsonObj, packageManager);
   moveManagedToolDependenciesToDevDependencies(jsonObj);
-  const dependencyUpdates = applyPackageJsonConventions(config, rootConfig, jsonObj);
+  const dependencyUpdates = await applyPackageJsonConventions(config, rootConfig, jsonObj);
   await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
   addDependencyVersionsToPackageJson(jsonObj, dependencyUpdates);
   await updatePrivatePackages(jsonObj);
@@ -196,11 +196,11 @@ function normalizeYarnWorkspaceForeachScripts(scripts: PackageJson.Scripts): voi
   }
 }
 
-function applyPackageJsonConventions(
+async function applyPackageJsonConventions(
   config: PackageConfig,
   rootConfig: PackageConfig,
   jsonObj: WritablePackageJson
-): DependencyUpdates {
+): Promise<DependencyUpdates> {
   const dependencies: string[] = [];
   const devDependencies = ['sort-package-json'];
   const pythonDevDependencies: string[] = [];
@@ -300,7 +300,7 @@ function applyPackageJsonConventions(
   }
 
   const tsconfigBaseDependencies = doesContainJsOrTs(config) ? getTsconfigBaseDependencies(config) : [];
-  removeUnusedTsconfigBaseDependencies(config, jsonObj, tsconfigBaseDependencies);
+  await removeUnusedTsconfigBaseDependencies(config, jsonObj, tsconfigBaseDependencies);
   if (doesContainJsOrTs(config)) {
     devDependencies.push(...tsconfigBaseDependencies);
   }
@@ -732,13 +732,13 @@ function removeWillBoosterConfigsManagedDependencies(
   }
 }
 
-function removeUnusedTsconfigBaseDependencies(
+async function removeUnusedTsconfigBaseDependencies(
   config: PackageConfig,
   jsonObj: WritablePackageJson,
   usedDependencies: string[]
-): void {
+): Promise<void> {
   const usedDependencySet = new Set(usedDependencies);
-  const existingTsconfigBaseDependencies = getExistingTsconfigBaseDependencies(config);
+  const existingTsconfigBaseDependencies = await getExistingTsconfigBaseDependencies(config);
   for (const dependency of managedTsconfigBaseDependencies) {
     if (usedDependencySet.has(dependency) || existingTsconfigBaseDependencies.has(dependency)) continue;
     // wbfy owns these base-config packages. Remove stale variants when repo
@@ -748,7 +748,7 @@ function removeUnusedTsconfigBaseDependencies(
   }
 }
 
-function getExistingTsconfigBaseDependencies(config: PackageConfig): Set<string> {
+async function getExistingTsconfigBaseDependencies(config: PackageConfig): Promise<Set<string>> {
   const existingTsconfigBaseDependencies = new Set<string>();
   const filePaths = fg.globSync('**/tsconfig*.json', {
     cwd: config.dirPath,
@@ -759,7 +759,10 @@ function getExistingTsconfigBaseDependencies(config: PackageConfig): Set<string>
   for (const filePath of filePaths) {
     const absoluteFilePath = path.resolve(config.dirPath, filePath);
     try {
-      const parsed = ts.parseConfigFileTextToJson(absoluteFilePath, fs.readFileSync(absoluteFilePath, 'utf8'));
+      const parsed = ts.parseConfigFileTextToJson(
+        absoluteFilePath,
+        await fs.promises.readFile(absoluteFilePath, 'utf8')
+      );
       if (parsed.error) {
         console.warn(
           `Preserve managed @tsconfig dependencies because ${absoluteFilePath} could not be parsed: ${formatTsDiagnostic(parsed.error)}`

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -301,9 +301,7 @@ async function applyPackageJsonConventions(
 
   const tsconfigBaseDependencies = doesContainJsOrTs(config) ? getTsconfigBaseDependencies(config) : [];
   await removeUnusedTsconfigBaseDependencies(config, jsonObj, tsconfigBaseDependencies);
-  if (doesContainJsOrTs(config)) {
-    devDependencies.push(...tsconfigBaseDependencies);
-  }
+  devDependencies.push(...tsconfigBaseDependencies);
 
   if (config.doesContainTypeScript || config.doesContainTypeScriptInPackages) {
     devDependencies.push(typescriptGoDependency);

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import merge from 'deepmerge';
 import fg from 'fast-glob';
 import { sortPackageJson } from 'sort-package-json';
+import ts from 'typescript';
 import type { PackageJson, SetRequired } from 'type-fest';
 
 import { getLatestCommitHash } from '../github/commit.js';
@@ -19,7 +20,7 @@ import { combineMerge } from '../utils/mergeUtil.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
 import { spawnSync, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
-import { getTsconfigBaseDependencies } from '../utils/tsconfigBase.js';
+import { getTsconfigBaseDependencies, managedTsconfigBaseDependencies } from '../utils/tsconfigBase.js';
 import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfigsUtil.js';
 
 const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', 'oxfmt', 'oxlint', 'oxlint-tsgolint'];
@@ -295,8 +296,10 @@ function applyPackageJsonConventions(
     devDependencies.push(...oxlintDeps);
   }
 
+  const tsconfigBaseDependencies = doesContainJsOrTs(config) ? getTsconfigBaseDependencies(config) : [];
+  removeUnusedTsconfigBaseDependencies(config, jsonObj, tsconfigBaseDependencies);
   if (doesContainJsOrTs(config)) {
-    devDependencies.push(...getTsconfigBaseDependencies(config));
+    devDependencies.push(...tsconfigBaseDependencies);
   }
 
   if (config.doesContainTypeScript || config.doesContainTypeScriptInPackages) {
@@ -724,6 +727,47 @@ function removeWillBoosterConfigsManagedDependencies(
       Reflect.deleteProperty(section, dependency);
     }
   }
+}
+
+function removeUnusedTsconfigBaseDependencies(
+  config: PackageConfig,
+  jsonObj: WritablePackageJson,
+  usedDependencies: string[]
+): void {
+  const usedDependencySet = new Set(usedDependencies);
+  for (const dependency of managedTsconfigBaseDependencies) {
+    if (usedDependencySet.has(dependency) || isReferencedByExistingTsconfig(config, dependency)) continue;
+    // wbfy owns these base-config packages. Remove stale variants when repo
+    // capabilities change, such as Next.js taking ownership of tsconfig.json.
+    delete jsonObj.dependencies[dependency];
+    delete jsonObj.devDependencies[dependency];
+  }
+}
+
+function isReferencedByExistingTsconfig(config: PackageConfig, dependency: string): boolean {
+  const filePaths = fg.globSync('**/tsconfig*.json', {
+    cwd: config.dirPath,
+    dot: true,
+    ignore: globIgnore,
+  });
+
+  return filePaths.some((filePath) => {
+    const absoluteFilePath = path.resolve(config.dirPath, filePath);
+    try {
+      const parsed = ts.parseConfigFileTextToJson(absoluteFilePath, fs.readFileSync(absoluteFilePath, 'utf8'));
+      return normalizeTsconfigExtends((parsed.config as { extends?: unknown } | undefined)?.extends).some(
+        (value) => value === dependency || value.startsWith(`${dependency}/`)
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
+function normalizeTsconfigExtends(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
 }
 
 function getDependencySections(jsonObj: PackageJson): Partial<Record<string, string>>[] {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -758,13 +758,26 @@ function isReferencedByExistingTsconfig(config: PackageConfig, dependency: strin
     const absoluteFilePath = path.resolve(config.dirPath, filePath);
     try {
       const parsed = ts.parseConfigFileTextToJson(absoluteFilePath, fs.readFileSync(absoluteFilePath, 'utf8'));
+      if (parsed.error) {
+        console.warn(
+          `Preserve ${dependency} because ${absoluteFilePath} could not be parsed: ${formatTsDiagnostic(parsed.error)}`
+        );
+        return true;
+      }
       return normalizeTsconfigExtends((parsed.config as { extends?: unknown } | undefined)?.extends).some(
         (value) => value === dependency || value.startsWith(`${dependency}/`)
       );
-    } catch {
-      return false;
+    } catch (error) {
+      console.warn(
+        `Preserve ${dependency} because ${absoluteFilePath} could not be read: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return true;
     }
   });
+}
+
+function formatTsDiagnostic(diagnostic: ts.Diagnostic): string {
+  return ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
 }
 
 function normalizeTsconfigExtends(value: unknown): string[] {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -54,6 +54,7 @@ const obsoleteLintDependencies = [
   'biome',
   'eslint',
   'eslint-config-flat-gitignore',
+  'eslint-config-next',
   'eslint-config-prettier',
   'eslint-import-resolver-node',
   'eslint-import-resolver-typescript',

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -738,8 +738,9 @@ function removeUnusedTsconfigBaseDependencies(
   usedDependencies: string[]
 ): void {
   const usedDependencySet = new Set(usedDependencies);
+  const existingTsconfigBaseDependencies = getExistingTsconfigBaseDependencies(config);
   for (const dependency of managedTsconfigBaseDependencies) {
-    if (usedDependencySet.has(dependency) || isReferencedByExistingTsconfig(config, dependency)) continue;
+    if (usedDependencySet.has(dependency) || existingTsconfigBaseDependencies.has(dependency)) continue;
     // wbfy owns these base-config packages. Remove stale variants when repo
     // capabilities change, such as Next.js taking ownership of tsconfig.json.
     delete jsonObj.dependencies[dependency];
@@ -747,33 +748,40 @@ function removeUnusedTsconfigBaseDependencies(
   }
 }
 
-function isReferencedByExistingTsconfig(config: PackageConfig, dependency: string): boolean {
+function getExistingTsconfigBaseDependencies(config: PackageConfig): Set<string> {
+  const existingTsconfigBaseDependencies = new Set<string>();
   const filePaths = fg.globSync('**/tsconfig*.json', {
     cwd: config.dirPath,
     dot: true,
     ignore: globIgnore,
   });
 
-  return filePaths.some((filePath) => {
+  for (const filePath of filePaths) {
     const absoluteFilePath = path.resolve(config.dirPath, filePath);
     try {
       const parsed = ts.parseConfigFileTextToJson(absoluteFilePath, fs.readFileSync(absoluteFilePath, 'utf8'));
       if (parsed.error) {
         console.warn(
-          `Preserve ${dependency} because ${absoluteFilePath} could not be parsed: ${formatTsDiagnostic(parsed.error)}`
+          `Preserve managed @tsconfig dependencies because ${absoluteFilePath} could not be parsed: ${formatTsDiagnostic(parsed.error)}`
         );
-        return true;
+        return new Set(managedTsconfigBaseDependencies);
       }
-      return normalizeTsconfigExtends((parsed.config as { extends?: unknown } | undefined)?.extends).some(
-        (value) => value === dependency || value.startsWith(`${dependency}/`)
-      );
+      for (const value of normalizeTsconfigExtends((parsed.config as { extends?: unknown } | undefined)?.extends)) {
+        for (const dependency of managedTsconfigBaseDependencies) {
+          if (value === dependency || value.startsWith(`${dependency}/`)) {
+            existingTsconfigBaseDependencies.add(dependency);
+          }
+        }
+      }
     } catch (error) {
       console.warn(
-        `Preserve ${dependency} because ${absoluteFilePath} could not be read: ${error instanceof Error ? error.message : String(error)}`
+        `Preserve managed @tsconfig dependencies because ${absoluteFilePath} could not be read: ${error instanceof Error ? error.message : String(error)}`
       );
-      return true;
+      return new Set(managedTsconfigBaseDependencies);
     }
-  });
+  }
+
+  return existingTsconfigBaseDependencies;
 }
 
 function formatTsDiagnostic(diagnostic: ts.Diagnostic): string {

--- a/packages/wbfy/src/utils/tsconfigBase.ts
+++ b/packages/wbfy/src/utils/tsconfigBase.ts
@@ -1,5 +1,12 @@
 import type { PackageConfig } from '../packageConfig.js';
 
+export const managedTsconfigBaseDependencies = [
+  '@tsconfig/bun',
+  '@tsconfig/node-lts',
+  '@tsconfig/node-ts',
+  '@tsconfig/react-native',
+];
+
 export function getTsconfigExtends(config: PackageConfig): string | string[] {
   if (config.isBun) {
     return '@tsconfig/bun/tsconfig.json';
@@ -11,6 +18,9 @@ export function getTsconfigExtends(config: PackageConfig): string | string[] {
 }
 
 export function getTsconfigBaseDependencies(config: PackageConfig): string[] {
+  if (config.depending.blitz || config.depending.next) {
+    return [];
+  }
   if (config.isBun) {
     return ['@tsconfig/bun'];
   }


### PR DESCRIPTION
## Summary

- Stop wbfy from adding `@tsconfig/node-lts` and `@tsconfig/node-ts` to Next/Blitz projects where wbfy does not generate a tsconfig that extends them.
- Track managed `@tsconfig/*` base packages and remove stale variants from package metadata when they are no longer selected.
- Preserve an existing managed `@tsconfig/*` dependency if any `tsconfig*.json` in the package still explicitly extends it.
- Warn and preserve managed `@tsconfig/*` dependencies when an existing tsconfig cannot be read or parsed, avoiding unsafe pruning on inconclusive inspection.
- Scan existing tsconfig files once, read them asynchronously, and reuse the collected referenced bases while pruning package metadata.
- Remove stale managed `@tsconfig/*` packages consistently from all dependency sections.
- Remove stale ESLint/Prettier-era packages after migration to oxlint/oxfmt, including React ESLint plugins, `eslint-config-next`, and Prettier plugins/config packages.

## Why

- `WillBoosterLab/ai-game-builder#417` shows wbfy adding `@tsconfig/node-lts` and `@tsconfig/node-ts` even though the target is a Next app and its tsconfig does not use those packages.
- The package dependency installer had drifted from the tsconfig generator: tsconfig generation returns early for Next/Blitz, but dependency installation still treated all JS/TS repos as needing the node base configs.
- Applying wbfy to `WillBooster/prompt-study` showed additional stale ESLint/Prettier direct deps that should be removed by the generator, not manually edited per repo.

## Testing

- `yarn workspace @willbooster/wbfy check-for-ai`
- `yarn check-for-ai`
- `yarn typecheck`
- Manually inspected `WillBoosterLab/ai-game-builder` main: it is a Next app, has no `@tsconfig/*` devDependencies, and its `tsconfig.json` does not extend `@tsconfig/node-lts` or `@tsconfig/node-ts`.
- Re-ran wbfy on `WillBooster/prompt-study` and verified stale direct ESLint/Prettier deps are removed.
- Confirmed latest PR CI passes after review fixes.
