### PR TITLE
feat: rename verify command

### DIFF
--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -28,8 +28,8 @@
     "start-prod": "yarn build && yarn wb",
     "test": "WB_ENV=test vitest run test",
     "typecheck": "tsgo --noEmit",
-    "verify-code": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify-code",
-    "verify-code-with-tests": "yarn verify-code && yarn test"
+    "verify": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify",
+    "verify-full": "yarn verify --full"
   },
   "dependencies": {
     "chalk": "5.6.2",

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -11,13 +11,19 @@ import { packageManager } from '../utils/runtime.js';
 import { lint, type LintCommandArgv } from './lint.js';
 import { test, type TestCommandArgv } from './test.js';
 
-const builder = {} as const;
+const builder = {
+  full: {
+    type: 'boolean',
+    default: false,
+    describe: 'Run tests after verifying project code',
+  },
+} as const;
 
 type VerifyCodeCommandOptions = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>;
 type VerifyCodeCommandArgv = ArgumentsCamelCase<VerifyCodeCommandOptions>;
 
 export const verifyCodeCommand: CommandModule<unknown, VerifyCodeCommandOptions> = {
-  command: 'verify-code',
+  command: 'verify',
   describe: 'Verify project code',
   builder,
   async handler(argv) {
@@ -28,22 +34,9 @@ export const verifyCodeCommand: CommandModule<unknown, VerifyCodeCommandOptions>
     }
 
     await verifyCode(projects.self, argv);
-  },
-};
-
-export const verifyCodeWithTestsCommand: CommandModule<unknown, VerifyCodeCommandOptions> = {
-  command: 'verify-code-with-tests',
-  describe: 'Verify project code and run tests',
-  builder,
-  async handler(argv) {
-    const projects = findRootAndSelfProjects(argv, false);
-    if (!projects) {
-      console.error(chalk.red('No project found.'));
-      process.exit(1);
+    if (argv.full) {
+      await runProjectTest(projects.self, argv);
     }
-
-    await verifyCode(projects.self, argv);
-    await runProjectTest(projects.self, argv);
   },
 };
 
@@ -54,18 +47,22 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
       silent: true,
     });
   }
-  await runInProcessCommand('format', () => lint({ ...argv, _: ['lint'], format: true } as LintCommandArgv), {
-    allowFailure: true,
-  });
+  await runInProcessCommand(
+    'format',
+    () => lint({ ...argv, _: ['lint'], format: true } as unknown as LintCommandArgv),
+    {
+      allowFailure: true,
+    }
+  );
   await runInProcessCommand('lint-fix', () =>
-    lint({ ...argv, _: ['lint'], fix: true, quiet: true } as LintCommandArgv)
+    lint({ ...argv, _: ['lint'], fix: true, quiet: true } as unknown as LintCommandArgv)
   );
 }
 
 async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Promise<void> {
   if (project.packageJson.scripts?.test?.includes('wb test')) {
     console.info('\n' + chalk.cyan(chalk.bold('Start:'), 'test'));
-    await test({ ...argv, _: ['test'], e2e: 'headless' } as TestCommandArgv);
+    await test({ ...argv, _: ['test'], e2e: 'headless' } as unknown as TestCommandArgv);
     console.info(chalk.green(chalk.bold('Finished:'), 'test'));
     return;
   }

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -18,7 +18,7 @@ import { testCommand } from './commands/test.js';
 import { testOnCiCommand } from './commands/testOnCi.js';
 import { treeKillCommand } from './commands/treeKill.js';
 import { tcCommand, typeCheckCommand } from './commands/typecheck.js';
-import { verifyCodeCommand, verifyCodeWithTestsCommand } from './commands/verifyCode.js';
+import { verifyCodeCommand } from './commands/verifyCode.js';
 import { sharedOptionsBuilder } from './sharedOptionsBuilder.js';
 
 await yargs(hideBin(process.argv))
@@ -33,7 +33,6 @@ await yargs(hideBin(process.argv))
 
     removeNpmAndYarnEnvironmentVariables(process.env);
   })
-  .command(verifyCodeWithTestsCommand)
   .command(verifyCodeCommand)
   .command(buildIfNeededCommand)
   .command(concurrentlyCommand)

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -29,8 +29,8 @@
     "test": "yarn run test/ci-setup && vitest test",
     "test/ci-setup": "rm -Rf test-fixtures/wbfy && mkdir -p test-fixtures && git clone https://github.com/WillBooster/test-fixtures-for-wbfy.git test-fixtures/wbfy",
     "typecheck": "tsgo --noEmit",
-    "verify-code": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify-code",
-    "verify-code-with-tests": "yarn verify-code && yarn test"
+    "verify": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify",
+    "verify-full": "yarn verify --full"
   },
   "dependencies": {
     "@octokit/core": "7.0.6",

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -677,6 +677,8 @@ async function removeDeprecatedStuff(
   delete jsonObj.scripts['format-python'];
   delete jsonObj.scripts.prettier;
   delete jsonObj.scripts['check-all'];
+  delete jsonObj.scripts['verify-code'];
+  delete jsonObj.scripts['verify-code-with-tests'];
   await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'lerna.json'), { force: true }));
 
   removeWillBoosterConfigsManagedDependencies(config, jsonObj);
@@ -971,6 +973,8 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       'lint-fix': 'bun --bun wb lint --fix',
       test: 'bun wb test',
       typecheck: 'bun --bun wb typecheck',
+      verify: 'bun --bun wb verify',
+      'verify-full': 'bun --bun wb verify --full',
     };
     if (!hasTypecheck) {
       delete scripts.typecheck;
@@ -1030,6 +1034,10 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       delete scripts.typecheck;
     } else if (config.depending.wb) {
       scripts.typecheck = 'wb typecheck';
+    }
+    if (config.depending.wb) {
+      scripts.verify = 'wb verify';
+      scripts['verify-full'] = 'wb verify --full';
     }
     return scripts;
   }


### PR DESCRIPTION
## Summary

- Rename `wb verify-code` to `wb verify`.
- Replace `wb verify-code-with-tests` with `wb verify --full`.
- Update `wbfy` package generation to emit `verify` and `verify-full` scripts and remove the obsolete script names.
- Update the `wb` and `wbfy` package scripts to use the new command names.

## Why

- The CLI now exposes one verification command with a `--full` option instead of two separate command names.
- `wbfy` needs to generate the new script names so managed repositories do not keep stale `verify-code` scripts after rerunning it.

## Testing

- `yarn check-for-ai` in `packages/wb`
- `yarn start verify --help` in `packages/wb`
- `yarn check-for-ai` in `packages/wbfy`
