### PR TITLE
fix: make wb verify output sequential

### DIFF
--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -9,6 +9,7 @@ import { findDescendantProjects } from '../project.js';
 import type { BufferedRunResult } from '../scripts/run.js';
 import { runWithSpawnInParallel, runWithSpawnInParallelBuffered } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { normalizeBufferedOutput, shouldPrintBufferedOutput } from '../utils/output.js';
 import { buildShellCommand } from '../utils/shell.js';
 
 const builder = {
@@ -303,25 +304,14 @@ function runLintCommand(
 function printSilentLintOutputs(results: LintRunResult[]): void {
   for (const result of results) {
     if (!('output' in result)) continue;
-    const output = removeNoColorWarning(result.output).trim();
-    if (result.exitCode === 0 && !hasWarningOutput(output)) continue;
+    if (!shouldPrintBufferedOutput(result.exitCode, result.output)) continue;
 
+    const output = normalizeBufferedOutput(result.output);
     if (output) {
       process.stdout.write(output);
       process.stdout.write('\n');
     }
   }
-}
-
-function hasWarningOutput(output: string): boolean {
-  return /\bwarn(?:ing)?s?\b/i.test(output.replaceAll(/\b0 warnings?\b/gi, ''));
-}
-
-function removeNoColorWarning(output: string): string {
-  return output.replaceAll(
-    /\(node:\d+\) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set\.\n\(Use `node --trace-warnings \.\.\.` to show where the warning was created\)\n?/g,
-    ''
-  );
 }
 
 export function buildLintCommand(

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -90,6 +90,8 @@ const prettierExtensions = new Set([
 const prettierOnlyExtensions = new Set([...prettierExtensions].filter((ext) => !oxfmtExtensions.has(ext)));
 const prettierFixtureIgnorePattern = '!**/test{-,/}fixtures/**';
 
+type LintRunResult = BufferedRunResult | { exitCode: number };
+
 export const lintCommand: CommandModule<unknown, LintCommandOptions> = {
   command: 'lint [files...]',
   describe: 'Lint code',
@@ -286,8 +288,6 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
 
   return lintExitCodes.some((exitCode) => exitCode !== 0) ? 1 : 0;
 }
-
-type LintRunResult = BufferedRunResult | { exitCode: number };
 
 function runLintCommand(
   command: string,

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -9,7 +9,7 @@ import { findDescendantProjects } from '../project.js';
 import type { BufferedRunResult } from '../scripts/run.js';
 import { runWithSpawnInParallel, runWithSpawnInParallelBuffered } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
-import { normalizeBufferedOutput, shouldPrintBufferedOutput } from '../utils/output.js';
+import { printBufferedOutput } from '../utils/output.js';
 import { buildShellCommand } from '../utils/shell.js';
 
 const builder = {
@@ -304,13 +304,8 @@ function runLintCommand(
 function printSilentLintOutputs(results: LintRunResult[]): void {
   for (const result of results) {
     if (!('output' in result)) continue;
-    if (!shouldPrintBufferedOutput(result.exitCode, result.output)) continue;
 
-    const output = normalizeBufferedOutput(result.output);
-    if (output) {
-      process.stdout.write(output);
-      process.stdout.write('\n');
-    }
+    printBufferedOutput(result.exitCode, result.output);
   }
 }
 

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -6,7 +6,8 @@ import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yar
 
 import type { Project } from '../project.js';
 import { findDescendantProjects } from '../project.js';
-import { runWithSpawnInParallel } from '../scripts/run.js';
+import type { BufferedRunResult } from '../scripts/run.js';
+import { runWithSpawnInParallel, runWithSpawnInParallelBuffered } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { buildShellCommand } from '../utils/shell.js';
 
@@ -21,6 +22,10 @@ const builder = {
   },
   quiet: {
     description: 'Report errors only',
+    type: 'boolean',
+  },
+  silent: {
+    description: 'Print only failed or warning command output',
     type: 'boolean',
   },
 } as const;
@@ -197,27 +202,25 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
     sortPackageJsonArgs = projects.descendants.map((p) => p.packageJsonPath);
   }
 
-  const lintPromises: Promise<number>[] = [];
+  const lintPromises: Promise<LintRunResult>[] = [];
   const lintRunOptions = { exitIfFailed: false, forceColor: true } as const;
   if (files.length > 0) {
     for (const [project, lintFilePaths] of lintFilePathsByProject) {
       const lintCommand = buildLintCommand(project, argv, lintFilePaths);
       if (!lintCommand) continue;
 
-      lintPromises.push(runWithSpawnInParallel(lintCommand, project, argv, lintRunOptions));
+      lintPromises.push(runLintCommand(lintCommand, project, argv, lintRunOptions));
     }
     if (argv.format) {
       for (const [project, oxfmtFilePaths] of oxfmtFilePathsByProject) {
-        lintPromises.push(runWithSpawnInParallel(buildOxfmtCommand(oxfmtFilePaths), project, argv, lintRunOptions));
+        lintPromises.push(runLintCommand(buildOxfmtCommand(oxfmtFilePaths), project, argv, lintRunOptions));
       }
     }
     for (const [project, pythonFilePaths] of pythonFilePathsByProject) {
-      lintPromises.push(
-        runWithSpawnInParallel(buildPoetryCommand(argv, pythonFilePaths), project, argv, lintRunOptions)
-      );
+      lintPromises.push(runLintCommand(buildPoetryCommand(argv, pythonFilePaths), project, argv, lintRunOptions));
     }
     for (const [project, dartFilePaths] of dartFilePathsByProject) {
-      lintPromises.push(runWithSpawnInParallel(buildDartCommand(argv, dartFilePaths), project, argv, lintRunOptions));
+      lintPromises.push(runLintCommand(buildDartCommand(argv, dartFilePaths), project, argv, lintRunOptions));
     }
   } else {
     for (const project of projects.descendants) {
@@ -226,21 +229,23 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
       const lintCommand = buildLintCommand(project, argv);
       if (!lintCommand) continue;
 
-      lintPromises.push(runWithSpawnInParallel(lintCommand, project, argv, lintRunOptions));
+      lintPromises.push(runLintCommand(lintCommand, project, argv, lintRunOptions));
     }
     for (const project of projects.descendants) {
       if (project.hasPoetryLock) {
-        lintPromises.push(runWithSpawnInParallel(buildPoetryCommand(argv), project, argv, lintRunOptions));
+        lintPromises.push(runLintCommand(buildPoetryCommand(argv), project, argv, lintRunOptions));
       }
       if (project.hasPubspecYaml) {
-        lintPromises.push(runWithSpawnInParallel(buildDartCommand(argv), project, argv, lintRunOptions));
+        lintPromises.push(runLintCommand(buildDartCommand(argv), project, argv, lintRunOptions));
       }
       if (project.hasOxfmt && argv.format) {
-        lintPromises.push(runWithSpawnInParallel(buildOxfmtCommand(), project, argv, lintRunOptions));
+        lintPromises.push(runLintCommand(buildOxfmtCommand(), project, argv, lintRunOptions));
       }
     }
   }
-  const lintExitCodes = await Promise.all(lintPromises);
+  const lintResults = await Promise.all(lintPromises);
+  printSilentLintOutputs(lintResults);
+  const lintExitCodes = lintResults.map((result) => result.exitCode);
 
   if (missingLintToolForExplicitFiles || lintExitCodes.some((exitCode) => exitCode !== 0)) {
     return 1;
@@ -248,37 +253,75 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
 
   if (argv.format) {
     if (prettierArgs.length > 0 && projects.self.hasPrettier) {
-      lintExitCodes.push(
-        await runWithSpawnInParallel(
-          buildShellCommand([
-            'YARN',
-            'prettier',
-            '--cache',
-            '--color',
-            '--no-error-on-unmatched-pattern',
-            '--write',
-            '--',
-            ...prettierArgs,
-          ]),
-          projects.self,
-          argv,
-          { exitIfFailed: false, forceColor: true }
-        )
+      const prettierResult = await runLintCommand(
+        buildShellCommand([
+          'YARN',
+          'prettier',
+          '--cache',
+          '--color',
+          '--no-error-on-unmatched-pattern',
+          '--write',
+          '--',
+          ...prettierArgs,
+        ]),
+        projects.self,
+        argv,
+        { exitIfFailed: false, forceColor: true }
       );
+      printSilentLintOutputs([prettierResult]);
+      lintExitCodes.push(prettierResult.exitCode);
     }
     if (sortPackageJsonArgs.length > 0) {
-      lintExitCodes.push(
-        await runWithSpawnInParallel(
-          buildShellCommand(['YARN', 'sort-package-json', '--', ...sortPackageJsonArgs]),
-          projects.self,
-          argv,
-          { exitIfFailed: false, forceColor: true }
-        )
+      const sortPackageJsonResult = await runLintCommand(
+        buildShellCommand(['YARN', 'sort-package-json', '--', ...sortPackageJsonArgs]),
+        projects.self,
+        argv,
+        { exitIfFailed: false, forceColor: true }
       );
+      printSilentLintOutputs([sortPackageJsonResult]);
+      lintExitCodes.push(sortPackageJsonResult.exitCode);
     }
   }
 
   return lintExitCodes.some((exitCode) => exitCode !== 0) ? 1 : 0;
+}
+
+type LintRunResult = BufferedRunResult | { exitCode: number };
+
+function runLintCommand(
+  command: string,
+  project: Project,
+  argv: LintCommandArgv,
+  options: Parameters<typeof runWithSpawnInParallel>[3]
+): Promise<LintRunResult> {
+  if (argv.silent) {
+    return runWithSpawnInParallelBuffered(command, project, argv, options);
+  }
+  return runWithSpawnInParallel(command, project, argv, options).then((exitCode) => ({ exitCode }));
+}
+
+function printSilentLintOutputs(results: LintRunResult[]): void {
+  for (const result of results) {
+    if (!('output' in result)) continue;
+    const output = removeNoColorWarning(result.output).trim();
+    if (result.exitCode === 0 && !hasWarningOutput(output)) continue;
+
+    if (output) {
+      process.stdout.write(output);
+      process.stdout.write('\n');
+    }
+  }
+}
+
+function hasWarningOutput(output: string): boolean {
+  return /\bwarn(?:ing)?s?\b/i.test(output.replaceAll(/\b0 warnings?\b/gi, ''));
+}
+
+function removeNoColorWarning(output: string): string {
+  return output.replaceAll(
+    /\(node:\d+\) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set\.\n\(Use `node --trace-warnings \.\.\.` to show where the warning was created\)\n?/g,
+    ''
+  );
 }
 
 export function buildLintCommand(

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -6,7 +6,7 @@ import type { Project } from '../project.js';
 import { findRootAndSelfProjects } from '../project.js';
 import { configureEnv } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
-import { normalizeBufferedOutput, shouldPrintBufferedOutput } from '../utils/output.js';
+import { printBufferedOutput } from '../utils/output.js';
 import { packageManager } from '../utils/runtime.js';
 
 import { lint, type LintCommandArgv } from './lint.js';
@@ -125,7 +125,7 @@ async function runPackageCommand(
   });
 
   if (options.silent) {
-    printOutputIfFailedOrWarned(ret.status ?? 1, ret.stdout);
+    printBufferedOutput(ret.status ?? 1, ret.stdout);
   }
   if (ret.status === 0 || options.allowFailure) {
     if (!options.silent) {
@@ -136,14 +136,4 @@ async function runPackageCommand(
     process.exit(ret.status ?? 1);
   }
   return ret.status ?? 1;
-}
-
-function printOutputIfFailedOrWarned(exitCode: number, output: string): void {
-  if (!shouldPrintBufferedOutput(exitCode, output)) return;
-
-  const trimmedOutput = normalizeBufferedOutput(output);
-  if (trimmedOutput) {
-    process.stdout.write(trimmedOutput);
-    process.stdout.write('\n');
-  }
 }

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -6,6 +6,7 @@ import type { Project } from '../project.js';
 import { findRootAndSelfProjects } from '../project.js';
 import { configureEnv } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { normalizeBufferedOutput, shouldPrintBufferedOutput } from '../utils/output.js';
 import { packageManager } from '../utils/runtime.js';
 
 import { lint, type LintCommandArgv } from './lint.js';
@@ -138,22 +139,11 @@ async function runPackageCommand(
 }
 
 function printOutputIfFailedOrWarned(exitCode: number, output: string): void {
-  const trimmedOutput = removeNoColorWarning(output).trim();
-  if (exitCode === 0 && !hasWarningOutput(trimmedOutput)) return;
+  if (!shouldPrintBufferedOutput(exitCode, output)) return;
 
+  const trimmedOutput = normalizeBufferedOutput(output);
   if (trimmedOutput) {
     process.stdout.write(trimmedOutput);
     process.stdout.write('\n');
   }
-}
-
-function hasWarningOutput(output: string): boolean {
-  return /\bwarn(?:ing)?s?\b/i.test(output.replaceAll(/\b0 warnings?\b/gi, ''));
-}
-
-function removeNoColorWarning(output: string): string {
-  return output.replaceAll(
-    /\(node:\d+\) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set\.\n\(Use `node --trace-warnings \.\.\.` to show where the warning was created\)\n?/g,
-    ''
-  );
 }

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -49,13 +49,16 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
   }
   await runInProcessCommand(
     'format',
-    () => lint({ ...argv, _: ['lint'], format: true } as unknown as LintCommandArgv),
+    () => lint({ ...argv, _: ['lint'], format: true, silent: true } as unknown as LintCommandArgv),
     {
       allowFailure: true,
+      silent: true,
     }
   );
-  await runInProcessCommand('lint-fix', () =>
-    lint({ ...argv, _: ['lint'], fix: true, quiet: true } as unknown as LintCommandArgv)
+  await runInProcessCommand(
+    'lint-fix',
+    () => lint({ ...argv, _: ['lint'], fix: true, quiet: true, silent: true } as unknown as LintCommandArgv),
+    { silent: true }
   );
 }
 
@@ -73,12 +76,16 @@ async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Pr
 async function runInProcessCommand(
   commandName: string,
   command: () => Promise<number | undefined>,
-  options: { allowFailure?: boolean } = {}
+  options: { allowFailure?: boolean; silent?: boolean } = {}
 ): Promise<number> {
-  console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName));
+  if (!options.silent) {
+    console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName));
+  }
   const exitCode = (await command()) ?? 0;
   if (exitCode === 0 || options.allowFailure) {
-    console.info(chalk.green(chalk.bold('Finished:'), commandName));
+    if (!options.silent) {
+      console.info(chalk.green(chalk.bold('Finished:'), commandName));
+    }
   } else {
     console.info(chalk.red(chalk.bold(`Failed (exit code ${exitCode}):`), commandName));
     process.exit(exitCode);
@@ -93,12 +100,16 @@ async function runPackageCommand(
   argv: VerifyCodeCommandArgv,
   options: { allowFailure?: boolean; silent?: boolean } = {}
 ): Promise<number> {
-  console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName) + chalk.gray(` at ${project.dirPath}`));
+  if (!options.silent) {
+    console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName) + chalk.gray(` at ${project.dirPath}`));
+  }
   if (argv.verbose) {
     console.info(chalk.gray(chalk.bold('Start (raw):'), command));
   }
   if (argv.dryRun) {
-    console.info(chalk.green(chalk.bold('Finished:'), commandName));
+    if (!options.silent) {
+      console.info(chalk.green(chalk.bold('Finished:'), commandName));
+    }
     return 0;
   }
 
@@ -106,16 +117,43 @@ async function runPackageCommand(
     cwd: project.dirPath,
     env: configureEnv(project.env, { forceColor: true }),
     shell: true,
-    stdio: options.silent ? ['ignore', 'ignore', 'inherit'] : 'inherit',
+    stdio: options.silent ? 'pipe' : 'inherit',
+    mergeOutAndError: options.silent,
     killOnExit: true,
     verbose: argv.verbose,
   });
 
+  if (options.silent) {
+    printOutputIfFailedOrWarned(ret.status ?? 1, ret.stdout);
+  }
   if (ret.status === 0 || options.allowFailure) {
-    console.info(chalk.green(chalk.bold('Finished:'), commandName));
+    if (!options.silent) {
+      console.info(chalk.green(chalk.bold('Finished:'), commandName));
+    }
   } else {
     console.info(chalk.red(chalk.bold(`Failed (exit code ${ret.status}):`), commandName));
     process.exit(ret.status ?? 1);
   }
   return ret.status ?? 1;
+}
+
+function printOutputIfFailedOrWarned(exitCode: number, output: string): void {
+  const trimmedOutput = removeNoColorWarning(output).trim();
+  if (exitCode === 0 && !hasWarningOutput(trimmedOutput)) return;
+
+  if (trimmedOutput) {
+    process.stdout.write(trimmedOutput);
+    process.stdout.write('\n');
+  }
+}
+
+function hasWarningOutput(output: string): boolean {
+  return /\bwarn(?:ing)?s?\b/i.test(output.replaceAll(/\b0 warnings?\b/gi, ''));
+}
+
+function removeNoColorWarning(output: string): string {
+  return output.replaceAll(
+    /\(node:\d+\) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set\.\n\(Use `node --trace-warnings \.\.\.` to show where the warning was created\)\n?/g,
+    ''
+  );
 }

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -19,6 +19,11 @@ const defaultOptions: Options = {
   exitIfFailed: true,
 };
 
+export interface BufferedRunResult {
+  exitCode: number;
+  output: string;
+}
+
 export async function runWithSpawn(
   script: string,
   project: Project,
@@ -89,6 +94,39 @@ export function runWithSpawnInParallel(
     }
     printFinishedAndExitIfNeeded(normalizedScript.printable, ret.status, opts);
     return ret.status ?? 1;
+  });
+}
+
+export function runWithSpawnInParallelBuffered(
+  script: string,
+  project: Project,
+  argv: Partial<ArgumentsCamelCase<InferredOptionTypes<typeof sharedOptionsBuilder>>>,
+  opts: Options = defaultOptions
+): Promise<BufferedRunResult> {
+  return promisePool.runAndWaitForReturnValue(async () => {
+    const normalizedScript = normalizeScript(script, project);
+    if (argv.dryRun) {
+      return {
+        exitCode: 0,
+        output: '',
+      };
+    }
+
+    const ret = await spawnAsync(normalizedScript.runnable, undefined, {
+      cwd: project.dirPath,
+      env: configureEnv(project.env, opts),
+      shell: true,
+      stdio: 'pipe',
+      timeout: opts.timeout,
+      mergeOutAndError: true,
+      killOnExit: true,
+      verbose: argv.verbose,
+    });
+    opts.onSignal?.(ret.signal);
+    return {
+      exitCode: ret.status ?? 1,
+      output: ret.stdout,
+    };
   });
 }
 

--- a/packages/wb/src/utils/output.ts
+++ b/packages/wb/src/utils/output.ts
@@ -1,11 +1,3 @@
-export function shouldPrintBufferedOutput(exitCode: number, output: string): boolean {
-  return exitCode !== 0 || hasWarningOutput(removeNoColorWarning(output));
-}
-
-export function normalizeBufferedOutput(output: string): string {
-  return removeNoColorWarning(output).trim();
-}
-
 export function printBufferedOutput(exitCode: number, output: string): void {
   if (!shouldPrintBufferedOutput(exitCode, output)) return;
 
@@ -14,6 +6,14 @@ export function printBufferedOutput(exitCode: number, output: string): void {
     process.stdout.write(normalizedOutput);
     process.stdout.write('\n');
   }
+}
+
+export function shouldPrintBufferedOutput(exitCode: number, output: string): boolean {
+  return exitCode !== 0 || hasWarningOutput(removeNoColorWarning(output));
+}
+
+export function normalizeBufferedOutput(output: string): string {
+  return removeNoColorWarning(output).trim();
 }
 
 function hasWarningOutput(output: string): boolean {

--- a/packages/wb/src/utils/output.ts
+++ b/packages/wb/src/utils/output.ts
@@ -6,8 +6,18 @@ export function normalizeBufferedOutput(output: string): string {
   return removeNoColorWarning(output).trim();
 }
 
+export function printBufferedOutput(exitCode: number, output: string): void {
+  if (!shouldPrintBufferedOutput(exitCode, output)) return;
+
+  const normalizedOutput = normalizeBufferedOutput(output);
+  if (normalizedOutput) {
+    process.stdout.write(normalizedOutput);
+    process.stdout.write('\n');
+  }
+}
+
 function hasWarningOutput(output: string): boolean {
-  return /\bwarn(?:ing)?s?\b/i.test(output.replaceAll(/\b0 warnings?\b/gi, ''));
+  return /\bwarn(?:ing)?s?\b/i.test(output.replaceAll(/\b(?:0|no) warnings?\b/gi, ''));
 }
 
 function removeNoColorWarning(output: string): string {

--- a/packages/wb/src/utils/output.ts
+++ b/packages/wb/src/utils/output.ts
@@ -1,0 +1,18 @@
+export function shouldPrintBufferedOutput(exitCode: number, output: string): boolean {
+  return exitCode !== 0 || hasWarningOutput(removeNoColorWarning(output));
+}
+
+export function normalizeBufferedOutput(output: string): string {
+  return removeNoColorWarning(output).trim();
+}
+
+function hasWarningOutput(output: string): boolean {
+  return /\bwarn(?:ing)?s?\b/i.test(output.replaceAll(/\b0 warnings?\b/gi, ''));
+}
+
+function removeNoColorWarning(output: string): string {
+  return output.replaceAll(
+    /\(node:\d+\) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set\.\n\(Use `node --trace-warnings \.\.\.` to show where the warning was created\)\n?/g,
+    ''
+  );
+}

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -24,6 +24,7 @@ const commonContent = `
 .playwright-cli/
 .serena/
 .tmp/
+.wb/
 __generated__/
 @willbooster/
 dist/


### PR DESCRIPTION
## Summary
- Add `wb lint --silent` to buffer parallel command output and print only failed or warning output sequentially.
- Use silent lint output from `wb verify` and suppress success-only decoration for successful silent verify steps.
- Share buffered output normalization, warning detection, and printing through `packages/wb/src/utils/output.ts`.
- Keep helper declarations ordered according to the repository style guide.

## Why
- `wb verify` should keep command execution parallel where applicable, but present relevant command output in a stable sequential order.
- Successful commands without warnings should stay quiet so verify output is easier to scan.

## Testing
- `yarn check-for-ai`
- `yarn workspace @willbooster/wb start --working-dir "$PWD" verify`
- `bunx @willbooster/agent-skills@latest check-pr-ci`
