### PR TITLE
fix: improve wb verify command logging

### DIFF
--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -274,7 +274,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
         ]),
         projects.self,
         argv,
-        { exitIfFailed: false, forceColor: !argv.printAllOutput }
+        lintRunOptions
       );
       printSilentLintOutputs([prettierResult], argv);
       lintExitCodes.push(prettierResult.exitCode);
@@ -284,7 +284,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
         buildShellCommand(['YARN', 'sort-package-json', '--', ...sortPackageJsonArgs]),
         projects.self,
         argv,
-        { exitIfFailed: false, forceColor: !argv.printAllOutput }
+        lintRunOptions
       );
       printSilentLintOutputs([sortPackageJsonResult], argv);
       lintExitCodes.push(sortPackageJsonResult.exitCode);

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -7,7 +7,7 @@ import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yar
 import type { Project } from '../project.js';
 import { findDescendantProjects } from '../project.js';
 import type { BufferedRunResult } from '../scripts/run.js';
-import { runWithSpawnInParallel, runWithSpawnInParallelBuffered } from '../scripts/run.js';
+import { normalizeScript, runWithSpawnInParallel, runWithSpawnInParallelBuffered } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { printBufferedOutput } from '../utils/output.js';
 import { buildShellCommand } from '../utils/shell.js';
@@ -41,7 +41,11 @@ const _argumentsBuilder = {
 export type LintCommandOptions = InferredOptionTypes<
   typeof builder & typeof sharedOptionsBuilder & typeof _argumentsBuilder
 >;
-export type LintCommandArgv = ArgumentsCamelCase<LintCommandOptions> & { '--'?: unknown[]; _: unknown[] };
+export type LintCommandArgv = ArgumentsCamelCase<LintCommandOptions> & {
+  '--'?: unknown[];
+  _: unknown[];
+  printAllOutput?: boolean;
+};
 
 const oxlintExtensions = new Set(['astro', 'cjs', 'cts', 'js', 'jsx', 'mjs', 'mts', 'svelte', 'ts', 'tsx', 'vue']);
 const pythonExtensions = new Set(['py']);
@@ -90,7 +94,8 @@ const prettierExtensions = new Set([
 const prettierOnlyExtensions = new Set([...prettierExtensions].filter((ext) => !oxfmtExtensions.has(ext)));
 const prettierFixtureIgnorePattern = '!**/test{-,/}fixtures/**';
 
-type LintRunResult = BufferedRunResult | { exitCode: number };
+type BufferedLintRunResult = BufferedRunResult & { command: string; cwd: string };
+type LintRunResult = BufferedLintRunResult | { exitCode: number };
 
 export const lintCommand: CommandModule<unknown, LintCommandOptions> = {
   command: 'lint [files...]',
@@ -247,7 +252,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
     }
   }
   const lintResults = await Promise.all(lintPromises);
-  printSilentLintOutputs(lintResults);
+  printSilentLintOutputs(lintResults, argv);
   const lintExitCodes = lintResults.map((result) => result.exitCode);
 
   if (missingLintToolForExplicitFiles || lintExitCodes.some((exitCode) => exitCode !== 0)) {
@@ -271,7 +276,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
         argv,
         { exitIfFailed: false, forceColor: true }
       );
-      printSilentLintOutputs([prettierResult]);
+      printSilentLintOutputs([prettierResult], argv);
       lintExitCodes.push(prettierResult.exitCode);
     }
     if (sortPackageJsonArgs.length > 0) {
@@ -281,7 +286,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
         argv,
         { exitIfFailed: false, forceColor: true }
       );
-      printSilentLintOutputs([sortPackageJsonResult]);
+      printSilentLintOutputs([sortPackageJsonResult], argv);
       lintExitCodes.push(sortPackageJsonResult.exitCode);
     }
   }
@@ -296,16 +301,36 @@ function runLintCommand(
   options: Parameters<typeof runWithSpawnInParallel>[3]
 ): Promise<LintRunResult> {
   if (argv.silent) {
-    return runWithSpawnInParallelBuffered(command, project, argv, options);
+    const normalizedScript = normalizeScript(command, project);
+    return runWithSpawnInParallelBuffered(command, project, argv, options).then((result) => ({
+      ...result,
+      command: normalizedScript.printable,
+      cwd: project.dirPath,
+    }));
   }
   return runWithSpawnInParallel(command, project, argv, options).then((exitCode) => ({ exitCode }));
 }
 
-function printSilentLintOutputs(results: LintRunResult[]): void {
+function printSilentLintOutputs(results: LintRunResult[], argv: Pick<LintCommandArgv, 'printAllOutput'>): void {
   for (const result of results) {
     if (!('output' in result)) continue;
 
-    printBufferedOutput(result.exitCode, result.output);
+    if (argv.printAllOutput) {
+      printCommandOutput(result);
+    } else {
+      printBufferedOutput(result.exitCode, result.output);
+    }
+  }
+}
+
+function printCommandOutput(result: BufferedLintRunResult): void {
+  console.info('\n' + chalk.cyan(chalk.bold('Command:'), result.command) + chalk.gray(` at ${result.cwd}`));
+
+  const output = result.output.trim();
+  if (output) {
+    process.stdout.write('\n');
+    process.stdout.write(output);
+    process.stdout.write('\n');
   }
 }
 

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -211,7 +211,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
   }
 
   const lintPromises: Promise<LintRunResult>[] = [];
-  const lintRunOptions = { exitIfFailed: false, forceColor: true } as const;
+  const lintRunOptions = { exitIfFailed: false, forceColor: !argv.printAllOutput } as const;
   if (files.length > 0) {
     for (const [project, lintFilePaths] of lintFilePathsByProject) {
       const lintCommand = buildLintCommand(project, argv, lintFilePaths);
@@ -274,7 +274,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
         ]),
         projects.self,
         argv,
-        { exitIfFailed: false, forceColor: true }
+        { exitIfFailed: false, forceColor: !argv.printAllOutput }
       );
       printSilentLintOutputs([prettierResult], argv);
       lintExitCodes.push(prettierResult.exitCode);
@@ -284,7 +284,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
         buildShellCommand(['YARN', 'sort-package-json', '--', ...sortPackageJsonArgs]),
         projects.self,
         argv,
-        { exitIfFailed: false, forceColor: true }
+        { exitIfFailed: false, forceColor: !argv.printAllOutput }
       );
       printSilentLintOutputs([sortPackageJsonResult], argv);
       lintExitCodes.push(sortPackageJsonResult.exitCode);

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -326,6 +326,8 @@ function printSilentLintOutputs(results: LintRunResult[], argv: Pick<LintCommand
 function printCommandOutput(result: BufferedLintRunResult): void {
   console.info('\n' + chalk.cyan(chalk.bold('Command:'), result.command) + chalk.gray(` at ${result.cwd}`));
 
+  if (result.exitCode === 0 && result.command.includes(' oxfmt ')) return;
+
   const output = result.output.trim();
   if (output) {
     process.stdout.write('\n');

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -326,7 +326,10 @@ function printSilentLintOutputs(results: LintRunResult[], argv: Pick<LintCommand
 function printCommandOutput(result: BufferedLintRunResult): void {
   console.info('\n' + chalk.cyan(chalk.bold('Command:'), result.command) + chalk.gray(` at ${result.cwd}`));
 
-  if (result.exitCode === 0 && result.command.includes(' oxfmt ')) return;
+  if (result.exitCode === 0 && result.command.includes(' oxfmt ')) {
+    console.info(chalk.green('Succeeded.'));
+    return;
+  }
 
   const output = result.output.trim();
   if (output) {

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -333,7 +333,6 @@ function printCommandOutput(result: BufferedLintRunResult): void {
 
   const output = result.output.trim();
   if (output) {
-    process.stdout.write('\n');
     process.stdout.write(output);
     process.stdout.write('\n');
   }

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -326,7 +326,7 @@ function printSilentLintOutputs(results: LintRunResult[], argv: Pick<LintCommand
 function printCommandOutput(result: BufferedLintRunResult): void {
   console.info('\n' + chalk.cyan(chalk.bold('Command:'), result.command) + chalk.gray(` at ${result.cwd}`));
 
-  if (result.exitCode === 0 && result.command.includes(' oxfmt ')) {
+  if (result.exitCode === 0 && shouldSuppressSuccessfulVerifyOutput(result.command)) {
     console.info(chalk.green('Succeeded.'));
     return;
   }
@@ -337,6 +337,10 @@ function printCommandOutput(result: BufferedLintRunResult): void {
     process.stdout.write(output);
     process.stdout.write('\n');
   }
+}
+
+function shouldSuppressSuccessfulVerifyOutput(command: string): boolean {
+  return command.includes(' oxfmt ') || command.includes(' sort-package-json ');
 }
 
 export function buildLintCommand(

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -114,7 +114,7 @@ async function runPackageCommand(
 
   const ret = await spawnAsync(command, undefined, {
     cwd: project.dirPath,
-    env: configureEnv(project.env, { forceColor: true }),
+    env: configureEnv(project.env, { forceColor: false }),
     shell: true,
     stdio: 'inherit',
     killOnExit: true,

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -6,7 +6,6 @@ import type { Project } from '../project.js';
 import { findRootAndSelfProjects } from '../project.js';
 import { configureEnv } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
-import { printBufferedOutput } from '../utils/output.js';
 import { packageManager } from '../utils/runtime.js';
 
 import { lint, type LintCommandArgv } from './lint.js';
@@ -42,24 +41,19 @@ export const verifyCodeCommand: CommandModule<unknown, VerifyCodeCommandOptions>
 };
 
 async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promise<void> {
-  await runPackageCommand('install', `${packageManager} install`, project, argv, { silent: true });
+  await runPackageCommand(`${packageManager} install`, project, argv);
   if (project.packageJson.scripts?.['gen-code']) {
-    await runPackageCommand('gen-code', `${packageManager} gen-code`, project, argv, {
-      silent: true,
-    });
+    await runPackageCommand(`${packageManager} gen-code`, project, argv);
   }
   await runInProcessCommand(
     'format',
-    () => lint({ ...argv, _: ['lint'], format: true, silent: true } as unknown as LintCommandArgv),
+    () => lint({ ...argv, _: ['lint'], format: true } as unknown as LintCommandArgv),
     {
       allowFailure: true,
-      silent: true,
     }
   );
-  await runInProcessCommand(
-    'lint-fix',
-    () => lint({ ...argv, _: ['lint'], fix: true, quiet: true, silent: true } as unknown as LintCommandArgv),
-    { silent: true }
+  await runInProcessCommand('lint-fix', () =>
+    lint({ ...argv, _: ['lint'], fix: true, quiet: true } as unknown as LintCommandArgv)
   );
 }
 
@@ -71,22 +65,18 @@ async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Pr
     return;
   }
 
-  await runPackageCommand('test', `${packageManager} test`, project, argv);
+  await runPackageCommand(`${packageManager} test`, project, argv);
 }
 
 async function runInProcessCommand(
   commandName: string,
   command: () => Promise<number | undefined>,
-  options: { allowFailure?: boolean; silent?: boolean } = {}
+  options: { allowFailure?: boolean } = {}
 ): Promise<number> {
-  if (!options.silent) {
-    console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName));
-  }
+  console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName));
   const exitCode = (await command()) ?? 0;
   if (exitCode === 0 || options.allowFailure) {
-    if (!options.silent) {
-      console.info(chalk.green(chalk.bold('Finished:'), commandName));
-    }
+    console.info(chalk.green(chalk.bold('Finished:'), commandName));
   } else {
     console.info(chalk.red(chalk.bold(`Failed (exit code ${exitCode}):`), commandName));
     process.exit(exitCode);
@@ -95,22 +85,14 @@ async function runInProcessCommand(
 }
 
 async function runPackageCommand(
-  commandName: string,
   command: string,
   project: Project,
   argv: VerifyCodeCommandArgv,
-  options: { allowFailure?: boolean; silent?: boolean } = {}
+  options: { allowFailure?: boolean } = {}
 ): Promise<number> {
-  if (!options.silent) {
-    console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName) + chalk.gray(` at ${project.dirPath}`));
-  }
-  if (argv.verbose) {
-    console.info(chalk.gray(chalk.bold('Start (raw):'), command));
-  }
+  console.info('\n' + chalk.cyan(chalk.bold('Start:'), command) + chalk.gray(` at ${project.dirPath}`));
   if (argv.dryRun) {
-    if (!options.silent) {
-      console.info(chalk.green(chalk.bold('Finished:'), commandName));
-    }
+    console.info(chalk.green(chalk.bold('Finished:'), command));
     return 0;
   }
 
@@ -118,21 +100,15 @@ async function runPackageCommand(
     cwd: project.dirPath,
     env: configureEnv(project.env, { forceColor: true }),
     shell: true,
-    stdio: options.silent ? 'pipe' : 'inherit',
-    mergeOutAndError: options.silent,
+    stdio: 'inherit',
     killOnExit: true,
     verbose: argv.verbose,
   });
 
-  if (options.silent) {
-    printBufferedOutput(ret.status ?? 1, ret.stdout);
-  }
   if (ret.status === 0 || options.allowFailure) {
-    if (!options.silent) {
-      console.info(chalk.green(chalk.bold('Finished:'), commandName));
-    }
+    console.info(chalk.green(chalk.bold('Finished:'), command));
   } else {
-    console.info(chalk.red(chalk.bold(`Failed (exit code ${ret.status}):`), commandName));
+    console.info(chalk.red(chalk.bold(`Failed (exit code ${ret.status}):`), command));
     process.exit(ret.status ?? 1);
   }
   return ret.status ?? 1;

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -138,7 +138,6 @@ function printPackageCommandOutput(command: string, exitCode: number, output: st
 
   const trimmedOutput = output.trim();
   if (trimmedOutput) {
-    process.stdout.write('\n');
     process.stdout.write(trimmedOutput);
     process.stdout.write('\n');
   }

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -131,7 +131,10 @@ async function runPackageCommand(
 }
 
 function printPackageCommandOutput(command: string, exitCode: number, output: string): void {
-  if (exitCode === 0 && command === `${packageManager} install`) return;
+  if (exitCode === 0 && command === `${packageManager} install`) {
+    console.info(chalk.green('Succeeded.'));
+    return;
+  }
 
   const trimmedOutput = output.trim();
   if (trimmedOutput) {

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -51,17 +51,21 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
       lint({ ...argv, _: ['lint'], format: true, printAllOutput: true, silent: true } as unknown as LintCommandArgv),
     {
       allowFailure: true,
+      silent: true,
     }
   );
-  await runInProcessCommand('lint-fix', () =>
-    lint({
-      ...argv,
-      _: ['lint'],
-      fix: true,
-      printAllOutput: true,
-      quiet: true,
-      silent: true,
-    } as unknown as LintCommandArgv)
+  await runInProcessCommand(
+    'lint-fix',
+    () =>
+      lint({
+        ...argv,
+        _: ['lint'],
+        fix: true,
+        printAllOutput: true,
+        quiet: true,
+        silent: true,
+      } as unknown as LintCommandArgv),
+    { silent: true }
   );
 }
 
@@ -79,12 +83,16 @@ async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Pr
 async function runInProcessCommand(
   commandName: string,
   command: () => Promise<number | undefined>,
-  options: { allowFailure?: boolean } = {}
+  options: { allowFailure?: boolean; silent?: boolean } = {}
 ): Promise<number> {
-  console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName));
+  if (!options.silent) {
+    console.info('\n' + chalk.cyan(chalk.bold('Start:'), commandName));
+  }
   const exitCode = (await command()) ?? 0;
   if (exitCode === 0 || options.allowFailure) {
-    console.info(chalk.green(chalk.bold('Finished:'), commandName));
+    if (!options.silent) {
+      console.info(chalk.green(chalk.bold('Finished:'), commandName));
+    }
   } else {
     console.info(chalk.red(chalk.bold(`Failed (exit code ${exitCode}):`), commandName));
     process.exit(exitCode);

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -106,9 +106,8 @@ async function runPackageCommand(
   argv: VerifyCodeCommandArgv,
   options: { allowFailure?: boolean } = {}
 ): Promise<number> {
-  console.info('\n' + chalk.cyan(chalk.bold('Start:'), command) + chalk.gray(` at ${project.dirPath}`));
+  printCommand(command, project.dirPath);
   if (argv.dryRun) {
-    console.info(chalk.green(chalk.bold('Finished:'), command));
     return 0;
   }
 
@@ -116,16 +115,32 @@ async function runPackageCommand(
     cwd: project.dirPath,
     env: configureEnv(project.env, { forceColor: false }),
     shell: true,
-    stdio: 'inherit',
+    stdio: 'pipe',
+    mergeOutAndError: true,
     killOnExit: true,
     verbose: argv.verbose,
   });
+  const exitCode = ret.status ?? 1;
+  printPackageCommandOutput(command, exitCode, ret.stdout);
 
-  if (ret.status === 0 || options.allowFailure) {
-    console.info(chalk.green(chalk.bold('Finished:'), command));
-  } else {
+  if (exitCode !== 0 && !options.allowFailure) {
     console.info(chalk.red(chalk.bold(`Failed (exit code ${ret.status}):`), command));
-    process.exit(ret.status ?? 1);
+    process.exit(exitCode);
   }
-  return ret.status ?? 1;
+  return exitCode;
+}
+
+function printPackageCommandOutput(command: string, exitCode: number, output: string): void {
+  if (exitCode === 0 && command === `${packageManager} install`) return;
+
+  const trimmedOutput = output.trim();
+  if (trimmedOutput) {
+    process.stdout.write('\n');
+    process.stdout.write(trimmedOutput);
+    process.stdout.write('\n');
+  }
+}
+
+function printCommand(command: string, cwd: string): void {
+  console.info('\n' + chalk.cyan(chalk.bold('Command:'), command) + chalk.gray(` at ${cwd}`));
 }

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -47,13 +47,21 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
   }
   await runInProcessCommand(
     'format',
-    () => lint({ ...argv, _: ['lint'], format: true } as unknown as LintCommandArgv),
+    () =>
+      lint({ ...argv, _: ['lint'], format: true, printAllOutput: true, silent: true } as unknown as LintCommandArgv),
     {
       allowFailure: true,
     }
   );
   await runInProcessCommand('lint-fix', () =>
-    lint({ ...argv, _: ['lint'], fix: true, quiet: true } as unknown as LintCommandArgv)
+    lint({
+      ...argv,
+      _: ['lint'],
+      fix: true,
+      printAllOutput: true,
+      quiet: true,
+      silent: true,
+    } as unknown as LintCommandArgv)
   );
 }
 

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -124,7 +124,7 @@ async function runPackageCommand(
   printPackageCommandOutput(command, exitCode, ret.stdout);
 
   if (exitCode !== 0 && !options.allowFailure) {
-    console.info(chalk.red(chalk.bold(`Failed (exit code ${ret.status}):`), command));
+    console.info(chalk.red(chalk.bold(`Failed (exit code ${exitCode}):`), command));
     process.exit(exitCode);
   }
   return exitCode;


### PR DESCRIPTION
## Summary

- Print every command run by `wb verify` with the working directory using a compact `Command: ... at ...` format.
- Show raw output for verify commands where it is useful, while replacing successful `yarn install`, `oxfmt`, and `sort-package-json` output with `Succeeded.`.
- Keep the compact output path scoped to `wb verify` and avoid changing generic parallel command logging.
- Avoid the `NO_COLOR` / `FORCE_COLOR` warning in verify output.

## Why

- `yarn start verify` previously surfaced only the install log even though it ran multiple commands.
- The new format makes the executed commands and their working directories explicit without flooding successful verify output with low-value logs.
- The change is scoped to verify so other `wb` command output remains stable.

## Testing

- `yarn start verify` from `packages/wb`
- `yarn check-for-ai`
