### PR TITLE
fix: improve wb verify and test output

### DIFF
--- a/packages/shared-lib-node/src/spawn.ts
+++ b/packages/shared-lib-node/src/spawn.ts
@@ -42,6 +42,8 @@ export type SpawnAsyncOptions = (
   printingStdout?: boolean;
   /** If true, stderr data will be printed to console as it's received */
   printingStderr?: boolean;
+  /** If true, blank-only lines are skipped while printing stdout/stderr in realtime */
+  omitBlankLinesWhilePrinting?: boolean;
 };
 
 /**
@@ -82,10 +84,12 @@ export async function spawnAsync(
 
       let stdout = '';
       let stderr = '';
+      const stdoutPrinter = createRealtimePrinter(process.stdout, options?.omitBlankLinesWhilePrinting);
+      const stderrPrinter = createRealtimePrinter(process.stderr, options?.omitBlankLinesWhilePrinting);
       proc.stdout?.on('data', (data: string) => {
         stdout += data;
         if (options?.printingStdout) {
-          process.stdout.write(data);
+          stdoutPrinter.write(data);
         }
       });
       proc.stderr?.on('data', (data: string) => {
@@ -95,7 +99,7 @@ export async function spawnAsync(
           stderr += data;
         }
         if (options?.printingStderr) {
-          process.stderr.write(data);
+          stderrPrinter.write(data);
         }
       });
 
@@ -147,6 +151,8 @@ export async function spawnAsync(
       });
       proc.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
         removeKillOnExitHandlers();
+        stdoutPrinter.flush();
+        stderrPrinter.flush();
         if (proc.pid === undefined) {
           reject(new Error('Process has no pid.'));
         } else {
@@ -169,4 +175,42 @@ export async function spawnAsync(
       reject(error);
     }
   });
+}
+
+const ANSI_ESCAPE_CODE_REGEXP = new RegExp(`${String.fromCodePoint(27)}\\[[0-?]*[ -/]*[@-~]`, 'g');
+
+function createRealtimePrinter(
+  stream: NodeJS.WriteStream,
+  omitBlankLines = false
+): { write: (data: string) => void; flush: () => void } {
+  if (!omitBlankLines) {
+    return {
+      write: (data) => stream.write(data),
+      flush: () => {},
+    };
+  }
+
+  let pending = '';
+  return {
+    write: (data) => {
+      pending += data;
+      const lines = pending.split(/\r?\n/);
+      pending = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!isBlankLine(line)) {
+          stream.write(`${line}\n`);
+        }
+      }
+    },
+    flush: () => {
+      if (!isBlankLine(pending)) {
+        stream.write(pending);
+      }
+      pending = '';
+    },
+  };
+}
+
+function isBlankLine(line: string): boolean {
+  return line.replaceAll(ANSI_ESCAPE_CODE_REGEXP, '').trim().length === 0;
 }

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -45,7 +45,6 @@ export type LintCommandArgv = ArgumentsCamelCase<LintCommandOptions> & {
   '--'?: unknown[];
   _: unknown[];
   printAllOutput?: boolean;
-  rawOutput?: boolean;
 };
 
 const oxlintExtensions = new Set(['astro', 'cjs', 'cts', 'js', 'jsx', 'mjs', 'mts', 'svelte', 'ts', 'tsx', 'vue']);
@@ -303,10 +302,8 @@ function runLintCommand(
 ): Promise<LintRunResult> {
   if (argv.silent) {
     const normalizedScript = normalizeScript(command, project);
-    if (argv.rawOutput) {
-      printCommandHeader(normalizedScript.printable, project.dirPath);
-    }
-    return runWithSpawnInParallelBuffered(command, project, argv, { ...options, printRawOutput: argv.rawOutput }).then(
+    printCommandHeader(normalizedScript.printable, project.dirPath);
+    return runWithSpawnInParallelBuffered(command, project, argv, { ...options, printRawOutput: true }).then(
       (result) => ({
         ...result,
         command: normalizedScript.printable,
@@ -319,9 +316,9 @@ function runLintCommand(
 
 function printSilentLintOutputs(
   results: LintRunResult[],
-  argv: Pick<LintCommandArgv, 'printAllOutput' | 'rawOutput'>
+  argv: Pick<LintCommandArgv, 'printAllOutput' | 'silent'>
 ): void {
-  if (argv.rawOutput) return;
+  if (argv.silent) return;
 
   for (const result of results) {
     if (!('output' in result)) continue;

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -303,6 +303,9 @@ function runLintCommand(
 ): Promise<LintRunResult> {
   if (argv.silent) {
     const normalizedScript = normalizeScript(command, project);
+    if (argv.rawOutput) {
+      printCommandHeader(normalizedScript.printable, project.dirPath);
+    }
     return runWithSpawnInParallelBuffered(command, project, argv, { ...options, printRawOutput: argv.rawOutput }).then(
       (result) => ({
         ...result,
@@ -332,7 +335,7 @@ function printSilentLintOutputs(
 }
 
 function printCommandOutput(result: BufferedLintRunResult): void {
-  console.info('\n' + chalk.cyan(chalk.bold('Command:'), result.command) + chalk.gray(` at ${result.cwd}`));
+  printCommandHeader(result.command, result.cwd);
 
   if (result.exitCode === 0 && shouldSuppressSuccessfulVerifyOutput(result.command)) {
     console.info(chalk.green('Succeeded.'));
@@ -344,6 +347,10 @@ function printCommandOutput(result: BufferedLintRunResult): void {
     process.stdout.write(output);
     process.stdout.write('\n');
   }
+}
+
+function printCommandHeader(command: string, cwd: string): void {
+  console.info('\n' + chalk.cyan(chalk.bold('Command:'), command) + chalk.gray(` at ${cwd}`));
 }
 
 function shouldSuppressSuccessfulVerifyOutput(command: string): boolean {

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -45,6 +45,7 @@ export type LintCommandArgv = ArgumentsCamelCase<LintCommandOptions> & {
   '--'?: unknown[];
   _: unknown[];
   printAllOutput?: boolean;
+  rawOutput?: boolean;
 };
 
 const oxlintExtensions = new Set(['astro', 'cjs', 'cts', 'js', 'jsx', 'mjs', 'mts', 'svelte', 'ts', 'tsx', 'vue']);
@@ -302,16 +303,23 @@ function runLintCommand(
 ): Promise<LintRunResult> {
   if (argv.silent) {
     const normalizedScript = normalizeScript(command, project);
-    return runWithSpawnInParallelBuffered(command, project, argv, options).then((result) => ({
-      ...result,
-      command: normalizedScript.printable,
-      cwd: project.dirPath,
-    }));
+    return runWithSpawnInParallelBuffered(command, project, argv, { ...options, printRawOutput: argv.rawOutput }).then(
+      (result) => ({
+        ...result,
+        command: normalizedScript.printable,
+        cwd: project.dirPath,
+      })
+    );
   }
   return runWithSpawnInParallel(command, project, argv, options).then((exitCode) => ({ exitCode }));
 }
 
-function printSilentLintOutputs(results: LintRunResult[], argv: Pick<LintCommandArgv, 'printAllOutput'>): void {
+function printSilentLintOutputs(
+  results: LintRunResult[],
+  argv: Pick<LintCommandArgv, 'printAllOutput' | 'rawOutput'>
+): void {
+  if (argv.rawOutput) return;
+
   for (const result of results) {
     if (!('output' in result)) continue;
 

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -69,10 +69,48 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
 
 function optimizeDevDependencies(argv: InferredOptionTypes<typeof builder>, packageJson: PackageJson): void {
   promoteRuntimeDevDependencies(packageJson);
-  if (argv.outside) return;
+  if (argv.outside) {
+    removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson);
+    return;
+  }
 
   delete packageJson.devDependencies;
   console.info('Removed all devDependencies.');
+}
+
+function removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson: PackageJson): void {
+  const devDeps = packageJson.devDependencies ?? {};
+  const nameWordsToBeRemoved = [
+    'artillery',
+    'concurrently',
+    'conventional-changelog-conventionalcommits',
+    'husky',
+    'imagemin',
+    'jest',
+    'kill-port',
+    'lint-staged',
+    'open-cli',
+    'playwright',
+    'prettier',
+    'pinst',
+    'railway',
+    'semantic-release',
+    'sort-package-json',
+    'wait-on',
+    'vitest',
+  ];
+  const removedDeps: string[] = [];
+  for (const name of Object.keys(devDeps)) {
+    if (
+      nameWordsToBeRemoved.some((word) => name.includes(word)) ||
+      (name.includes('willbooster') && name.includes('config'))
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete devDeps[name];
+      removedDeps.push(name);
+    }
+  }
+  console.info('Removed devDependencies:', removedDeps.join(', ') || 'none');
 }
 
 function promoteRuntimeDevDependencies(packageJson: PackageJson): void {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -80,6 +80,8 @@ function optimizeDevDependencies(argv: InferredOptionTypes<typeof builder>, pack
 
 function removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson: PackageJson): void {
   const devDeps = packageJson.devDependencies ?? {};
+  // In --outside mode, Docker still runs codegen/build before a second in-image optimization.
+  // Remove only tooling that is not needed for that build phase.
   const nameWordsToBeRemoved = [
     'artillery',
     'concurrently',
@@ -157,6 +159,8 @@ function optimizeDockerInstallPrepareScript(argv: InferredOptionTypes<typeof bui
   const devDependencyNames = Object.keys(packageJson.devDependencies ?? {});
   if (devDependencyNames.length === 0) return;
 
+  // Bun validates the lockfile even with --production. This script lets Docker rewrite
+  // the image-local lockfile after --outside pruning, without hard-coding packages in app Dockerfiles.
   const scripts = packageJson.scripts ?? {};
   scripts['docker/install/prepare'] = `bun remove ${devDependencyNames.join(' ')}`;
   packageJson.scripts = scripts;

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -48,6 +48,8 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
 
       optimizeScripts(packageJson);
 
+      optimizeDockerInstallPrepareScript(argv, packageJson);
+
       optimizeRootProps(packageJson);
 
       if (argv.dryRun) continue;
@@ -67,44 +69,10 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
 
 function optimizeDevDependencies(argv: InferredOptionTypes<typeof builder>, packageJson: PackageJson): void {
   promoteRuntimeDevDependencies(packageJson);
-  if (!argv.outside) {
-    delete packageJson.devDependencies;
-    console.info('Removed all devDependencies.');
-    return;
-  }
+  if (argv.outside) return;
 
-  const devDeps = packageJson.devDependencies ?? {};
-  const nameWordsToBeRemoved = [
-    'artillery',
-    'concurrently',
-    'conventional-changelog-conventionalcommits',
-    'husky',
-    'imagemin',
-    'jest',
-    'kill-port',
-    'lint-staged',
-    'open-cli',
-    'playwright',
-    'prettier',
-    'pinst',
-    'railway',
-    'semantic-release',
-    'sort-package-json',
-    'wait-on',
-    'vitest',
-  ];
-  const removedDeps: string[] = [];
-  for (const name of Object.keys(devDeps)) {
-    if (
-      nameWordsToBeRemoved.some((word) => name.includes(word)) ||
-      (name.includes('willbooster') && name.includes('config'))
-    ) {
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-      delete devDeps[name];
-      removedDeps.push(name);
-    }
-  }
-  console.info('Removed devDependencies:', removedDeps.join(', ') || 'none');
+  delete packageJson.devDependencies;
+  console.info('Removed all devDependencies.');
 }
 
 function promoteRuntimeDevDependencies(packageJson: PackageJson): void {
@@ -143,6 +111,18 @@ function optimizeScripts(packageJson: PackageJson): void {
     }
   }
   console.info('Removed scripts:', removedScripts.join(', ') || 'none');
+}
+
+function optimizeDockerInstallPrepareScript(argv: InferredOptionTypes<typeof builder>, packageJson: PackageJson): void {
+  if (!argv.outside || packageManager !== 'bun') return;
+
+  const devDependencyNames = Object.keys(packageJson.devDependencies ?? {});
+  if (devDependencyNames.length === 0) return;
+
+  const scripts = packageJson.scripts ?? {};
+  scripts['docker/install/prepare'] = `bun remove ${devDependencyNames.join(' ')}`;
+  packageJson.scripts = scripts;
+  console.info('Added docker/install/prepare script.');
 }
 
 function optimizeRootProps(packageJson: PackageJson): void {

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -118,9 +118,12 @@ export async function test(argv: TestCommandArgv): Promise<void> {
     console.info(`Running "test" for ${project.name} ...`);
 
     // Run unit tests if needed
-    if (shouldRunUnit && fs.existsSync(path.join(project.dirPath, 'test', 'unit'))) {
+    const defaultUnitTargets = getDefaultUnitTargets(project);
+    if (shouldRunUnit && defaultUnitTargets !== false) {
       const unitTargets = testTargets.filter((target) => target.includes('/unit'));
-      const unitArgv = { ...argv, targets: unitTargets.length > 0 ? unitTargets : undefined };
+      const targets =
+        unitTargets.length > 0 ? unitTargets : defaultUnitTargets.length > 0 ? defaultUnitTargets : undefined;
+      const unitArgv = { ...argv, targets };
       await runWithSpawn(scripts.testUnit(project, unitArgv), project, argv, { timeout: argv.unitTimeout });
     }
     // Skip e2e tests if not needed or no e2e directory exists
@@ -228,6 +231,16 @@ export async function test(argv: TestCommandArgv): Promise<void> {
       }
     }
   }
+}
+
+function getDefaultUnitTargets(project: Project): string[] | false {
+  if (fs.existsSync(path.join(project.dirPath, 'test', 'unit'))) {
+    return [];
+  }
+  if (project.hasVitest && fs.existsSync(path.join(project.dirPath, 'test'))) {
+    return ['test'];
+  }
+  return false;
 }
 
 async function testOnDocker(

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -76,18 +76,7 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
 }
 
 async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Promise<void> {
-  if (hasWbTestCommand(project.packageJson.scripts?.test)) {
-    await test({ ...argv, _: ['test'], e2e: 'headless', silent: true } as unknown as TestCommandArgv);
-    return;
-  }
-
-  await runPackageCommand(`${packageManager} test`, project, argv, { printRawOutput: true });
-}
-
-function hasWbTestCommand(script: string | undefined): boolean {
-  if (!script) return false;
-  const commandPrefix = String.raw`(?:^|[&(;|]\s*|\s)(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:(?:yarn|bun|pnpm)\s+(?:run\s+)?)?wb\s+`;
-  return new RegExp(`${commandPrefix}test(?:\\s|$)`).test(script);
+  await test({ ...argv, _: ['test'], e2e: 'headless', silent: true } as unknown as TestCommandArgv);
 }
 
 async function runInProcessCommand(

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { spawnAsync } from '@willbooster/shared-lib-node/src';
 import chalk from 'chalk';
 import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
@@ -33,12 +36,23 @@ export const verifyCodeCommand: CommandModule<unknown, VerifyCodeCommandOptions>
       process.exit(1);
     }
 
-    await verifyCode(projects.self, argv);
-    if (argv.full) {
-      await runProjectTest(projects.self, argv);
-    }
+    await (argv.full ? verifyCodeFully(projects.self, argv) : verifyCode(projects.self, argv));
   },
 };
+
+async function verifyCodeFully(project: Project, argv: VerifyCodeCommandArgv): Promise<void> {
+  const reporter = startVerifyFullReporter(project);
+  try {
+    await verifyCode(project, argv);
+    await runProjectTest(project, argv);
+    reporter.succeed();
+  } catch (error) {
+    reporter.fail(error);
+    throw error;
+  } finally {
+    reporter.finish();
+  }
+}
 
 async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promise<void> {
   await runPackageCommand(`${packageManager} install`, project, argv);
@@ -148,4 +162,88 @@ function printPackageCommandOutput(command: string, exitCode: number, output: st
 
 function printCommand(command: string, cwd: string): void {
   console.info('\n' + chalk.cyan(chalk.bold('Command:'), command) + chalk.gray(` at ${cwd}`));
+}
+
+function startVerifyFullReporter(project: Project): {
+  fail: (error?: unknown) => void;
+  finish: () => void;
+  succeed: () => void;
+} {
+  const startedAt = Date.now();
+  const wbDirPath = path.join(project.dirPath, '.wb');
+  fs.mkdirSync(wbDirPath, { recursive: true });
+
+  const logFilePath = path.join(wbDirPath, 'verify-full.log');
+  const logFile = fs.openSync(logFilePath, 'w');
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  let succeeded = false;
+  let finished = false;
+
+  process.stdout.write = teeWrite(process.stdout.fd, logFile) as typeof process.stdout.write;
+  process.stderr.write = teeWrite(process.stderr.fd, logFile) as typeof process.stderr.write;
+
+  const finish = (): void => {
+    if (finished) return;
+    finished = true;
+
+    process.stdout.write = originalStdoutWrite as typeof process.stdout.write;
+    process.stderr.write = originalStderrWrite as typeof process.stderr.write;
+
+    const elapsedTime = formatElapsedTime(Date.now() - startedAt);
+    const status = succeeded ? 'Succeeded' : 'Failed';
+    const summary = `${status} in ${elapsedTime}. Full log: ${logFilePath}\n`;
+    const coloredSummary = succeeded ? chalk.green(summary) : chalk.red(summary);
+    originalStdoutWrite(coloredSummary);
+    fs.writeSync(logFile, summary);
+    fs.closeSync(logFile);
+  };
+
+  process.once('exit', finish);
+
+  return {
+    fail: (error) => {
+      succeeded = false;
+      if (error) {
+        console.error(error);
+      }
+    },
+    finish: () => {
+      process.removeListener('exit', finish);
+      finish();
+    },
+    succeed: () => {
+      succeeded = true;
+    },
+  };
+}
+
+function teeWrite(outputFile: number, logFile: number): typeof process.stdout.write {
+  return ((
+    chunk: Uint8Array | string,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void
+  ) => {
+    const buffer =
+      typeof chunk === 'string'
+        ? Buffer.from(chunk, typeof encodingOrCallback === 'string' ? encodingOrCallback : 'utf8')
+        : chunk;
+    fs.writeSync(logFile, buffer);
+    fs.writeSync(outputFile, buffer);
+    if (typeof encodingOrCallback === 'function') {
+      encodingOrCallback();
+    }
+    callback?.();
+    return true;
+  }) as typeof process.stdout.write;
+}
+
+function formatElapsedTime(milliseconds: number): string {
+  const seconds = Math.round(milliseconds / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes === 0) {
+    return `${remainingSeconds}s`;
+  }
+  return `${minutes}m ${remainingSeconds}s`;
 }

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -48,7 +48,14 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
   await runInProcessCommand(
     'format',
     () =>
-      lint({ ...argv, _: ['lint'], format: true, printAllOutput: true, silent: true } as unknown as LintCommandArgv),
+      lint({
+        ...argv,
+        _: ['lint'],
+        format: true,
+        printAllOutput: true,
+        rawOutput: true,
+        silent: true,
+      } as unknown as LintCommandArgv),
     {
       allowFailure: true,
       silent: true,
@@ -63,6 +70,7 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
         fix: true,
         printAllOutput: true,
         quiet: true,
+        rawOutput: true,
         silent: true,
       } as unknown as LintCommandArgv),
     { silent: true }
@@ -77,7 +85,7 @@ async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Pr
     return;
   }
 
-  await runPackageCommand(`${packageManager} test`, project, argv);
+  await runPackageCommand(`${packageManager} test`, project, argv, { printRawOutput: true });
 }
 
 async function runInProcessCommand(
@@ -104,7 +112,7 @@ async function runPackageCommand(
   command: string,
   project: Project,
   argv: VerifyCodeCommandArgv,
-  options: { allowFailure?: boolean } = {}
+  options: { allowFailure?: boolean; printRawOutput?: boolean } = {}
 ): Promise<number> {
   printCommand(command, project.dirPath);
   if (argv.dryRun) {
@@ -118,10 +126,14 @@ async function runPackageCommand(
     stdio: 'pipe',
     mergeOutAndError: true,
     killOnExit: true,
+    printingStdout: options.printRawOutput,
+    printingStderr: options.printRawOutput,
     verbose: argv.verbose,
   });
   const exitCode = ret.status ?? 1;
-  printPackageCommandOutput(command, exitCode, ret.stdout);
+  if (!options.printRawOutput) {
+    printPackageCommandOutput(command, exitCode, ret.stdout);
+  }
 
   if (exitCode !== 0 && !options.allowFailure) {
     console.info(chalk.red(chalk.bold(`Failed (exit code ${exitCode}):`), command));

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -10,7 +10,6 @@ import { packageManager } from '../utils/runtime.js';
 
 import { lint, type LintCommandArgv } from './lint.js';
 import { test, type TestCommandArgv } from './test.js';
-import { testOnCi } from './testOnCi.js';
 
 const builder = {
   full: {
@@ -77,26 +76,18 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
 }
 
 async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Promise<void> {
-  switch (findWbTestCommand(project.packageJson.scripts?.test)) {
-    case 'test': {
-      await test({ ...argv, _: ['test'], e2e: 'headless', silent: true } as unknown as TestCommandArgv);
-      return;
-    }
-    case 'test-on-ci': {
-      await testOnCi({ ...argv, _: ['test-on-ci'], silent: true } as unknown as Parameters<typeof testOnCi>[0]);
-      return;
-    }
+  if (hasWbTestCommand(project.packageJson.scripts?.test)) {
+    await test({ ...argv, _: ['test'], e2e: 'headless', silent: true } as unknown as TestCommandArgv);
+    return;
   }
 
   await runPackageCommand(`${packageManager} test`, project, argv, { printRawOutput: true });
 }
 
-function findWbTestCommand(script: string | undefined): 'test' | 'test-on-ci' | undefined {
-  if (!script) return;
+function hasWbTestCommand(script: string | undefined): boolean {
+  if (!script) return false;
   const commandPrefix = String.raw`(?:^|[&(;|]\s*|\s)(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:(?:yarn|bun|pnpm)\s+(?:run\s+)?)?wb\s+`;
-  if (new RegExp(`${commandPrefix}test-on-ci(?:\\s|$)`).test(script)) return 'test-on-ci';
-  if (new RegExp(`${commandPrefix}test(?:\\s|$)`).test(script)) return 'test';
-  return;
+  return new RegExp(`${commandPrefix}test(?:\\s|$)`).test(script);
 }
 
 async function runInProcessCommand(

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -10,6 +10,7 @@ import { packageManager } from '../utils/runtime.js';
 
 import { lint, type LintCommandArgv } from './lint.js';
 import { test, type TestCommandArgv } from './test.js';
+import { testOnCi } from './testOnCi.js';
 
 const builder = {
   full: {
@@ -78,14 +79,30 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
 }
 
 async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Promise<void> {
-  if (project.packageJson.scripts?.test?.includes('wb test')) {
-    console.info('\n' + chalk.cyan(chalk.bold('Start:'), 'test'));
-    await test({ ...argv, _: ['test'], e2e: 'headless' } as unknown as TestCommandArgv);
-    console.info(chalk.green(chalk.bold('Finished:'), 'test'));
-    return;
+  switch (findWbTestCommand(project.packageJson.scripts?.test)) {
+    case 'test': {
+      console.info('\n' + chalk.cyan(chalk.bold('Start:'), 'test'));
+      await test({ ...argv, _: ['test'], e2e: 'headless' } as unknown as TestCommandArgv);
+      console.info(chalk.green(chalk.bold('Finished:'), 'test'));
+      return;
+    }
+    case 'test-on-ci': {
+      console.info('\n' + chalk.cyan(chalk.bold('Start:'), 'test-on-ci'));
+      await testOnCi({ ...argv, _: ['test-on-ci'] } as unknown as Parameters<typeof testOnCi>[0]);
+      console.info(chalk.green(chalk.bold('Finished:'), 'test-on-ci'));
+      return;
+    }
   }
 
   await runPackageCommand(`${packageManager} test`, project, argv, { printRawOutput: true });
+}
+
+function findWbTestCommand(script: string | undefined): 'test' | 'test-on-ci' | undefined {
+  if (!script) return;
+  const commandPrefix = String.raw`(?:^|[&(;|]\s*|\s)(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*(?:(?:yarn|bun|pnpm)\s+(?:run\s+)?)?wb\s+`;
+  if (new RegExp(`${commandPrefix}test-on-ci(?:\\s|$)`).test(script)) return 'test-on-ci';
+  if (new RegExp(`${commandPrefix}test(?:\\s|$)`).test(script)) return 'test';
+  return;
 }
 
 async function runInProcessCommand(

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -182,6 +182,7 @@ function startVerifyFullReporter(project: Project): {
 
   process.stdout.write = teeWrite(process.stdout.fd, logFile) as typeof process.stdout.write;
   process.stderr.write = teeWrite(process.stderr.fd, logFile) as typeof process.stderr.write;
+  console.info(chalk.cyan(chalk.bold('Full log:'), logFilePath));
 
   const finish = (): void => {
     if (finished) return;

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -79,15 +79,11 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
 async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Promise<void> {
   switch (findWbTestCommand(project.packageJson.scripts?.test)) {
     case 'test': {
-      console.info('\n' + chalk.cyan(chalk.bold('Start:'), 'test'));
-      await test({ ...argv, _: ['test'], e2e: 'headless' } as unknown as TestCommandArgv);
-      console.info(chalk.green(chalk.bold('Finished:'), 'test'));
+      await test({ ...argv, _: ['test'], e2e: 'headless', silent: true } as unknown as TestCommandArgv);
       return;
     }
     case 'test-on-ci': {
-      console.info('\n' + chalk.cyan(chalk.bold('Start:'), 'test-on-ci'));
-      await testOnCi({ ...argv, _: ['test-on-ci'] } as unknown as Parameters<typeof testOnCi>[0]);
-      console.info(chalk.green(chalk.bold('Finished:'), 'test-on-ci'));
+      await testOnCi({ ...argv, _: ['test-on-ci'], silent: true } as unknown as Parameters<typeof testOnCi>[0]);
       return;
     }
   }

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -54,7 +54,6 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
         _: ['lint'],
         format: true,
         printAllOutput: true,
-        rawOutput: true,
         silent: true,
       } as unknown as LintCommandArgv),
     {
@@ -71,7 +70,6 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
         fix: true,
         printAllOutput: true,
         quiet: true,
-        rawOutput: true,
         silent: true,
       } as unknown as LintCommandArgv),
     { silent: true }

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -45,9 +45,12 @@ export async function runWithSpawn(
     cwd: project.dirPath,
     env: configureEnv(project.env, opts),
     shell: true,
-    stdio: 'inherit',
+    stdio: argv.silent ? 'pipe' : 'inherit',
     timeout: opts.timeout,
     killOnExit: true,
+    printingStdout: argv.silent,
+    printingStderr: argv.silent,
+    omitBlankLinesWhilePrinting: argv.silent,
     verbose: argv.verbose,
   });
   opts.onSignal?.(ret.signal);

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -12,6 +12,7 @@ interface Options {
   exitIfFailed?: boolean;
   onSignal?: (signal: NodeJS.Signals | null) => void;
   forceColor?: boolean;
+  printRawOutput?: boolean;
   timeout?: number;
 }
 
@@ -80,6 +81,8 @@ export function runWithSpawnInParallel(
       timeout: opts.timeout,
       mergeOutAndError: true,
       killOnExit: true,
+      printingStdout: opts.printRawOutput,
+      printingStderr: opts.printRawOutput,
       verbose: argv.verbose,
     });
     opts.onSignal?.(ret.signal);
@@ -88,7 +91,7 @@ export function runWithSpawnInParallel(
       printStart(normalizedScript.runnable, project, 'Started (raw)', true);
     }
     const out = ret.stdout.trim();
-    if (out) {
+    if (out && !opts.printRawOutput) {
       process.stdout.write(out);
       process.stdout.write('\n');
     }
@@ -120,6 +123,8 @@ export function runWithSpawnInParallelBuffered(
       timeout: opts.timeout,
       mergeOutAndError: true,
       killOnExit: true,
+      printingStdout: opts.printRawOutput,
+      printingStderr: opts.printRawOutput,
       verbose: argv.verbose,
     });
     opts.onSignal?.(ret.signal);

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -28,16 +28,16 @@ export interface BufferedRunResult {
 export async function runWithSpawn(
   script: string,
   project: Project,
-  argv: Partial<ArgumentsCamelCase<InferredOptionTypes<typeof sharedOptionsBuilder>>>,
+  argv: Partial<ArgumentsCamelCase<InferredOptionTypes<typeof sharedOptionsBuilder>>> & { silent?: boolean },
   opts: Options = defaultOptions
 ): Promise<number> {
   const normalizedScript = normalizeScript(script, project);
-  printStart(normalizedScript.printable, project);
+  printStart(normalizedScript.printable, project, argv.silent ? 'Command' : 'Start');
   if (argv.verbose) {
     printStart(normalizedScript.runnable, project, 'Start (raw)', true);
   }
   if (argv.dryRun) {
-    printFinishedAndExitIfNeeded(normalizedScript.printable, 0, opts);
+    printFinishedAndExitIfNeeded(normalizedScript.printable, 0, opts, { silentSuccess: argv.silent });
     return 0;
   }
 
@@ -51,7 +51,7 @@ export async function runWithSpawn(
     verbose: argv.verbose,
   });
   opts.onSignal?.(ret.signal);
-  printFinishedAndExitIfNeeded(normalizedScript.printable, ret.status, opts);
+  printFinishedAndExitIfNeeded(normalizedScript.printable, ret.status, opts, { silentSuccess: argv.silent });
   return ret.status ?? 1;
 }
 
@@ -187,9 +187,11 @@ export function printStart(normalizedScript: string, project: Project, prefix = 
 export function printFinishedAndExitIfNeeded(
   script: string,
   exitCode: number | null,
-  opts: Omit<Options, 'timeout'>
+  opts: Omit<Options, 'timeout'>,
+  printOptions: { silentSuccess?: boolean } = {}
 ): void {
   if (exitCode === 0) {
+    if (printOptions.silentSuccess) return;
     console.info(chalk.green(chalk.bold('Finished:'), script));
   } else {
     console.info(chalk.red(chalk.bold(`Failed (exit code ${exitCode}): `), script));


### PR DESCRIPTION
## Summary

- Stream silent lint and test command output during `wb verify` and `wb test` with explicit `Command:` labels.
- Run `wb test` directly from `verify --full` instead of spawning a package-manager test script.
- Make `wb test --silent` execute Vitest projects that have `test/` but no `test/unit/`, so the actual test command is shown.
- Write the complete `verify --full` log to `.wb/verify-full.log`.
- Print the generated full-log path at the start of `verify --full` and keep the final success/failure plus elapsed-time summary.

## Why

- Silent verification output was hiding which commands were running and could omit useful child-process logs.
- Calling `wb test` in-process avoids spawning another yarn/bun instance from `wb verify`.
- Long `verify --full` runs need a stable full-log path that is visible immediately, not only after completion.

## Testing

- `yarn check-for-ai`
- `yarn workspace @willbooster/wb verify --full`
- `tail -n 5 packages/wb/.wb/verify-full.log`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBooster/shared/packages/wb test --silent`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBooster/shared/packages/wb verify --full --dry-run`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBoosterLab/exercode test test/unit/ --silent`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBoosterLab/exercode verify --full`
