### PR TITLE
fix: improve wb verify output for agents

### DIFF
--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -35,6 +35,7 @@
     "chalk": "5.6.2",
     "dotenv": "17.4.2",
     "dotenv-expand": "12.0.3",
+    "fastest-levenshtein": "1.0.16",
     "globby": "16.2.0",
     "kill-port": "2.0.1",
     "minimal-promise-pool": "6.0.1",

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -302,14 +302,11 @@ function runLintCommand(
 ): Promise<LintRunResult> {
   if (argv.silent) {
     const normalizedScript = normalizeScript(command, project);
-    printCommandHeader(normalizedScript.printable, project.dirPath);
-    return runWithSpawnInParallelBuffered(command, project, argv, { ...options, printRawOutput: true }).then(
-      (result) => ({
-        ...result,
-        command: normalizedScript.printable,
-        cwd: project.dirPath,
-      })
-    );
+    return runWithSpawnInParallelBuffered(command, project, argv, options).then((result) => ({
+      ...result,
+      command: normalizedScript.printable,
+      cwd: project.dirPath,
+    }));
   }
   return runWithSpawnInParallel(command, project, argv, options).then((exitCode) => ({ exitCode }));
 }
@@ -318,7 +315,7 @@ function printSilentLintOutputs(
   results: LintRunResult[],
   argv: Pick<LintCommandArgv, 'printAllOutput' | 'silent'>
 ): void {
-  if (argv.silent) return;
+  if (argv.silent && !argv.printAllOutput) return;
 
   for (const result of results) {
     if (!('output' in result)) continue;

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -315,9 +315,11 @@ function printSilentLintOutputs(
   results: LintRunResult[],
   argv: Pick<LintCommandArgv, 'printAllOutput' | 'silent'>
 ): void {
-  if (argv.silent && !argv.printAllOutput) return;
+  const printableResults =
+    argv.silent && !argv.printAllOutput ? results.filter((result) => result.exitCode !== 0) : results;
+  if (printableResults.length === 0) return;
 
-  for (const result of results) {
+  for (const result of printableResults) {
     if (!('output' in result)) continue;
 
     if (argv.printAllOutput) {

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -325,6 +325,9 @@ function printSilentLintOutputs(
     if (argv.printAllOutput) {
       printCommandOutput(result);
     } else {
+      if (argv.silent) {
+        printCommandHeader(result.command, result.cwd);
+      }
       printBufferedOutput(result.exitCode, result.output);
     }
   }

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import type { PackageJson } from 'type-fest';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
-import { findDescendantProjects } from '../project.js';
+import { findDescendantProjects, type Project } from '../project.js';
 import { packageManager } from '../utils/runtime.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
@@ -48,7 +48,7 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
 
       optimizeScripts(packageJson);
 
-      optimizeDockerInstallPrepareScript(argv, packageJson);
+      optimizeDockerInstallPrepareScript(argv, project, packageJson);
 
       optimizeRootProps(packageJson);
 
@@ -153,8 +153,14 @@ function optimizeScripts(packageJson: PackageJson): void {
   console.info('Removed scripts:', removedScripts.join(', ') || 'none');
 }
 
-function optimizeDockerInstallPrepareScript(argv: InferredOptionTypes<typeof builder>, packageJson: PackageJson): void {
-  if (!argv.outside || packageManager !== 'bun') return;
+function optimizeDockerInstallPrepareScript(
+  argv: InferredOptionTypes<typeof builder>,
+  project: Project,
+  packageJson: PackageJson
+): void {
+  // The published wb binary may run under Node even when invoked by a Bun project script.
+  // Use the target project instead of the current CLI runtime when deciding Docker install steps.
+  if (!argv.outside || !project.isBunAvailable) return;
 
   const devDependencyNames = Object.keys(packageJson.devDependencies ?? {});
   if (devDependencyNames.length === 0) return;

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -25,6 +25,7 @@ import { httpServerPackages } from './httpServerPackages.js';
 
 const ANSI_ESCAPE_CODE_REGEXP = new RegExp(`${String.fromCodePoint(27)}\\[[0-?]*[ -/]*[@-~]`, 'g');
 const SIMILAR_TEST_OUTPUT_LOOKBACK_LINE_COUNT = 200;
+const SIMILAR_TEST_OUTPUT_DISTANCE_RATIO = 0.05;
 
 const builder = {
   e2e: {
@@ -308,8 +309,9 @@ function normalizeLineForSimilarity(line: string): string {
 function areLinesSimilar(a: string, b: string): boolean {
   const maxLength = Math.max(a.length, b.length);
   if (maxLength === 0) return true;
+  if (Math.abs(a.length - b.length) > maxLength * SIMILAR_TEST_OUTPUT_DISTANCE_RATIO) return false;
 
-  return distance(a, b) / maxLength <= 0.05;
+  return distance(a, b) / maxLength <= SIMILAR_TEST_OUTPUT_DISTANCE_RATIO;
 }
 
 export function buildPlaywrightArgsForE2E(

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -22,6 +22,8 @@ import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
 import { httpServerPackages } from './httpServerPackages.js';
 
+const ANSI_ESCAPE_CODE_REGEXP = new RegExp(`${String.fromCodePoint(27)}\\[[0-?]*[ -/]*[@-~]`, 'g');
+
 const builder = {
   e2e: {
     description:
@@ -124,7 +126,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
       const targets =
         unitTargets.length > 0 ? unitTargets : defaultUnitTargets.length > 0 ? defaultUnitTargets : undefined;
       const unitArgv = { ...argv, targets };
-      await runWithSpawn(scripts.testUnit(project, unitArgv), project, argv, { timeout: argv.unitTimeout });
+      await runTestCommand(scripts.testUnit(project, unitArgv), project, argv, { timeout: argv.unitTimeout });
     }
     // Skip e2e tests if not needed or no e2e directory exists
     if (!shouldRunE2e || !fs.existsSync(path.join(project.dirPath, 'test', 'e2e'))) {
@@ -137,7 +139,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
 
     switch (argv.e2e) {
       case 'headless': {
-        await runWithSpawn(
+        await runTestCommand(
           await scripts.testE2EProduction(project, e2eArgv, {
             playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs),
             forwardedPlaywrightArgs,
@@ -148,7 +150,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
         continue;
       }
       case 'headless-dev': {
-        await runWithSpawn(
+        await runTestCommand(
           await scripts.testE2EDev(project, e2eArgv, {
             playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs),
             forwardedPlaywrightArgs,
@@ -182,7 +184,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
     if (deps.blitz || deps.next || devDeps['@remix-run/dev'] || devDeps.vite) {
       switch (argv.e2e) {
         case 'headed': {
-          await runWithSpawn(
+          await runTestCommand(
             await scripts.testE2EProduction(project, e2eArgv, {
               playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs, ['--headed']),
               forwardedPlaywrightArgs,
@@ -193,7 +195,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
           break;
         }
         case 'headed-dev': {
-          await runWithSpawn(
+          await runTestCommand(
             await scripts.testE2EDev(project, e2eArgv, {
               playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs, ['--headed']),
               forwardedPlaywrightArgs,
@@ -204,7 +206,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
           break;
         }
         case 'debug': {
-          await runWithSpawn(
+          await runTestCommand(
             await scripts.testE2EProduction(project, e2eArgv, {
               playwrightArgs: buildPlaywrightArgsForE2E(e2eTargets, forwardedPlaywrightArgs, ['--debug']),
               forwardedPlaywrightArgs,
@@ -215,7 +217,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
           break;
         }
         case 'generate': {
-          await runWithSpawn(
+          await runTestCommand(
             await scripts.testE2EProduction(project, e2eArgv, {
               playwrightArgs: ['codegen', `http://localhost:${project.env.PORT}`],
             }),
@@ -225,7 +227,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
           break;
         }
         case 'trace': {
-          await runWithSpawn(`BUN playwright show-trace`, project, argv);
+          await runTestCommand(`BUN playwright show-trace`, project, argv);
           break;
         }
       }
@@ -252,7 +254,7 @@ async function testOnDocker(
 ): Promise<void> {
   project.env.WB_DOCKER ||= '1';
   await runWithSpawn(`${scripts.buildDocker(project, 'test')}${toDevNull(argv)}`, project, argv);
-  process.exitCode = await runWithSpawn(
+  process.exitCode = await runTestCommand(
     await scripts.testE2EDocker(project, argv, {
       playwrightArgs,
       forwardedPlaywrightArgs,
@@ -262,6 +264,71 @@ async function testOnDocker(
     { exitIfFailed: false }
   );
   await runWithSpawn(dockerScripts.stop(project), project, argv);
+}
+
+function runTestCommand(
+  script: string,
+  project: Project,
+  argv: Parameters<typeof runWithSpawn>[2],
+  options: Parameters<typeof runWithSpawn>[3] = {}
+): Promise<number> {
+  return runWithSpawn(script, project, argv, {
+    ...options,
+    processSilentOutput: dedupeNoisyTestOutput,
+  });
+}
+
+function dedupeNoisyTestOutput(output: string): string {
+  const printedLines: string[] = [];
+  return output
+    .split('\n')
+    .filter((line) => {
+      const normalizedLine = normalizeLineForSimilarity(line);
+      if (!normalizedLine) return true;
+      if (printedLines.some((printedLine) => areLinesSimilar(printedLine, normalizedLine))) return false;
+
+      printedLines.push(normalizedLine);
+      return true;
+    })
+    .join('\n');
+}
+
+function normalizeLineForSimilarity(line: string): string {
+  return line
+    .replaceAll(ANSI_ESCAPE_CODE_REGEXP, '')
+    .trim()
+    .replaceAll(/^(?:\[[^\]]+\]\s*)+/g, '')
+    .replaceAll(/\d+/g, '<number>');
+}
+
+function areLinesSimilar(a: string, b: string): boolean {
+  const maxLength = Math.max(a.length, b.length);
+  if (maxLength === 0) return true;
+
+  return calculateEditDistance(a, b) / maxLength <= 0.05;
+}
+
+function calculateEditDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const previousDistances = Array.from({ length: b.length + 1 }, (_, index) => index);
+  const currentDistances = Array.from({ length: b.length + 1 }, () => 0);
+
+  for (let aIndex = 0; aIndex < a.length; aIndex++) {
+    currentDistances[0] = aIndex + 1;
+    for (let bIndex = 0; bIndex < b.length; bIndex++) {
+      const substitutionCost = a[aIndex] === b[bIndex] ? 0 : 1;
+      const insertionDistance = (currentDistances[bIndex] ?? Number.POSITIVE_INFINITY) + 1;
+      const deletionDistance = (previousDistances[bIndex + 1] ?? Number.POSITIVE_INFINITY) + 1;
+      const substitutionDistance = (previousDistances[bIndex] ?? Number.POSITIVE_INFINITY) + substitutionCost;
+      currentDistances[bIndex + 1] = Math.min(insertionDistance, deletionDistance, substitutionDistance);
+    }
+    previousDistances.splice(0, previousDistances.length, ...currentDistances);
+  }
+
+  return previousDistances[b.length] ?? 0;
 }
 
 export function buildPlaywrightArgsForE2E(

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -283,33 +283,41 @@ function runTestCommand(
 
 function dedupeNoisyTestOutput(output: string): string {
   const recentPrintedLines: string[] = [];
-  const recentPrintedLineCounts = new Map<string, number>();
-  return output
-    .split('\n')
-    .filter((line) => {
-      const normalizedLine = normalizeLineForSimilarity(line);
-      if (recentPrintedLineCounts.has(normalizedLine)) return false;
-      if (recentPrintedLines.some((printedLine) => areLinesSimilar(printedLine, normalizedLine))) return false;
+  const recentPrintedLineSet = new Set<string>();
+  const dedupedLines: string[] = [];
+  for (const line of iterateLines(output)) {
+    const normalizedLine = normalizeLineForSimilarity(line);
+    if (recentPrintedLineSet.has(normalizedLine)) continue;
+    if (recentPrintedLines.some((printedLine) => areLinesSimilar(printedLine, normalizedLine))) continue;
 
-      pushRecentPrintedLine(recentPrintedLines, recentPrintedLineCounts, normalizedLine);
-      return true;
-    })
-    .join('\n');
+    pushRecentPrintedLine(recentPrintedLines, recentPrintedLineSet, normalizedLine);
+    dedupedLines.push(line);
+  }
+  return dedupedLines.join('\n');
 }
 
-function pushRecentPrintedLine(lines: string[], lineCounts: Map<string, number>, line: string): void {
+function* iterateLines(output: string): Generator<string> {
+  let lineStartIndex = 0;
+  while (lineStartIndex <= output.length) {
+    const lineEndIndex = output.indexOf('\n', lineStartIndex);
+    if (lineEndIndex === -1) {
+      yield output.slice(lineStartIndex);
+      return;
+    }
+
+    yield output.slice(lineStartIndex, lineEndIndex);
+    lineStartIndex = lineEndIndex + 1;
+  }
+}
+
+function pushRecentPrintedLine(lines: string[], lineSet: Set<string>, line: string): void {
   lines.push(line);
-  lineCounts.set(line, (lineCounts.get(line) ?? 0) + 1);
+  lineSet.add(line);
   if (lines.length <= SIMILAR_TEST_OUTPUT_LOOKBACK_LINE_COUNT) return;
 
   const removedLine = lines.shift();
-  if (removedLine === undefined) return;
-
-  const count = lineCounts.get(removedLine) ?? 0;
-  if (count <= 1) {
-    lineCounts.delete(removedLine);
-  } else {
-    lineCounts.set(removedLine, count - 1);
+  if (removedLine !== undefined) {
+    lineSet.delete(removedLine);
   }
 }
 

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -283,19 +283,34 @@ function runTestCommand(
 
 function dedupeNoisyTestOutput(output: string): string {
   const recentPrintedLines: string[] = [];
+  const recentPrintedLineCounts = new Map<string, number>();
   return output
     .split('\n')
     .filter((line) => {
       const normalizedLine = normalizeLineForSimilarity(line);
+      if (recentPrintedLineCounts.has(normalizedLine)) return false;
       if (recentPrintedLines.some((printedLine) => areLinesSimilar(printedLine, normalizedLine))) return false;
 
-      recentPrintedLines.push(normalizedLine);
-      if (recentPrintedLines.length > SIMILAR_TEST_OUTPUT_LOOKBACK_LINE_COUNT) {
-        recentPrintedLines.shift();
-      }
+      pushRecentPrintedLine(recentPrintedLines, recentPrintedLineCounts, normalizedLine);
       return true;
     })
     .join('\n');
+}
+
+function pushRecentPrintedLine(lines: string[], lineCounts: Map<string, number>, line: string): void {
+  lines.push(line);
+  lineCounts.set(line, (lineCounts.get(line) ?? 0) + 1);
+  if (lines.length <= SIMILAR_TEST_OUTPUT_LOOKBACK_LINE_COUNT) return;
+
+  const removedLine = lines.shift();
+  if (removedLine === undefined) return;
+
+  const count = lineCounts.get(removedLine) ?? 0;
+  if (count <= 1) {
+    lineCounts.delete(removedLine);
+  } else {
+    lineCounts.set(removedLine, count - 1);
+  }
 }
 
 function normalizeLineForSimilarity(line: string): string {
@@ -303,7 +318,9 @@ function normalizeLineForSimilarity(line: string): string {
     .replaceAll(ANSI_ESCAPE_CODE_REGEXP, '')
     .trim()
     .replaceAll(/^(?:\[[^\]]+\]\s*)+/g, '')
-    .replaceAll(/\d+/g, '<number>');
+    .replaceAll(/\(node:\d+\)/g, '(node:<number>)')
+    .replaceAll(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\b/g, '<timestamp>')
+    .replaceAll(/([?&]cache=)\d+/g, '$1<number>');
 }
 
 function areLinesSimilar(a: string, b: string): boolean {

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import chalk from 'chalk';
+import { distance } from 'fastest-levenshtein';
 import type { Argv, ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
 
 import type { Project } from '../project.js';
@@ -305,30 +306,7 @@ function areLinesSimilar(a: string, b: string): boolean {
   const maxLength = Math.max(a.length, b.length);
   if (maxLength === 0) return true;
 
-  return calculateEditDistance(a, b) / maxLength <= 0.05;
-}
-
-function calculateEditDistance(a: string, b: string): number {
-  if (a === b) return 0;
-  if (a.length === 0) return b.length;
-  if (b.length === 0) return a.length;
-
-  const previousDistances = Array.from({ length: b.length + 1 }, (_, index) => index);
-  const currentDistances = Array.from({ length: b.length + 1 }, () => 0);
-
-  for (let aIndex = 0; aIndex < a.length; aIndex++) {
-    currentDistances[0] = aIndex + 1;
-    for (let bIndex = 0; bIndex < b.length; bIndex++) {
-      const substitutionCost = a[aIndex] === b[bIndex] ? 0 : 1;
-      const insertionDistance = (currentDistances[bIndex] ?? Number.POSITIVE_INFINITY) + 1;
-      const deletionDistance = (previousDistances[bIndex + 1] ?? Number.POSITIVE_INFINITY) + 1;
-      const substitutionDistance = (previousDistances[bIndex] ?? Number.POSITIVE_INFINITY) + substitutionCost;
-      currentDistances[bIndex + 1] = Math.min(insertionDistance, deletionDistance, substitutionDistance);
-    }
-    previousDistances.splice(0, previousDistances.length, ...currentDistances);
-  }
-
-  return previousDistances[b.length] ?? 0;
+  return distance(a, b) / maxLength <= 0.05;
 }
 
 export function buildPlaywrightArgsForE2E(

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -24,6 +24,7 @@ import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { httpServerPackages } from './httpServerPackages.js';
 
 const ANSI_ESCAPE_CODE_REGEXP = new RegExp(`${String.fromCodePoint(27)}\\[[0-?]*[ -/]*[@-~]`, 'g');
+const SIMILAR_TEST_OUTPUT_LOOKBACK_LINE_COUNT = 200;
 
 const builder = {
   e2e: {
@@ -280,15 +281,17 @@ function runTestCommand(
 }
 
 function dedupeNoisyTestOutput(output: string): string {
-  const printedLines: string[] = [];
+  const recentPrintedLines: string[] = [];
   return output
     .split('\n')
     .filter((line) => {
       const normalizedLine = normalizeLineForSimilarity(line);
-      if (!normalizedLine) return true;
-      if (printedLines.some((printedLine) => areLinesSimilar(printedLine, normalizedLine))) return false;
+      if (recentPrintedLines.some((printedLine) => areLinesSimilar(printedLine, normalizedLine))) return false;
 
-      printedLines.push(normalizedLine);
+      recentPrintedLines.push(normalizedLine);
+      if (recentPrintedLines.length > SIMILAR_TEST_OUTPUT_LOOKBACK_LINE_COUNT) {
+        recentPrintedLines.shift();
+      }
       return true;
     })
     .join('\n');

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -148,9 +148,14 @@ async function runPackageCommand(
 }
 
 /**
- * `wb verify` is primarily consumed by AI coding agents.
- * Keep its command output meaningful enough to diagnose failures, but minimal
- * enough that agents can fit the result in their working context.
+ * Prints package command output for `wb verify`.
+ *
+ * `wb verify` is primarily consumed by AI coding agents, so successful noisy
+ * commands are summarized while failure output remains available for diagnosis.
+ *
+ * @param command The executed command.
+ * @param exitCode The command exit code.
+ * @param output The merged stdout and stderr output from the command.
  */
 function printPackageCommandOutput(command: string, exitCode: number, output: string): void {
   if (exitCode === 0 && (command === `${packageManager} install` || command === `${packageManager} gen-code`)) {

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -147,6 +147,11 @@ async function runPackageCommand(
   return exitCode;
 }
 
+/**
+ * `wb verify` is primarily consumed by AI coding agents.
+ * Keep its command output meaningful enough to diagnose failures, but minimal
+ * enough that agents can fit the result in their working context.
+ */
 function printPackageCommandOutput(command: string, exitCode: number, output: string): void {
   if (exitCode === 0 && command === `${packageManager} install`) {
     console.info(chalk.green('Succeeded.'));

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -153,7 +153,7 @@ async function runPackageCommand(
  * enough that agents can fit the result in their working context.
  */
 function printPackageCommandOutput(command: string, exitCode: number, output: string): void {
-  if (exitCode === 0 && command === `${packageManager} install`) {
+  if (exitCode === 0 && shouldSuppressSuccessfulPackageCommandOutput(command)) {
     console.info(chalk.green('Succeeded.'));
     return;
   }
@@ -163,6 +163,10 @@ function printPackageCommandOutput(command: string, exitCode: number, output: st
     process.stdout.write(trimmedOutput);
     process.stdout.write('\n');
   }
+}
+
+function shouldSuppressSuccessfulPackageCommandOutput(command: string): boolean {
+  return command === `${packageManager} install` || command === `${packageManager} gen-code`;
 }
 
 function printCommand(command: string, cwd: string): void {

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -153,7 +153,7 @@ async function runPackageCommand(
  * enough that agents can fit the result in their working context.
  */
 function printPackageCommandOutput(command: string, exitCode: number, output: string): void {
-  if (exitCode === 0 && shouldSuppressSuccessfulPackageCommandOutput(command)) {
+  if (exitCode === 0 && (command === `${packageManager} install` || command === `${packageManager} gen-code`)) {
     console.info(chalk.green('Succeeded.'));
     return;
   }
@@ -163,10 +163,6 @@ function printPackageCommandOutput(command: string, exitCode: number, output: st
     process.stdout.write(trimmedOutput);
     process.stdout.write('\n');
   }
-}
-
-function shouldSuppressSuccessfulPackageCommandOutput(command: string): boolean {
-  return command === `${packageManager} install` || command === `${packageManager} gen-code`;
 }
 
 function printCommand(command: string, cwd: string): void {

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -26,11 +26,28 @@ export class Project {
 
   @memoizeOne
   get isBunAvailable(): boolean {
+    if (this.hasBunToolVersion()) return true;
+    if (this.hasBunLockfile()) return true;
+    return this.hasBunPackageManager();
+  }
+
+  private hasBunToolVersion(): boolean {
     try {
       return /(^|\n)bun\s/.test(fs.readFileSync(path.join(this.rootDirPath, '.tool-versions'), 'utf8'));
     } catch {
       return false;
     }
+  }
+
+  private hasBunLockfile(): boolean {
+    // Some repositories rely on the lockfile or packageManager field instead of mise.
+    // Docker optimization must follow the target project, not the runtime that launched wb.
+    return ['bun.lock', 'bun.lockb'].some((fileName) => fs.existsSync(path.join(this.rootDirPath, fileName)));
+  }
+
+  private hasBunPackageManager(): boolean {
+    const packageManager = this.rootPackageJson?.packageManager ?? this.packageJson.packageManager;
+    return typeof packageManager === 'string' && packageManager.startsWith('bun@');
   }
 
   @memoizeOne

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -12,6 +12,7 @@ interface Options {
   exitIfFailed?: boolean;
   onSignal?: (signal: NodeJS.Signals | null) => void;
   forceColor?: boolean;
+  processSilentOutput?: (output: string) => string;
   printRawOutput?: boolean;
   timeout?: number;
 }
@@ -41,18 +42,27 @@ export async function runWithSpawn(
     return 0;
   }
 
+  const shouldProcessSilentOutput = Boolean(argv.silent && opts.processSilentOutput);
   const ret = await spawnAsync(normalizedScript.runnable, undefined, {
     cwd: project.dirPath,
     env: configureEnv(project.env, opts),
     shell: true,
     stdio: argv.silent ? 'pipe' : 'inherit',
     timeout: opts.timeout,
+    mergeOutAndError: shouldProcessSilentOutput,
     killOnExit: true,
-    printingStdout: argv.silent,
-    printingStderr: argv.silent,
+    printingStdout: argv.silent && !shouldProcessSilentOutput,
+    printingStderr: argv.silent && !shouldProcessSilentOutput,
     omitBlankLinesWhilePrinting: argv.silent,
     verbose: argv.verbose,
   });
+  if (shouldProcessSilentOutput) {
+    const output = opts.processSilentOutput?.(ret.stdout).trim();
+    if (output) {
+      process.stdout.write(output);
+      process.stdout.write('\n');
+    }
+  }
   opts.onSignal?.(ret.signal);
   printFinishedAndExitIfNeeded(normalizedScript.printable, ret.status, opts, { silentSuccess: argv.silent });
   return ret.status ?? 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6132,6 +6132,7 @@ __metadata:
     chalk: "npm:5.6.2"
     dotenv: "npm:17.4.2"
     dotenv-expand: "npm:12.0.3"
+    fastest-levenshtein: "npm:1.0.16"
     globby: "npm:16.2.0"
     kill-port: "npm:2.0.1"
     minimal-promise-pool: "npm:6.0.1"


### PR DESCRIPTION
## Summary

- Make `wb verify` output more compact for AI agents by suppressing successful `install`, `gen-code`, formatter, and package-json sort output while preserving failure output.
- Dedupe repeated silent test log lines with normalized edit distance via `fastest-levenshtein`.
- Keep silent lint output sequential by printing each buffered command header with its own result after parallel execution completes, including direct silent lint failures.
- Bound and optimize test-output dedupe with a recent-line window, exact-match Set lookup, conservative volatile-token normalization, and a Levenshtein length fast path.
- Detect Bun target projects from `.tool-versions`, Bun lockfiles, or `packageManager`, and use the target project when optimizing Docker install scripts.

## Why

- `wb verify` is primarily consumed by AI agents, so successful noisy command output should stay meaningful but minimal.
- Test runners and web servers can emit repeated warnings that consume context without adding diagnostic value.
- Silent lint output previously printed command headers before buffered parallel outputs, making logs look non-sequential.
- Docker optimization should follow the target project configuration, not the runtime used to launch `wb`.

## Testing

- `yarn check-for-ai`
- `yarn workspace @willbooster/wb start --working-dir "$HOME/ghq/github.com/WillBoosterLab/survey-system" test --silent`
- `yarn workspace @willbooster/wb start --working-dir "$HOME/ghq/github.com/WillBoosterLab/survey-system" verify --full`
- `yarn workspace @willbooster/wb start --working-dir "/Users/exkazuu/ghq/github.com/WillBooster/understandability-survey" verify --full` exits 1 after confirming compact/sequential verify output; the remaining failure is Vitest loading Playwright E2E files.
- `bunx @willbooster/agent-skills@latest check-pr-ci`

## Review

- Addressed and resolved all Gemini review threads.
- Latest CI workflows passed.
