### PR TITLE
fix: avoid typeless config warnings in wbfy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .playwright-cli/
 .serena/
 .tmp/
+.wb/
 __generated__/
 @willbooster/
 dist/

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "prepare": "lefthook install || true",
     "release": "yarn multi-semantic-release --debug",
     "test": "CI=1 FORCE_COLOR=3 yarn workspaces foreach --all --verbose run test",
-    "typecheck": "yarn workspaces foreach --all --parallel --verbose run typecheck",
-    "verify-code": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify-code",
-    "verify-code-with-tests": "yarn verify-code && yarn test"
+    "typecheck": "yarn workspaces foreach --all --parallel --verbose run typecheck"
   },
   "devDependencies": {
     "@anolilab/multi-semantic-release": "4.4.1",

--- a/packages/shared-lib-blitz-next/.gitignore
+++ b/packages/shared-lib-blitz-next/.gitignore
@@ -14,6 +14,7 @@
 .playwright-cli/
 .serena/
 .tmp/
+.wb/
 __generated__/
 @willbooster/
 dist/

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -40,9 +40,7 @@
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "vitest",
-    "typecheck": "tsgo --noEmit",
-    "verify-code": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify-code",
-    "verify-code-with-tests": "yarn verify-code && yarn test"
+    "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@tsconfig/node-lts": "24.0.0",

--- a/packages/shared-lib-next/.gitignore
+++ b/packages/shared-lib-next/.gitignore
@@ -14,6 +14,7 @@
 .playwright-cli/
 .serena/
 .tmp/
+.wb/
 __generated__/
 @willbooster/
 dist/

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -40,9 +40,7 @@
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "vitest",
-    "typecheck": "tsgo --noEmit",
-    "verify-code": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify-code",
-    "verify-code-with-tests": "yarn verify-code && yarn test"
+    "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@tsconfig/node-lts": "24.0.0",

--- a/packages/shared-lib-node/.gitignore
+++ b/packages/shared-lib-node/.gitignore
@@ -14,6 +14,7 @@
 .playwright-cli/
 .serena/
 .tmp/
+.wb/
 __generated__/
 @willbooster/
 dist/

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -40,9 +40,7 @@
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "vitest test/",
-    "typecheck": "tsgo --noEmit",
-    "verify-code": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify-code",
-    "verify-code-with-tests": "yarn verify-code && yarn test"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "dotenv": "17.4.2",

--- a/packages/shared-lib-react/.gitignore
+++ b/packages/shared-lib-react/.gitignore
@@ -14,6 +14,7 @@
 .playwright-cli/
 .serena/
 .tmp/
+.wb/
 __generated__/
 @willbooster/
 dist/

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -37,9 +37,7 @@
     "lint-fix": "yarn lint --fix",
     "storybook": "start-storybook -p 6006",
     "test/ci": "yarn build-storybook",
-    "typecheck": "tsgo --noEmit",
-    "verify-code": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify-code",
-    "verify-code-with-tests": "yarn verify-code && yarn test"
+    "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",

--- a/packages/shared-lib/.gitignore
+++ b/packages/shared-lib/.gitignore
@@ -14,6 +14,7 @@
 .playwright-cli/
 .serena/
 .tmp/
+.wb/
 __generated__/
 @willbooster/
 dist/

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -40,9 +40,7 @@
     "lint": "oxlint --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "vitest",
-    "typecheck": "tsgo --noEmit",
-    "verify-code": "yarn workspace @willbooster/wb start --working-dir \"$INIT_CWD\" verify-code",
-    "verify-code-with-tests": "yarn verify-code && yarn test"
+    "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@tsconfig/node-lts": "24.0.0",

--- a/packages/wb/.gitignore
+++ b/packages/wb/.gitignore
@@ -14,6 +14,7 @@
 .playwright-cli/
 .serena/
 .tmp/
+.wb/
 __generated__/
 @willbooster/
 dist/

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import type { PackageJson } from 'type-fest';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
-import { findDescendantProjects, type Project } from '../project.js';
+import { findDescendantProjects } from '../project.js';
 import { packageManager } from '../utils/runtime.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
@@ -47,8 +47,6 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       optimizeDevDependencies(argv, packageJson);
 
       optimizeScripts(packageJson);
-
-      optimizeDockerInstallPrepareScript(argv, project, packageJson);
 
       optimizeRootProps(packageJson);
 
@@ -151,26 +149,6 @@ function optimizeScripts(packageJson: PackageJson): void {
     }
   }
   console.info('Removed scripts:', removedScripts.join(', ') || 'none');
-}
-
-function optimizeDockerInstallPrepareScript(
-  argv: InferredOptionTypes<typeof builder>,
-  project: Project,
-  packageJson: PackageJson
-): void {
-  // The published wb binary may run under Node even when invoked by a Bun project script.
-  // Use the target project instead of the current CLI runtime when deciding Docker install steps.
-  if (!argv.outside || !project.isBunAvailable) return;
-
-  const devDependencyNames = Object.keys(packageJson.devDependencies ?? {});
-  if (devDependencyNames.length === 0) return;
-
-  // Bun validates the lockfile even with --production. This script lets Docker rewrite
-  // the image-local lockfile after --outside pruning, without hard-coding packages in app Dockerfiles.
-  const scripts = packageJson.scripts ?? {};
-  scripts['docker/install/prepare'] = `bun remove ${devDependencyNames.join(' ')}`;
-  packageJson.scripts = scripts;
-  console.info('Added docker/install/prepare script.');
 }
 
 function optimizeRootProps(packageJson: PackageJson): void {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -11,6 +11,8 @@ import { packageManager } from '../utils/runtime.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
 
+// These tools are declared as devDependencies in source repos, but optimized Docker
+// package.json files still need them for in-image codegen/build steps.
 const runtimeDevDependencies = ['@willbooster/wb', 'build-ts'];
 
 const builder = {
@@ -39,6 +41,8 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
         const deps = packageJson[key] ?? {};
         for (const [name, value] of Object.entries(deps)) {
           if (value?.startsWith('git@github.com:')) {
+            // Docker builds cannot access private SSH URLs unless credentials are forwarded.
+            // The Dockerfile copies those workspace packages into the image instead.
             deps[name] = `./${name}`;
           }
         }
@@ -68,10 +72,13 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
 function optimizeDevDependencies(argv: InferredOptionTypes<typeof builder>, packageJson: PackageJson): void {
   promoteRuntimeDevDependencies(packageJson);
   if (argv.outside) {
+    // Outside optimization writes dist/package.json before Docker builds the app.
+    // Keep build-time packages for that later in-image build and remove only known non-build tooling.
     removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson);
     return;
   }
 
+  // Inside Docker, codegen/build has already finished, so production install should not see dev tooling.
   delete packageJson.devDependencies;
   console.info('Removed all devDependencies.');
 }
@@ -103,6 +110,7 @@ function removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson: Pack
   for (const name of Object.keys(devDeps)) {
     if (
       nameWordsToBeRemoved.some((word) => name.includes(word)) ||
+      // Shared config packages are needed only for lint/format/test commands, not Docker builds.
       (name.includes('willbooster') && name.includes('config'))
     ) {
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete

--- a/packages/wbfy/.gitignore
+++ b/packages/wbfy/.gitignore
@@ -14,6 +14,7 @@
 .playwright-cli/
 .serena/
 .tmp/
+.wb/
 __generated__/
 @willbooster/
 dist/

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -8,15 +8,20 @@ import { promisePool } from '../utils/promisePool.js';
 
 export async function generateOxfmtConfig(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxfmtConfig', async () => {
-    const legacyConfigPath = path.resolve(config.dirPath, '.oxfmtrc.json');
+    const legacyJsonConfigPath = path.resolve(config.dirPath, '.oxfmtrc.json');
+    const unusedMtsConfigPath = path.resolve(config.dirPath, 'oxfmt.config.mts');
     const filePath = path.resolve(config.dirPath, 'oxfmt.config.ts');
-    await promisePool.run(() => fs.promises.rm(legacyConfigPath, { force: true }));
-    if (fs.existsSync(filePath)) return;
-    await promisePool.run(() => fsUtil.generateFile(filePath, configContent));
+    await Promise.all([
+      promisePool.run(() => fs.promises.rm(legacyJsonConfigPath, { force: true })),
+      promisePool.run(() => fsUtil.generateFile(filePath, configContent)),
+      // Current oxfmt auto-discovers oxfmt.config.ts but not oxfmt.config.mts.
+      promisePool.run(() => fs.promises.rm(unusedMtsConfigPath, { force: true })),
+    ]);
   });
 }
 
-const configContent = `import config from '@willbooster/oxfmt-config';
+const configContent = `// oxlint-disable unicorn/prefer-module -- Oxfmt only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
+const oxfmtConfig = require('@willbooster/oxfmt-config');
 
-export default config;
+module.exports = oxfmtConfig.default ?? oxfmtConfig;
 `;

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -12,10 +12,13 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
   return logger.functionIgnoringException('generateOxfmtConfig', async () => {
     const legacyJsonConfigPath = path.resolve(config.dirPath, '.oxfmtrc.json');
     const filePath = path.resolve(config.dirPath, 'oxfmt.config.ts');
-    await Promise.all([
-      promisePool.run(() => fs.promises.rm(legacyJsonConfigPath, { force: true })),
-      promisePool.run(() => fsUtil.generateFile(filePath, getConfigContent(config))),
-    ]);
+    const existingContent = await fsUtil.readFileIgnoringError(filePath);
+    const desiredContent = getConfigContent(config);
+    const promises = [promisePool.run(() => fs.promises.rm(legacyJsonConfigPath, { force: true }))];
+    if (normalizeContent(existingContent) !== normalizeContent(desiredContent)) {
+      promises.push(promisePool.run(() => fsUtil.generateFile(filePath, desiredContent)));
+    }
+    await Promise.all(promises);
   });
 }
 
@@ -25,4 +28,8 @@ function getConfigContent(config: PackageConfig): string {
     packageName: '@willbooster/oxfmt-config',
     toolName: 'Oxfmt',
   });
+}
+
+function normalizeContent(content: string | undefined): string | undefined {
+  return content?.trim();
 }

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -13,15 +13,24 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
     const filePath = path.resolve(config.dirPath, 'oxfmt.config.ts');
     await Promise.all([
       promisePool.run(() => fs.promises.rm(legacyJsonConfigPath, { force: true })),
-      promisePool.run(() => fsUtil.generateFile(filePath, configContent)),
+      promisePool.run(() => fsUtil.generateFile(filePath, getConfigContent(config))),
       // Current oxfmt auto-discovers oxfmt.config.ts but not oxfmt.config.mts.
       promisePool.run(() => fs.promises.rm(unusedMtsConfigPath, { force: true })),
     ]);
   });
 }
 
-const configContent = `// oxlint-disable unicorn/prefer-module -- Oxfmt only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
+function getConfigContent(config: PackageConfig): string {
+  if (config.packageJson?.type === 'module') {
+    return `import config from '@willbooster/oxfmt-config';
+
+export default config;
+`;
+  }
+
+  return `// oxlint-disable unicorn/prefer-module -- Oxfmt only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
 const oxfmtConfig = require('@willbooster/oxfmt-config');
 
 module.exports = oxfmtConfig.default ?? oxfmtConfig;
 `;
+}

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -6,7 +6,7 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
-import { generateToolConfigContent } from './toolConfigContent.js';
+import { generateToolConfigContent, normalizeToolConfigContent } from './toolConfigContent.js';
 
 export async function generateOxfmtConfig(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxfmtConfig', async () => {
@@ -15,7 +15,7 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
     const existingContent = await fsUtil.readFileIgnoringError(filePath);
     const desiredContent = getConfigContent(config);
     const promises = [promisePool.run(() => fs.promises.rm(legacyJsonConfigPath, { force: true }))];
-    if (normalizeContent(existingContent) !== normalizeContent(desiredContent)) {
+    if (normalizeToolConfigContent(existingContent) !== normalizeToolConfigContent(desiredContent)) {
       promises.push(promisePool.run(() => fsUtil.generateFile(filePath, desiredContent)));
     }
     await Promise.all(promises);
@@ -28,8 +28,4 @@ function getConfigContent(config: PackageConfig): string {
     packageName: '@willbooster/oxfmt-config',
     toolName: 'Oxfmt',
   });
-}
-
-function normalizeContent(content: string | undefined): string | undefined {
-  return content?.trim();
 }

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -9,13 +9,10 @@ import { promisePool } from '../utils/promisePool.js';
 export async function generateOxfmtConfig(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxfmtConfig', async () => {
     const legacyJsonConfigPath = path.resolve(config.dirPath, '.oxfmtrc.json');
-    const unusedMtsConfigPath = path.resolve(config.dirPath, 'oxfmt.config.mts');
     const filePath = path.resolve(config.dirPath, 'oxfmt.config.ts');
     await Promise.all([
       promisePool.run(() => fs.promises.rm(legacyJsonConfigPath, { force: true })),
       promisePool.run(() => fsUtil.generateFile(filePath, getConfigContent(config))),
-      // Current oxfmt auto-discovers oxfmt.config.ts but not oxfmt.config.mts.
-      promisePool.run(() => fs.promises.rm(unusedMtsConfigPath, { force: true })),
     ]);
   });
 }

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -6,6 +6,8 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
+import { generateToolConfigContent } from './toolConfigContent.js';
+
 export async function generateOxfmtConfig(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxfmtConfig', async () => {
     const legacyJsonConfigPath = path.resolve(config.dirPath, '.oxfmtrc.json');
@@ -18,16 +20,9 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
 }
 
 function getConfigContent(config: PackageConfig): string {
-  if (config.packageJson?.type === 'module') {
-    return `import config from '@willbooster/oxfmt-config';
-
-export default config;
-`;
-  }
-
-  return `// oxlint-disable unicorn/prefer-module -- Oxfmt only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
-const oxfmtConfig = require('@willbooster/oxfmt-config');
-
-module.exports = oxfmtConfig.default ?? oxfmtConfig;
-`;
+  return generateToolConfigContent(config, {
+    commonJsVariableName: 'oxfmtConfig',
+    packageName: '@willbooster/oxfmt-config',
+    toolName: 'Oxfmt',
+  });
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -13,7 +13,12 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
     // must not remove package-provided linter settings.
     const shouldPreservePublishedLinterConfig = isPublishedWillboosterConfigsPackage(config);
     const filePath = path.resolve(config.dirPath, 'oxlint.config.ts');
-    const existingContent = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
+    const unusedMtsConfigPath = path.resolve(config.dirPath, 'oxlint.config.mts');
+    const existingContent = shouldPreservePublishedLinterConfig
+      ? fs.existsSync(filePath)
+        ? fs.readFileSync(filePath, 'utf8')
+        : undefined
+      : undefined;
 
     const promises: Promise<void>[] = [];
     if (!shouldPreservePublishedLinterConfig) {
@@ -33,14 +38,17 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
         promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.ts'), { force: true }))
       );
     }
-    if (!existingContent) {
-      promises.push(promisePool.run(() => fsUtil.generateFile(filePath, configContent)));
-    }
+    promises.push(
+      promisePool.run(() => fsUtil.generateFile(filePath, existingContent ?? configContent)),
+      // Current oxlint auto-discovers oxlint.config.ts but not oxlint.config.mts.
+      promisePool.run(() => fs.promises.rm(unusedMtsConfigPath, { force: true }))
+    );
     await Promise.all(promises);
   });
 }
 
-const configContent = `import config from '@willbooster/oxlint-config';
+const configContent = `// oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
+const oxlintConfig = require('@willbooster/oxlint-config');
 
-export default config;
+module.exports = oxlintConfig.default ?? oxlintConfig;
 `;

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -15,11 +15,9 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
     // must not remove package-provided linter settings.
     const shouldPreservePublishedLinterConfig = isPublishedWillboosterConfigsPackage(config);
     const filePath = path.resolve(config.dirPath, 'oxlint.config.ts');
-    const existingContent = shouldPreservePublishedLinterConfig
-      ? fs.existsSync(filePath)
-        ? fs.readFileSync(filePath, 'utf8')
-        : undefined
-      : undefined;
+    const existingContent = await fsUtil.readFileIgnoringError(filePath);
+    const desiredContent =
+      shouldPreservePublishedLinterConfig && existingContent ? existingContent : getConfigContent(config);
 
     const promises: Promise<void>[] = [];
     if (!shouldPreservePublishedLinterConfig) {
@@ -39,7 +37,9 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
         promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.ts'), { force: true }))
       );
     }
-    promises.push(promisePool.run(() => fsUtil.generateFile(filePath, existingContent ?? getConfigContent(config))));
+    if (normalizeContent(existingContent) !== normalizeContent(desiredContent)) {
+      promises.push(promisePool.run(() => fsUtil.generateFile(filePath, desiredContent)));
+    }
     await Promise.all(promises);
   });
 }
@@ -50,4 +50,8 @@ function getConfigContent(config: PackageConfig): string {
     packageName: '@willbooster/oxlint-config',
     toolName: 'Oxlint',
   });
+}
+
+function normalizeContent(content: string | undefined): string | undefined {
+  return content?.trim();
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -13,7 +13,6 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
     // must not remove package-provided linter settings.
     const shouldPreservePublishedLinterConfig = isPublishedWillboosterConfigsPackage(config);
     const filePath = path.resolve(config.dirPath, 'oxlint.config.ts');
-    const unusedMtsConfigPath = path.resolve(config.dirPath, 'oxlint.config.mts');
     const existingContent = shouldPreservePublishedLinterConfig
       ? fs.existsSync(filePath)
         ? fs.readFileSync(filePath, 'utf8')
@@ -38,11 +37,7 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
         promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.ts'), { force: true }))
       );
     }
-    promises.push(
-      promisePool.run(() => fsUtil.generateFile(filePath, existingContent ?? getConfigContent(config))),
-      // Current oxlint auto-discovers oxlint.config.ts but not oxlint.config.mts.
-      promisePool.run(() => fs.promises.rm(unusedMtsConfigPath, { force: true }))
-    );
+    promises.push(promisePool.run(() => fsUtil.generateFile(filePath, existingContent ?? getConfigContent(config))));
     await Promise.all(promises);
   });
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -7,6 +7,8 @@ import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfigsUtil.js';
 
+import { generateToolConfigContent } from './toolConfigContent.js';
+
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
     // willbooster-configs publishes config files as product code, so migration
@@ -43,16 +45,9 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
 }
 
 function getConfigContent(config: PackageConfig): string {
-  if (config.packageJson?.type === 'module') {
-    return `import config from '@willbooster/oxlint-config';
-
-export default config;
-`;
-  }
-
-  return `// oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
-const oxlintConfig = require('@willbooster/oxlint-config');
-
-module.exports = oxlintConfig.default ?? oxlintConfig;
-`;
+  return generateToolConfigContent(config, {
+    commonJsVariableName: 'oxlintConfig',
+    packageName: '@willbooster/oxlint-config',
+    toolName: 'Oxlint',
+  });
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -7,7 +7,7 @@ import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfigsUtil.js';
 
-import { generateToolConfigContent } from './toolConfigContent.js';
+import { generateToolConfigContent, normalizeToolConfigContent } from './toolConfigContent.js';
 
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
@@ -37,7 +37,7 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
         promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.ts'), { force: true }))
       );
     }
-    if (normalizeContent(existingContent) !== normalizeContent(desiredContent)) {
+    if (normalizeToolConfigContent(existingContent) !== normalizeToolConfigContent(desiredContent)) {
       promises.push(promisePool.run(() => fsUtil.generateFile(filePath, desiredContent)));
     }
     await Promise.all(promises);
@@ -50,8 +50,4 @@ function getConfigContent(config: PackageConfig): string {
     packageName: '@willbooster/oxlint-config',
     toolName: 'Oxlint',
   });
-}
-
-function normalizeContent(content: string | undefined): string | undefined {
-  return content?.trim();
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -39,7 +39,7 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
       );
     }
     promises.push(
-      promisePool.run(() => fsUtil.generateFile(filePath, existingContent ?? configContent)),
+      promisePool.run(() => fsUtil.generateFile(filePath, existingContent ?? getConfigContent(config))),
       // Current oxlint auto-discovers oxlint.config.ts but not oxlint.config.mts.
       promisePool.run(() => fs.promises.rm(unusedMtsConfigPath, { force: true }))
     );
@@ -47,8 +47,17 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
   });
 }
 
-const configContent = `// oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
+function getConfigContent(config: PackageConfig): string {
+  if (config.packageJson?.type === 'module') {
+    return `import config from '@willbooster/oxlint-config';
+
+export default config;
+`;
+  }
+
+  return `// oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
 const oxlintConfig = require('@willbooster/oxlint-config');
 
 module.exports = oxlintConfig.default ?? oxlintConfig;
 `;
+}

--- a/packages/wbfy/src/generators/toolConfigContent.ts
+++ b/packages/wbfy/src/generators/toolConfigContent.ts
@@ -7,7 +7,7 @@ interface ToolConfigContentOptions {
 }
 
 export function generateToolConfigContent(config: PackageConfig, options: ToolConfigContentOptions): string {
-  if (config.packageJson?.type === 'module') {
+  if (config.isEsmPackage) {
     return `import config from '${options.packageName}';
 
 export default config;
@@ -19,4 +19,8 @@ const ${options.commonJsVariableName} = require('${options.packageName}');
 
 module.exports = ${options.commonJsVariableName}.default ?? ${options.commonJsVariableName};
 `;
+}
+
+export function normalizeToolConfigContent(content: string | undefined): string | undefined {
+  return content?.trim();
 }

--- a/packages/wbfy/src/generators/toolConfigContent.ts
+++ b/packages/wbfy/src/generators/toolConfigContent.ts
@@ -1,0 +1,22 @@
+import type { PackageConfig } from '../packageConfig.js';
+
+interface ToolConfigContentOptions {
+  commonJsVariableName: string;
+  packageName: string;
+  toolName: string;
+}
+
+export function generateToolConfigContent(config: PackageConfig, options: ToolConfigContentOptions): string {
+  if (config.packageJson?.type === 'module') {
+    return `import config from '${options.packageName}';
+
+export default config;
+`;
+  }
+
+  return `// oxlint-disable unicorn/prefer-module -- ${options.toolName} only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
+const ${options.commonJsVariableName} = require('${options.packageName}');
+
+module.exports = ${options.commonJsVariableName}.default ?? ${options.commonJsVariableName};
+`;
+}


### PR DESCRIPTION
## Summary

- update wbfy-generated oxlint and oxfmt config content so typeless/CommonJS packages avoid Node's typeless ESM reparsing warning while module packages keep ESM config files
- keep no-flag `oxlint .` / `oxfmt .` auto-discovery by continuing to generate `*.config.ts`
- avoid redundant generated config writes by reading existing files asynchronously and only writing when content changes
- apply current wbfy output to this repository, including `.wb/` ignores and removal of deprecated `verify-code*` scripts

## Why

- Current oxlint/oxfmt auto-discover `*.config.ts`, but not `*.config.mts`, so `.mts` cannot satisfy the no-`-c` command requirement.
- Typeless packages using ESM syntax in `.ts` configs trigger Node's `MODULE_TYPELESS_PACKAGE_JSON` warning.
- Packages with `"type": "module"` must still receive ESM config content because CommonJS `require` is unavailable there.

## Testing

- Ran `yarn start /Users/exkazuu/ghq/github.com/WillBooster/shared` from `packages/wbfy`.
- Ran `yarn start /Users/exkazuu/ghq/github.com/WillBooster/understandability-survey` from `packages/wbfy`.
- Ran `yarn check-for-ai` in `shared`.
- Ran `yarn check-for-ai` in `understandability-survey`.
- Ran `NODE_OPTIONS="--trace-warnings" yarn oxlint --no-error-on-unmatched-pattern .` in `understandability-survey`.
- Verified PR CI passes.

## Notes

- `shared` still has pre-existing `@willbooster/wbfy` `unicorn/no-null` warnings in `test/packageJsonGenerator.test.ts`.
- `understandability-survey` still prints Prisma's package.json config deprecation warning during `check-for-ai`; oxlint finishes cleanly.
