### PR TITLE
fix: improve wb test command

### DIFF
--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -243,7 +243,7 @@ function getDefaultUnitTargets(project: Project): string[] | false {
     return [];
   }
   if (project.hasVitest && fs.existsSync(path.join(project.dirPath, 'test'))) {
-    return ['test'];
+    return fs.existsSync(path.join(project.dirPath, 'test', 'e2e')) ? ['test', '--exclude', 'test/e2e/**'] : ['test'];
   }
   return false;
 }

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -98,7 +98,7 @@ export abstract class BaseScripts {
       : project.hasDrizzle
         ? drizzleScripts.migrate(project)
         : '';
-    return [...migrationCommand.split('&&'), ...commands]
+    return [...(migrationCommand ? migrationCommand.split('&&') : []), ...commands]
       .filter(Boolean)
       .map((cmd) => `${cmd} ${toDevNull(argv)}`.trim())
       .join(' && ');

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -6,6 +6,7 @@ import { buildShellCommand, buildShellEnvironmentAssignment } from '../../utils/
 import type { ScriptArgv } from '../builder.js';
 import { toDevNull } from '../builder.js';
 import { dockerScripts } from '../dockerScripts.js';
+import { drizzleScripts } from '../drizzleScripts.js';
 import { prismaScripts } from '../prismaScripts.js';
 
 export interface TestE2EOptions {
@@ -88,11 +89,16 @@ export abstract class BaseScripts {
       ecosystemConfigPath === undefined
         ? [
             `YARN wb buildIfNeeded ${argv.verbose ? '--verbose' : ''}`.trim(),
-            `node dist/index.js ${argv.normalizedArgsText ?? ''}`.trim(),
+            `${project.isBunAvailable ? 'BUN' : 'node'} dist/index.js ${argv.normalizedArgsText ?? ''}`.trim(),
           ]
         : [project.buildCommand, `pm2-runtime start --no-autorestart ${ecosystemConfigPath}`];
 
-    return [...(project.hasPrisma ? prismaScripts.migrate(project).split('&&') : []), ...commands]
+    const migrationCommand = project.hasPrisma
+      ? prismaScripts.migrate(project)
+      : project.hasDrizzle
+        ? drizzleScripts.migrate(project)
+        : '';
+    return [...migrationCommand.split('&&'), ...commands]
       .filter(Boolean)
       .map((cmd) => `${cmd} ${toDevNull(argv)}`.trim())
       .join(' && ');

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -93,12 +93,11 @@ export abstract class BaseScripts {
           ]
         : [project.buildCommand, `pm2-runtime start --no-autorestart ${ecosystemConfigPath}`];
 
-    const migrationCommand = project.hasPrisma
-      ? prismaScripts.migrate(project)
-      : project.hasDrizzle
-        ? drizzleScripts.migrate(project)
-        : '';
-    return [...(migrationCommand ? migrationCommand.split('&&') : []), ...commands]
+    const migrationCommands = [
+      ...(project.hasPrisma ? [prismaScripts.migrate(project)] : []),
+      ...(project.hasDrizzle ? [drizzleScripts.migrate(project)] : []),
+    ];
+    return [...migrationCommands.flatMap((cmd) => cmd.split('&&')), ...commands]
       .filter(Boolean)
       .map((cmd) => `${cmd} ${toDevNull(argv)}`.trim())
       .join(' && ');

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -89,7 +89,7 @@ export abstract class BaseScripts {
       ecosystemConfigPath === undefined
         ? [
             `YARN wb buildIfNeeded ${argv.verbose ? '--verbose' : ''}`.trim(),
-            `${project.isBunAvailable ? 'BUN' : 'node'} dist/index.js ${argv.normalizedArgsText ?? ''}`.trim(),
+            `${project.isBunAvailable ? 'bun' : 'node'} dist/index.js ${argv.normalizedArgsText ?? ''}`.trim(),
           ]
         : [project.buildCommand, `pm2-runtime start --no-autorestart ${ecosystemConfigPath}`];
 

--- a/packages/wb/src/scripts/execution/httpServerScripts.ts
+++ b/packages/wb/src/scripts/execution/httpServerScripts.ts
@@ -33,18 +33,20 @@ class HttpServerScripts extends BaseScripts {
     const port = await checkAndKillPortProcess(project.env.PORT, project);
     const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
     const targets = argv.targets?.map(String);
+    const normalizedTargets = targets && targets.length > 0 ? targets : ['test/e2e/'];
     const testCommand = project.hasVitest
       ? buildShellCommand([
           'vitest',
           'run',
-          ...(targets && targets.length > 0 ? targets : ['test/e2e/']),
+          ...normalizedTargets,
           '--color',
           '--passWithNoTests',
           '--allowOnly',
           ...(argv.bail ? ['--bail=1'] : []),
         ])
       : project.isBunAvailable
-        ? buildShellCommand(['bun', 'test', ...(targets && targets.length > 0 ? targets : ['test/e2e/'])])
+        ? // Use literal `bun test`; the `BUN` placeholder normalizes to `bun --bun run` and may recurse into a `test` package script.
+          buildShellCommand(['bun', 'test', ...normalizedTargets])
         : 'echo "No tests."';
     return buildShellCommand([
       'YARN',

--- a/packages/wb/src/scripts/execution/httpServerScripts.ts
+++ b/packages/wb/src/scripts/execution/httpServerScripts.ts
@@ -34,20 +34,7 @@ class HttpServerScripts extends BaseScripts {
     const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
     const targets = argv.targets?.map(String);
     const normalizedTargets = targets && targets.length > 0 ? targets : ['test/e2e/'];
-    const testCommand = project.hasVitest
-      ? buildShellCommand([
-          'vitest',
-          'run',
-          ...normalizedTargets,
-          '--color',
-          '--passWithNoTests',
-          '--allowOnly',
-          ...(argv.bail ? ['--bail=1'] : []),
-        ])
-      : project.isBunAvailable
-        ? // Use literal `bun test`; the `BUN` placeholder normalizes to `bun --bun run` and may recurse into a `test` package script.
-          buildShellCommand(['bun', 'test', ...normalizedTargets, ...(argv.bail ? ['--bail'] : [])])
-        : 'echo "No tests."';
+    const testCommand = this.buildFallbackTestCommand(project, argv, normalizedTargets);
     return buildShellCommand([
       'YARN',
       'wb',
@@ -59,6 +46,25 @@ class HttpServerScripts extends BaseScripts {
       `${startCommand} && exit 1`,
       `wait-on -t 600000 -i 2000 http-get://127.0.0.1:${port} && ${testCommand}${suffix}`,
     ]);
+  }
+
+  private buildFallbackTestCommand(project: Project, argv: TestArgv, targets: string[]): string {
+    if (project.hasVitest) {
+      return buildShellCommand([
+        'vitest',
+        'run',
+        ...targets,
+        '--color',
+        '--passWithNoTests',
+        '--allowOnly',
+        ...(argv.bail ? ['--bail=1'] : []),
+      ]);
+    }
+    if (project.isBunAvailable) {
+      // Use literal `bun test`; the `BUN` placeholder normalizes to `bun --bun run` and may recurse into a `test` package script.
+      return buildShellCommand(['bun', 'test', ...targets, ...(argv.bail ? ['--bail'] : [])]);
+    }
+    return 'echo "No tests."';
   }
 }
 

--- a/packages/wb/src/scripts/execution/httpServerScripts.ts
+++ b/packages/wb/src/scripts/execution/httpServerScripts.ts
@@ -34,7 +34,7 @@ class HttpServerScripts extends BaseScripts {
     const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
     const targets = argv.targets?.map(String);
     const normalizedTargets = targets?.length ? targets : ['test/e2e/'];
-    const testCommand = this.buildFallbackTestCommand(project, argv, normalizedTargets);
+    const testCommand = this.testUnit(project, { ...argv, targets: normalizedTargets });
     return buildShellCommand([
       'YARN',
       'wb',
@@ -46,25 +46,6 @@ class HttpServerScripts extends BaseScripts {
       `${startCommand} && exit 1`,
       `wait-on -t 600000 -i 2000 http-get://127.0.0.1:${port} && ${testCommand}${suffix}`,
     ]);
-  }
-
-  private buildFallbackTestCommand(project: Project, argv: TestArgv, targets: string[]): string {
-    if (project.hasVitest) {
-      return buildShellCommand([
-        'vitest',
-        'run',
-        ...targets,
-        '--color',
-        '--passWithNoTests',
-        '--allowOnly',
-        ...(argv.bail ? ['--bail=1'] : []),
-      ]);
-    }
-    if (project.isBunAvailable) {
-      // Use literal `bun test`; the `BUN` placeholder normalizes to `bun --bun run` and may recurse into a `test` package script.
-      return buildShellCommand(['bun', 'test', ...targets, ...(argv.bail ? ['--bail'] : [])]);
-    }
-    return 'echo "No tests."';
   }
 }
 

--- a/packages/wb/src/scripts/execution/httpServerScripts.ts
+++ b/packages/wb/src/scripts/execution/httpServerScripts.ts
@@ -33,7 +33,7 @@ class HttpServerScripts extends BaseScripts {
     const port = await checkAndKillPortProcess(project.env.PORT, project);
     const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
     const targets = argv.targets?.map(String);
-    const normalizedTargets = targets && targets.length > 0 ? targets : ['test/e2e/'];
+    const normalizedTargets = targets?.length ? targets : ['test/e2e/'];
     const testCommand = this.buildFallbackTestCommand(project, argv, normalizedTargets);
     return buildShellCommand([
       'YARN',

--- a/packages/wb/src/scripts/execution/httpServerScripts.ts
+++ b/packages/wb/src/scripts/execution/httpServerScripts.ts
@@ -46,7 +46,7 @@ class HttpServerScripts extends BaseScripts {
         ])
       : project.isBunAvailable
         ? // Use literal `bun test`; the `BUN` placeholder normalizes to `bun --bun run` and may recurse into a `test` package script.
-          buildShellCommand(['bun', 'test', ...normalizedTargets])
+          buildShellCommand(['bun', 'test', ...normalizedTargets, ...(argv.bail ? ['--bail'] : [])])
         : 'echo "No tests."';
     return buildShellCommand([
       'YARN',

--- a/packages/wb/src/scripts/execution/httpServerScripts.ts
+++ b/packages/wb/src/scripts/execution/httpServerScripts.ts
@@ -33,6 +33,19 @@ class HttpServerScripts extends BaseScripts {
     const port = await checkAndKillPortProcess(project.env.PORT, project);
     const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
     const targets = argv.targets?.map(String);
+    const testCommand = project.hasVitest
+      ? buildShellCommand([
+          'vitest',
+          'run',
+          ...(targets && targets.length > 0 ? targets : ['test/e2e/']),
+          '--color',
+          '--passWithNoTests',
+          '--allowOnly',
+          ...(argv.bail ? ['--bail=1'] : []),
+        ])
+      : project.isBunAvailable
+        ? buildShellCommand(['bun', 'test', ...(targets && targets.length > 0 ? targets : ['test/e2e/'])])
+        : 'echo "No tests."';
     return buildShellCommand([
       'YARN',
       'wb',
@@ -42,16 +55,7 @@ class HttpServerScripts extends BaseScripts {
       '--success',
       'first',
       `${startCommand} && exit 1`,
-      `wait-on -t 600000 -i 2000 http-get://127.0.0.1:${port}
-        && ${buildShellCommand([
-          'vitest',
-          'run',
-          ...(targets && targets.length > 0 ? targets : ['test/e2e/']),
-          '--color',
-          '--passWithNoTests',
-          '--allowOnly',
-          ...(argv.bail ? ['--bail=1'] : []),
-        ])}${suffix}`,
+      `wait-on -t 600000 -i 2000 http-get://127.0.0.1:${port} && ${testCommand}${suffix}`,
     ]);
   }
 }

--- a/packages/wb/test/scripts/execution/httpServerScripts.test.ts
+++ b/packages/wb/test/scripts/execution/httpServerScripts.test.ts
@@ -76,6 +76,7 @@ describe('HttpServerScripts.testE2E', () => {
         'first',
         'YARN wb buildIfNeeded && node dist/index.js && exit 1',
         `wait-on -t 600000 -i 2000 http-get://127.0.0.1:3000 && ${buildShellCommand([
+          'YARN',
           'vitest',
           'run',
           `test/e2e/quo'te.spec.ts`,
@@ -83,6 +84,7 @@ describe('HttpServerScripts.testE2E', () => {
           '--color',
           '--passWithNoTests',
           '--allowOnly',
+          '--watch=false',
         ])}`,
       ])
     );

--- a/packages/wb/test/scripts/execution/httpServerScripts.test.ts
+++ b/packages/wb/test/scripts/execution/httpServerScripts.test.ts
@@ -18,6 +18,7 @@ describe('HttpServerScripts.testE2E', () => {
       env: { WB_ENV: 'test', PORT: '3000' },
       packageJson: { scripts: {} },
       hasPlaywrightConfig: false,
+      hasVitest: true,
       hasPrisma: false,
       buildCommand: 'echo "no build"',
       findFile: vi.fn().mockImplementation(() => {
@@ -51,6 +52,7 @@ describe('HttpServerScripts.testE2E', () => {
       env: { WB_ENV: 'test', PORT: '3000' },
       packageJson: { scripts: {} },
       hasPlaywrightConfig: false,
+      hasVitest: true,
       hasPrisma: false,
       buildCommand: 'echo "no build"',
       findFile: vi.fn().mockImplementation(() => {
@@ -73,8 +75,7 @@ describe('HttpServerScripts.testE2E', () => {
         '--success',
         'first',
         'YARN wb buildIfNeeded && node dist/index.js && exit 1',
-        `wait-on -t 600000 -i 2000 http-get://127.0.0.1:3000
-        && ${buildShellCommand([
+        `wait-on -t 600000 -i 2000 http-get://127.0.0.1:3000 && ${buildShellCommand([
           'vitest',
           'run',
           `test/e2e/quo'te.spec.ts`,


### PR DESCRIPTION
## Summary

- Exclude `test/e2e/**` from default Vitest unit runs so Playwright specs are not collected by Vitest when `wb test` runs all tests.
- Run fallback HTTP-server E2E tests with `bun test` for Bun projects that do not have a Playwright config.
- Start Bun projects with Bun in production-style test startup and run Drizzle migrations before startup, matching the existing Prisma migration behavior.

## Why

Cross-repo `wb test` debugging exposed target-project runtime gaps. Bun HTTP-server projects could be started or tested through Node/Vitest, and Drizzle-backed projects could reach E2E before their schema existed. Repos with only E2E tests plus Vitest could also have Playwright tests collected as unit tests.

## Testing

- Ran `wb test` via local `@willbooster/wb` source across repos listed in `/Users/exkazuu/ghq/github.com/WillBooster/self-host-utils/scripts/process-repos.sh`.
- Reran `moti-ai` after fixes: `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBooster/moti-ai test --silent` passed.
- Reran `understandability-survey`; it now reaches Playwright tests instead of failing during Vitest collection. Remaining failures are app/test behavior in Playwright.
- `yarn workspace @willbooster/wb build`
- `yarn workspace @willbooster/wb test`
- `yarn check-for-ai`

## Notes

Several repos in the process list were not cloned locally. Other failures from the initial scan were repo-local setup or dependency issues, such as missing installs, missing environment variables, or existing test failures.
