### PR TITLE
fix: respect bun projects in wb test

### DIFF
--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -95,6 +95,9 @@ export async function test(argv: TestCommandArgv): Promise<void> {
   }
 
   process.env.FORCE_COLOR ||= '3';
+  if (process.env.FORCE_COLOR) {
+    delete process.env.NO_COLOR;
+  }
   process.env.WB_ENV ||= 'test';
 
   // Get test targets from positional arguments

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -95,9 +95,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
   }
 
   process.env.FORCE_COLOR ||= '3';
-  if (process.env.FORCE_COLOR) {
-    delete process.env.NO_COLOR;
-  }
+  delete process.env.NO_COLOR;
   process.env.WB_ENV ||= 'test';
 
   // Get test targets from positional arguments

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -160,9 +160,10 @@ export function normalizeScript(script: string, project: Project): { printable: 
       project.packageJson.dependencies?.blitz ? 'PRISMA generate ' : 'PRISMA generate --no-hints '
     )
     .replaceAll('PRISMA ', project.packageJson.dependencies?.blitz ? 'YARN blitz prisma ' : 'YARN prisma ')
-    .replaceAll('BUN ', project.isBunAvailable ? 'bun --bun run ' : 'YARN ')
+    .replaceAll('BUN run ', project.isBunAvailable ? `${projectPackageManagerWithRun} ` : 'YARN run ')
+    .replaceAll('BUN ', project.isBunAvailable ? `${projectPackageManagerWithRun} ` : 'YARN ')
     // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`.
-    .replaceAll('YARN run ', project.isBunAvailable ? 'bun --bun run ' : 'yarn run ');
+    .replaceAll('YARN run ', project.isBunAvailable ? `${projectPackageManagerWithRun} ` : 'yarn run ');
   if (project.isBunAvailable) {
     newScript = newScript
       .replaceAll('YARN build-ts run', 'bun --bun run')

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -162,7 +162,7 @@ export function normalizeScript(script: string, project: Project): { printable: 
     .replaceAll('PRISMA ', project.packageJson.dependencies?.blitz ? 'YARN blitz prisma ' : 'YARN prisma ')
     .replaceAll('BUN ', project.isBunAvailable ? 'bun --bun run ' : 'YARN ')
     // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`.
-    .replaceAll('YARN run ', `${projectPackageManagerWithRun}${project.isBunAvailable ? '' : ' run'} `);
+    .replaceAll('YARN run ', project.isBunAvailable ? 'bun --bun run ' : 'yarn run ');
   if (project.isBunAvailable) {
     newScript = newScript
       .replaceAll('YARN build-ts run', 'bun --bun run')

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -5,7 +5,7 @@ import type { ArgumentsCamelCase, InferredOptionTypes } from 'yargs';
 import type { Project } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { promisePool } from '../utils/promisePool.js';
-import { isRunningOnBun, packageManagerWithRun } from '../utils/runtime.js';
+import { packageManagerWithRun } from '../utils/runtime.js';
 
 interface Options {
   ci?: boolean;
@@ -152,6 +152,7 @@ export function runWithSpawnInParallelBuffered(
  * Replace capitalized commands (e.g., YARN, PRISMA, BUN) with suitable commands.
  */
 export function normalizeScript(script: string, project: Project): { printable: string; runnable: string } {
+  const projectPackageManagerWithRun = project.isBunAvailable ? 'bun --bun run' : 'yarn';
   let newScript = script
     .replaceAll('\n', '')
     .replaceAll(/\s\s+/g, ' ')
@@ -161,9 +162,9 @@ export function normalizeScript(script: string, project: Project): { printable: 
     )
     .replaceAll('PRISMA ', project.packageJson.dependencies?.blitz ? 'YARN blitz prisma ' : 'YARN prisma ')
     .replaceAll('BUN ', project.isBunAvailable ? 'bun --bun run ' : 'YARN ')
-    // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`
-    .replaceAll('YARN run ', isRunningOnBun ? 'bun --bun run ' : 'yarn run ');
-  if (isRunningOnBun) {
+    // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`.
+    .replaceAll('YARN run ', `${projectPackageManagerWithRun} `);
+  if (project.isBunAvailable) {
     newScript = newScript
       .replaceAll('YARN build-ts run', 'bun --bun run')
       .replaceAll('bun --bun run bun --bun run', 'bun --bun run')
@@ -174,17 +175,17 @@ export function normalizeScript(script: string, project: Project): { printable: 
       .replaceAll(/ --color --passWithNoTests(?: --allowOnly)?/g, '');
   }
   newScript = newScript.trim();
-  const printableScript = fixBunCommand(newScript.replaceAll('YARN ', `${packageManagerWithRun} `));
+  const printableScript = fixBunCommand(newScript.replaceAll('YARN ', `${projectPackageManagerWithRun} `));
   const runnableScript = fixBunCommand(
     newScript
       // Because we need to use `yarn playwright` in a project depending on `artillery-engine-playwright`.
       .replaceAll('YARN playwright ', `${packageManagerWithRun} playwright `)
-      .replaceAll('YARN ', !isRunningOnBun && project.binExists ? '' : `${packageManagerWithRun} `)
+      .replaceAll('YARN ', !project.isBunAvailable && project.binExists ? '' : `${projectPackageManagerWithRun} `)
   );
   // Add cascade option when WB_ENV is defined
   const cascadeOption = project.env.WB_ENV ? ` -c=${project.env.WB_ENV || 'development'}` : '';
   return {
-    printable: `${packageManagerWithRun} dotenv${cascadeOption} -- ${printableScript}`,
+    printable: `${projectPackageManagerWithRun} dotenv${cascadeOption} -- ${printableScript}`,
     runnable: runnableScript,
   };
 }

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -5,7 +5,6 @@ import type { ArgumentsCamelCase, InferredOptionTypes } from 'yargs';
 import type { Project } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { promisePool } from '../utils/promisePool.js';
-import { packageManagerWithRun } from '../utils/runtime.js';
 
 interface Options {
   ci?: boolean;
@@ -163,7 +162,7 @@ export function normalizeScript(script: string, project: Project): { printable: 
     .replaceAll('PRISMA ', project.packageJson.dependencies?.blitz ? 'YARN blitz prisma ' : 'YARN prisma ')
     .replaceAll('BUN ', project.isBunAvailable ? 'bun --bun run ' : 'YARN ')
     // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`.
-    .replaceAll('YARN run ', `${projectPackageManagerWithRun} `);
+    .replaceAll('YARN run ', `${projectPackageManagerWithRun}${project.isBunAvailable ? '' : ' run'} `);
   if (project.isBunAvailable) {
     newScript = newScript
       .replaceAll('YARN build-ts run', 'bun --bun run')
@@ -178,8 +177,8 @@ export function normalizeScript(script: string, project: Project): { printable: 
   const printableScript = fixBunCommand(newScript.replaceAll('YARN ', `${projectPackageManagerWithRun} `));
   const runnableScript = fixBunCommand(
     newScript
-      // Because we need to use `yarn playwright` in a project depending on `artillery-engine-playwright`.
-      .replaceAll('YARN playwright ', `${packageManagerWithRun} playwright `)
+      // Keep Playwright as a package-manager command instead of resolving it through node_modules/.bin.
+      .replaceAll('YARN playwright ', `${projectPackageManagerWithRun} playwright `)
       .replaceAll('YARN ', !project.isBunAvailable && project.binExists ? '' : `${projectPackageManagerWithRun} `)
   );
   // Add cascade option when WB_ENV is defined


### PR DESCRIPTION
## Summary

- Resolve `YARN` and `BUN` placeholders using the target project package manager instead of the runtime that launched `wb`.
- Keep Bun-project `wb test` e2e startup commands on `bun --bun run`, including nested `wb concurrently`, migrations, `buildIfNeeded`, and Playwright commands.
- Preserve `yarn run` behavior for Yarn projects and avoid generating `bun --bun run run ...` for `BUN run ...` inputs.
- Remove inherited `NO_COLOR` when `wb test` forces color output, avoiding repeated runtime warnings in test logs.

## Why

Running the local `wb test` implementation across repositories from `self-host-utils/scripts/process-repos.sh` exposed `moti-ai` failing before its tests could run because the generated e2e command called `yarn wb ...` in a Bun project where mise had no Yarn version configured. The placeholder normalization should follow the target project, not the process used to launch `wb`.

## Testing

- `yarn workspace @willbooster/wb build`
- Cross-repo sweep with local `packages/wb/bin/index.js test` over repos listed in `/Users/exkazuu/ghq/github.com/WillBooster/self-host-utils/scripts/process-repos.sh`, excluding `ai-game-builder`
- Reran `moti-ai` after the fix; the original Yarn shim failure disappeared and the command reached app e2e assertions using Bun commands
- `yarn check-for-ai`
- `bunx @willbooster/agent-skills@latest check-pr-ci`

## Notes

Other sweep failures were target repo state or app test failures, including missing checkouts, missing installs, missing environment variables, and app-level assertion failures. Review feedback has been addressed and unresolved review threads are clear.
