### PR TITLE
fix: preserve package manager for wb test

### DIFF
--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -95,6 +95,9 @@ export async function test(argv: TestCommandArgv): Promise<void> {
   }
 
   process.env.FORCE_COLOR ||= '3';
+  if (process.env.FORCE_COLOR) {
+    delete process.env.NO_COLOR;
+  }
   process.env.WB_ENV ||= 'test';
 
   // Get test targets from positional arguments

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -95,9 +95,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
   }
 
   process.env.FORCE_COLOR ||= '3';
-  if (process.env.FORCE_COLOR) {
-    delete process.env.NO_COLOR;
-  }
+  delete process.env.NO_COLOR;
   process.env.WB_ENV ||= 'test';
 
   // Get test targets from positional arguments

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -27,6 +27,11 @@ export class Project {
   @memoizeOne
   get isBunAvailable(): boolean {
     if (this.hasBunToolVersion()) return true;
+    return this.usesBunPackageManager;
+  }
+
+  @memoizeOne
+  get usesBunPackageManager(): boolean {
     if (this.hasBunLockfile()) return true;
     return this.hasBunPackageManager();
   }

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -160,9 +160,10 @@ export function normalizeScript(script: string, project: Project): { printable: 
       project.packageJson.dependencies?.blitz ? 'PRISMA generate ' : 'PRISMA generate --no-hints '
     )
     .replaceAll('PRISMA ', project.packageJson.dependencies?.blitz ? 'YARN blitz prisma ' : 'YARN prisma ')
-    .replaceAll('BUN ', project.isBunAvailable ? 'bun --bun run ' : 'YARN ')
+    .replaceAll('BUN run ', project.isBunAvailable ? `${projectPackageManagerWithRun} ` : 'YARN run ')
+    .replaceAll('BUN ', project.isBunAvailable ? `${projectPackageManagerWithRun} ` : 'YARN ')
     // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`.
-    .replaceAll('YARN run ', project.isBunAvailable ? 'bun --bun run ' : 'yarn run ');
+    .replaceAll('YARN run ', project.isBunAvailable ? `${projectPackageManagerWithRun} ` : 'yarn run ');
   if (project.isBunAvailable) {
     newScript = newScript
       .replaceAll('YARN build-ts run', 'bun --bun run')

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -162,7 +162,7 @@ export function normalizeScript(script: string, project: Project): { printable: 
     .replaceAll('PRISMA ', project.packageJson.dependencies?.blitz ? 'YARN blitz prisma ' : 'YARN prisma ')
     .replaceAll('BUN ', project.isBunAvailable ? 'bun --bun run ' : 'YARN ')
     // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`.
-    .replaceAll('YARN run ', `${projectPackageManagerWithRun}${project.isBunAvailable ? '' : ' run'} `);
+    .replaceAll('YARN run ', project.isBunAvailable ? 'bun --bun run ' : 'yarn run ');
   if (project.isBunAvailable) {
     newScript = newScript
       .replaceAll('YARN build-ts run', 'bun --bun run')

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -5,7 +5,7 @@ import type { ArgumentsCamelCase, InferredOptionTypes } from 'yargs';
 import type { Project } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { promisePool } from '../utils/promisePool.js';
-import { isRunningOnBun, packageManagerWithRun } from '../utils/runtime.js';
+import { packageManagerWithRun } from '../utils/runtime.js';
 
 interface Options {
   ci?: boolean;
@@ -152,6 +152,7 @@ export function runWithSpawnInParallelBuffered(
  * Replace capitalized commands (e.g., YARN, PRISMA, BUN) with suitable commands.
  */
 export function normalizeScript(script: string, project: Project): { printable: string; runnable: string } {
+  const projectPackageManagerWithRun = project.isBunAvailable ? 'bun --bun run' : 'yarn';
   let newScript = script
     .replaceAll('\n', '')
     .replaceAll(/\s\s+/g, ' ')
@@ -161,9 +162,9 @@ export function normalizeScript(script: string, project: Project): { printable: 
     )
     .replaceAll('PRISMA ', project.packageJson.dependencies?.blitz ? 'YARN blitz prisma ' : 'YARN prisma ')
     .replaceAll('BUN ', project.isBunAvailable ? 'bun --bun run ' : 'YARN ')
-    // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`
-    .replaceAll('YARN run ', isRunningOnBun ? 'bun --bun run ' : 'yarn run ');
-  if (isRunningOnBun) {
+    // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`.
+    .replaceAll('YARN run ', `${projectPackageManagerWithRun} `);
+  if (project.isBunAvailable) {
     newScript = newScript
       .replaceAll('YARN build-ts run', 'bun --bun run')
       .replaceAll('bun --bun run bun --bun run', 'bun --bun run')
@@ -174,17 +175,17 @@ export function normalizeScript(script: string, project: Project): { printable: 
       .replaceAll(/ --color --passWithNoTests(?: --allowOnly)?/g, '');
   }
   newScript = newScript.trim();
-  const printableScript = fixBunCommand(newScript.replaceAll('YARN ', `${packageManagerWithRun} `));
+  const printableScript = fixBunCommand(newScript.replaceAll('YARN ', `${projectPackageManagerWithRun} `));
   const runnableScript = fixBunCommand(
     newScript
       // Because we need to use `yarn playwright` in a project depending on `artillery-engine-playwright`.
       .replaceAll('YARN playwright ', `${packageManagerWithRun} playwright `)
-      .replaceAll('YARN ', !isRunningOnBun && project.binExists ? '' : `${packageManagerWithRun} `)
+      .replaceAll('YARN ', !project.isBunAvailable && project.binExists ? '' : `${projectPackageManagerWithRun} `)
   );
   // Add cascade option when WB_ENV is defined
   const cascadeOption = project.env.WB_ENV ? ` -c=${project.env.WB_ENV || 'development'}` : '';
   return {
-    printable: `${packageManagerWithRun} dotenv${cascadeOption} -- ${printableScript}`,
+    printable: `${projectPackageManagerWithRun} dotenv${cascadeOption} -- ${printableScript}`,
     runnable: runnableScript,
   };
 }

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -5,7 +5,6 @@ import type { ArgumentsCamelCase, InferredOptionTypes } from 'yargs';
 import type { Project } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { promisePool } from '../utils/promisePool.js';
-import { packageManagerWithRun } from '../utils/runtime.js';
 
 interface Options {
   ci?: boolean;
@@ -163,7 +162,7 @@ export function normalizeScript(script: string, project: Project): { printable: 
     .replaceAll('PRISMA ', project.packageJson.dependencies?.blitz ? 'YARN blitz prisma ' : 'YARN prisma ')
     .replaceAll('BUN ', project.isBunAvailable ? 'bun --bun run ' : 'YARN ')
     // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`.
-    .replaceAll('YARN run ', `${projectPackageManagerWithRun} `);
+    .replaceAll('YARN run ', `${projectPackageManagerWithRun}${project.isBunAvailable ? '' : ' run'} `);
   if (project.isBunAvailable) {
     newScript = newScript
       .replaceAll('YARN build-ts run', 'bun --bun run')
@@ -178,8 +177,8 @@ export function normalizeScript(script: string, project: Project): { printable: 
   const printableScript = fixBunCommand(newScript.replaceAll('YARN ', `${projectPackageManagerWithRun} `));
   const runnableScript = fixBunCommand(
     newScript
-      // Because we need to use `yarn playwright` in a project depending on `artillery-engine-playwright`.
-      .replaceAll('YARN playwright ', `${packageManagerWithRun} playwright `)
+      // Keep Playwright as a package-manager command instead of resolving it through node_modules/.bin.
+      .replaceAll('YARN playwright ', `${projectPackageManagerWithRun} playwright `)
       .replaceAll('YARN ', !project.isBunAvailable && project.binExists ? '' : `${projectPackageManagerWithRun} `)
   );
   // Add cascade option when WB_ENV is defined

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -151,7 +151,7 @@ export function runWithSpawnInParallelBuffered(
  * Replace capitalized commands (e.g., YARN, PRISMA, BUN) with suitable commands.
  */
 export function normalizeScript(script: string, project: Project): { printable: string; runnable: string } {
-  const projectPackageManagerWithRun = project.isBunAvailable ? 'bun --bun run' : 'yarn';
+  const projectPackageManagerWithRun = project.usesBunPackageManager ? 'bun --bun run' : 'yarn';
   let newScript = script
     .replaceAll('\n', '')
     .replaceAll(/\s\s+/g, ' ')
@@ -160,19 +160,16 @@ export function normalizeScript(script: string, project: Project): { printable: 
       project.packageJson.dependencies?.blitz ? 'PRISMA generate ' : 'PRISMA generate --no-hints '
     )
     .replaceAll('PRISMA ', project.packageJson.dependencies?.blitz ? 'YARN blitz prisma ' : 'YARN prisma ')
-    .replaceAll('BUN run ', project.isBunAvailable ? `${projectPackageManagerWithRun} ` : 'YARN run ')
-    .replaceAll('BUN ', project.isBunAvailable ? `${projectPackageManagerWithRun} ` : 'YARN ')
+    .replaceAll('BUN run ', project.usesBunPackageManager ? `${projectPackageManagerWithRun} ` : 'YARN run ')
+    .replaceAll('BUN ', project.usesBunPackageManager ? `${projectPackageManagerWithRun} ` : 'YARN ')
     // Avoid replacing `YARN run` with `run` by replacing `YARN` with `(yarn|bun --bun) run`.
-    .replaceAll('YARN run ', project.isBunAvailable ? `${projectPackageManagerWithRun} ` : 'yarn run ');
-  if (project.isBunAvailable) {
+    .replaceAll('YARN run ', project.usesBunPackageManager ? `${projectPackageManagerWithRun} ` : 'yarn run ');
+  if (project.usesBunPackageManager) {
     newScript = newScript
       .replaceAll('YARN build-ts run', 'bun --bun run')
       .replaceAll('bun --bun run bun --bun run', 'bun --bun run')
       // Because bun can run src/index.ts directly.
-      .replaceAll('dist/index.js', 'src/index.ts')
-      .replaceAll(/(?:YARN )?vitest run/g, 'bun test')
-      // '--allowOnly' is sometimes removed.
-      .replaceAll(/ --color --passWithNoTests(?: --allowOnly)?/g, '');
+      .replaceAll('dist/index.js', 'src/index.ts');
   }
   newScript = newScript.trim();
   const printableScript = fixBunCommand(newScript.replaceAll('YARN ', `${projectPackageManagerWithRun} `));
@@ -180,7 +177,10 @@ export function normalizeScript(script: string, project: Project): { printable: 
     newScript
       // Keep Playwright as a package-manager command instead of resolving it through node_modules/.bin.
       .replaceAll('YARN playwright ', `${projectPackageManagerWithRun} playwright `)
-      .replaceAll('YARN ', !project.isBunAvailable && project.binExists ? '' : `${projectPackageManagerWithRun} `)
+      .replaceAll(
+        'YARN ',
+        !project.usesBunPackageManager && project.binExists ? '' : `${projectPackageManagerWithRun} `
+      )
   );
   // Add cascade option when WB_ENV is defined
   const cascadeOption = project.env.WB_ENV ? ` -c=${project.env.WB_ENV || 'development'}` : '';


### PR DESCRIPTION
## Summary

- Stop treating Bun from `.tool-versions` as the target repo package manager.
- Preserve `vitest run` for Vitest projects instead of rewriting it to Bun's test runner.
- Keep Bun-specific command normalization for projects that actually use Bun via `bun.lock`, `bun.lockb`, or `packageManager: bun@...`.

## Why

Running `wb test` across the repositories listed in `self-host-utils/scripts/process-repos.sh` exposed that Yarn projects with Bun in `.tool-versions` were executed as Bun package-manager projects. This generated commands such as `bun test ... --watch=false` or `bun --bun run vitest`, which failed before real project tests could run.

The fix separates Bun runtime availability from Bun package-manager selection. Vitest projects now run through their package manager's Vitest binary, while Bun-only projects can still use Bun.

## Testing

- Ran this branch's `wb test --silent` against all active repositories listed in `/Users/exkazuu/ghq/github.com/WillBooster/self-host-utils/scripts/process-repos.sh`.
- Reproduced `wb` command-generation failures in `judge` and `exercode-problem-utils`.
- Reran `judge` and `exercode-problem-utils` after the fix and confirmed the generated command changed to `yarn vitest run ...`; remaining failures are local missing install state, not Bun/Vitest command generation.
- `yarn workspace @willbooster/wb check-for-ai`
- `yarn check-for-ai`

## Notes

Other cross-repo failures observed during the sweep were outside this `wb` fix: missing local repos, missing local dependency installs, missing environment variables, dependency resolution issues in target repos, or target repo test failures/state.
