### PR TITLE
fix: preserve marked oxlint config customizations

### DIFF
--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -7,7 +7,7 @@ import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfigsUtil.js';
 
-import { generateToolConfigContent, normalizeToolConfigContent } from './toolConfigContent.js';
+import { normalizeToolConfigContent } from './toolConfigContent.js';
 
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
@@ -17,7 +17,9 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
     const filePath = path.resolve(config.dirPath, 'oxlint.config.ts');
     const existingContent = await fsUtil.readFileIgnoringError(filePath);
     const desiredContent =
-      shouldPreservePublishedLinterConfig && existingContent ? existingContent : getConfigContent(config);
+      shouldPreservePublishedLinterConfig && existingContent
+        ? existingContent
+        : getConfigContentWithManagedBlocks(config, existingContent, filePath);
 
     const promises: Promise<void>[] = [];
     if (!shouldPreservePublishedLinterConfig) {
@@ -45,9 +47,84 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
 }
 
 function getConfigContent(config: PackageConfig): string {
-  return generateToolConfigContent(config, {
-    commonJsVariableName: 'oxlintConfig',
-    packageName: '@willbooster/oxlint-config',
-    toolName: 'Oxlint',
-  });
+  if (config.isEsmPackage) {
+    return `${getManagedBlock('base', "import config from '@willbooster/oxlint-config';")}
+
+${getManagedBlock('export', 'export default config;')}
+`;
+  }
+
+  return `${getManagedBlock(
+    'base',
+    `// oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
+const oxlintBaseConfig = require('@willbooster/oxlint-config');
+
+const config = oxlintBaseConfig.default ?? oxlintBaseConfig;`
+  )}
+
+${getManagedBlock('export', 'module.exports = config;')}
+`;
+}
+
+function getConfigContentWithManagedBlocks(
+  config: PackageConfig,
+  existingContent: string | undefined,
+  filePath: string
+): string {
+  const desiredContent = getConfigContent(config);
+  if (!existingContent) return desiredContent;
+  if (hasManagedBlocks(existingContent)) return replaceManagedBlocks(existingContent, desiredContent, filePath);
+  return desiredContent;
+}
+
+function hasManagedBlocks(content: string): boolean {
+  return content.includes(getStartMarker('base')) || content.includes(getStartMarker('export'));
+}
+
+function replaceManagedBlocks(existingContent: string, desiredContent: string, filePath: string): string {
+  let content = existingContent;
+  for (const blockName of ['base', 'export'] as const) {
+    const replacement = extractManagedBlock(desiredContent, blockName);
+    if (!replacement) continue;
+
+    const nextContent = replaceManagedBlock(content, blockName, replacement);
+    if (!nextContent) {
+      console.warn(`Skipped updating incomplete ${blockName} block in oxlint config: ${filePath}`);
+      return existingContent;
+    }
+    content = nextContent;
+  }
+  return content;
+}
+
+function extractManagedBlock(content: string, blockName: 'base' | 'export'): string | undefined {
+  return new RegExp(
+    `${escapeRegExp(getStartMarker(blockName))}[\\s\\S]*?${escapeRegExp(getEndMarker(blockName))}`
+  ).exec(content)?.[0];
+}
+
+function replaceManagedBlock(content: string, blockName: 'base' | 'export', replacement: string): string | undefined {
+  const pattern = new RegExp(
+    `${escapeRegExp(getStartMarker(blockName))}[\\s\\S]*?${escapeRegExp(getEndMarker(blockName))}`
+  );
+  if (!pattern.test(content)) return undefined;
+  return content.replace(pattern, replacement);
+}
+
+function getManagedBlock(blockName: 'base' | 'export', content: string): string {
+  return `${getStartMarker(blockName)}
+${content}
+${getEndMarker(blockName)}`;
+}
+
+function getStartMarker(blockName: 'base' | 'export'): string {
+  return `// wbfy:start oxlint-${blockName}`;
+}
+
+function getEndMarker(blockName: 'base' | 'export'): string {
+  return `// wbfy:end oxlint-${blockName}`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -46,6 +46,17 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
   });
 }
 
+function getConfigContentWithManagedBlocks(
+  config: PackageConfig,
+  existingContent: string | undefined,
+  filePath: string
+): string {
+  const desiredContent = getConfigContent(config);
+  if (!existingContent) return desiredContent;
+  if (hasManagedBlocks(existingContent)) return replaceManagedBlocks(existingContent, desiredContent, filePath);
+  return desiredContent;
+}
+
 function getConfigContent(config: PackageConfig): string {
   if (config.isEsmPackage) {
     return `${getManagedBlock('base', "import config from '@willbooster/oxlint-config';")}
@@ -64,17 +75,6 @@ const config = oxlintBaseConfig.default ?? oxlintBaseConfig;`
 
 ${getManagedBlock('export', 'module.exports = config;')}
 `;
-}
-
-function getConfigContentWithManagedBlocks(
-  config: PackageConfig,
-  existingContent: string | undefined,
-  filePath: string
-): string {
-  const desiredContent = getConfigContent(config);
-  if (!existingContent) return desiredContent;
-  if (hasManagedBlocks(existingContent)) return replaceManagedBlocks(existingContent, desiredContent, filePath);
-  return desiredContent;
 }
 
 function hasManagedBlocks(content: string): boolean {

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -9,6 +9,8 @@ import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfig
 
 import { normalizeToolConfigContent } from './toolConfigContent.js';
 
+type OxlintBlockName = 'base' | 'export';
+
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
     // willbooster-configs publishes config files as product code, so migration
@@ -83,7 +85,7 @@ function hasManagedBlocks(content: string): boolean {
 
 function replaceManagedBlocks(existingContent: string, desiredContent: string, filePath: string): string {
   let content = existingContent;
-  for (const blockName of ['base', 'export'] as const) {
+  for (const blockName of ['base', 'export'] satisfies OxlintBlockName[]) {
     const replacement = extractManagedBlock(desiredContent, blockName);
     if (!replacement) continue;
 
@@ -97,31 +99,31 @@ function replaceManagedBlocks(existingContent: string, desiredContent: string, f
   return content;
 }
 
-function extractManagedBlock(content: string, blockName: 'base' | 'export'): string | undefined {
-  return new RegExp(
-    `${escapeRegExp(getStartMarker(blockName))}[\\s\\S]*?${escapeRegExp(getEndMarker(blockName))}`
-  ).exec(content)?.[0];
+function extractManagedBlock(content: string, blockName: OxlintBlockName): string | undefined {
+  return getManagedBlockRegExp(blockName).exec(content)?.[0];
 }
 
-function replaceManagedBlock(content: string, blockName: 'base' | 'export', replacement: string): string | undefined {
-  const pattern = new RegExp(
-    `${escapeRegExp(getStartMarker(blockName))}[\\s\\S]*?${escapeRegExp(getEndMarker(blockName))}`
-  );
+function replaceManagedBlock(content: string, blockName: OxlintBlockName, replacement: string): string | undefined {
+  const pattern = getManagedBlockRegExp(blockName);
   if (!pattern.test(content)) return undefined;
   return content.replace(pattern, replacement);
 }
 
-function getManagedBlock(blockName: 'base' | 'export', content: string): string {
+function getManagedBlockRegExp(blockName: OxlintBlockName): RegExp {
+  return new RegExp(`${escapeRegExp(getStartMarker(blockName))}[\\s\\S]*?${escapeRegExp(getEndMarker(blockName))}`);
+}
+
+function getManagedBlock(blockName: OxlintBlockName, content: string): string {
   return `${getStartMarker(blockName)}
 ${content}
 ${getEndMarker(blockName)}`;
 }
 
-function getStartMarker(blockName: 'base' | 'export'): string {
+function getStartMarker(blockName: OxlintBlockName): string {
   return `// wbfy:start oxlint-${blockName}`;
 }
 
-function getEndMarker(blockName: 'base' | 'export'): string {
+function getEndMarker(blockName: OxlintBlockName): string {
   return `// wbfy:end oxlint-${blockName}`;
 }
 

--- a/packages/wbfy/test/oxlintConfigGenerator.test.ts
+++ b/packages/wbfy/test/oxlintConfigGenerator.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, test } from 'vitest';
+
+import { generateOxlintConfig } from '../src/generators/oxlintConfig.js';
+import type { PackageConfig } from '../src/packageConfig.js';
+import { promisePool } from '../src/utils/promisePool.js';
+import { createConfig as createBaseConfig } from './testConfig.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dirPath) => fs.promises.rm(dirPath, { force: true, recursive: true })));
+  tempDirs.length = 0;
+});
+
+test('overwrites unmarked oxlint config with managed blocks', async () => {
+  const dirPath = createTempDir();
+  await fs.promises.writeFile(
+    path.join(dirPath, 'oxlint.config.ts'),
+    `import config from '@willbooster/oxlint-config';
+
+config.ignorePatterns?.push('generated/**');
+
+export default config;
+`
+  );
+
+  await generateOxlintConfig(createConfig({ dirPath }), createConfig({ dirPath }));
+  await promisePool.promiseAll();
+
+  const content = await readOxlintConfig(dirPath);
+  expect(content).toContain('// wbfy:start oxlint-base');
+  expect(content).toContain('// wbfy:start oxlint-export');
+  expect(content).not.toContain("config.ignorePatterns?.push('generated/**');");
+});
+
+test('updates only managed blocks in marked oxlint config', async () => {
+  const dirPath = createTempDir();
+  await fs.promises.writeFile(
+    path.join(dirPath, 'oxlint.config.ts'),
+    `// wbfy:start oxlint-base
+const staleConfig = require('@willbooster/oxlint-config');
+// wbfy:end oxlint-base
+
+config.ignorePatterns?.push('generated/**');
+
+// wbfy:start oxlint-export
+module.exports = staleConfig;
+// wbfy:end oxlint-export
+`
+  );
+
+  await generateOxlintConfig(createConfig({ dirPath }), createConfig({ dirPath }));
+  await promisePool.promiseAll();
+
+  const content = await readOxlintConfig(dirPath);
+  expect(content).toContain('const oxlintBaseConfig = require');
+  expect(content).toContain("config.ignorePatterns?.push('generated/**');");
+  expect(content).toContain('module.exports = config;');
+  expect(content).not.toContain('staleConfig');
+});
+
+function createTempDir(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-oxlint-config-'));
+  tempDirs.push(tempDir);
+  return tempDir;
+}
+
+async function readOxlintConfig(dirPath: string): Promise<string> {
+  return fs.promises.readFile(path.join(dirPath, 'oxlint.config.ts'), 'utf8');
+}
+
+function createConfig(overrides: Partial<PackageConfig> = {}): PackageConfig {
+  return createBaseConfig({
+    isRoot: true,
+    doesContainPackageJson: true,
+    doesContainTypeScript: true,
+    ...overrides,
+  });
+}


### PR DESCRIPTION
## Summary

- Changed the `oxlint.config.ts` generator to emit `wbfy` managed blocks for base config loading and export.
- Keeps overwriting unmarked configs into the managed template.
- Updates only marked blocks after migration so repo-local code between markers is preserved.
- Added focused generator tests for unmarked overwrite and marked local customization preservation.
- Addressed review feedback by ordering helpers top-down and deduplicating managed-block regex construction.

## Why

- Whole-file regeneration discarded repo-local oxlint settings such as `ignorePatterns` extensions.
- Managed blocks let `wbfy` own only the generated import/export portions while leaving local settings outside those blocks intact.

## Testing

- `yarn vitest test/oxlintConfigGenerator.test.ts`
- `yarn check-for-ai`
- Ran local `wbfy` against exercode twice: first to migrate to managed blocks, then after adding a local `ignorePatterns` setting to verify it was preserved.
- PR CI passed on head `05933b3`.
- Unresolved review threads: none.
