### PR TITLE
feat(wbfy): support mise-managed package tasks

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -74,11 +74,7 @@ function generateAgentInstruction(
   - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.
   - Always create new commits. Avoid using \`--amend\`.
 - Always use heredoc syntax when passing multi-line content to any command.
-${
-  allConfigs.some((c) => c.hasStartTestServer)
-    ? `- Use \`${packageManager} start-test-server\` to launch a web server for debugging or testing.`
-    : ''
-}
+${hasStartTestServerScript(allConfigs) ? `- Use \`${packageManager} start-test-server\` to launch a web server for debugging or testing.` : ''}
 
 ${generateAgentCodingStyle(allConfigs)}
 `
@@ -119,6 +115,7 @@ ${
     ? `- When introducing new string literals in React components, update the language resource files in the \`i18n\` directory (e.g., \`i18n/ja-JP.json\`). Reference these strings using the \`i18n\` utility. For example, use \`i18n.pages.home.title()\` for \`{ "pages": { "home": { "title": "My App" } } }\`.`
     : ''
 }
+
 ${
   allConfigs.some((c) => c.depending.react || c.depending.next)
     ? `- Prefer lambda over \`function\` for React components, e.g., \`const Button: React.FC = () => {\`.
@@ -137,4 +134,14 @@ ${
     .replaceAll(/\.\n\n+-/g, '.\n-')
     .replaceAll(/\n{3,}/g, '\n\n')
     .trim();
+}
+
+function hasStartTestServerScript(configs: PackageConfig[]): boolean {
+  return configs.some((config) => {
+    if (config.hasStartTestServer) return true;
+    // wbfy generates start-test-server later for Playwright repos once wb is
+    // present. Bun repos get wb as part of wbfy's managed toolchain, so agent
+    // instructions must anticipate the generated script during the first run.
+    return config.depending.playwrightTest && (config.depending.wb || config.isBun);
+  });
 }

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -28,6 +28,7 @@ const commonContent = `
 __generated__/
 @willbooster/
 dist/
+drizzle/mount/
 temp/
 tmp/
 `;

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -155,7 +155,9 @@ async function core(config: PackageConfig): Promise<void> {
 function getPrePushScript(config: PackageConfig): string {
   let lintCommand: string;
   if (config.isBun) {
-    lintCommand = config.depending.wb ? 'bun --bun wb lint' : 'bun run lint';
+    // Bun repos receive wb as part of wbfy's managed toolchain, so generate the
+    // final hook command on the first run instead of changing it on the second.
+    lintCommand = 'bun --bun wb lint';
   } else {
     lintCommand = config.depending.wb ? 'yarn wb lint' : 'yarn run lint';
   }
@@ -219,13 +221,10 @@ yarn workspace @willbooster/wb start --working-dir "$(git rev-parse --show-tople
   // staged-file hooks must use the language-specific formatter path below.
   const canUseWbForStagedFiles = doesContainJsOrTs(config) || doesContainJava(config);
   if ((config.isBun || config.depending.wb) && canUseWbForStagedFiles) {
-    const packageManager = config.isBun ? 'bun' : 'yarn';
-    return config.depending.wb
-      ? `
+    return `
 # Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
 ${config.isBun ? 'bun --bun wb' : 'yarn wb'} lint --fix --format -- {staged_files}
-`.trim()
-      : `${packageManager} run format && ${packageManager} run lint-fix`;
+`.trim();
   }
 
   const oxlintPattern = extensions.oxlint.map((extension) => String.raw`\.${extension}$`).join('|');

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -898,12 +898,18 @@ function isWorkspaceProtocolRange(version: string): boolean {
 }
 
 function addStartTestServerScriptIfNeeded(config: PackageConfig, jsonObj: PackageJson): void {
-  if (!config.depending.playwrightTest || !config.depending.wb || jsonObj.scripts?.['start-test-server']) {
+  if (
+    !config.depending.playwrightTest ||
+    !(config.depending.wb || config.isBun) ||
+    jsonObj.scripts?.['start-test-server']
+  ) {
     return;
   }
 
   jsonObj.scripts ??= {};
-  jsonObj.scripts['start-test-server'] = 'wb start --mode test';
+  // mise often owns env loading and database preparation for local web servers.
+  // Prefer the repo task when it exists; otherwise fall back to wb's test server.
+  jsonObj.scripts['start-test-server'] = hasMiseTask(config, 'start') ? 'mise run start' : 'wb start --mode test';
 }
 
 function formatRepositoryForPackageJson(
@@ -976,6 +982,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       verify: 'bun --bun wb verify',
       'verify-full': 'bun --bun wb verify --full',
     };
+    applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
     if (!hasTypecheck) {
       delete scripts.typecheck;
     } else if (config.depending.pyright) {
@@ -1039,8 +1046,44 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       scripts.verify = 'wb verify';
       scripts['verify-full'] = 'wb verify --full';
     }
+    applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
     return scripts;
   }
+}
+
+function applyMiseTaskScripts(
+  config: PackageConfig,
+  scripts: Record<string, string>,
+  oldScripts: PackageJson.Scripts,
+  names: string[]
+): void {
+  for (const name of names) {
+    if (!hasMiseTask(config, name)) continue;
+    if (doesMiseTaskCallPackageScript(config, name)) continue;
+    if (oldScripts[name] && !isWbfyManagedMiseBridge(oldScripts[name], name) && !(name in scripts)) continue;
+    scripts[name] = `mise run ${name}`;
+  }
+}
+
+function hasMiseTask(config: PackageConfig, name: string): boolean {
+  return Object.hasOwn(config.miseTasks, name);
+}
+
+function doesMiseTaskCallPackageScript(config: PackageConfig, name: string): boolean {
+  const task = config.miseTasks[name];
+  if (!task) return false;
+  const packageManagers = ['bun', 'yarn', 'npm', 'pnpm'];
+  return packageManagers.some((packageManager) =>
+    new RegExp(String.raw`\b${packageManager}\s+(?:run\s+)?${escapeRegExp(name)}\b`, 'u').test(task)
+  );
+}
+
+function isWbfyManagedMiseBridge(script: unknown, name: string): boolean {
+  return script === `mise run ${name}`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 function generateFormatScript(hasJsOrTs: boolean, hasJava: boolean): string {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -908,8 +908,9 @@ function addStartTestServerScriptIfNeeded(config: PackageConfig, jsonObj: Packag
 
   jsonObj.scripts ??= {};
   // mise often owns env loading and database preparation for local web servers.
-  // Prefer the repo task when it exists; otherwise fall back to wb's test server.
-  jsonObj.scripts['start-test-server'] = hasMiseTask(config, 'start') ? 'mise run start' : 'wb start --mode test';
+  // Prefer a dedicated non-recursive test-server task before falling back to the generic start task.
+  const taskName = getSafeMiseTaskName(config, ['start-test-server', 'start']);
+  jsonObj.scripts['start-test-server'] = taskName ? `mise run ${taskName}` : 'wb start --mode test';
 }
 
 function formatRepositoryForPackageJson(
@@ -1069,12 +1070,16 @@ function hasMiseTask(config: PackageConfig, name: string): boolean {
   return Object.hasOwn(config.miseTasks, name);
 }
 
+function getSafeMiseTaskName(config: PackageConfig, names: string[]): string | undefined {
+  return names.find((name) => hasMiseTask(config, name) && !doesMiseTaskCallPackageScript(config, name));
+}
+
 function doesMiseTaskCallPackageScript(config: PackageConfig, name: string): boolean {
   const task = config.miseTasks[name];
   if (!task) return false;
   const packageManagers = ['bun', 'yarn', 'npm', 'pnpm'];
   return packageManagers.some((packageManager) =>
-    new RegExp(String.raw`\b${packageManager}\s+(?:run\s+)?${escapeRegExp(name)}\b`, 'u').test(task)
+    new RegExp(String.raw`\b${packageManager}\s+(?:run\s+)?${escapeRegExp(name)}(?![a-zA-Z0-9_\-:.])`, 'u').test(task)
   );
 }
 

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -19,7 +19,8 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
     }
 
     const repository = config.repository?.slice(config.repository.indexOf(':') + 1);
-    const fileNames = fs.readdirSync(`${config.dirPath}/.github/workflows`);
+    const workflowsPath = path.resolve(config.dirPath, '.github', 'workflows');
+    const fileNames = fs.existsSync(workflowsPath) ? fs.readdirSync(workflowsPath) : [];
     for (const fileName of fileNames) {
       if (!fileName.startsWith('test') && !fileName.startsWith('deploy')) continue;
 

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -139,6 +139,7 @@ async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promi
   try {
     const settings = JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as TsConfigJson;
     normalizeNextTsconfigModuleSettings(settings.compilerOptions);
+    normalizeNextTsconfigPathAliases(settings.compilerOptions);
     await promisePool.run(() => fsUtil.generateFile(filePath, JSON.stringify(settings, undefined, 2)));
   } catch {
     // Next/Blitz own their tsconfig shape, but TypeScript 6 no longer accepts
@@ -158,6 +159,27 @@ function normalizeNextTsconfigModuleSettings(compilerOptions: TsConfigJson.Compi
     // tsgolint treats that spelling as the removed node10 resolver.
     compilerOptions.moduleResolution = 'bundler';
   }
+}
+
+function normalizeNextTsconfigPathAliases(compilerOptions: TsConfigJson.CompilerOptions | undefined): void {
+  if (!compilerOptions) return;
+
+  // tsgolint follows TypeScript 6 validation, where baseUrl is removed and
+  // path targets must be explicitly relative. Next.js still accepts the alias
+  // shape after each target is written with a leading ./.
+  delete compilerOptions.baseUrl;
+  if (!compilerOptions.paths) return;
+
+  for (const [alias, targets] of Object.entries(compilerOptions.paths)) {
+    compilerOptions.paths[alias] = normalizePathAliasTargets(targets);
+  }
+}
+
+function normalizePathAliasTargets(targets: string[]): string[] {
+  return targets.map((target) => {
+    if (target.startsWith('./') || target.startsWith('../') || path.isAbsolute(target)) return target;
+    return `./${target}`;
+  });
 }
 
 function getRootDir(config: PackageConfig): string {

--- a/packages/wbfy/src/github/template.ts
+++ b/packages/wbfy/src/github/template.ts
@@ -58,6 +58,10 @@ Close #<IssueNumber>
 
 export async function generateGitHubTemplates(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateGitHubTemplates', async () => {
+    if (!config.isWillBoosterRepo) {
+      return;
+    }
+
     for (const [fileName, newContent] of Object.entries(templates)) {
       const content = applyPackageManagerTemplate(newContent, config);
       const filePath = path.resolve(config.dirPath, '.github', fileName);

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import fg from 'fast-glob';
 import { simpleGit } from 'simple-git';
+import toml from 'smol-toml';
 import type { PackageJson } from 'type-fest';
 import { z } from 'zod';
 
@@ -68,6 +69,7 @@ export interface PackageConfig {
     npm: boolean;
   };
   hasVersionSettings: boolean;
+  miseTasks: Record<string, string>;
   packageJson?: PackageJson;
   wbfyJson?: WbfyJson;
 }
@@ -226,6 +228,7 @@ export async function getPackageConfig(
         npm: releasePlugins.includes('@semantic-release/npm'),
       },
       hasVersionSettings,
+      miseTasks: await readMiseTasks(dirPath),
       packageJson,
       wbfyJson,
     };
@@ -253,6 +256,28 @@ function hasVersionSettingsFile(dirPath: string): boolean {
     fs.existsSync(path.join(current, '.mise.toml')) ||
     fs.existsSync(path.join(current, '.tool-versions'))
   );
+}
+
+async function readMiseTasks(dirPath: string): Promise<Record<string, string>> {
+  const tasks: Record<string, string> = {};
+  for (const fileName of ['mise.toml', '.mise.toml']) {
+    const filePath = path.resolve(dirPath, fileName);
+    try {
+      const settings = toml.parse(await fsp.readFile(filePath, 'utf8')) as { tasks?: Record<string, unknown> };
+      for (const [name, value] of Object.entries(settings.tasks ?? {})) {
+        if (typeof value === 'string') {
+          tasks[name] = value;
+        } else if (value && typeof value === 'object' && typeof (value as { run?: unknown }).run === 'string') {
+          tasks[name] = (value as { run: string }).run;
+        } else {
+          tasks[name] = '';
+        }
+      }
+    } catch {
+      // Missing or temporarily invalid mise files should not block other wbfy generators.
+    }
+  }
+  return tasks;
 }
 
 function containsAny(pattern: string, dirPath: string): boolean {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -265,19 +265,21 @@ async function readMiseTasks(dirPath: string): Promise<Record<string, string>> {
     try {
       const settings = toml.parse(await fsp.readFile(filePath, 'utf8')) as { tasks?: Record<string, unknown> };
       for (const [name, value] of Object.entries(settings.tasks ?? {})) {
-        if (typeof value === 'string') {
-          tasks[name] = value;
-        } else if (value && typeof value === 'object' && typeof (value as { run?: unknown }).run === 'string') {
-          tasks[name] = (value as { run: string }).run;
-        } else {
-          tasks[name] = '';
-        }
+        tasks[name] = readMiseTaskCommand(value);
       }
     } catch {
       // Missing or temporarily invalid mise files should not block other wbfy generators.
     }
   }
   return tasks;
+}
+
+function readMiseTaskCommand(value: unknown): string {
+  if (typeof value === 'string') return value;
+  // Preserve array-form mise commands so recursion checks can still see package script calls.
+  if (Array.isArray(value)) return value.filter((command): command is string => typeof command === 'string').join('\n');
+  if (value && typeof value === 'object') return readMiseTaskCommand((value as { run?: unknown }).run);
+  return '';
 }
 
 function containsAny(pattern: string, dirPath: string): boolean {

--- a/packages/wbfy/test/agentInstructions.test.ts
+++ b/packages/wbfy/test/agentInstructions.test.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, test } from 'vitest';
+
+import { generateAgentInstructions } from '../src/generators/agents.js';
+import { promisePool } from '../src/utils/promisePool.js';
+import { createConfig } from './testConfig.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dirPath) => fs.promises.rm(dirPath, { force: true, recursive: true })));
+  tempDirs.length = 0;
+});
+
+test('mentions generated start-test-server for Bun Playwright projects on the first run', async () => {
+  const dirPath = createTempDir();
+  const config = createConfig({
+    dirPath,
+    isBun: true,
+    isRoot: true,
+    depending: {
+      ...createConfig().depending,
+      playwrightTest: true,
+    },
+    packageJson: {
+      name: 'app',
+      description: 'App',
+    },
+  });
+
+  await generateAgentInstructions(config, [config]);
+  await promisePool.promiseAll();
+
+  const content = await fs.promises.readFile(path.join(dirPath, 'AGENTS.md'), 'utf8');
+  expect(content).toContain('Use `bun start-test-server` to launch a web server for debugging or testing.');
+});
+
+function createTempDir(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-agent-instructions-'));
+  tempDirs.push(tempDir);
+  return tempDir;
+}

--- a/packages/wbfy/test/githubTemplate.test.ts
+++ b/packages/wbfy/test/githubTemplate.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, test } from 'vitest';
+
+import { generateGitHubTemplates } from '../src/github/template.js';
+import { promisePool } from '../src/utils/promisePool.js';
+import { createConfig } from './testConfig.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dirPath) => fs.promises.rm(dirPath, { force: true, recursive: true })));
+  tempDirs.length = 0;
+});
+
+test('does not generate pull request template for non-WillBooster repositories', async () => {
+  const dirPath = createTempDir();
+
+  await generateGitHubTemplates(
+    createConfig({
+      dirPath,
+      isWillBoosterRepo: false,
+      repository: 'github:exKAZUu/doco-san',
+    })
+  );
+  await promisePool.promiseAll();
+
+  await expect(fs.promises.access(path.join(dirPath, '.github', 'pull_request_template.md'))).rejects.toThrow();
+});
+
+function createTempDir(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-github-template-'));
+  tempDirs.push(tempDir);
+  return tempDir;
+}

--- a/packages/wbfy/test/lefthookGenerator.test.ts
+++ b/packages/wbfy/test/lefthookGenerator.test.ts
@@ -141,6 +141,24 @@ test('uses quiet lint in pre-push hooks for wb projects', async () => {
   expect(prePushScript).toContain('yarn wb lint --quiet');
 });
 
+test('uses generated wb commands for Bun projects on the first run', async () => {
+  const dirPath = createTempDir();
+
+  await generateLefthookUpdatingPackageJson(
+    createConfig({
+      dirPath,
+      isBun: true,
+      doesContainPackageJson: true,
+      doesContainTypeScript: true,
+    })
+  );
+
+  const lefthookConfig = await fs.promises.readFile(path.join(dirPath, 'lefthook.yml'), 'utf8');
+  const prePushScript = await fs.promises.readFile(path.join(dirPath, '.lefthook', 'pre-push', 'check.sh'), 'utf8');
+  expect(lefthookConfig).toContain('bun --bun wb lint --fix --format -- {staged_files}');
+  expect(prePushScript).toContain('bun --bun wb lint --quiet');
+});
+
 test('uses quiet lint in pre-push hooks for plain oxlint projects', async () => {
   const dirPath = createTempDir();
 

--- a/packages/wbfy/test/packageConfig.test.ts
+++ b/packages/wbfy/test/packageConfig.test.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { getPackageConfig } from '../src/packageConfig.js';
+
+describe('getPackageConfig', () => {
+  test('reads mise task commands from string and array forms', async () => {
+    const rootPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-config-'));
+    await fs.promises.writeFile(path.join(rootPath, 'package.json'), '{"private":true}\n');
+    const dirPath = path.join(rootPath, 'packages', 'mise-package');
+    await fs.promises.mkdir(dirPath, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(dirPath, 'package.json'),
+      `${JSON.stringify({ name: 'mise-package', private: true }, undefined, 2)}\n`
+    );
+    await fs.promises.writeFile(
+      path.join(dirPath, 'mise.toml'),
+      `
+[tasks]
+build = "bun run build"
+test = ["bun run test:unit", "bun run test:e2e"]
+
+[tasks.typecheck]
+run = ["bun run tsc --noEmit", "bun run tsgo --noEmit"]
+`
+    );
+
+    const config = await getPackageConfig(dirPath);
+
+    expect(config?.miseTasks).toMatchObject({
+      build: 'bun run build',
+      test: 'bun run test:unit\nbun run test:e2e',
+      typecheck: 'bun run tsc --noEmit\nbun run tsgo --noEmit',
+    });
+  });
+});

--- a/packages/wbfy/test/packageJsonGenerator.test.ts
+++ b/packages/wbfy/test/packageJsonGenerator.test.ts
@@ -176,6 +176,48 @@ describe('generatePackageJson', () => {
     expect(packageJson.devDependencies?.typescript).toMatch(/^\d+\.\d+\.\d+/u);
     expect(packageJson.devDependencies?.['@typescript/native-preview']).toBeDefined();
   });
+
+  test('bridges package scripts to mise tasks without creating recursive scripts', async () => {
+    const dirPath = await createPackageDir({
+      name: 'mise-package',
+      private: true,
+      scripts: {
+        caution: 'Use mise tasks instead.',
+      },
+      dependencies: {
+        next: '16.1.6',
+      },
+      devDependencies: {
+        '@playwright/test': '1.59.1',
+      },
+    });
+    const config = createConfig({
+      dirPath,
+      isBun: true,
+      doesContainTypeScript: true,
+      depending: {
+        ...createConfig().depending,
+        next: true,
+        playwrightTest: true,
+      },
+      miseTasks: {
+        build: 'bun run next build',
+        start: 'mise run db:push && bun run next dev',
+        test: 'bun run playwright test',
+        typecheck: 'bun run tsc --noEmit --pretty',
+      },
+      packageJson: readPackageJson(dirPath),
+    });
+
+    await generatePackageJson(config, createRootConfig(path.dirname(dirPath)), true);
+
+    const packageJson = readPackageJson(dirPath);
+    expect(packageJson.scripts?.build).toBe('mise run build');
+    expect(packageJson.scripts?.test).toBe('mise run test');
+    expect(packageJson.scripts?.typecheck).toBe('mise run typecheck');
+    expect(packageJson.scripts?.['start-test-server']).toBe('mise run start');
+    expect(packageJson.scripts?.start).toBe('mise run start');
+  });
 });
 
 async function createPackageDir(packageJson: PackageJson): Promise<string> {

--- a/packages/wbfy/test/packageJsonGenerator.test.ts
+++ b/packages/wbfy/test/packageJsonGenerator.test.ts
@@ -203,7 +203,7 @@ describe('generatePackageJson', () => {
       miseTasks: {
         build: 'bun run next build',
         start: 'mise run db:push && bun run next dev',
-        test: 'bun run playwright test',
+        test: 'bun run test:unit',
         typecheck: 'bun run tsc --noEmit --pretty',
       },
       packageJson: readPackageJson(dirPath),
@@ -217,6 +217,38 @@ describe('generatePackageJson', () => {
     expect(packageJson.scripts?.typecheck).toBe('mise run typecheck');
     expect(packageJson.scripts?.['start-test-server']).toBe('mise run start');
     expect(packageJson.scripts?.start).toBe('mise run start');
+  });
+
+  test('prefers a dedicated mise start-test-server task when generating the test server script', async () => {
+    const dirPath = await createPackageDir({
+      name: 'mise-test-server-package',
+      private: true,
+      dependencies: {
+        next: '16.1.6',
+      },
+      devDependencies: {
+        '@playwright/test': '1.59.1',
+      },
+    });
+    const config = createConfig({
+      dirPath,
+      isBun: true,
+      depending: {
+        ...createConfig().depending,
+        next: true,
+        playwrightTest: true,
+      },
+      miseTasks: {
+        start: 'bun run next dev',
+        'start-test-server': 'mise run db:push && bun run next dev',
+      },
+      packageJson: readPackageJson(dirPath),
+    });
+
+    await generatePackageJson(config, createRootConfig(path.dirname(dirPath)), true);
+
+    const packageJson = readPackageJson(dirPath);
+    expect(packageJson.scripts?.['start-test-server']).toBe('mise run start-test-server');
   });
 });
 

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -53,6 +53,7 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
       npm: false,
     },
     hasVersionSettings: false,
+    miseTasks: {},
     packageJson: {},
     ...overrides,
   };

--- a/packages/wbfy/test/tsconfigGenerator.test.ts
+++ b/packages/wbfy/test/tsconfigGenerator.test.ts
@@ -158,6 +158,38 @@ test('drops stale generated test globals when the package dependency is absent',
   expect(tsconfig.compilerOptions.types).toEqual(['node', 'custom-test-env']);
 });
 
+test('normalizes Next.js aliases for TypeScript 6 linting', async () => {
+  const dirPath = createTempDir();
+  await fs.promises.writeFile(
+    path.join(dirPath, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        baseUrl: '.',
+        moduleResolution: 'node',
+        paths: {
+          '@/*': ['src/*'],
+        },
+      },
+    })
+  );
+
+  await generateTsconfig(
+    createConfig({
+      dirPath,
+      depending: {
+        ...createConfig().depending,
+        next: true,
+      },
+    })
+  );
+  await promisePool.promiseAll();
+
+  const tsconfig = await readTsconfig(dirPath);
+  expect(tsconfig.compilerOptions.baseUrl).toBeUndefined();
+  expect(tsconfig.compilerOptions.moduleResolution).toBe('bundler');
+  expect(tsconfig.compilerOptions.paths).toEqual({ '@/*': ['./src/*'] });
+});
+
 function createTempDir(): string {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-tsconfig-'));
   tempDirs.push(tempDir);
@@ -166,9 +198,12 @@ function createTempDir(): string {
 
 async function readTsconfig(dirPath: string): Promise<{
   compilerOptions: {
+    baseUrl?: string;
     declaration?: boolean;
+    moduleResolution?: string;
     noEmit?: boolean;
     outDir?: string;
+    paths?: Record<string, string[]>;
     rootDir?: string;
     sourceMap?: boolean;
     types?: string[];
@@ -177,9 +212,12 @@ async function readTsconfig(dirPath: string): Promise<{
 }> {
   return JSON.parse(await fs.promises.readFile(path.join(dirPath, 'tsconfig.json'), 'utf8')) as {
     compilerOptions: {
+      baseUrl?: string;
       declaration?: boolean;
+      moduleResolution?: string;
       noEmit?: boolean;
       outDir?: string;
+      paths?: Record<string, string[]>;
       rootDir?: string;
       sourceMap?: boolean;
       types?: string[];

--- a/packages/wbfy/test/workflowGenerator.test.ts
+++ b/packages/wbfy/test/workflowGenerator.test.ts
@@ -84,6 +84,7 @@ test('skips generating workflows for reusable-workflows repository', async () =>
       npm: false,
     },
     hasVersionSettings: false,
+    miseTasks: {},
     packageJson: {},
     wbfyJson: undefined,
   };


### PR DESCRIPTION
## Summary

- Detect mise tasks from `mise.toml` and `.mise.toml` and bridge standard package scripts to safe `mise run ...` commands
- Preserve array-form mise task commands so recursive package-script checks still work
- Prefer a dedicated mise `start-test-server` task before falling back to `start`
- Avoid generating PR templates for non-WillBooster repositories
- Add `drizzle/mount/` to generated `.gitignore`
- Normalize generated Next.js tsconfig path aliases for TypeScript 6 compatibility
- Make generated Bun hooks and agent instructions idempotent

## Testing

- `yarn check-for-ai`
- `yarn test packageConfig.test.ts`
- `yarn test packageJsonGenerator.test.ts packageConfig.test.ts`
- `bunx @willbooster/agent-skills@latest check-pr-ci`
- Re-applied local `wbfy` to `exKAZUu/doco-san` and verified rerun idempotency from generated output
