### PR TITLE
fix: clarify generated agent comment guidance

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -104,8 +104,9 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
 - Place calling functions above the functions they call to maintain a clear top-down order.
   - e.g., \`function caller() { callee(); } function callee() { ... }\`
   - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments to explain "why" and use JSDoc to explain "what" for complex logic.
-  - Avoid stating what is obvious from the code itself.
+- Write comments and JSDoc for complex or hard-to-understand code.
+  - Explain "why" in comments and "what" in JSDoc.
+  - Avoid stating what can be easily understood from the code itself.
 - Prefer \`undefined\` over \`null\` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of \`join()\` with an array of strings.
 - Assume that all environment variables are properly defined.

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -104,8 +104,8 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
 - Place calling functions above the functions they call to maintain a clear top-down order.
   - e.g., \`function caller() { callee(); } function callee() { ... }\`
   - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments that explain "why" and use JSDoc to explain "what".
-  - Avoid stating what can be easily understood from the code itself.
+- Write comments to explain "why" and use JSDoc to explain "what" for complex logic.
+  - Avoid stating what is obvious from the code itself.
 - Prefer \`undefined\` over \`null\` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of \`join()\` with an array of strings.
 - Assume that all environment variables are properly defined.


### PR DESCRIPTION
## Summary

- Refine generated AGENTS coding-style guidance for comments and JSDoc.
- Scope is limited to `packages/wbfy/src/generators/agents.ts`.
- No runtime behavior changes.

## Why

- The generated guidance now focuses comments and JSDoc on complex or hard-to-understand code.
- It keeps the distinction between explaining "why" in comments and "what" in JSDoc while discouraging obvious restatements.

## Testing

- `yarn check-for-ai`

## Notes

- `yarn check-for-ai` passed with 0 errors; it reported 4 warnings in `@willbooster/wbfy`.
