### PR TITLE
fix: remove start-test-server from wbfy

### DIFF
--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -40,7 +40,7 @@ const defaultConfig = toParsedObject({
     video: literal("process.env.CI ? 'on-first-retry' : 'retain-on-failure'"),
   }),
   webServer: asObject({
-    command: literal("'yarn start-test-server'"),
+    command: literal("'wb start --mode test'"),
     url: literal('process.env.NEXT_PUBLIC_BASE_URL'),
     reuseExistingServer: literal('!!process.env.CI'),
     timeout: literal('300_000'),
@@ -84,14 +84,7 @@ export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> 
 
     // Keep filling missing defaults, but don't overwrite local adjustments on every regeneration.
     const merged = mergeParsedObjects(defaultConfig, parsed);
-    const hasStartTestServer = Boolean(config.packageJson?.scripts?.['start-test-server']);
-    const hasExistingWebServer = Boolean(parsed.properties.webServer);
-    // Only drop wbfy's default server command. Repos with custom Playwright
-    // server setup still need it even when they do not expose start-test-server.
-    if (!hasStartTestServer && !hasExistingWebServer) {
-      delete merged.properties.webServer;
-    }
-    setWebServerCommand(config, merged);
+    setWebServerCommand(merged);
 
     const newObjectLiteral = stringifyValue({ kind: 'object', value: merged }, 0);
     const start = extractedObjectLiteral.node.getStart(extractedObjectLiteral.source);
@@ -160,13 +153,13 @@ function getEnvFilePaths(dirPath: string): string[] {
   return envFilePaths;
 }
 
-function setWebServerCommand(config: PackageConfig, object: ParsedObject): void {
+function setWebServerCommand(object: ParsedObject): void {
   const webServer = object.properties.webServer;
   if (webServer?.kind !== 'object') return;
 
-  // wbfy owns the package script, so Playwright should consistently call that
-  // script while preserving the rest of each repository's webServer settings.
-  webServer.value.properties.command = literal(config.isBun ? "'bun start-test-server'" : "'yarn start-test-server'");
+  // wb owns the canonical test-server startup path; keep custom Playwright
+  // server settings while normalizing the command itself.
+  webServer.value.properties.command = literal("'wb start --mode test'");
 }
 
 function extractDefineConfigObjectLiteral(content: string): ExtractedObjectLiteral | undefined {

--- a/packages/wbfy/src/fixers/typos.ts
+++ b/packages/wbfy/src/fixers/typos.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 
 import fg from 'fast-glob';
@@ -23,7 +22,8 @@ export async function fixTypos(packageConfig: PackageConfig): Promise<void> {
     for (const mdFile of docFiles) {
       const filePath = path.join(dirPath, mdFile);
       void promisePool.run(async () => {
-        const content = await fs.promises.readFile(filePath, 'utf8');
+        const content = await fsUtil.readFileIgnoringError(filePath);
+        if (content === undefined) return;
         let newContent = fixTyposInText(content);
         newContent = replaceWithConfig(newContent, packageConfig, 'doc');
         if (content !== newContent) {
@@ -45,7 +45,8 @@ export async function fixTypos(packageConfig: PackageConfig): Promise<void> {
     for (const tsFile of tsFiles) {
       const filePath = path.join(dirPath, tsFile);
       void promisePool.run(async () => {
-        const oldContent = await fs.promises.readFile(filePath, 'utf8');
+        const oldContent = await fsUtil.readFileIgnoringError(filePath);
+        if (oldContent === undefined) return;
         let newContent = fixTyposInCode(oldContent);
         newContent = replaceWithConfig(newContent, packageConfig, 'ts');
 
@@ -66,7 +67,8 @@ export async function fixTypos(packageConfig: PackageConfig): Promise<void> {
     for (const file of textBasedFiles) {
       const filePath = path.join(dirPath, file);
       void promisePool.run(async () => {
-        const oldContent = await fs.promises.readFile(filePath, 'utf8');
+        const oldContent = await fsUtil.readFileIgnoringError(filePath);
+        if (oldContent === undefined) return;
         let newContent = fixTyposInText(oldContent);
         newContent = replaceWithConfig(newContent, packageConfig, 'text');
 

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -74,7 +74,7 @@ function generateAgentInstruction(
   - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.
   - Always create new commits. Avoid using \`--amend\`.
 - Always use heredoc syntax when passing multi-line content to any command.
-${hasStartTestServerScript(allConfigs) ? `- Use \`${packageManager} start-test-server\` to launch a web server for debugging or testing.` : ''}
+${hasPlaywrightTestServer(allConfigs) ? `- Use \`wb start --mode test\` to launch a web server for debugging or testing.` : ''}
 
 ${generateAgentCodingStyle(allConfigs)}
 `
@@ -137,12 +137,6 @@ ${
     .trim();
 }
 
-function hasStartTestServerScript(configs: PackageConfig[]): boolean {
-  return configs.some((config) => {
-    if (config.hasStartTestServer) return true;
-    // wbfy generates start-test-server later for Playwright repos once wb is
-    // present. Bun repos get wb as part of wbfy's managed toolchain, so agent
-    // instructions must anticipate the generated script during the first run.
-    return config.depending.playwrightTest && (config.depending.wb || config.isBun);
-  });
+function hasPlaywrightTestServer(configs: PackageConfig[]): boolean {
+  return configs.some((config) => config.depending.playwrightTest);
 }

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -13,7 +13,7 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
     const legacyJsonConfigPath = path.resolve(config.dirPath, '.oxfmtrc.json');
     const filePath = path.resolve(config.dirPath, 'oxfmt.config.ts');
     const existingContent = await fsUtil.readFileIgnoringError(filePath);
-    const desiredContent = getConfigContent(config);
+    const desiredContent = getConfigContent();
     const promises = [promisePool.run(() => fs.promises.rm(legacyJsonConfigPath, { force: true }))];
     if (normalizeToolConfigContent(existingContent) !== normalizeToolConfigContent(desiredContent)) {
       promises.push(promisePool.run(() => fsUtil.generateFile(filePath, desiredContent)));
@@ -22,10 +22,8 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
   });
 }
 
-function getConfigContent(config: PackageConfig): string {
-  return generateToolConfigContent(config, {
-    commonJsVariableName: 'oxfmtConfig',
+function getConfigContent(): string {
+  return generateToolConfigContent({
     packageName: '@willbooster/oxfmt-config',
-    toolName: 'Oxfmt',
   });
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -53,29 +53,16 @@ function getConfigContentWithManagedBlocks(
   existingContent: string | undefined,
   filePath: string
 ): string {
-  const desiredContent = getConfigContent(config);
+  const desiredContent = getConfigContent();
   if (!existingContent) return desiredContent;
   if (hasManagedBlocks(existingContent)) return replaceManagedBlocks(existingContent, desiredContent, filePath);
   return desiredContent;
 }
 
-function getConfigContent(config: PackageConfig): string {
-  if (config.isEsmPackage) {
-    return `${getManagedBlock('base', "import config from '@willbooster/oxlint-config';")}
+function getConfigContent(): string {
+  return `${getManagedBlock('base', "import config from '@willbooster/oxlint-config';")}
 
 ${getManagedBlock('export', 'export default config;')}
-`;
-  }
-
-  return `${getManagedBlock(
-    'base',
-    `// oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
-const oxlintBaseConfig = require('@willbooster/oxlint-config');
-
-const config = oxlintBaseConfig.default ?? oxlintBaseConfig;`
-  )}
-
-${getManagedBlock('export', 'module.exports = config;')}
 `;
 }
 

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -153,7 +153,7 @@ async function updateScripts(
   removeLegacyInstallCommands(jsonObj.scripts);
 
   jsonObj.scripts = { ...jsonObj.scripts, ...generateScripts(config, jsonObj.scripts) };
-  addStartTestServerScriptIfNeeded(config, jsonObj);
+  delete jsonObj.scripts['start-test-server'];
   addInstallStepToCheckForAi(jsonObj.scripts, packageManager);
 
   const scripts = jsonObj.scripts;
@@ -898,22 +898,6 @@ function isWorkspaceProtocolRange(version: string): boolean {
   return version.startsWith('workspace:');
 }
 
-function addStartTestServerScriptIfNeeded(config: PackageConfig, jsonObj: PackageJson): void {
-  if (
-    !config.depending.playwrightTest ||
-    !(config.depending.wb || config.isBun) ||
-    jsonObj.scripts?.['start-test-server']
-  ) {
-    return;
-  }
-
-  jsonObj.scripts ??= {};
-  // mise often owns env loading and database preparation for local web servers.
-  // Prefer a dedicated non-recursive test-server task before falling back to the generic start task.
-  const taskName = getSafeMiseTaskName(config, ['start-test-server', 'start']);
-  jsonObj.scripts['start-test-server'] = taskName ? `mise run ${taskName}` : 'wb start --mode test';
-}
-
 function formatRepositoryForPackageJson(
   repository: PackageJson['repository'],
   existingRepository?: PackageJson['repository']
@@ -1076,10 +1060,6 @@ function applyMiseTaskScripts(
 
 function hasMiseTask(config: PackageConfig, name: string): boolean {
   return Object.hasOwn(config.miseTasks, name);
-}
-
-function getSafeMiseTaskName(config: PackageConfig, names: string[]): string | undefined {
-  return names.find((name) => hasMiseTask(config, name) && !doesMiseTaskCallPackageScript(config, name));
 }
 
 function doesMiseTaskCallPackageScript(config: PackageConfig, name: string): boolean {

--- a/packages/wbfy/src/generators/toolConfigContent.ts
+++ b/packages/wbfy/src/generators/toolConfigContent.ts
@@ -1,23 +1,11 @@
-import type { PackageConfig } from '../packageConfig.js';
-
 interface ToolConfigContentOptions {
-  commonJsVariableName: string;
   packageName: string;
-  toolName: string;
 }
 
-export function generateToolConfigContent(config: PackageConfig, options: ToolConfigContentOptions): string {
-  if (config.isEsmPackage) {
-    return `import config from '${options.packageName}';
+export function generateToolConfigContent(options: ToolConfigContentOptions): string {
+  return `import config from '${options.packageName}';
 
 export default config;
-`;
-  }
-
-  return `// oxlint-disable unicorn/prefer-module -- ${options.toolName} only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
-const ${options.commonJsVariableName} = require('${options.packageName}');
-
-module.exports = ${options.commonJsVariableName}.default ?? ${options.commonJsVariableName};
 `;
 }
 

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -46,8 +46,6 @@ export interface PackageConfig {
   doesContainJsxOrTsxInPackages: boolean;
   doesContainJavaInPackages: boolean;
 
-  hasStartTestServer: boolean;
-
   depending: {
     blitz: boolean;
     firebase: boolean;
@@ -201,7 +199,6 @@ export async function getPackageConfig(
       doesContainTypeScriptInPackages: containsAny('packages/**/{app,src,test,scripts}/**/*.{cts,mts,ts,tsx}', dirPath),
       doesContainJsxOrTsxInPackages: containsAny('packages/**/{app,src,test}/**/*.{t,j}sx', dirPath),
       doesContainJavaInPackages: containsAny('packages/**/*.java', dirPath),
-      hasStartTestServer: !!packageJson.scripts?.['start-test-server'],
       depending: {
         blitz: !!dependencies.blitz,
         firebase: !!devDependencies['firebase-tools'],

--- a/packages/wbfy/test/agentInstructions.test.ts
+++ b/packages/wbfy/test/agentInstructions.test.ts
@@ -15,7 +15,7 @@ afterEach(async () => {
   tempDirs.length = 0;
 });
 
-test('mentions generated start-test-server for Bun Playwright projects on the first run', async () => {
+test('mentions wb test server startup for Playwright projects on the first run', async () => {
   const dirPath = createTempDir();
   const config = createConfig({
     dirPath,
@@ -35,7 +35,7 @@ test('mentions generated start-test-server for Bun Playwright projects on the fi
   await promisePool.promiseAll();
 
   const content = await fs.promises.readFile(path.join(dirPath, 'AGENTS.md'), 'utf8');
-  expect(content).toContain('Use `bun start-test-server` to launch a web server for debugging or testing.');
+  expect(content).toContain('Use `wb start --mode test` to launch a web server for debugging or testing.');
 });
 
 function createTempDir(): string {

--- a/packages/wbfy/test/oxlintConfigGenerator.test.ts
+++ b/packages/wbfy/test/oxlintConfigGenerator.test.ts
@@ -57,9 +57,9 @@ module.exports = staleConfig;
   await promisePool.promiseAll();
 
   const content = await readOxlintConfig(dirPath);
-  expect(content).toContain('const oxlintBaseConfig = require');
+  expect(content).toContain("import config from '@willbooster/oxlint-config';");
   expect(content).toContain("config.ignorePatterns?.push('generated/**');");
-  expect(content).toContain('module.exports = config;');
+  expect(content).toContain('export default config;');
   expect(content).not.toContain('staleConfig');
 });
 

--- a/packages/wbfy/test/packageJsonGenerator.test.ts
+++ b/packages/wbfy/test/packageJsonGenerator.test.ts
@@ -177,7 +177,7 @@ describe('generatePackageJson', () => {
     expect(packageJson.devDependencies?.['@typescript/native-preview']).toBeDefined();
   });
 
-  test('bridges package scripts to mise tasks without creating recursive scripts', async () => {
+  test('bridges regular package scripts to mise tasks without creating recursive scripts', async () => {
     const dirPath = await createPackageDir({
       name: 'mise-package',
       private: true,
@@ -215,11 +215,11 @@ describe('generatePackageJson', () => {
     expect(packageJson.scripts?.build).toBe('mise run build');
     expect(packageJson.scripts?.test).toBe('mise run test');
     expect(packageJson.scripts?.typecheck).toBe('mise run typecheck');
-    expect(packageJson.scripts?.['start-test-server']).toBe('mise run start');
+    expect(packageJson.scripts).not.toHaveProperty('start-test-server');
     expect(packageJson.scripts?.start).toBe('mise run start');
   });
 
-  test('prefers a dedicated mise start-test-server task when generating the test server script', async () => {
+  test('removes start-test-server even when a dedicated mise task exists', async () => {
     const dirPath = await createPackageDir({
       name: 'mise-test-server-package',
       private: true,
@@ -248,7 +248,7 @@ describe('generatePackageJson', () => {
     await generatePackageJson(config, createRootConfig(path.dirname(dirPath)), true);
 
     const packageJson = readPackageJson(dirPath);
-    expect(packageJson.scripts?.['start-test-server']).toBe('mise run start-test-server');
+    expect(packageJson.scripts).not.toHaveProperty('start-test-server');
   });
 });
 

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -31,7 +31,6 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
     doesContainTypeScriptInPackages: false,
     doesContainJsxOrTsxInPackages: false,
     doesContainJavaInPackages: false,
-    hasStartTestServer: false,
     depending: {
       blitz: false,
       firebase: false,

--- a/packages/wbfy/test/workflowGenerator.test.ts
+++ b/packages/wbfy/test/workflowGenerator.test.ts
@@ -62,7 +62,6 @@ test('skips generating workflows for reusable-workflows repository', async () =>
     doesContainTypeScriptInPackages: false,
     doesContainJsxOrTsxInPackages: false,
     doesContainJavaInPackages: false,
-    hasStartTestServer: false,
     depending: {
       blitz: false,
       firebase: false,


### PR DESCRIPTION
## Summary

- Stop generating `start-test-server` scripts in `wbfy` and always remove existing `start-test-server` entries from package scripts.
- Normalize Playwright `webServer.command` to `wb start --mode test` and update generated agent instructions accordingly.
- Fix two repo-sweep issues found while verifying the change: typo fixing now tolerates files removed during the same `wbfy` run, and generated oxlint/oxfmt configs use `import`/`export default` so JS-only repos do not need Node globals for config files.

## Why

`wbfy` now installs `@willbooster/wb`, so the package-script bridge is no longer needed. Keeping one canonical startup command reduces generated package.json surface area and removes the old mise-specific indirection.

## Testing

- `yarn workspace @willbooster/wbfy vitest run test/packageJsonGenerator.test.ts test/agentInstructions.test.ts`
- `yarn workspace @willbooster/wbfy typecheck && yarn workspace @willbooster/wbfy lint`
- `yarn verify`
- Ran local `packages/wbfy` against fresh clones from `self-host-utils/scripts/process-repos.sh`.
  - Fixed and reran `brand` and `gen-em-web` after generator-side failures.
  - `gen-em-web` final focused rerun passed `wbfy`, `yarn check-for-ai`, and no `start-test-server` search.
  - Remaining target check failures were unrelated existing/project issues: `chofu-walking`, `gen-em-artifacts` (`poetry` unavailable), `investment-helper`, and `turtle-graphics`.
  - Fresh `shared` clone still contained old `start-test-server` strings in its own `wbfy` source because it was cloned from `main`; this branch removes those source references except the deletion/assertion checks needed to remove the script.
