### PR TITLE
fix: restore commonjs configs and drop AI check scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
   ],
   "scripts": {
     "build": "yarn workspaces foreach --all --parallel --verbose run build",
-    "check-all-for-ai": "yarn check-for-ai && yarn test",
-    "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code && yarn workspaces foreach --all --parallel --verbose run format",
     "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -17,8 +17,6 @@
   ],
   "scripts": {
     "build": "build-ts app",
-    "check-all-for-ai": "yarn check-for-ai && yarn test",
-    "check-for-ai": "yarn install > /dev/null && yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet",
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
     "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -120,7 +120,8 @@ ${
 ${
   allConfigs.some((c) => c.depending.react || c.depending.next)
     ? `- Prefer lambda over \`function\` for React components, e.g., \`const Button: React.FC = () => {\`.
-- Prefer \`useImmer\` for storing an array or an object to \`useState\`.`
+- Prefer \`useImmer\` for storing an array or an object to \`useState\`.
+- Allow \`autoFocus\` to minimize user effort.`
     : ''
 }
 ${

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -13,7 +13,7 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
     const legacyJsonConfigPath = path.resolve(config.dirPath, '.oxfmtrc.json');
     const filePath = path.resolve(config.dirPath, 'oxfmt.config.ts');
     const existingContent = await fsUtil.readFileIgnoringError(filePath);
-    const desiredContent = getConfigContent();
+    const desiredContent = getConfigContent(config);
     const promises = [promisePool.run(() => fs.promises.rm(legacyJsonConfigPath, { force: true }))];
     if (normalizeToolConfigContent(existingContent) !== normalizeToolConfigContent(desiredContent)) {
       promises.push(promisePool.run(() => fsUtil.generateFile(filePath, desiredContent)));
@@ -22,8 +22,9 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
   });
 }
 
-function getConfigContent(): string {
+function getConfigContent(config: PackageConfig): string {
   return generateToolConfigContent({
+    isEsmPackage: config.isEsmPackage,
     packageName: '@willbooster/oxfmt-config',
   });
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -10,6 +10,8 @@ import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfig
 import { normalizeToolConfigContent } from './toolConfigContent.js';
 
 type OxlintBlockName = 'base' | 'export';
+const tsNoCheckHeader =
+  '// @ts-nocheck -- Tool config files may be loaded as CommonJS before the package opts into ESM.';
 
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
@@ -55,15 +57,23 @@ function getConfigContentWithManagedBlocks(
 ): string {
   const desiredContent = getConfigContent();
   if (!existingContent) return desiredContent;
-  if (hasManagedBlocks(existingContent)) return replaceManagedBlocks(existingContent, desiredContent, filePath);
+  if (hasManagedBlocks(existingContent))
+    return addTsNoCheckHeader(replaceManagedBlocks(existingContent, desiredContent, filePath));
   return desiredContent;
 }
 
 function getConfigContent(): string {
-  return `${getManagedBlock('base', "import config from '@willbooster/oxlint-config';")}
+  return `${tsNoCheckHeader}
+${getManagedBlock('base', "import config from '@willbooster/oxlint-config';")}
 
 ${getManagedBlock('export', 'export default config;')}
 `;
+}
+
+function addTsNoCheckHeader(content: string): string {
+  if (content.startsWith(tsNoCheckHeader)) return content;
+  return `${tsNoCheckHeader}
+${content}`;
 }
 
 function hasManagedBlocks(content: string): boolean {

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -10,8 +10,6 @@ import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfig
 import { normalizeToolConfigContent } from './toolConfigContent.js';
 
 type OxlintBlockName = 'base' | 'export';
-const tsNoCheckHeader =
-  '// @ts-nocheck -- Tool config files may be loaded as CommonJS before the package opts into ESM.';
 
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
@@ -55,25 +53,30 @@ function getConfigContentWithManagedBlocks(
   existingContent: string | undefined,
   filePath: string
 ): string {
-  const desiredContent = getConfigContent();
+  const desiredContent = getConfigContent(config);
   if (!existingContent) return desiredContent;
-  if (hasManagedBlocks(existingContent))
-    return addTsNoCheckHeader(replaceManagedBlocks(existingContent, desiredContent, filePath));
+  if (hasManagedBlocks(existingContent)) return replaceManagedBlocks(existingContent, desiredContent, filePath);
   return desiredContent;
 }
 
-function getConfigContent(): string {
-  return `${tsNoCheckHeader}
-${getManagedBlock('base', "import config from '@willbooster/oxlint-config';")}
+function getConfigContent(config: PackageConfig): string {
+  if (!config.isEsmPackage) {
+    return `${getManagedBlock(
+      'base',
+      `// oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
+const oxlintBaseConfig = require('@willbooster/oxlint-config');
+
+const config = oxlintBaseConfig.default ?? oxlintBaseConfig;`
+    )}
+
+${getManagedBlock('export', 'module.exports = config;')}
+`;
+  }
+
+  return `${getManagedBlock('base', "import config from '@willbooster/oxlint-config';")}
 
 ${getManagedBlock('export', 'export default config;')}
 `;
-}
-
-function addTsNoCheckHeader(content: string): string {
-  if (content.startsWith(tsNoCheckHeader)) return content;
-  return `${tsNoCheckHeader}
-${content}`;
 }
 
 function hasManagedBlocks(content: string): boolean {

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -60,6 +60,10 @@ function getConfigContentWithManagedBlocks(
 }
 
 function getConfigContent(config: PackageConfig): string {
+  // Do not collapse this to a static import for every package. CommonJS packages
+  // type-check auto-discovered oxlint.config.ts as CommonJS, so importing the ESM
+  // @willbooster/oxlint-config package triggers TS1479. Keep this in sync with
+  // literacy-test's generated config pattern.
   if (!config.isEsmPackage) {
     return `${getManagedBlock(
       'base',

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -107,7 +107,7 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
   const packageManager = config.isBun ? 'bun' : 'yarn';
 
   await removeDeprecatedStuff(config, jsonObj);
-  await updateScripts(config, jsonObj, packageManager);
+  await updateScripts(config, jsonObj);
   moveManagedToolDependenciesToDevDependencies(jsonObj);
   const dependencyUpdates = await applyPackageJsonConventions(config, rootConfig, jsonObj);
   await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
@@ -145,16 +145,11 @@ async function readPackageJson(filePath: string): Promise<WritablePackageJson> {
   return jsonObj as WritablePackageJson;
 }
 
-async function updateScripts(
-  config: PackageConfig,
-  jsonObj: WritablePackageJson,
-  packageManager: 'bun' | 'yarn'
-): Promise<void> {
+async function updateScripts(config: PackageConfig, jsonObj: WritablePackageJson): Promise<void> {
   removeLegacyInstallCommands(jsonObj.scripts);
 
   jsonObj.scripts = { ...jsonObj.scripts, ...generateScripts(config, jsonObj.scripts) };
   delete jsonObj.scripts['start-test-server'];
-  addInstallStepToCheckForAi(jsonObj.scripts, packageManager);
 
   const scripts = jsonObj.scripts;
   if (config.isBun || !doesContainJava(config)) {
@@ -173,15 +168,6 @@ function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
       scripts[key] = value.replaceAll(/yarn\s*(?:install\s*)?&&\s*/gu, '');
     }
   }
-}
-
-function addInstallStepToCheckForAi(scripts: PackageJson.Scripts, packageManager: 'bun' | 'yarn'): void {
-  if (!('check-for-ai' in scripts)) return;
-
-  if ('gen-code' in scripts) {
-    scripts['check-for-ai'] = `${packageManager} gen-code > /dev/null && ${scripts['check-for-ai']}`;
-  }
-  scripts['check-for-ai'] = `${packageManager} install > /dev/null && ${scripts['check-for-ai']}`;
 }
 
 function normalizeYarnWorkspaceForeachScripts(scripts: PackageJson.Scripts): void {
@@ -385,7 +371,7 @@ async function normalizePackageMetadata(
       if (!config.doesContainJavaScript && !config.doesContainTypeScript) {
         delete jsonObj.scripts.lint;
         delete jsonObj.scripts['lint-fix'];
-        for (const scriptName of ['cleanup', 'check-for-ai']) {
+        for (const scriptName of ['cleanup']) {
           const script = jsonObj.scripts[scriptName];
           if (!script) continue;
           jsonObj.scripts[scriptName] = script.replace(/ ?&& ?yarn lint-fix(?: --quiet)?/, '');
@@ -658,6 +644,8 @@ async function removeDeprecatedStuff(
   replaceWillBoosterConfigsWorkspaceDependencyRanges(config, jsonObj);
   delete jsonObj.scripts['sort-package-json'];
   delete jsonObj.scripts['sort-all-package-json'];
+  delete jsonObj.scripts['check-all-for-ai'];
+  delete jsonObj.scripts['check-for-ai'];
   delete jsonObj.scripts['typecheck/warn'];
   delete jsonObj.scripts['typecheck:gen-code'];
   delete jsonObj.scripts['typecheck:codegen'];
@@ -957,8 +945,6 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
   if (config.isBun) {
     const hasTypecheck = config.doesContainTypeScript || config.doesContainTypeScriptInPackages;
     const scripts: Record<string, string> = {
-      'check-all-for-ai': 'bun run check-for-ai && bun run test',
-      'check-for-ai': 'bun run cleanup',
       cleanup: 'bun --bun wb lint --fix --format',
       format: `bun --bun wb lint --format`,
       lint: `bun --bun wb lint`,
@@ -981,8 +967,6 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
     const hasJava = doesContainJava(config);
     const oldTest = oldScripts.test;
     let scripts: Record<string, string> = {
-      'check-all-for-ai': 'yarn check-for-ai && yarn test',
-      'check-for-ai': `yarn format > /dev/null 2> /dev/null || true && yarn lint-fix --quiet`,
       cleanup: 'yarn format && yarn lint-fix',
       format: generateFormatScript(hasJsOrTs, hasJava),
       lint: `oxlint --no-error-on-unmatched-pattern .`,

--- a/packages/wbfy/src/generators/toolConfigContent.ts
+++ b/packages/wbfy/src/generators/toolConfigContent.ts
@@ -1,10 +1,18 @@
 interface ToolConfigContentOptions {
+  isEsmPackage: boolean;
   packageName: string;
 }
 
 export function generateToolConfigContent(options: ToolConfigContentOptions): string {
-  return `// @ts-nocheck -- Tool config files may be loaded as CommonJS before the package opts into ESM.
-import config from '${options.packageName}';
+  if (!options.isEsmPackage) {
+    return `// oxlint-disable unicorn/prefer-module -- Tool config files are auto-discovered as .ts, and CommonJS avoids Node typeless ESM warnings.
+const toolConfig = require('${options.packageName}');
+
+module.exports = toolConfig.default ?? toolConfig;
+`;
+  }
+
+  return `import config from '${options.packageName}';
 
 export default config;
 `;

--- a/packages/wbfy/src/generators/toolConfigContent.ts
+++ b/packages/wbfy/src/generators/toolConfigContent.ts
@@ -4,6 +4,9 @@ interface ToolConfigContentOptions {
 }
 
 export function generateToolConfigContent(options: ToolConfigContentOptions): string {
+  // CommonJS packages need require/module.exports here: these .ts config files are
+  // auto-discovered and type-checked as CommonJS, but the shared config packages
+  // are ESM-only.
   if (!options.isEsmPackage) {
     return `// oxlint-disable unicorn/prefer-module -- Tool config files are auto-discovered as .ts, and CommonJS avoids Node typeless ESM warnings.
 const toolConfig = require('${options.packageName}');

--- a/packages/wbfy/src/generators/toolConfigContent.ts
+++ b/packages/wbfy/src/generators/toolConfigContent.ts
@@ -3,7 +3,8 @@ interface ToolConfigContentOptions {
 }
 
 export function generateToolConfigContent(options: ToolConfigContentOptions): string {
-  return `import config from '${options.packageName}';
+  return `// @ts-nocheck -- Tool config files may be loaded as CommonJS before the package opts into ESM.
+import config from '${options.packageName}';
 
 export default config;
 `;

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -126,6 +126,7 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     // aliases without relying on baseUrl's broad fallback resolution.
     delete newSettings.compilerOptions?.baseUrl;
     deleteLegacyModuleSettings(newSettings.compilerOptions, config);
+    normalizeCommonJsTsconfigSettings(newSettings.compilerOptions, config);
     if (config.depending.reactNative) {
       delete newSettings.compilerOptions?.verbatimModuleSyntax;
     }
@@ -266,6 +267,21 @@ function deleteLegacyModuleSettings(
   // Node base configs now pair their resolver with a matching module kind. Keeping
   // older ESNext overrides creates invalid generated configs for TS 6.
   delete compilerOptions.module;
+}
+
+function normalizeCommonJsTsconfigSettings(
+  compilerOptions: TsConfigJson.CompilerOptions | undefined,
+  config: PackageConfig
+): void {
+  if (!compilerOptions || config.isBun || config.depending.reactNative || config.isEsmPackage) return;
+
+  if (compilerOptions.module === 'commonjs') {
+    // @tsconfig/node-lts now provides moduleResolution=node16. TypeScript requires
+    // the module kind to move with that resolver, while verbatimModuleSyntax=false
+    // preserves the long-standing CommonJS emit shape for existing packages.
+    compilerOptions.module = 'Node16';
+  }
+  compilerOptions.verbatimModuleSyntax = false;
 }
 
 function pickExistingEmitMetadata(

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -275,7 +275,7 @@ function normalizeCommonJsTsconfigSettings(
 ): void {
   if (!compilerOptions || config.isBun || config.depending.reactNative || config.isEsmPackage) return;
 
-  if (compilerOptions.module === 'commonjs') {
+  if (compilerOptions.module?.toLowerCase() === 'commonjs') {
     // @tsconfig/node-lts now provides moduleResolution=node16. TypeScript requires
     // the module kind to move with that resolver, while verbatimModuleSyntax=false
     // preserves the long-standing CommonJS emit shape for existing packages.

--- a/packages/wbfy/test/oxlintConfigGenerator.test.ts
+++ b/packages/wbfy/test/oxlintConfigGenerator.test.ts
@@ -32,6 +32,9 @@ export default config;
   await promisePool.promiseAll();
 
   const content = await readOxlintConfig(dirPath);
+  expect(content).toContain(
+    '// @ts-nocheck -- Tool config files may be loaded as CommonJS before the package opts into ESM.'
+  );
   expect(content).toContain('// wbfy:start oxlint-base');
   expect(content).toContain('// wbfy:start oxlint-export');
   expect(content).not.toContain("config.ignorePatterns?.push('generated/**');");
@@ -57,6 +60,9 @@ module.exports = staleConfig;
   await promisePool.promiseAll();
 
   const content = await readOxlintConfig(dirPath);
+  expect(content).toContain(
+    '// @ts-nocheck -- Tool config files may be loaded as CommonJS before the package opts into ESM.'
+  );
   expect(content).toContain("import config from '@willbooster/oxlint-config';");
   expect(content).toContain("config.ignorePatterns?.push('generated/**');");
   expect(content).toContain('export default config;');

--- a/packages/wbfy/test/oxlintConfigGenerator.test.ts
+++ b/packages/wbfy/test/oxlintConfigGenerator.test.ts
@@ -32,11 +32,11 @@ export default config;
   await promisePool.promiseAll();
 
   const content = await readOxlintConfig(dirPath);
-  expect(content).toContain(
-    '// @ts-nocheck -- Tool config files may be loaded as CommonJS before the package opts into ESM.'
-  );
   expect(content).toContain('// wbfy:start oxlint-base');
   expect(content).toContain('// wbfy:start oxlint-export');
+  expect(content).toContain("const oxlintBaseConfig = require('@willbooster/oxlint-config');");
+  expect(content).toContain('const config = oxlintBaseConfig.default ?? oxlintBaseConfig;');
+  expect(content).toContain('module.exports = config;');
   expect(content).not.toContain("config.ignorePatterns?.push('generated/**');");
 });
 
@@ -60,13 +60,21 @@ module.exports = staleConfig;
   await promisePool.promiseAll();
 
   const content = await readOxlintConfig(dirPath);
-  expect(content).toContain(
-    '// @ts-nocheck -- Tool config files may be loaded as CommonJS before the package opts into ESM.'
-  );
-  expect(content).toContain("import config from '@willbooster/oxlint-config';");
+  expect(content).toContain("const oxlintBaseConfig = require('@willbooster/oxlint-config');");
   expect(content).toContain("config.ignorePatterns?.push('generated/**');");
-  expect(content).toContain('export default config;');
+  expect(content).toContain('module.exports = config;');
   expect(content).not.toContain('staleConfig');
+});
+
+test('generates esm oxlint config for esm packages', async () => {
+  const dirPath = createTempDir();
+
+  await generateOxlintConfig(createConfig({ dirPath, isEsmPackage: true }), createConfig({ dirPath }));
+  await promisePool.promiseAll();
+
+  const content = await readOxlintConfig(dirPath);
+  expect(content).toContain("import config from '@willbooster/oxlint-config';");
+  expect(content).toContain('export default config;');
 });
 
 function createTempDir(): string {

--- a/packages/wbfy/test/tsconfigGenerator.test.ts
+++ b/packages/wbfy/test/tsconfigGenerator.test.ts
@@ -40,6 +40,7 @@ test('generates explicit TS 6 types and rootDir for a root package', async () =>
   expect(tsconfig.compilerOptions.noEmit).toBe(true);
   expect(tsconfig.compilerOptions.rootDir).toBe('.');
   expect(tsconfig.compilerOptions.types).toEqual(['node', 'vitest/globals']);
+  expect(tsconfig.compilerOptions.verbatimModuleSyntax).toBe(false);
   expect(tsconfig.include).toContain('*.config.ts');
 });
 
@@ -124,6 +125,34 @@ test('sets subpackage rootDir to the repository root', async () => {
   expect(tsconfig.compilerOptions.noEmit).toBe(true);
   expect(tsconfig.compilerOptions.rootDir).toBe('../..');
   expect(tsconfig.compilerOptions.types).toEqual(['node']);
+  expect(tsconfig.compilerOptions.verbatimModuleSyntax).toBe(false);
+});
+
+test('normalizes legacy CommonJS module override for Node16 resolution', async () => {
+  const dirPath = createTempDir();
+  await fs.promises.mkdir(path.join(dirPath, 'src'), { recursive: true });
+  await fs.promises.writeFile(path.join(dirPath, 'src', 'index.ts'), 'export const value = 1;\n');
+  await fs.promises.writeFile(
+    path.join(dirPath, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        module: 'commonjs',
+      },
+    })
+  );
+
+  await generateTsconfig(
+    createConfig({
+      dirPath,
+      doesContainPackageJson: true,
+      doesContainTypeScript: true,
+    })
+  );
+  await promisePool.promiseAll();
+
+  const tsconfig = await readTsconfig(dirPath);
+  expect(tsconfig.compilerOptions.module).toBe('Node16');
+  expect(tsconfig.compilerOptions.verbatimModuleSyntax).toBe(false);
 });
 
 test('drops stale generated test globals when the package dependency is absent', async () => {
@@ -201,12 +230,14 @@ async function readTsconfig(dirPath: string): Promise<{
     baseUrl?: string;
     declaration?: boolean;
     moduleResolution?: string;
+    module?: string;
     noEmit?: boolean;
     outDir?: string;
     paths?: Record<string, string[]>;
     rootDir?: string;
     sourceMap?: boolean;
     types?: string[];
+    verbatimModuleSyntax?: boolean;
   };
   include?: string[];
 }> {
@@ -215,12 +246,14 @@ async function readTsconfig(dirPath: string): Promise<{
       baseUrl?: string;
       declaration?: boolean;
       moduleResolution?: string;
+      module?: string;
       noEmit?: boolean;
       outDir?: string;
       paths?: Record<string, string[]>;
       rootDir?: string;
       sourceMap?: boolean;
       types?: string[];
+      verbatimModuleSyntax?: boolean;
     };
     include?: string[];
   };


### PR DESCRIPTION
## Summary

- Restore CommonJS-aware generation for oxlint and oxfmt TypeScript config files while keeping ESM output for packages that declare `type: module`.
- Add regression coverage for CommonJS oxlint config generation and for ESM package output.
- Document generated config guidance and remove deprecated `check-for-ai` / `check-all-for-ai` package scripts from wbfy-managed manifests.

## Why

- `af60356` accidentally simplified tool config generation so CommonJS packages received static ESM imports in auto-discovered `.ts` config files.
- Type-aware oxlint then treated those config files as CommonJS and failed with TS1479 when importing ESM-only shared config packages.
- The restored output matches the proven `literacy-test` pattern, and the deprecated AI check scripts should no longer be generated or preserved by wbfy.

## Testing

- `yarn verify`
- `yarn check-for-ai`
- `yarn test test/oxlintConfigGenerator.test.ts test/tsconfigGenerator.test.ts`
- Applied the local `wbfy` branch to `investment-helper` and `survey-system`; both generated auto-discovered oxlint configs without `@ts-nocheck` and resolved the expected oxlint settings.

## Notes

- `yarn verify` completed with existing oxlint warnings in unrelated files, but no errors.
