### PR TITLE
fix: pass mise age key to docker builds

### DIFF
--- a/packages/wb/src/scripts/dockerScripts.ts
+++ b/packages/wb/src/scripts/dockerScripts.ts
@@ -13,12 +13,15 @@ class DockerScripts {
     const prefix = project.dockerPackageJson.scripts?.['docker/build/prepare']
       ? 'YARN run docker/build/prepare && '
       : '';
+    const miseAgeKeySecretOption = project.env.MISE_AGE_KEY
+      ? '\n        --secret id=mise_age_key,env=MISE_AGE_KEY'
+      : '';
     return `cd ${path.dirname(project.findFile('Dockerfile'))}
     && ${prefix}YARN wb optimizeForDockerBuild --outside
     && YARN wb retry -- docker build -t ${project.dockerImageName}
         --build-arg ARCH=$([ $(uname -m) = 'arm64' ] && echo arm64 || echo x86_64)
         --build-arg WB_ENV=${project.env.WB_ENV}
-        --build-arg WB_VERSION=${version} .`;
+        --build-arg WB_VERSION=${version}${miseAgeKeySecretOption} .`;
   }
 
   stopAndStart(project: Project, additionalOptions = '', additionalArgs = ''): string {


### PR DESCRIPTION
## Summary
- pass `MISE_AGE_KEY` into generated `docker build` commands as a BuildKit secret when it is defined
- keep the existing Dockerfile-facing secret id as `mise_age_key`

## Verification
- `yarn verify`
