### PR TITLE
fix: pass mise age key to docker run

### DIFF
--- a/packages/wb/src/scripts/dockerScripts.ts
+++ b/packages/wb/src/scripts/dockerScripts.ts
@@ -31,7 +31,8 @@ class DockerScripts {
   start(project: Project, additionalOptions = '', additionalArgs = ''): string {
     spawnSyncOnExit(this.stop(project), project);
     const allocateTty = additionalArgs.includes('/bin/bash');
-    return `docker run --rm ${allocateTty ? '-it ' : ''}--publish ${project.env.PORT}:8080 --name ${project.dockerImageName} ${additionalOptions} ${project.dockerImageName} ${additionalArgs}`;
+    const miseAgeKeyEnvOption = project.env.MISE_AGE_KEY ? '--env MISE_AGE_KEY ' : '';
+    return `docker run --rm ${allocateTty ? '-it ' : ''}${miseAgeKeyEnvOption}--publish ${project.env.PORT}:8080 --name ${project.dockerImageName} ${additionalOptions} ${project.dockerImageName} ${additionalArgs}`;
   }
 
   stop(project: Project): string {


### PR DESCRIPTION
## Summary
- pass `MISE_AGE_KEY` through generated `docker run` commands when it is defined
- keeps runtime mise decryption in entrypoints without baking the age key into images

## Verification
- `yarn verify`
