### PR TITLE
fix: include framework TypeScript scripts in tsconfig

### DIFF
--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -42,10 +42,10 @@ function getConfigContent(config: PackageConfig): string {
       `// oxlint-disable unicorn/prefer-module -- Oxfmt config files are only auto-discovered as .ts, and CommonJS avoids Node typeless ESM warnings.
 const oxfmtConfig = require('@willbooster/oxfmt-config');
 
-const config = oxfmtConfig.default ?? oxfmtConfig;`
+const oxfmtResolvedConfig = oxfmtConfig.default ?? oxfmtConfig;`
     )}
 
-${managedConfigBlocks.getBlock('export', 'module.exports = config;')}
+${managedConfigBlocks.getBlock('export', 'module.exports = oxfmtResolvedConfig;')}
 `;
   }
 

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -68,15 +68,15 @@ function getConfigContent(config: PackageConfig): string {
       `// oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
 const oxlintBaseConfig = require('@willbooster/oxlint-config');
 
-const config = oxlintBaseConfig.default ?? oxlintBaseConfig;`
+const oxlintResolvedConfig = oxlintBaseConfig.default ?? oxlintBaseConfig;`
     )}
 
-${managedConfigBlocks.getBlock('export', 'module.exports = config;')}
+${managedConfigBlocks.getBlock('export', 'module.exports = oxlintResolvedConfig;')}
 `;
   }
 
-  return `${managedConfigBlocks.getBlock('base', "import config from '@willbooster/oxlint-config';")}
+  return `${managedConfigBlocks.getBlock('base', "import oxlintResolvedConfig from '@willbooster/oxlint-config';")}
 
-${managedConfigBlocks.getBlock('export', 'export default config;')}
+${managedConfigBlocks.getBlock('export', 'export default oxlintResolvedConfig;')}
 `;
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -26,11 +26,13 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
     const desiredContent =
       shouldPreservePublishedLinterConfig && existingContent
         ? existingContent
-        : managedConfigBlocks.getConfigContent({
-            desiredContent: getConfigContent(config),
-            existingContent,
-            filePath,
-          });
+        : replaceLegacyConfigReferences(
+            managedConfigBlocks.getConfigContent({
+              desiredContent: getConfigContent(config),
+              existingContent,
+              filePath,
+            })
+          );
 
     const promises: Promise<void>[] = [];
     if (!shouldPreservePublishedLinterConfig) {
@@ -55,6 +57,10 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
     }
     await Promise.all(promises);
   });
+}
+
+function replaceLegacyConfigReferences(content: string): string {
+  return content.replaceAll('config.', 'oxlintResolvedConfig.');
 }
 
 function getConfigContent(config: PackageConfig): string {

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -150,9 +150,11 @@ async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promi
 }
 
 function addScriptsIncludeForFrameworkProject(settings: TsConfigJson): void {
-  if (settings.include?.includes('scripts/**/*')) return;
+  // Omitting include lets framework tsconfigs keep TypeScript's default
+  // "all TS/TSX files" behavior, which already covers scripts.
+  if (!settings.include) return;
+  if (settings.include.includes('scripts/**/*')) return;
 
-  settings.include ??= [];
   settings.include.push('scripts/**/*');
   settings.include.sort();
 }

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import merge from 'deepmerge';
-import fg from 'fast-glob';
 import type { TsConfigJson } from 'type-fest';
 
 import { logger } from '../logger.js';
@@ -142,7 +141,7 @@ async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promi
     const settings = JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as TsConfigJson;
     normalizeNextTsconfigModuleSettings(settings.compilerOptions);
     normalizeNextTsconfigPathAliases(settings.compilerOptions);
-    await addScriptsIncludeForFrameworkProject(settings, config);
+    addScriptsIncludeForFrameworkProject(settings);
     await promisePool.run(() => fsUtil.generateFile(filePath, JSON.stringify(settings, undefined, 2)));
   } catch {
     // Next/Blitz own their tsconfig shape, but TypeScript 6 no longer accepts
@@ -150,21 +149,12 @@ async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promi
   }
 }
 
-async function addScriptsIncludeForFrameworkProject(settings: TsConfigJson, config: PackageConfig): Promise<void> {
-  if (settings.include?.includes('scripts/**/*') || !(await doesContainScriptsTypeScript(config))) return;
+function addScriptsIncludeForFrameworkProject(settings: TsConfigJson): void {
+  if (settings.include?.includes('scripts/**/*')) return;
 
   settings.include ??= [];
   settings.include.push('scripts/**/*');
   settings.include.sort();
-}
-
-async function doesContainScriptsTypeScript(config: PackageConfig): Promise<boolean> {
-  const filePaths = await fg.glob('scripts/**/*.{cts,mts,ts,tsx}', {
-    cwd: config.dirPath,
-    onlyFiles: true,
-  });
-
-  return filePaths.length > 0;
 }
 
 function normalizeNextTsconfigModuleSettings(compilerOptions: TsConfigJson.CompilerOptions | undefined): void {

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import merge from 'deepmerge';
+import fg from 'fast-glob';
 import type { TsConfigJson } from 'type-fest';
 
 import { logger } from '../logger.js';
@@ -141,11 +142,29 @@ async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promi
     const settings = JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as TsConfigJson;
     normalizeNextTsconfigModuleSettings(settings.compilerOptions);
     normalizeNextTsconfigPathAliases(settings.compilerOptions);
+    await addScriptsIncludeForFrameworkProject(settings, config);
     await promisePool.run(() => fsUtil.generateFile(filePath, JSON.stringify(settings, undefined, 2)));
   } catch {
     // Next/Blitz own their tsconfig shape, but TypeScript 6 no longer accepts
     // node10 resolver spellings that older projects commonly inherited.
   }
+}
+
+async function addScriptsIncludeForFrameworkProject(settings: TsConfigJson, config: PackageConfig): Promise<void> {
+  if (settings.include?.includes('scripts/**/*') || !(await doesContainScriptsTypeScript(config))) return;
+
+  settings.include ??= [];
+  settings.include.push('scripts/**/*');
+  settings.include.sort();
+}
+
+async function doesContainScriptsTypeScript(config: PackageConfig): Promise<boolean> {
+  const filePaths = await fg.glob('scripts/**/*.{cts,mts,ts,tsx}', {
+    cwd: config.dirPath,
+    onlyFiles: true,
+  });
+
+  return filePaths.length > 0;
 }
 
 function normalizeNextTsconfigModuleSettings(compilerOptions: TsConfigJson.CompilerOptions | undefined): void {

--- a/packages/wbfy/test/oxlintConfigGenerator.test.ts
+++ b/packages/wbfy/test/oxlintConfigGenerator.test.ts
@@ -35,8 +35,8 @@ export default config;
   expect(content).toContain('// wbfy:start oxlint-base');
   expect(content).toContain('// wbfy:start oxlint-export');
   expect(content).toContain("const oxlintBaseConfig = require('@willbooster/oxlint-config');");
-  expect(content).toContain('const config = oxlintBaseConfig.default ?? oxlintBaseConfig;');
-  expect(content).toContain('module.exports = config;');
+  expect(content).toContain('const oxlintResolvedConfig = oxlintBaseConfig.default ?? oxlintBaseConfig;');
+  expect(content).toContain('module.exports = oxlintResolvedConfig;');
   expect(content).not.toContain("config.ignorePatterns?.push('generated/**');");
 });
 
@@ -48,7 +48,7 @@ test('updates only managed blocks in marked oxlint config', async () => {
 const staleConfig = require('@willbooster/oxlint-config');
 // wbfy:end oxlint-base
 
-config.ignorePatterns?.push('generated/**');
+oxlintResolvedConfig.ignorePatterns?.push('generated/**');
 
 // wbfy:start oxlint-export
 module.exports = staleConfig;
@@ -61,8 +61,8 @@ module.exports = staleConfig;
 
   const content = await readOxlintConfig(dirPath);
   expect(content).toContain("const oxlintBaseConfig = require('@willbooster/oxlint-config');");
-  expect(content).toContain("config.ignorePatterns?.push('generated/**');");
-  expect(content).toContain('module.exports = config;');
+  expect(content).toContain("oxlintResolvedConfig.ignorePatterns?.push('generated/**');");
+  expect(content).toContain('module.exports = oxlintResolvedConfig;');
   expect(content).not.toContain('staleConfig');
 });
 
@@ -73,8 +73,8 @@ test('generates esm oxlint config for esm packages', async () => {
   await promisePool.promiseAll();
 
   const content = await readOxlintConfig(dirPath);
-  expect(content).toContain("import config from '@willbooster/oxlint-config';");
-  expect(content).toContain('export default config;');
+  expect(content).toContain("import oxlintResolvedConfig from '@willbooster/oxlint-config';");
+  expect(content).toContain('export default oxlintResolvedConfig;');
 });
 
 function createTempDir(): string {

--- a/packages/wbfy/test/oxlintConfigGenerator.test.ts
+++ b/packages/wbfy/test/oxlintConfigGenerator.test.ts
@@ -48,7 +48,7 @@ test('updates only managed blocks in marked oxlint config', async () => {
 const staleConfig = require('@willbooster/oxlint-config');
 // wbfy:end oxlint-base
 
-oxlintResolvedConfig.ignorePatterns?.push('generated/**');
+config.ignorePatterns?.push('generated/**');
 
 // wbfy:start oxlint-export
 module.exports = staleConfig;

--- a/packages/wbfy/test/tsconfigGenerator.test.ts
+++ b/packages/wbfy/test/tsconfigGenerator.test.ts
@@ -219,9 +219,8 @@ test('normalizes Next.js aliases for TypeScript 6 linting', async () => {
   expect(tsconfig.compilerOptions.paths).toEqual({ '@/*': ['./src/*'] });
 });
 
-test('adds scripts include for Next.js projects with TypeScript scripts', async () => {
+test('adds scripts include for Next.js projects', async () => {
   const dirPath = createTempDir();
-  await fs.promises.mkdir(path.join(dirPath, 'scripts'), { recursive: true });
   await fs.promises.writeFile(
     path.join(dirPath, 'tsconfig.json'),
     JSON.stringify({
@@ -231,7 +230,6 @@ test('adds scripts include for Next.js projects with TypeScript scripts', async 
       include: ['src/**/*'],
     })
   );
-  await fs.promises.writeFile(path.join(dirPath, 'scripts', 'run.ts'), 'console.log(process.cwd());\n');
 
   await generateTsconfig(
     createConfig({
@@ -248,7 +246,7 @@ test('adds scripts include for Next.js projects with TypeScript scripts', async 
   expect(tsconfig.include).toEqual(['scripts/**/*', 'src/**/*']);
 });
 
-test('does not add scripts include for Next.js projects without TypeScript scripts', async () => {
+test('does not duplicate scripts include for Next.js projects', async () => {
   const dirPath = createTempDir();
   await fs.promises.writeFile(
     path.join(dirPath, 'tsconfig.json'),
@@ -256,7 +254,7 @@ test('does not add scripts include for Next.js projects without TypeScript scrip
       compilerOptions: {
         moduleResolution: 'bundler',
       },
-      include: ['src/**/*'],
+      include: ['scripts/**/*', 'src/**/*'],
     })
   );
 
@@ -272,7 +270,7 @@ test('does not add scripts include for Next.js projects without TypeScript scrip
   await promisePool.promiseAll();
 
   const tsconfig = await readTsconfig(dirPath);
-  expect(tsconfig.include).toEqual(['src/**/*']);
+  expect(tsconfig.include).toEqual(['scripts/**/*', 'src/**/*']);
 });
 
 function createTempDir(): string {

--- a/packages/wbfy/test/tsconfigGenerator.test.ts
+++ b/packages/wbfy/test/tsconfigGenerator.test.ts
@@ -219,6 +219,62 @@ test('normalizes Next.js aliases for TypeScript 6 linting', async () => {
   expect(tsconfig.compilerOptions.paths).toEqual({ '@/*': ['./src/*'] });
 });
 
+test('adds scripts include for Next.js projects with TypeScript scripts', async () => {
+  const dirPath = createTempDir();
+  await fs.promises.mkdir(path.join(dirPath, 'scripts'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(dirPath, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        moduleResolution: 'bundler',
+      },
+      include: ['src/**/*'],
+    })
+  );
+  await fs.promises.writeFile(path.join(dirPath, 'scripts', 'run.ts'), 'console.log(process.cwd());\n');
+
+  await generateTsconfig(
+    createConfig({
+      dirPath,
+      depending: {
+        ...createConfig().depending,
+        next: true,
+      },
+    })
+  );
+  await promisePool.promiseAll();
+
+  const tsconfig = await readTsconfig(dirPath);
+  expect(tsconfig.include).toEqual(['scripts/**/*', 'src/**/*']);
+});
+
+test('does not add scripts include for Next.js projects without TypeScript scripts', async () => {
+  const dirPath = createTempDir();
+  await fs.promises.writeFile(
+    path.join(dirPath, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        moduleResolution: 'bundler',
+      },
+      include: ['src/**/*'],
+    })
+  );
+
+  await generateTsconfig(
+    createConfig({
+      dirPath,
+      depending: {
+        ...createConfig().depending,
+        next: true,
+      },
+    })
+  );
+  await promisePool.promiseAll();
+
+  const tsconfig = await readTsconfig(dirPath);
+  expect(tsconfig.include).toEqual(['src/**/*']);
+});
+
 function createTempDir(): string {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-tsconfig-'));
   tempDirs.push(tempDir);


### PR DESCRIPTION
## Summary
- Update wbfy Next/Blitz tsconfig cleanup to always include `scripts/**/*` in the existing framework-owned `tsconfig.json`.
- Preserve the rest of the framework tsconfig shape instead of applying the generic generated tsconfig or creating a nested script config.
- Avoid type-aware global scope collisions by giving the generated CommonJS `oxfmt.config.ts` a unique resolved config variable name.
- Add generator coverage for adding `scripts/**/*` and avoiding duplicate includes.

## Verification
- `yarn vitest test/tsconfigGenerator.test.ts` from `packages/wbfy`
- `yarn verify`
- Applied local wbfy to WillBoosterLab/exercode and WillBoosterLab/survey-system, then ran `yarn verify` in both target repos
