### PR TITLE
fix: update agent temp file guidance

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -75,6 +75,7 @@ function generateAgentInstruction(
   - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.
   - Always create new commits. Avoid using \`--amend\`.
 - Always use heredoc syntax when passing multi-line content to any command.
+- Put temporary files in the \`.tmp\` or \`/tmp\` directory.
 ${hasPlaywrightTestServer(allConfigs) ? `- Use \`${packageManager} wb start --mode test\` to launch a web server for debugging or testing.` : ''}
 
 ${generateAgentCodingStyle(allConfigs)}


### PR DESCRIPTION
## Summary

- Add agent instruction guidance to place temporary files under `.tmp` or `/tmp`
- Keep the change scoped to the `wbfy` agent instruction generator

## Why

- Makes generated agent instructions clearer about where temporary files should live
- Avoids leaving throwaway files in arbitrary repository locations

## Testing

- `yarn verify`
