### PR TITLE
chore: refine agent temp file guidance

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -47,6 +47,8 @@ function generateAgentInstruction(
   extraContent?: string
 ): string {
   const packageManager = getPackageManagerCommand(rootConfig);
+  // Ask agents to isolate temporary files so parallel runs in shared workspaces do not collide.
+  const temporaryFileInstruction = '- Put temporary files in a unique location within the ".tmp" or "/tmp" directory.';
   const baseContent = `
 ## Project Information
 
@@ -75,7 +77,7 @@ function generateAgentInstruction(
   - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.
   - Always create new commits. Avoid using \`--amend\`.
 - Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the \`.tmp\` or \`/tmp\` directory.
+${temporaryFileInstruction}
 ${hasPlaywrightTestServer(allConfigs) ? `- Use \`${packageManager} wb start --mode test\` to launch a web server for debugging or testing.` : ''}
 
 ${generateAgentCodingStyle(allConfigs)}


### PR DESCRIPTION
## Summary

- Update `wbfy` generated agent instructions to require temporary files to use a unique location.
- Keep temporary files constrained to the `.tmp` or `/tmp` directory.

## Why

- Avoids name collisions when multiple agents or commands use temporary files in shared workspaces.
- Ensures downstream repositories receive the guidance through `wbfy` generation instead of manual edits.

## Testing

- `yarn verify`
