### PR TITLE
fix: omit root-only oxlint options in package configs

### DIFF
--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -16,7 +16,7 @@ const managedConfigBlocks = new ManagedConfigBlocks({
   toolName: 'oxlint',
 });
 
-export async function generateOxlintConfig(config: PackageConfig, rootConfig: PackageConfig): Promise<void> {
+export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
     // willbooster-configs publishes config files as product code, so migration
     // must not remove package-provided linter settings.
@@ -28,7 +28,7 @@ export async function generateOxlintConfig(config: PackageConfig, rootConfig: Pa
         ? existingContent
         : replaceLegacyConfigReferences(
             managedConfigBlocks.getConfigContent({
-              desiredContent: getConfigContent(config, rootConfig),
+              desiredContent: getConfigContent(config),
               existingContent,
               filePath,
             })
@@ -63,8 +63,8 @@ function replaceLegacyConfigReferences(content: string): string {
   return content.replaceAll('config.', 'oxlintResolvedConfig.');
 }
 
-function getConfigContent(config: PackageConfig, rootConfig: PackageConfig): string {
-  const isRootConfig = config.dirPath === rootConfig.dirPath;
+function getConfigContent(config: PackageConfig): string {
+  const isRootConfig = config.isRoot;
 
   // Do not collapse this to a static import for every package. CommonJS packages
   // type-check auto-discovered oxlint.config.ts as CommonJS, so importing the ESM

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -16,7 +16,7 @@ const managedConfigBlocks = new ManagedConfigBlocks({
   toolName: 'oxlint',
 });
 
-export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
+export async function generateOxlintConfig(config: PackageConfig, rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
     // willbooster-configs publishes config files as product code, so migration
     // must not remove package-provided linter settings.
@@ -28,7 +28,7 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
         ? existingContent
         : replaceLegacyConfigReferences(
             managedConfigBlocks.getConfigContent({
-              desiredContent: getConfigContent(config),
+              desiredContent: getConfigContent(config, rootConfig),
               existingContent,
               filePath,
             })
@@ -63,7 +63,9 @@ function replaceLegacyConfigReferences(content: string): string {
   return content.replaceAll('config.', 'oxlintResolvedConfig.');
 }
 
-function getConfigContent(config: PackageConfig): string {
+function getConfigContent(config: PackageConfig, rootConfig: PackageConfig): string {
+  const isRootConfig = config.dirPath === rootConfig.dirPath;
+
   // Do not collapse this to a static import for every package. CommonJS packages
   // type-check auto-discovered oxlint.config.ts as CommonJS, so importing the ESM
   // @willbooster/oxlint-config package triggers TS1479. Keep this in sync with
@@ -74,15 +76,30 @@ function getConfigContent(config: PackageConfig): string {
       `// oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
 const oxlintBaseConfig = require('@willbooster/oxlint-config');
 
-const oxlintResolvedConfig = oxlintBaseConfig.default ?? oxlintBaseConfig;`
+${getResolvedConfigContent('oxlintBaseConfig.default ?? oxlintBaseConfig', isRootConfig)}`
     )}
 
 ${managedConfigBlocks.getBlock('export', 'module.exports = oxlintResolvedConfig;')}
 `;
   }
 
-  return `${managedConfigBlocks.getBlock('base', "import oxlintResolvedConfig from '@willbooster/oxlint-config';")}
+  return `${managedConfigBlocks.getBlock(
+    'base',
+    `import oxlintBaseConfig from '@willbooster/oxlint-config';
+
+${getResolvedConfigContent('oxlintBaseConfig', isRootConfig)}`
+  )}
 
 ${managedConfigBlocks.getBlock('export', 'export default oxlintResolvedConfig;')}
 `;
+}
+
+function getResolvedConfigContent(baseConfigName: string, isRootConfig: boolean): string {
+  if (isRootConfig) {
+    return `const oxlintResolvedConfig = ${baseConfigName};`;
+  }
+
+  return `// Oxlint only supports type-aware options in the root config, while it
+// still auto-discovers package-local config files in monorepos.
+const { options: _rootOnlyOptions, ...oxlintResolvedConfig } = ${baseConfigName};`;
 }

--- a/packages/wbfy/test/oxlintConfigGenerator.test.ts
+++ b/packages/wbfy/test/oxlintConfigGenerator.test.ts
@@ -82,7 +82,10 @@ test('omits root-only oxlint options for sub-package configs', async () => {
   const rootDirPath = createTempDir();
   const dirPath = createTempDir();
 
-  await generateOxlintConfig(createConfig({ dirPath, isEsmPackage: true }), createConfig({ dirPath: rootDirPath }));
+  await generateOxlintConfig(
+    createConfig({ dirPath, isEsmPackage: true, isRoot: false }),
+    createConfig({ dirPath: rootDirPath })
+  );
   await promisePool.promiseAll();
 
   const content = await readOxlintConfig(dirPath);

--- a/packages/wbfy/test/oxlintConfigGenerator.test.ts
+++ b/packages/wbfy/test/oxlintConfigGenerator.test.ts
@@ -73,7 +73,21 @@ test('generates esm oxlint config for esm packages', async () => {
   await promisePool.promiseAll();
 
   const content = await readOxlintConfig(dirPath);
-  expect(content).toContain("import oxlintResolvedConfig from '@willbooster/oxlint-config';");
+  expect(content).toContain("import oxlintBaseConfig from '@willbooster/oxlint-config';");
+  expect(content).toContain('const oxlintResolvedConfig = oxlintBaseConfig;');
+  expect(content).toContain('export default oxlintResolvedConfig;');
+});
+
+test('omits root-only oxlint options for sub-package configs', async () => {
+  const rootDirPath = createTempDir();
+  const dirPath = createTempDir();
+
+  await generateOxlintConfig(createConfig({ dirPath, isEsmPackage: true }), createConfig({ dirPath: rootDirPath }));
+  await promisePool.promiseAll();
+
+  const content = await readOxlintConfig(dirPath);
+  expect(content).toContain('options: _rootOnlyOptions');
+  expect(content).toContain('...oxlintResolvedConfig');
   expect(content).toContain('export default oxlintResolvedConfig;');
 });
 


### PR DESCRIPTION
## 概要
- wbfy が生成するサブパッケージ用 oxlint config から root-only な `options` を除外
- root config では既存の `@willbooster/oxlint-config` をそのまま利用
- 生成内容を oxlint config generator のテストで固定

## 検証
- `yarn vitest run test/oxlintConfigGenerator.test.ts`
- `yarn verify`
