### PR TITLE
fix: reduce silent test output

### DIFF
--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -34,6 +34,10 @@ export const yargsOptionsBuilderForEnv = {
     type: 'string',
     default: '.env.example',
   },
+  'quiet-env': {
+    description: 'Suppress .env file loading information.',
+    type: 'boolean',
+  },
   verbose: {
     description: 'Whether to show verbose information',
     type: 'boolean',
@@ -77,7 +81,8 @@ export function readEnvironmentVariables(
     );
   }
   envPaths = envPaths.filter((envPath) => fs.existsSync(envPath)).map((envPath) => path.relative(cwd, envPath));
-  if (argv.verbose) {
+  const shouldSuppressOutput = shouldSuppressEnvironmentOutput(argv);
+  if (argv.verbose && !shouldSuppressOutput) {
     console.info(`WB_ENV: ${process.env.WB_ENV}, NODE_ENV: ${process.env.NODE_ENV}`);
     console.info('Reading env files:', envPaths.join(', '));
   }
@@ -93,11 +98,11 @@ export function readEnvironmentVariables(
       }
     }
     envPathAndLoadedEnvVarNames.push([envPath, keys]);
-    if (argv.verbose && keys.length > 0) {
+    if (argv.verbose && !shouldSuppressOutput && keys.length > 0) {
       console.info(`Read ${keys.length} environment variables from ${envPath}`);
     }
   }
-  if (!argv.verbose) {
+  if (!argv.verbose && !shouldSuppressOutput) {
     console.info(
       `Read env files: ${envPathAndLoadedEnvVarNames.map(([envPath, keys]) => (keys.length > 0 ? `${envPath} (${keys.join(', ')})` : envPath)).join(', ') || 'nothing'}`
     );
@@ -111,6 +116,11 @@ export function readEnvironmentVariables(
     }
   }
   return [expand({ parsed: envVars, processEnv: {} }).parsed ?? envVars, envPathAndLoadedEnvVarNames];
+}
+
+export function shouldSuppressEnvironmentOutput(argv: EnvReaderOptions): boolean {
+  const outputOptions = argv as EnvReaderOptions & { quietEnv?: boolean; silent?: boolean };
+  return outputOptions.quietEnv === true || outputOptions.silent === true;
 }
 
 /**

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -120,7 +120,7 @@ export function readEnvironmentVariables(
 
 export function shouldSuppressEnvironmentOutput(argv: EnvReaderOptions): boolean {
   const outputOptions = argv as EnvReaderOptions & { quietEnv?: boolean; silent?: boolean };
-  return outputOptions.quietEnv === true || outputOptions.silent === true;
+  return outputOptions.quietEnv === true || (outputOptions.quietEnv !== false && outputOptions.silent === true);
 }
 
 /**

--- a/packages/shared-lib-node/src/index.ts
+++ b/packages/shared-lib-node/src/index.ts
@@ -2,6 +2,7 @@ export {
   readEnvironmentVariables,
   readAndApplyEnvironmentVariables,
   removeNpmAndYarnEnvironmentVariables,
+  shouldSuppressEnvironmentOutput,
   yargsOptionsBuilderForEnv,
 } from './env.js';
 export type { EnvReaderOptions } from './env.js';

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -131,7 +131,7 @@ export async function test(argv: TestCommandArgv): Promise<void> {
       const targets =
         unitTargets.length > 0 ? unitTargets : defaultUnitTargets.length > 0 ? defaultUnitTargets : undefined;
       const unitArgv = { ...argv, targets };
-      await runTestCommand(scripts.testUnit(project, unitArgv), project, argv, { timeout: argv.unitTimeout });
+      await runUnitTestCommand(scripts.testUnit(project, unitArgv), project, argv, { timeout: argv.unitTimeout });
     }
     // Skip e2e tests if not needed or no e2e directory exists
     if (!shouldRunE2e || !fs.existsSync(path.join(project.dirPath, 'test', 'e2e'))) {
@@ -280,6 +280,21 @@ function runTestCommand(
   return runWithSpawn(script, project, argv, {
     ...options,
     processSilentOutput: dedupeNoisyTestOutput,
+  });
+}
+
+function runUnitTestCommand(
+  script: string,
+  project: Project,
+  argv: Parameters<typeof runWithSpawn>[2],
+  options: Parameters<typeof runWithSpawn>[3] = {}
+): Promise<number> {
+  return runWithSpawn(script, project, argv, {
+    ...options,
+    omitSilentStart: true,
+    printSilentOutputOnFailureOnly: true,
+    silentProgressIntervalMs: 10_000,
+    silentSuccessMessage: 'Unit tests passed.',
   });
 }
 

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type { EnvReaderOptions } from '@willbooster/shared-lib-node/src';
-import { readEnvironmentVariables } from '@willbooster/shared-lib-node/src';
+import { readEnvironmentVariables, shouldSuppressEnvironmentOutput } from '@willbooster/shared-lib-node/src';
 import { memoizeOne } from 'at-decorators';
 import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
@@ -110,8 +110,10 @@ export class Project {
     if (!this.loadEnv) return process.env;
 
     const [envVars, envPathAndLoadedEnvVarCountPairs] = readEnvironmentVariables(this.argv, this.dirPath);
-    for (const [envPath, count] of envPathAndLoadedEnvVarCountPairs) {
-      console.info(`Loaded ${count} environment variables from ${envPath}`);
+    if (!shouldSuppressEnvironmentOutput(this.argv)) {
+      for (const [envPath, count] of envPathAndLoadedEnvVarCountPairs) {
+        console.info(`Loaded ${count} environment variables from ${envPath}`);
+      }
     }
     return { ...envVars, ...process.env };
   }

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -36,7 +36,7 @@ export async function runWithSpawn(
   opts: Options = defaultOptions
 ): Promise<number> {
   const normalizedScript = normalizeScript(script, project);
-  if (!(argv.silent && opts.omitSilentStart)) {
+  if (!(argv.silent && opts.omitSilentStart && !argv.dryRun)) {
     printStart(normalizedScript.printable, project, argv.silent ? 'Command' : 'Start');
   }
   if (argv.verbose) {

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -11,8 +11,12 @@ interface Options {
   exitIfFailed?: boolean;
   onSignal?: (signal: NodeJS.Signals | null) => void;
   forceColor?: boolean;
+  omitSilentStart?: boolean;
   processSilentOutput?: (output: string) => string;
   printRawOutput?: boolean;
+  printSilentOutputOnFailureOnly?: boolean;
+  silentProgressIntervalMs?: number;
+  silentSuccessMessage?: string;
   timeout?: number;
 }
 
@@ -32,7 +36,9 @@ export async function runWithSpawn(
   opts: Options = defaultOptions
 ): Promise<number> {
   const normalizedScript = normalizeScript(script, project);
-  printStart(normalizedScript.printable, project, argv.silent ? 'Command' : 'Start');
+  if (!(argv.silent && opts.omitSilentStart)) {
+    printStart(normalizedScript.printable, project, argv.silent ? 'Command' : 'Start');
+  }
   if (argv.verbose) {
     printStart(normalizedScript.runnable, project, 'Start (raw)', true);
   }
@@ -41,7 +47,17 @@ export async function runWithSpawn(
     return 0;
   }
 
-  const shouldProcessSilentOutput = Boolean(argv.silent && opts.processSilentOutput);
+  const shouldProcessSilentOutput = Boolean(
+    argv.silent && (opts.processSilentOutput ?? opts.printSilentOutputOnFailureOnly)
+  );
+  let wroteSilentProgress = false;
+  const progressTimer =
+    argv.silent && opts.silentProgressIntervalMs
+      ? setInterval(() => {
+          process.stdout.write('.');
+          wroteSilentProgress = true;
+        }, opts.silentProgressIntervalMs)
+      : undefined;
   const ret = await spawnAsync(normalizedScript.runnable, undefined, {
     cwd: project.dirPath,
     env: configureEnv(project.env, opts),
@@ -54,17 +70,28 @@ export async function runWithSpawn(
     printingStderr: argv.silent && !shouldProcessSilentOutput,
     omitBlankLinesWhilePrinting: argv.silent,
     verbose: argv.verbose,
+  }).finally(() => {
+    if (progressTimer) {
+      clearInterval(progressTimer);
+    }
   });
-  if (shouldProcessSilentOutput) {
-    const output = opts.processSilentOutput?.(ret.stdout).trim();
+  const exitCode = ret.status ?? 1;
+  if (wroteSilentProgress) {
+    process.stdout.write('\n');
+  }
+  if (shouldProcessSilentOutput && (!opts.printSilentOutputOnFailureOnly || exitCode !== 0)) {
+    const output = (opts.processSilentOutput ? opts.processSilentOutput(ret.stdout) : ret.stdout).trim();
     if (output) {
       process.stdout.write(output);
       process.stdout.write('\n');
     }
   }
+  if (argv.silent && exitCode === 0 && opts.silentSuccessMessage) {
+    console.info(chalk.green(opts.silentSuccessMessage));
+  }
   opts.onSignal?.(ret.signal);
-  printFinishedAndExitIfNeeded(normalizedScript.printable, ret.status, opts, { silentSuccess: argv.silent });
-  return ret.status ?? 1;
+  printFinishedAndExitIfNeeded(normalizedScript.printable, exitCode, opts, { silentSuccess: argv.silent });
+  return exitCode;
 }
 
 export function runWithSpawnInParallel(

--- a/packages/wb/src/sharedOptionsBuilder.ts
+++ b/packages/wb/src/sharedOptionsBuilder.ts
@@ -36,6 +36,9 @@ export function buildEnvReaderOptionArgs(argv: EnvReaderOptions): string[] {
       }
     }
   }
+  if ((argv as EnvReaderOptions & { silent?: boolean }).silent === true && getOptionValue(argv, 'quiet-env') !== true) {
+    args.push('--quiet-env');
+  }
   return args;
 }
 

--- a/packages/wb/src/sharedOptionsBuilder.ts
+++ b/packages/wb/src/sharedOptionsBuilder.ts
@@ -36,7 +36,10 @@ export function buildEnvReaderOptionArgs(argv: EnvReaderOptions): string[] {
       }
     }
   }
-  if ((argv as EnvReaderOptions & { silent?: boolean }).silent === true && getOptionValue(argv, 'quiet-env') !== true) {
+  if (
+    (argv as EnvReaderOptions & { silent?: boolean }).silent === true &&
+    getOptionValue(argv, 'quiet-env') === undefined
+  ) {
     args.push('--quiet-env');
   }
   return args;

--- a/packages/wbfy/src/generators/yarnrc.ts
+++ b/packages/wbfy/src/generators/yarnrc.ts
@@ -88,6 +88,7 @@ export async function generateYarnrcYml(config: PackageConfig): Promise<void> {
       // To deal with CVE like https://nextjs.org/blog/CVE-2025-66478
       'next',
       '@next/*',
+      '@types/*',
       '@typescript/*',
       '@oxfmt/*',
       '@oxlint/*',


### PR DESCRIPTION
## Summary

- suppress successful unit test output in `wb test --silent` while printing a `.` progress marker every 10 seconds
- print buffered unit test output only when the unit test command fails
- add `quiet-env` support and propagate it to nested `wb` commands without overriding explicit `--quiet-env=false`
- preapprove `@types/*` packages in generated Yarn config so managed type dependencies are not blocked by `npmMinimalAgeGate`

## Why

- Silent test runs should stay quiet for short unit test phases while still showing liveness for longer runs.
- Failed unit tests still need the full buffered output for debugging.
- Environment-loading logs should be suppressible during silent runs, but explicit user preferences must remain authoritative.
- `wbfy` generated projects can otherwise fail cleanup when a freshly published `@types/*` version is selected and Yarn quarantines it.

## Testing

- `yarn workspace @willbooster/wb start test --silent`
- `node packages/wb/bin/index.js test --silent --dry-run`
- `yarn workspace @willbooster/wbfy test test/cleanupIdempotency.test.ts`
- `yarn verify`
- `bunx @willbooster/agent-skills@latest review --agent all`
- `bunx @willbooster/agent-skills@latest check-pr-ci`

## Notes

- A local full `yarn test` run hit an unrelated `@willbooster/shared-lib-node` SIGTERM/killOnExit timeout on macOS; the CI test workflow passed after the `wbfy` fix.
