### PR TITLE
fix: preserve agent skill files during wbfy

### DIFF
--- a/packages/wbfy/src/generators/skills.ts
+++ b/packages/wbfy/src/generators/skills.ts
@@ -1,21 +1,9 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
-
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 
-export async function installAgentSkills(rootConfig: PackageConfig): Promise<void> {
+export async function installAgentSkills(_rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('installAgentSkills', async () => {
     // TODO: We are temporarily not installing managed agent skills into repos.
-    // await runInstallAgentSkills(rootConfig);
-    await Promise.all([
-      fs.rm(path.resolve(rootConfig.dirPath, '.claude'), {
-        force: true,
-        recursive: true,
-      }),
-      fs.rm(path.resolve(rootConfig.dirPath, 'skills-lock.json'), {
-        force: true,
-      }),
-    ]);
+    // await runInstallAgentSkills(_rootConfig);
   });
 }

--- a/packages/wbfy/src/generators/skills.ts
+++ b/packages/wbfy/src/generators/skills.ts
@@ -6,13 +6,9 @@ import type { PackageConfig } from '../packageConfig.js';
 
 export async function installAgentSkills(rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('installAgentSkills', async () => {
-    // TODO: We are temporarily removing agent skills from the repo
+    // TODO: We are temporarily not installing managed agent skills into repos.
     // await runInstallAgentSkills(rootConfig);
     await Promise.all([
-      fs.rm(path.resolve(rootConfig.dirPath, '.agents'), {
-        force: true,
-        recursive: true,
-      }),
       fs.rm(path.resolve(rootConfig.dirPath, '.claude'), {
         force: true,
         recursive: true,


### PR DESCRIPTION
## Summary

- stop `wbfy` from deleting the repository `.agents` directory while managed agent skill installation is disabled
- keep the temporary cleanup for `.claude` and `skills-lock.json`

## Verification

- `yarn verify`
