### PR TITLE
fix: generate oxlint config for non-code workspaces

### DIFF
--- a/packages/wbfy/src/generators/managedConfigBlock.ts
+++ b/packages/wbfy/src/generators/managedConfigBlock.ts
@@ -39,7 +39,7 @@ ${content}
 ${this.getEndMarker(blockName)}`;
   }
 
-  private hasManagedBlocks(content: string): boolean {
+  hasManagedBlocks(content: string): boolean {
     return this.blockNames.some((blockName) => content.includes(this.getStartMarker(blockName)));
   }
 

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -19,20 +19,22 @@ const managedConfigBlocks = new ManagedConfigBlocks({
 export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
     // willbooster-configs publishes config files as product code, so migration
-    // must not remove package-provided linter settings.
+    // must not remove package-provided linter settings. Generated files with
+    // managed blocks are still safe to update.
     const shouldPreservePublishedLinterConfig = isPublishedWillboosterConfigsPackage(config);
     const filePath = path.resolve(config.dirPath, 'oxlint.config.ts');
     const existingContent = await fsUtil.readFileIgnoringError(filePath);
-    const desiredContent =
-      shouldPreservePublishedLinterConfig && existingContent
-        ? existingContent
-        : replaceLegacyConfigReferences(
-            managedConfigBlocks.getConfigContent({
-              desiredContent: getConfigContent(config),
-              existingContent,
-              filePath,
-            })
-          );
+    const shouldPreserveExistingContent =
+      shouldPreservePublishedLinterConfig && existingContent && !managedConfigBlocks.hasManagedBlocks(existingContent);
+    const desiredContent = shouldPreserveExistingContent
+      ? existingContent
+      : replaceLegacyConfigReferences(
+          managedConfigBlocks.getConfigContent({
+            desiredContent: getConfigContent(config),
+            existingContent,
+            filePath,
+          })
+        );
 
     const promises: Promise<void>[] = [];
     if (!shouldPreservePublishedLinterConfig) {

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -100,6 +100,9 @@ function getResolvedConfigContent(baseConfigName: string, isRootConfig: boolean)
   }
 
   return `// Oxlint only supports type-aware options in the root config, while it
-// still auto-discovers package-local config files in monorepos.
-const { options: _rootOnlyOptions, ...oxlintResolvedConfig } = ${baseConfigName};`;
+// still auto-discovers package-local config files in monorepos. Keep this as a
+// plain object copy so package typechecks do not export oxlint's private helper
+// types through the generated config variable.
+const oxlintResolvedConfig: Record<string, unknown> = { ...${baseConfigName} };
+delete oxlintResolvedConfig.options;`;
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -712,9 +712,9 @@ function removeWillBoosterConfigsManagedDependencies(
 
   const sections = getDependencySections(jsonObj);
   for (const dependency of willBoosterConfigsManagedDependencies) {
-    // willbooster-configs publishes these managed config packages from the same
-    // monorepo. Keeping them in subpackage metadata creates local workspace
-    // graph edges that multi-semantic-release sorts as release dependencies.
+    // willbooster-configs owns these config packages. Package-local formatter
+    // and linter config files are repo tooling, not published package data, so
+    // the package metadata only needs the formatter/linter executables.
     for (const section of sections) {
       Reflect.deleteProperty(section, dependency);
     }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import merge from 'deepmerge';
 import fg from 'fast-glob';
+import semver from 'semver';
 import { sortPackageJson } from 'sort-package-json';
 import ts from 'typescript';
 import type { PackageJson, SetRequired } from 'type-fest';
@@ -872,14 +873,19 @@ function shouldUpdateExistingManagedDependency(dependency: string, currentVersio
   if (!currentVersion) return true;
   if (currentVersion === '*') return true;
   if (isWorkspaceProtocolRange(currentVersion)) return true;
+  if (dependency === typescriptGoDependency) return isNewerManagedDependencyVersion(dependency, currentVersion);
   // wbfy-managed tools must be kept current even when the package already pins
   // a concrete version. In particular, build-ts owns declaration output paths.
-  return (
-    dependency === '@willbooster/wb' ||
-    dependency === buildTsDependency ||
-    oxlintDeps.includes(dependency) ||
-    dependency === typescriptGoDependency
-  );
+  return dependency === '@willbooster/wb' || dependency === buildTsDependency || oxlintDeps.includes(dependency);
+}
+
+function isNewerManagedDependencyVersion(dependency: string, currentVersion: string): boolean {
+  const latestVersion = getLatestDependencyVersion(dependency);
+  const validLatestVersion = semver.valid(latestVersion);
+  const validCurrentVersion = semver.valid(currentVersion);
+  // The TypeScript beta dist-tag can lag behind newer concrete dev snapshots
+  // already pinned by Renovate. Keep the existing pin instead of downgrading.
+  return !validLatestVersion || !validCurrentVersion || semver.gt(validLatestVersion, validCurrentVersion);
 }
 
 function isWorkspaceProtocolRange(version: string): boolean {

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -172,6 +172,11 @@ async function main(): Promise<void> {
       if (doesContainJsOrTs(config)) {
         promises.push(generateOxfmtConfig(config));
         promises.push(generateOxlintConfig(config, rootConfig));
+      } else if (!config.isRoot && config.doesContainPackageJson && doesContainJsOrTs(rootConfig)) {
+        // Monorepo verification can invoke oxlint from every workspace. Give
+        // non-code packages a local config so oxlint does not climb to the
+        // root config and reject root-only type-aware options from a package cwd.
+        promises.push(generateOxlintConfig(config, rootConfig));
       }
       if (config.depending.pyright) {
         promises.push(generatePyrightConfigJson(config));

--- a/packages/wbfy/test/oxlintConfigGenerator.test.ts
+++ b/packages/wbfy/test/oxlintConfigGenerator.test.ts
@@ -89,8 +89,8 @@ test('omits root-only oxlint options for sub-package configs', async () => {
   await promisePool.promiseAll();
 
   const content = await readOxlintConfig(dirPath);
-  expect(content).toContain('options: _rootOnlyOptions');
-  expect(content).toContain('...oxlintResolvedConfig');
+  expect(content).toContain('const oxlintResolvedConfig: Record<string, unknown> = { ...oxlintBaseConfig };');
+  expect(content).toContain('delete oxlintResolvedConfig.options;');
   expect(content).toContain('export default oxlintResolvedConfig;');
 });
 


### PR DESCRIPTION
## Summary

- Generate package-local oxlint configs for non-code workspaces in JS/TS monorepos.
- Strip root-only oxlint `options` from package-local configs without exporting inferred private oxlint helper types.
- Continue preserving hand-written published config files, while still updating `wbfy` managed blocks in generated files.

## Why

- Monorepo verification can invoke oxlint from every workspace, including packages without source files.
- If oxlint climbs to the repo root from those package directories, root-only type-aware options are rejected.
- The first managed-block implementation used destructuring that made package typechecks infer and export private oxlint types, which broke `willbooster-configs` CI.

## Testing

- `yarn verify`
- pre-commit cleanup hook
- pre-push check hook
- Re-applied the local fixed generator to WillBooster/willbooster-configs#984 and confirmed CI passed.
