### PR TITLE
fix: run IDEA watcher shims directly

### DIFF
--- a/packages/wbfy/src/generators/idea.ts
+++ b/packages/wbfy/src/generators/idea.ts
@@ -26,17 +26,24 @@ export async function generateIdeaSettings(config: PackageConfig): Promise<void>
 }
 
 function getWatcherTasksContent(config: PackageConfig): string {
-  const taskOptions: string[] = [];
-  if (doesContainJsOrTs(config)) {
-    const args = '--write --no-error-on-unmatched-pattern !**/package.json';
-    taskOptions.push(...extensions.oxfmt.map((ext) => createTaskOptions(oxfmtProgram, args, 'Oxfmt', ext)));
-  }
-  if (doesContainJava(config)) {
-    const args = '--cache --write';
-    taskOptions.push(
-      ...extensions.prettierOnly.map((ext) => createTaskOptions(prettierProgram, args, 'Prettier', ext))
-    );
-  }
+  const taskOptions = [
+    {
+      args: '--write --no-error-on-unmatched-pattern !**/package.json',
+      condition: doesContainJsOrTs(config),
+      extensions: extensions.oxfmt,
+      name: 'Oxfmt',
+      program: oxfmtProgram,
+    },
+    {
+      args: '--cache --write',
+      condition: doesContainJava(config),
+      extensions: extensions.prettierOnly,
+      name: 'Prettier',
+      program: prettierProgram,
+    },
+  ]
+    .filter((task) => task.condition)
+    .flatMap((task) => task.extensions.map((ext) => createTaskOptions(task.program, task.args, task.name, ext)));
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">

--- a/packages/wbfy/src/generators/idea.ts
+++ b/packages/wbfy/src/generators/idea.ts
@@ -11,6 +11,7 @@ import { promisePool } from '../utils/promisePool.js';
 // IDEA invokes File Watcher arguments through node, so pass JavaScript entrypoints
 // instead of package-manager wrapper scripts.
 const oxfmtNodeEntrypoint = 'node_modules/oxfmt/bin/oxfmt';
+// wbfy installs the current Prettier package, so generated watchers use the current bin layout.
 const prettierNodeEntrypoint = 'node_modules/prettier/bin/prettier.cjs';
 
 export async function generateIdeaSettings(config: PackageConfig): Promise<void> {
@@ -28,23 +29,12 @@ export async function generateIdeaSettings(config: PackageConfig): Promise<void>
 function getWatcherTasksContent(config: PackageConfig): string {
   const taskOptions: string[] = [];
   if (doesContainJsOrTs(config)) {
-    taskOptions.push(
-      ...extensions.oxfmt.map((ext) =>
-        createTaskOptions(
-          'node',
-          `${oxfmtNodeEntrypoint} --write --no-error-on-unmatched-pattern !**/package.json`,
-          'Oxfmt',
-          ext
-        )
-      )
-    );
+    const args = `${oxfmtNodeEntrypoint} --write --no-error-on-unmatched-pattern !**/package.json`;
+    taskOptions.push(...extensions.oxfmt.map((ext) => createTaskOptions('node', args, 'Oxfmt', ext)));
   }
   if (doesContainJava(config)) {
-    taskOptions.push(
-      ...extensions.prettierOnly.map((ext) =>
-        createTaskOptions('node', `${prettierNodeEntrypoint} --cache --write`, 'Prettier', ext)
-      )
-    );
+    const args = `${prettierNodeEntrypoint} --cache --write`;
+    taskOptions.push(...extensions.prettierOnly.map((ext) => createTaskOptions('node', args, 'Prettier', ext)));
   }
 
   return `<?xml version="1.0" encoding="UTF-8"?>

--- a/packages/wbfy/src/generators/idea.ts
+++ b/packages/wbfy/src/generators/idea.ts
@@ -8,10 +8,9 @@ import { fsUtil } from '../utils/fsUtil.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
 
-// Windows package-manager shims can be .cmd wrappers, which are not valid
-// JavaScript when IDEA invokes them through node.
-const oxfmtNodeEntrypoint = 'node_modules/oxfmt/bin/oxfmt';
-const prettierNodeEntrypoint = 'node_modules/prettier/bin/prettier.cjs';
+// Keep wrapper scripts in the File Watcher program field so node never parses package-manager shims.
+const oxfmtProgram = '$ProjectFileDir$/node_modules/.bin/oxfmt';
+const prettierProgram = '$ProjectFileDir$/node_modules/.bin/prettier';
 
 export async function generateIdeaSettings(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateIdeaSettings', async () => {
@@ -26,23 +25,19 @@ export async function generateIdeaSettings(config: PackageConfig): Promise<void>
 }
 
 function getWatcherTasksContent(config: PackageConfig): string {
-  const taskOptions = [
-    ...(doesContainJsOrTs(config)
-      ? extensions.oxfmt.map((ext) =>
-          createTaskOptions(
-            'node',
-            `${oxfmtNodeEntrypoint} --write --no-error-on-unmatched-pattern !**/package.json`,
-            'Oxfmt',
-            ext
-          )
-        )
-      : []),
-    ...(doesContainJava(config)
-      ? extensions.prettierOnly.map((ext) =>
-          createTaskOptions('node', `${prettierNodeEntrypoint} --cache --write`, 'Prettier', ext)
-        )
-      : []),
-  ];
+  const taskOptions: string[] = [];
+  if (doesContainJsOrTs(config)) {
+    taskOptions.push(
+      ...extensions.oxfmt.map((ext) =>
+        createTaskOptions(oxfmtProgram, '--write --no-error-on-unmatched-pattern !**/package.json', 'Oxfmt', ext)
+      )
+    );
+  }
+  if (doesContainJava(config)) {
+    taskOptions.push(
+      ...extensions.prettierOnly.map((ext) => createTaskOptions(prettierProgram, '--cache --write', 'Prettier', ext))
+    );
+  }
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">

--- a/packages/wbfy/src/generators/idea.ts
+++ b/packages/wbfy/src/generators/idea.ts
@@ -48,7 +48,8 @@ function getWatcherTasksContent(config: PackageConfig): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-${taskOptions.join('')}  </component>
+    ${taskOptions.join('')}
+  </component>
 </project>
 `;
 }

--- a/packages/wbfy/src/generators/idea.ts
+++ b/packages/wbfy/src/generators/idea.ts
@@ -8,6 +8,9 @@ import { fsUtil } from '../utils/fsUtil.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
 
+const oxfmtNodeEntrypoint = 'node_modules/oxfmt/bin/oxfmt';
+const prettierNodeEntrypoint = 'node_modules/prettier/bin/prettier.cjs';
+
 export async function generateIdeaSettings(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateIdeaSettings', async () => {
     const dirPath = path.resolve(config.dirPath, '.idea');
@@ -48,8 +51,8 @@ function getWatcherTasksContent(config: PackageConfig): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-${doesContainJsOrTs(config) ? extensions.oxfmt.map((ext) => createTaskOptions('node', 'node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern !**/package.json', 'Oxfmt', ext)).join('') : ''}
-${doesContainJava(config) ? extensions.prettierOnly.map((ext) => createTaskOptions('node', 'node_modules/.bin/prettier --cache --write', 'Prettier', ext)).join('') : ''}
+${doesContainJsOrTs(config) ? extensions.oxfmt.map((ext) => createTaskOptions('node', `${oxfmtNodeEntrypoint} --write --no-error-on-unmatched-pattern !**/package.json`, 'Oxfmt', ext)).join('') : ''}
+${doesContainJava(config) ? extensions.prettierOnly.map((ext) => createTaskOptions('node', `${prettierNodeEntrypoint} --cache --write`, 'Prettier', ext)).join('') : ''}
   </component>
 </project>
 `;

--- a/packages/wbfy/src/generators/idea.ts
+++ b/packages/wbfy/src/generators/idea.ts
@@ -8,6 +8,8 @@ import { fsUtil } from '../utils/fsUtil.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
 
+// Windows package-manager shims can be .cmd wrappers, which are not valid
+// JavaScript when IDEA invokes them through node.
 const oxfmtNodeEntrypoint = 'node_modules/oxfmt/bin/oxfmt';
 const prettierNodeEntrypoint = 'node_modules/prettier/bin/prettier.cjs';
 
@@ -24,12 +26,28 @@ export async function generateIdeaSettings(config: PackageConfig): Promise<void>
 }
 
 function getWatcherTasksContent(config: PackageConfig): string {
+  const taskOptions = [
+    ...(doesContainJsOrTs(config)
+      ? extensions.oxfmt.map((ext) =>
+          createTaskOptions(
+            'node',
+            `${oxfmtNodeEntrypoint} --write --no-error-on-unmatched-pattern !**/package.json`,
+            'Oxfmt',
+            ext
+          )
+        )
+      : []),
+    ...(doesContainJava(config)
+      ? extensions.prettierOnly.map((ext) =>
+          createTaskOptions('node', `${prettierNodeEntrypoint} --cache --write`, 'Prettier', ext)
+        )
+      : []),
+  ];
+
   return `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-${doesContainJsOrTs(config) ? extensions.oxfmt.map((ext) => createTaskOptions('node', `${oxfmtNodeEntrypoint} --write --no-error-on-unmatched-pattern !**/package.json`, 'Oxfmt', ext)).join('') : ''}
-${doesContainJava(config) ? extensions.prettierOnly.map((ext) => createTaskOptions('node', `${prettierNodeEntrypoint} --cache --write`, 'Prettier', ext)).join('') : ''}
-  </component>
+${taskOptions.join('')}  </component>
 </project>
 `;
 }

--- a/packages/wbfy/src/generators/idea.ts
+++ b/packages/wbfy/src/generators/idea.ts
@@ -23,6 +23,17 @@ export async function generateIdeaSettings(config: PackageConfig): Promise<void>
   });
 }
 
+function getWatcherTasksContent(config: PackageConfig): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectTasksOptions">
+${doesContainJsOrTs(config) ? extensions.oxfmt.map((ext) => createTaskOptions('node', `${oxfmtNodeEntrypoint} --write --no-error-on-unmatched-pattern !**/package.json`, 'Oxfmt', ext)).join('') : ''}
+${doesContainJava(config) ? extensions.prettierOnly.map((ext) => createTaskOptions('node', `${prettierNodeEntrypoint} --cache --write`, 'Prettier', ext)).join('') : ''}
+  </component>
+</project>
+`;
+}
+
 function createTaskOptions(runner: string, args: string, name: string, extension: string): string {
   return `    <TaskOptions isEnabled="true">
       <option name="arguments" value="${args} $FilePathRelativeToProjectRoot$" />
@@ -44,16 +55,5 @@ function createTaskOptions(runner: string, args: string, name: string, extension
       <option name="workingDir" value="$ProjectFileDir$" />
       <envs />
     </TaskOptions>
-`;
-}
-
-function getWatcherTasksContent(config: PackageConfig): string {
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectTasksOptions">
-${doesContainJsOrTs(config) ? extensions.oxfmt.map((ext) => createTaskOptions('node', `${oxfmtNodeEntrypoint} --write --no-error-on-unmatched-pattern !**/package.json`, 'Oxfmt', ext)).join('') : ''}
-${doesContainJava(config) ? extensions.prettierOnly.map((ext) => createTaskOptions('node', `${prettierNodeEntrypoint} --cache --write`, 'Prettier', ext)).join('') : ''}
-  </component>
-</project>
 `;
 }

--- a/packages/wbfy/src/generators/idea.ts
+++ b/packages/wbfy/src/generators/idea.ts
@@ -8,9 +8,10 @@ import { fsUtil } from '../utils/fsUtil.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
 
-// Keep wrapper scripts in the File Watcher program field so node never parses package-manager shims.
-const oxfmtProgram = '$ProjectFileDir$/node_modules/.bin/oxfmt';
-const prettierProgram = '$ProjectFileDir$/node_modules/.bin/prettier';
+// IDEA invokes File Watcher arguments through node, so pass JavaScript entrypoints
+// instead of package-manager wrapper scripts.
+const oxfmtNodeEntrypoint = 'node_modules/oxfmt/bin/oxfmt';
+const prettierNodeEntrypoint = 'node_modules/prettier/bin/prettier.cjs';
 
 export async function generateIdeaSettings(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateIdeaSettings', async () => {
@@ -29,13 +30,20 @@ function getWatcherTasksContent(config: PackageConfig): string {
   if (doesContainJsOrTs(config)) {
     taskOptions.push(
       ...extensions.oxfmt.map((ext) =>
-        createTaskOptions(oxfmtProgram, '--write --no-error-on-unmatched-pattern !**/package.json', 'Oxfmt', ext)
+        createTaskOptions(
+          'node',
+          `${oxfmtNodeEntrypoint} --write --no-error-on-unmatched-pattern !**/package.json`,
+          'Oxfmt',
+          ext
+        )
       )
     );
   }
   if (doesContainJava(config)) {
     taskOptions.push(
-      ...extensions.prettierOnly.map((ext) => createTaskOptions(prettierProgram, '--cache --write', 'Prettier', ext))
+      ...extensions.prettierOnly.map((ext) =>
+        createTaskOptions('node', `${prettierNodeEntrypoint} --cache --write`, 'Prettier', ext)
+      )
     );
   }
 

--- a/packages/wbfy/src/generators/idea.ts
+++ b/packages/wbfy/src/generators/idea.ts
@@ -8,11 +8,10 @@ import { fsUtil } from '../utils/fsUtil.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
 
-// IDEA invokes File Watcher arguments through node, so pass JavaScript entrypoints
-// instead of package-manager wrapper scripts.
-const oxfmtNodeEntrypoint = 'node_modules/oxfmt/bin/oxfmt';
-// wbfy installs the current Prettier package, so generated watchers use the current bin layout.
-const prettierNodeEntrypoint = 'node_modules/prettier/bin/prettier.cjs';
+// Keep package-manager shims in the File Watcher program field so node does not
+// parse wrapper scripts passed through arguments.
+const oxfmtProgram = '$ProjectFileDir$/node_modules/.bin/oxfmt';
+const prettierProgram = '$ProjectFileDir$/node_modules/.bin/prettier';
 
 export async function generateIdeaSettings(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateIdeaSettings', async () => {
@@ -29,12 +28,14 @@ export async function generateIdeaSettings(config: PackageConfig): Promise<void>
 function getWatcherTasksContent(config: PackageConfig): string {
   const taskOptions: string[] = [];
   if (doesContainJsOrTs(config)) {
-    const args = `${oxfmtNodeEntrypoint} --write --no-error-on-unmatched-pattern !**/package.json`;
-    taskOptions.push(...extensions.oxfmt.map((ext) => createTaskOptions('node', args, 'Oxfmt', ext)));
+    const args = '--write --no-error-on-unmatched-pattern !**/package.json';
+    taskOptions.push(...extensions.oxfmt.map((ext) => createTaskOptions(oxfmtProgram, args, 'Oxfmt', ext)));
   }
   if (doesContainJava(config)) {
-    const args = `${prettierNodeEntrypoint} --cache --write`;
-    taskOptions.push(...extensions.prettierOnly.map((ext) => createTaskOptions('node', args, 'Prettier', ext)));
+    const args = '--cache --write';
+    taskOptions.push(
+      ...extensions.prettierOnly.map((ext) => createTaskOptions(prettierProgram, args, 'Prettier', ext))
+    );
   }
 
   return `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

- Generate IntelliJ File Watchers that run package-manager shims as the watcher `program` instead of asking `node` to execute those shim files.
- Use `$ProjectFileDir$/node_modules/.bin/oxfmt` as the Oxfmt watcher program with formatter flags in `arguments`.
- Use `$ProjectFileDir$/node_modules/.bin/prettier` as the Java Prettier watcher program with formatter flags in `arguments`.
- Reordered helper functions top-down and simplified task option construction.
- Merged the latest `origin/main` into the PR branch.

## Why

- `program=node` with `node_modules/.bin/*` in `arguments` makes Node parse package-manager shim files.
- Running the tool shim as the File Watcher program keeps wrapper execution in the IDE layer and avoids hardcoding internal package entrypoint paths.
- This follows the repository policy to drop Windows support instead of adding Windows-specific entrypoint handling.

## Testing

- `yarn verify`
- `bunx @willbooster/agent-skills@latest check-pr-ci`
- Pre-commit cleanup hook passed.
- Pre-push check hook passed.

## Notes

- All review threads are resolved.
- The shared repo still reports four pre-existing lint warnings outside this change: three `unicorn/no-null` warnings in `test/packageJsonGenerator.test.ts` and one `import/no-named-as-default-member` warning in `src/packageConfig.ts`.
