### PR TITLE
fix: harden wbfy dependency source policy

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,6 +6,8 @@ defaultSemverRangePrefix: ''
 
 enableGlobalCache: true
 
+enableScripts: false
+
 nmMode: hardlinks-global
 
 nodeLinker: node-modules

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,6 @@
 approvedGitRepositories:
+  - 'https://github.com/WillBooster/*.git'
+  - 'ssh://git@github.com/WillBooster/*.git'
   - 'https://github.com/WillBoosterLab/*.git'
   - 'ssh://git@github.com/WillBoosterLab/*.git'
 

--- a/packages/wbfy/src/generators/yarnrc.ts
+++ b/packages/wbfy/src/generators/yarnrc.ts
@@ -75,6 +75,8 @@ export async function generateYarnrcYml(config: PackageConfig): Promise<void> {
     settings.npmMinimalAgeGate = '5d';
     settings.approvedGitRepositories = [
       // Yarn 4.14 blocks git dependencies unless the repository URL is explicitly allowed.
+      'https://github.com/WillBooster/*.git',
+      'ssh://git@github.com/WillBooster/*.git',
       'https://github.com/WillBoosterLab/*.git',
       'ssh://git@github.com/WillBoosterLab/*.git',
     ];

--- a/packages/wbfy/src/generators/yarnrc.ts
+++ b/packages/wbfy/src/generators/yarnrc.ts
@@ -14,6 +14,7 @@ import { spawnSync, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
 type Settings = {
   approvedGitRepositories?: string[];
   defaultSemverRangePrefix: string;
+  enableScripts?: boolean;
   nmMode: string;
   nodeLinker: string;
   npmMinimalAgeGate?: string;
@@ -66,6 +67,9 @@ export async function generateYarnrcYml(config: PackageConfig): Promise<void> {
       // do nothing
     }
     settings.defaultSemverRangePrefix = '';
+    // Install-time scripts are a common supply-chain execution path. Keep this
+    // explicit so stale project settings cannot re-enable them globally.
+    settings.enableScripts = false;
     settings.nodeLinker = 'node-modules';
     settings.nmMode = 'hardlinks-global';
     settings.npmMinimalAgeGate = '5d';

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -41,6 +41,7 @@ import { generateGitHubTemplates } from './github/template.js';
 import { logger } from './logger.js';
 import { options } from './options.js';
 import { getPackageConfig } from './packageConfig.js';
+import { assertSafeDependencySources } from './utils/dependencySourcePolicy.js';
 import { doesContainJsOrTs } from './utils/packageCapabilities.js';
 import { promisePool } from './utils/promisePool.js';
 import { spawnSync, spawnSyncAndReturnStatus } from './utils/spawnUtil.js';
@@ -110,6 +111,7 @@ async function main(): Promise<void> {
         console.info(config);
       }
     }
+    assertSafeDependencySources(allPackageConfigs);
 
     // Install yarn berry
     await generateYarnrcYml(rootConfig);

--- a/packages/wbfy/src/utils/dependencySourcePolicy.ts
+++ b/packages/wbfy/src/utils/dependencySourcePolicy.ts
@@ -5,6 +5,7 @@ import type { PackageConfig } from '../packageConfig.js';
 const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
 const allowedGitHubOrganizationPattern = String.raw`(?:WillBooster|WillBoosterLab)`;
 const allowedGitDependencyPatterns = [
+  new RegExp(`^${allowedGitHubOrganizationPattern}/[^#\\s]+(?:#\\S+)?$`, 'u'),
   new RegExp(`^github:${allowedGitHubOrganizationPattern}/[^#\\s]+(?:#\\S+)?$`, 'u'),
   new RegExp(
     `^(?:git\\+)?https://github\\.com/${allowedGitHubOrganizationPattern}/[^#\\s]+(?:\\.git)?(?:#\\S+)?$`,
@@ -67,6 +68,11 @@ function getDisallowedDependencySources(config: PackageConfig): DisallowedDepend
 
 function isGitDependencySpecifier(specifier: string): boolean {
   return (
+    isGitHubShorthandSpecifier(specifier) ||
+    /^(?:bitbucket|gist|gitlab):/u.test(specifier) ||
+    /^https?:\/\/github\.com\//u.test(specifier) ||
+    /^https?:\/\/\S+\.git(?:#\S+)?$/u.test(specifier) ||
+    /^ssh:\/\/\S+\.git(?:#\S+)?$/u.test(specifier) ||
     specifier.startsWith('github:') ||
     specifier.startsWith('git:') ||
     specifier.startsWith('git+') ||
@@ -74,6 +80,10 @@ function isGitDependencySpecifier(specifier: string): boolean {
     specifier.startsWith('https://github.com/') ||
     specifier.startsWith('git@github.com:')
   );
+}
+
+function isGitHubShorthandSpecifier(specifier: string): boolean {
+  return /^[a-zA-Z0-9][\w.-]*\/[\w.-]+(?:#\S+)?$/u.test(specifier);
 }
 
 function isAllowedGitDependencySpecifier(specifier: string): boolean {

--- a/packages/wbfy/src/utils/dependencySourcePolicy.ts
+++ b/packages/wbfy/src/utils/dependencySourcePolicy.ts
@@ -12,7 +12,7 @@ const allowedGitDependencyPatterns = [
     'u'
   ),
   new RegExp(
-    `^(?:git\\+)?ssh://git@github\\.com/${allowedGitHubOrganizationPattern}/[^#\\s]+(?:\\.git)?(?:#\\S+)?$`,
+    `^(?:git\\+)?ssh://git@github\\.com[:/]${allowedGitHubOrganizationPattern}/[^#\\s]+(?:\\.git)?(?:#\\S+)?$`,
     'u'
   ),
   new RegExp(`^git@github\\.com:${allowedGitHubOrganizationPattern}/[^#\\s]+(?:\\.git)?(?:#\\S+)?$`, 'u'),
@@ -73,6 +73,7 @@ function isGitDependencySpecifier(specifier: string): boolean {
     /^https?:\/\/github\.com\//u.test(specifier) ||
     /^https?:\/\/\S+\.git(?:#\S+)?$/u.test(specifier) ||
     /^ssh:\/\/\S+\.git(?:#\S+)?$/u.test(specifier) ||
+    /^[^@\s]+@[^:\s]+:\S+(?:#\S+)?$/u.test(specifier) ||
     specifier.startsWith('github:') ||
     specifier.startsWith('git:') ||
     specifier.startsWith('git+') ||

--- a/packages/wbfy/src/utils/dependencySourcePolicy.ts
+++ b/packages/wbfy/src/utils/dependencySourcePolicy.ts
@@ -3,6 +3,19 @@ import path from 'node:path';
 import type { PackageConfig } from '../packageConfig.js';
 
 const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
+const allowedGitHubOrganizationPattern = String.raw`(?:WillBooster|WillBoosterLab)`;
+const allowedGitDependencyPatterns = [
+  new RegExp(`^github:${allowedGitHubOrganizationPattern}/[^#\\s]+(?:#\\S+)?$`, 'u'),
+  new RegExp(
+    `^(?:git\\+)?https://github\\.com/${allowedGitHubOrganizationPattern}/[^#\\s]+(?:\\.git)?(?:#\\S+)?$`,
+    'u'
+  ),
+  new RegExp(
+    `^(?:git\\+)?ssh://git@github\\.com/${allowedGitHubOrganizationPattern}/[^#\\s]+(?:\\.git)?(?:#\\S+)?$`,
+    'u'
+  ),
+  new RegExp(`^git@github\\.com:${allowedGitHubOrganizationPattern}/[^#\\s]+(?:\\.git)?(?:#\\S+)?$`, 'u'),
+];
 
 interface DisallowedDependencySource {
   dependencyName: string;
@@ -23,7 +36,7 @@ export function assertSafeDependencySources(configs: PackageConfig[]): void {
     .join('\n');
 
   throw new Error(
-    `Disallowed Git dependency sources found.\nOnly WillBoosterLab GitHub dependencies are allowed.\n${details}`
+    `Disallowed Git dependency sources found.\nOnly WillBooster and WillBoosterLab GitHub dependencies are allowed.\n${details}`
   );
 }
 
@@ -64,10 +77,5 @@ function isGitDependencySpecifier(specifier: string): boolean {
 }
 
 function isAllowedGitDependencySpecifier(specifier: string): boolean {
-  return (
-    /^github:WillBoosterLab\/[^#\s]+(?:#\S+)?$/u.test(specifier) ||
-    /^(?:git\+)?https:\/\/github\.com\/WillBoosterLab\/[^#\s]+(?:\.git)?(?:#\S+)?$/u.test(specifier) ||
-    /^(?:git\+)?ssh:\/\/git@github\.com\/WillBoosterLab\/[^#\s]+(?:\.git)?(?:#\S+)?$/u.test(specifier) ||
-    /^git@github\.com:WillBoosterLab\/[^#\s]+(?:\.git)?(?:#\S+)?$/u.test(specifier)
-  );
+  return allowedGitDependencyPatterns.some((pattern) => pattern.test(specifier));
 }

--- a/packages/wbfy/src/utils/dependencySourcePolicy.ts
+++ b/packages/wbfy/src/utils/dependencySourcePolicy.ts
@@ -71,6 +71,7 @@ function isGitDependencySpecifier(specifier: string): boolean {
     isGitHubShorthandSpecifier(specifier) ||
     /^(?:bitbucket|gist|gitlab):/u.test(specifier) ||
     /^https?:\/\/github\.com\//u.test(specifier) ||
+    /^https?:\/\/(?:bitbucket\.org|gitlab\.com)\//u.test(specifier) ||
     /^https?:\/\/\S+\.git(?:#\S+)?$/u.test(specifier) ||
     /^ssh:\/\/\S+\.git(?:#\S+)?$/u.test(specifier) ||
     /^[^@\s]+@[^:\s]+:\S+(?:#\S+)?$/u.test(specifier) ||

--- a/packages/wbfy/src/utils/dependencySourcePolicy.ts
+++ b/packages/wbfy/src/utils/dependencySourcePolicy.ts
@@ -1,0 +1,73 @@
+import path from 'node:path';
+
+import type { PackageConfig } from '../packageConfig.js';
+
+const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
+
+interface DisallowedDependencySource {
+  dependencyName: string;
+  dirPath: string;
+  sectionName: (typeof dependencySectionKeys)[number];
+  specifier: string;
+}
+
+export function assertSafeDependencySources(configs: PackageConfig[]): void {
+  const disallowedSources = configs.flatMap(getDisallowedDependencySources);
+  if (disallowedSources.length === 0) return;
+
+  const details = disallowedSources
+    .map(
+      ({ dependencyName, dirPath, sectionName, specifier }) =>
+        `- ${path.join(dirPath, 'package.json')}: ${sectionName}.${dependencyName} uses ${specifier}`
+    )
+    .join('\n');
+
+  throw new Error(
+    `Disallowed Git dependency sources found.\nOnly WillBoosterLab GitHub dependencies are allowed.\n${details}`
+  );
+}
+
+function getDisallowedDependencySources(config: PackageConfig): DisallowedDependencySource[] {
+  const packageJson = config.packageJson;
+  if (!packageJson) return [];
+
+  const disallowedSources: DisallowedDependencySource[] = [];
+  for (const sectionName of dependencySectionKeys) {
+    const section = packageJson[sectionName];
+    if (!section) continue;
+
+    for (const [dependencyName, specifier] of Object.entries(section)) {
+      if (!specifier) continue;
+      if (!isGitDependencySpecifier(specifier)) continue;
+      if (isAllowedGitDependencySpecifier(specifier)) continue;
+
+      disallowedSources.push({
+        dependencyName,
+        dirPath: config.dirPath,
+        sectionName,
+        specifier,
+      });
+    }
+  }
+  return disallowedSources;
+}
+
+function isGitDependencySpecifier(specifier: string): boolean {
+  return (
+    specifier.startsWith('github:') ||
+    specifier.startsWith('git:') ||
+    specifier.startsWith('git+') ||
+    specifier.startsWith('ssh://git@') ||
+    specifier.startsWith('https://github.com/') ||
+    specifier.startsWith('git@github.com:')
+  );
+}
+
+function isAllowedGitDependencySpecifier(specifier: string): boolean {
+  return (
+    /^github:WillBoosterLab\/[^#\s]+(?:#\S+)?$/u.test(specifier) ||
+    /^(?:git\+)?https:\/\/github\.com\/WillBoosterLab\/[^#\s]+(?:\.git)?(?:#\S+)?$/u.test(specifier) ||
+    /^(?:git\+)?ssh:\/\/git@github\.com\/WillBoosterLab\/[^#\s]+(?:\.git)?(?:#\S+)?$/u.test(specifier) ||
+    /^git@github\.com:WillBoosterLab\/[^#\s]+(?:\.git)?(?:#\S+)?$/u.test(specifier)
+  );
+}

--- a/packages/wbfy/src/utils/dependencySourcePolicy.ts
+++ b/packages/wbfy/src/utils/dependencySourcePolicy.ts
@@ -15,7 +15,7 @@ const allowedGitDependencyPatterns = [
     `^(?:git\\+)?ssh://git@github\\.com[:/]${allowedGitHubOrganizationPattern}/[^#\\s]+(?:\\.git)?(?:#\\S+)?$`,
     'u'
   ),
-  new RegExp(`^git@github\\.com:${allowedGitHubOrganizationPattern}/[^#\\s]+(?:\\.git)?(?:#\\S+)?$`, 'u'),
+  new RegExp(`^(?:git\\+)?git@github\\.com:${allowedGitHubOrganizationPattern}/[^#\\s]+(?:\\.git)?(?:#\\S+)?$`, 'u'),
 ];
 
 interface DisallowedDependencySource {

--- a/packages/wbfy/src/utils/dependencySourcePolicy.ts
+++ b/packages/wbfy/src/utils/dependencySourcePolicy.ts
@@ -69,18 +69,13 @@ function getDisallowedDependencySources(config: PackageConfig): DisallowedDepend
 function isGitDependencySpecifier(specifier: string): boolean {
   return (
     isGitHubShorthandSpecifier(specifier) ||
-    /^(?:bitbucket|gist|gitlab):/u.test(specifier) ||
-    /^https?:\/\/github\.com\//u.test(specifier) ||
-    /^https?:\/\/(?:bitbucket\.org|gitlab\.com)\//u.test(specifier) ||
-    /^https?:\/\/\S+\.git(?:#\S+)?$/u.test(specifier) ||
-    /^ssh:\/\/\S+\.git(?:#\S+)?$/u.test(specifier) ||
+    /^(?:bitbucket|gist|github|gitlab):/u.test(specifier) ||
+    /^https?:\/\/(?:bitbucket\.org|github\.com|gitlab\.com)\//u.test(specifier) ||
+    /^(?:https?|ssh):\/\/\S+\.git(?:#\S+)?$/u.test(specifier) ||
     /^[^@\s]+@[^:\s]+:\S+(?:#\S+)?$/u.test(specifier) ||
-    specifier.startsWith('github:') ||
     specifier.startsWith('git:') ||
     specifier.startsWith('git+') ||
-    specifier.startsWith('ssh://git@') ||
-    specifier.startsWith('https://github.com/') ||
-    specifier.startsWith('git@github.com:')
+    specifier.startsWith('ssh://git@')
   );
 }
 


### PR DESCRIPTION
## Summary

- Generate `enableScripts: false` in `.yarnrc.yml` so Yarn install scripts stay globally disabled even when older project settings had enabled them.
- Add a wbfy dependency source policy that rejects direct Git/GitHub dependency specifiers unless they point to allowed WillBooster GitHub organizations.
- Cover GitHub shorthand, hosted GitHub/GitLab/Bitbucket URLs, scp-style specs, insecure Git protocols, and git-prefixed scp specs such as `git+git@github.com:WillBoosterLab/repo.git#hash`.
- Simplify the Git dependency detection predicates after review feedback.
- Update this repository's generated `.yarnrc.yml` with the new explicit Yarn setting.

## Why

- The Mini Shai-Hulud/TanStack compromise used an optional GitHub dependency and its install lifecycle script as the execution path.
- Yarn already has repository approval, but explicitly disabling scripts prevents stale `enableScripts: true` settings from weakening the generated config.
- Bun does not have a matching Git repository allowlist setting, so wbfy now blocks unsafe direct Git dependency sources before generated Bun projects continue.

## Testing

- `yarn verify`
- `yarn workspace @willbooster/wbfy typecheck`
- `bunx @willbooster/agent-skills@latest check-pr-ci`
