### PR TITLE
feat: add db migrate idempotency check

### DIFF
--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -121,10 +121,10 @@ const migrateCommand: CommandModule<unknown, InferredOptionTypes<typeof migrateB
     const allProjects = await findDatabaseOrmProjects(argv);
     const unknownOptions = extractUnknownOptions(argv, ['check-idempotency']);
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db migrate', allProjects)) {
-      const migrateScript = getDatabaseOrmScripts(orm).migrate(project, unknownOptions);
-      await runWithSpawn(migrateScript, project, argv);
+      const ormScripts = getDatabaseOrmScripts(orm);
+      await runWithSpawn(ormScripts.migrate(project, unknownOptions), project, argv);
       if (argv.checkIdempotency && !isProductionEnvironment(project)) {
-        await runWithSpawn(migrateScript, project, argv);
+        await runWithSpawn(ormScripts.deploy(project, unknownOptions), project, argv);
       }
     }
   },

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -123,8 +123,12 @@ const migrateCommand: CommandModule<unknown, InferredOptionTypes<typeof migrateB
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db migrate', allProjects)) {
       const ormScripts = getDatabaseOrmScripts(orm);
       await runWithSpawn(ormScripts.migrate(project, unknownOptions), project, argv);
-      if (argv.checkIdempotency && !isProductionEnvironment(project)) {
-        await runWithSpawn(ormScripts.deploy(project, unknownOptions), project, argv);
+      if (argv.checkIdempotency) {
+        if (isProductionEnvironment(project)) {
+          console.info(chalk.yellow(`Skipping idempotency check for ${project.name} in production environment.`));
+        } else {
+          await runWithSpawn(ormScripts.deploy(project, unknownOptions), project, argv);
+        }
       }
     }
   },

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -123,12 +123,16 @@ const migrateCommand: CommandModule<unknown, InferredOptionTypes<typeof migrateB
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db migrate', allProjects)) {
       const migrateScript = getDatabaseOrmScripts(orm).migrate(project, unknownOptions);
       await runWithSpawn(migrateScript, project, argv);
-      if (argv.checkIdempotency) {
+      if (argv.checkIdempotency && !isProductionEnvironment(project)) {
         await runWithSpawn(migrateScript, project, argv);
       }
     }
   },
 };
+
+function isProductionEnvironment(project: Project): boolean {
+  return project.env.WB_ENV === 'production' || project.env.MISE_ENV === 'production';
+}
 
 const migrateDevCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> = {
   command: 'migrate-dev',

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -105,15 +105,27 @@ const listBackupsCommand: CommandModule<unknown, InferredOptionTypes<typeof buil
   },
 };
 
-const migrateCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> = {
+const migrateBuilder = {
+  ...builder,
+  'check-idempotency': {
+    description: 'Run the migration command twice to confirm it is idempotent.',
+    type: 'boolean',
+  },
+} as const;
+
+const migrateCommand: CommandModule<unknown, InferredOptionTypes<typeof migrateBuilder>> = {
   command: 'migrate',
   describe: 'Apply migration to DB with initializing it',
-  builder,
+  builder: migrateBuilder,
   async handler(argv) {
     const allProjects = await findDatabaseOrmProjects(argv);
-    const unknownOptions = extractUnknownOptions(argv);
+    const unknownOptions = extractUnknownOptions(argv, ['check-idempotency']);
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db migrate', allProjects)) {
-      await runWithSpawn(getDatabaseOrmScripts(orm).migrate(project, unknownOptions), project, argv);
+      const migrateScript = getDatabaseOrmScripts(orm).migrate(project, unknownOptions);
+      await runWithSpawn(migrateScript, project, argv);
+      if (argv.checkIdempotency) {
+        await runWithSpawn(migrateScript, project, argv);
+      }
     }
   },
 };


### PR DESCRIPTION
## Summary

- add `wb db migrate --check-idempotency`
- run the full ORM migrate command once, then rerun only the ORM deploy command for the idempotency check
- skip the idempotency check in production environments and print an explicit skip message
- keep `--check-idempotency` out of forwarded ORM options

## Why

- matches the non-production migration idempotency check used by `doco-san`
- avoids rerunning Prisma generate or seed during the check pass

## Testing

- `yarn workspace @willbooster/wb vitest run test/prisma.test.ts`
- `yarn verify`
- PR CI passed
