### PR TITLE
fix: seed drizzle migrations for local preparation

### DIFF
--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -23,7 +23,7 @@ class DrizzleScripts {
       return "echo 'wb db reset supports Drizzle only when DATABASE_PATH or file: DATABASE_URL is set.' && exit 1";
     }
 
-    return `${removeCommand} && ${this.migrate(project, additionalOptions)} && ${this.seed(project)}`;
+    return `${removeCommand} && ${this.migrate(project, additionalOptions)}`;
   }
 
   seed(project: Project, scriptPath?: string): string {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -9,8 +9,8 @@ class DrizzleScripts {
     return this.migrate(project, additionalOptions);
   }
 
-  migrate(_project: Project, additionalOptions = ''): string {
-    return `YARN drizzle-kit migrate ${additionalOptions}`;
+  migrate(project: Project, additionalOptions = ''): string {
+    return `YARN drizzle-kit migrate ${additionalOptions} && ${this.seed(project)}`;
   }
 
   migrateDev(_project: Project, additionalOptions = ''): string {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -5,8 +5,8 @@ import type { Project } from '../project.js';
 const FILE_SCHEMA = 'file:';
 
 class DrizzleScripts {
-  deploy(project: Project, additionalOptions = ''): string {
-    return this.migrate(project, additionalOptions);
+  deploy(_project: Project, additionalOptions = ''): string {
+    return `YARN drizzle-kit migrate ${additionalOptions}`;
   }
 
   reset(project: Project, additionalOptions = ''): string {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -5,10 +5,6 @@ import type { Project } from '../project.js';
 const FILE_SCHEMA = 'file:';
 
 class DrizzleScripts {
-  deploy(_project: Project, additionalOptions = ''): string {
-    return `YARN drizzle-kit migrate ${additionalOptions}`;
-  }
-
   reset(project: Project, additionalOptions = ''): string {
     const removeCommand = buildRemoveSqliteDbCommand(project);
     if (!removeCommand) {
@@ -19,7 +15,13 @@ class DrizzleScripts {
   }
 
   migrate(project: Project, additionalOptions = ''): string {
-    return `YARN drizzle-kit migrate ${additionalOptions} && ${this.seed(project)}`;
+    const seedCommand = this.seed(project);
+    const migrateCommand = this.deploy(project, additionalOptions);
+    return seedCommand === 'true' ? migrateCommand : `${migrateCommand} && ${seedCommand}`;
+  }
+
+  deploy(_project: Project, additionalOptions = ''): string {
+    return `YARN drizzle-kit migrate ${additionalOptions}`;
   }
 
   migrateDev(_project: Project, additionalOptions = ''): string {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -9,14 +9,6 @@ class DrizzleScripts {
     return this.migrate(project, additionalOptions);
   }
 
-  migrate(project: Project, additionalOptions = ''): string {
-    return `YARN drizzle-kit migrate ${additionalOptions} && ${this.seed(project)}`;
-  }
-
-  migrateDev(_project: Project, additionalOptions = ''): string {
-    return `YARN drizzle-kit generate ${additionalOptions}`;
-  }
-
   reset(project: Project, additionalOptions = ''): string {
     const removeCommand = buildRemoveSqliteDbCommand(project);
     if (!removeCommand) {
@@ -24,6 +16,14 @@ class DrizzleScripts {
     }
 
     return `${removeCommand} && ${this.migrate(project, additionalOptions)}`;
+  }
+
+  migrate(project: Project, additionalOptions = ''): string {
+    return `YARN drizzle-kit migrate ${additionalOptions} && ${this.seed(project)}`;
+  }
+
+  migrateDev(_project: Project, additionalOptions = ''): string {
+    return `YARN drizzle-kit generate ${additionalOptions}`;
   }
 
   seed(project: Project, scriptPath?: string): string {


### PR DESCRIPTION
## Summary

- Run Drizzle seed scripts after `wb db migrate` when a seed script exists, matching the local/test preparation behavior expected by Prisma-backed projects.
- Keep `wb db deploy` seedless so production deploy-style migration remains migration-only.
- Avoid duplicate seeding during `wb db reset` and avoid appending `&& true` when no seed command exists.

## Why

- `agent-challenges` failed its baseline smoke test because `wb start --mode test` migrated a fresh Drizzle database but did not seed articles before Playwright hit `/articles`.
- The fix belongs in `wb` because the shared Drizzle command generation was missing the seed step used by test/start migration flows.

## Testing

- `yarn verify`
- `bun --bun run dotenv -c=test -- bun run playwright test test/e2e/smoke.spec.ts` in `agent-challenges`
- PR CI passed via `check-pr-ci`
