### PR TITLE
fix: preserve renovate extends in wbfy

### DIFF
--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -14,7 +14,10 @@ const jsonObj = {
   extends: ['github>WillBooster/willbooster-configs:renovate.json5'],
 };
 
-type Settings = typeof jsonObj & { packageRules?: { matchPackageNames: string[]; enabled?: boolean }[] };
+type Settings = Omit<typeof jsonObj, 'extends'> & {
+  extends?: string[];
+  packageRules?: { matchPackageNames: string[]; enabled?: boolean }[];
+};
 
 export async function generateRenovateJson(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateRenovateJson', async () => {
@@ -30,7 +33,7 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
       newSettings = merge.all([newSettings, oldSettings, newSettings], {
         arrayMerge: overwriteMerge,
       }) as Settings;
-      newSettings.extends = newSettings.extends.filter((item: string) => item !== '@willbooster');
+      newSettings.extends = mergeRenovateExtends(jsonObj.extends, oldSettings.extends ?? []);
     } catch {
       // do nothing
     }
@@ -52,4 +55,8 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
     const newContent = JSON.stringify(newSettings, undefined, 2);
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
   });
+}
+
+function mergeRenovateExtends(generatedExtends: string[], existingExtends: string[]): string[] {
+  return [...new Set([...generatedExtends, ...existingExtends])].filter((item) => item !== '@willbooster');
 }

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -15,7 +15,7 @@ const jsonObj = {
 };
 
 type Settings = Omit<typeof jsonObj, 'extends'> & {
-  extends?: string | string[];
+  extends?: string[];
   packageRules?: { matchPackageNames: string[]; enabled?: boolean }[];
 };
 
@@ -33,7 +33,7 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
       newSettings = merge.all([newSettings, oldSettings, newSettings], {
         arrayMerge: overwriteMerge,
       }) as Settings;
-      newSettings.extends = mergeRenovateExtends(jsonObj.extends, oldSettings.extends);
+      newSettings.extends = mergeRenovateExtends(jsonObj.extends, oldSettings.extends ?? []);
     } catch {
       // do nothing
     }
@@ -57,12 +57,6 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
   });
 }
 
-function mergeRenovateExtends(generatedExtends: string | string[], existingExtends: string | string[] = []): string[] {
-  return [...new Set([...normalizeExtends(generatedExtends), ...normalizeExtends(existingExtends)])].filter(
-    (item) => item !== '@willbooster'
-  );
-}
-
-function normalizeExtends(value: string | string[]): string[] {
-  return Array.isArray(value) ? value : [value];
+function mergeRenovateExtends(generatedExtends: string[], existingExtends: string[]): string[] {
+  return [...new Set([...generatedExtends, ...existingExtends])].filter((item) => item !== '@willbooster');
 }

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -15,7 +15,7 @@ const jsonObj = {
 };
 
 type Settings = Omit<typeof jsonObj, 'extends'> & {
-  extends?: string[];
+  extends?: string | string[];
   packageRules?: { matchPackageNames: string[]; enabled?: boolean }[];
 };
 
@@ -33,7 +33,7 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
       newSettings = merge.all([newSettings, oldSettings, newSettings], {
         arrayMerge: overwriteMerge,
       }) as Settings;
-      newSettings.extends = mergeRenovateExtends(jsonObj.extends, oldSettings.extends ?? []);
+      newSettings.extends = mergeRenovateExtends(jsonObj.extends, oldSettings.extends);
     } catch {
       // do nothing
     }
@@ -57,6 +57,12 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
   });
 }
 
-function mergeRenovateExtends(generatedExtends: string[], existingExtends: string[]): string[] {
-  return [...new Set([...generatedExtends, ...existingExtends])].filter((item) => item !== '@willbooster');
+function mergeRenovateExtends(generatedExtends: string | string[], existingExtends: string | string[] = []): string[] {
+  return [...new Set([...normalizeExtends(generatedExtends), ...normalizeExtends(existingExtends)])].filter(
+    (item) => item !== '@willbooster'
+  );
+}
+
+function normalizeExtends(value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value];
 }


### PR DESCRIPTION
## Summary

- Preserve existing repo-local Renovate `extends` entries when `wbfy` regenerates `renovate.json`.
- Keep the generated WillBooster Renovate preset first while deduplicating local presets such as `:preserveSemverRanges`.
- Continue removing the deprecated `@willbooster` preset.

## Why

- Some repositories need local Renovate presets that should survive future `wbfy` runs without changing the global WillBooster Renovate defaults.

## Testing

- `yarn verify`
- `yarn start /Users/exkazuu/ghq/github.com/WillBoosterLab/llm-proxy` from `packages/wbfy`, confirming `llm-proxy/renovate.json` kept `:preserveSemverRanges`.
- `bunx @willbooster/agent-skills@1.24.1 check-pr-ci`
