### PR TITLE
fix: enable Docker idempotency checks

### DIFF
--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -135,7 +135,7 @@ const migrateCommand: CommandModule<unknown, InferredOptionTypes<typeof migrateB
 };
 
 function shouldCheckIdempotency(project: Project, checkIdempotency: boolean | undefined): boolean {
-  return checkIdempotency === true || isDockerEnabled(project);
+  return checkIdempotency ?? isDockerEnabled(project);
 }
 
 function isDockerEnabled(project: Project): boolean {

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -123,7 +123,7 @@ const migrateCommand: CommandModule<unknown, InferredOptionTypes<typeof migrateB
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db migrate', allProjects)) {
       const ormScripts = getDatabaseOrmScripts(orm);
       await runWithSpawn(ormScripts.migrate(project, unknownOptions), project, argv);
-      if (argv.checkIdempotency) {
+      if (shouldCheckIdempotency(project, argv.checkIdempotency)) {
         if (isProductionEnvironment(project)) {
           console.info(chalk.yellow(`Skipping idempotency check for ${project.name} in production environment.`));
         } else {
@@ -133,6 +133,14 @@ const migrateCommand: CommandModule<unknown, InferredOptionTypes<typeof migrateB
     }
   },
 };
+
+function shouldCheckIdempotency(project: Project, checkIdempotency: boolean | undefined): boolean {
+  return checkIdempotency === true || isDockerEnabled(project);
+}
+
+function isDockerEnabled(project: Project): boolean {
+  return !!project.env.WB_DOCKER && project.env.WB_DOCKER !== '0' && project.env.WB_DOCKER !== 'false';
+}
 
 function isProductionEnvironment(project: Project): boolean {
   return project.env.WB_ENV === 'production' || project.env.MISE_ENV === 'production';


### PR DESCRIPTION
## Summary

- Enable Prisma migration idempotency checks automatically when `WB_DOCKER` is enabled.
- Preserve the existing production-environment skip behavior.
- Let explicit `--check-idempotency` / `--no-check-idempotency` CLI values override Docker auto-detection.

## Why

- Docker migration runs should verify idempotency by default.
- Explicit CLI flags should remain the highest-precedence user intent.

## Testing

- `yarn verify`
- PR CI passed
