### PR TITLE
feat: support pm2-free production start scripts

### DIFF
--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -84,15 +84,30 @@ export abstract class BaseScripts {
 
   protected abstract startDevProtected(_: Project, argv: ScriptArgv): string;
   protected startProductionProtected(project: Project, argv: ScriptArgv): string {
-    const ecosystemConfigPath = findEcosystemConfigPath(project);
-    const commands =
-      ecosystemConfigPath === undefined
-        ? [
-            `YARN wb buildIfNeeded ${argv.verbose ? '--verbose' : ''}`.trim(),
-            `${project.isBunAvailable ? 'bun' : 'node'} dist/index.js ${argv.normalizedArgsText ?? ''}`.trim(),
-          ]
-        : [project.buildCommand, `pm2-runtime start --no-autorestart ${ecosystemConfigPath}`];
+    const customStartScriptPath = findCustomProductionStartScriptPath(project);
+    if (customStartScriptPath) {
+      return this.buildProductionCommand(project, argv, [
+        project.buildCommand,
+        `${buildShellCommand(['bash', customStartScriptPath])} ${argv.normalizedArgsText ?? ''}`.trim(),
+      ]);
+    }
 
+    const ecosystemConfigPath = findEcosystemConfigPath(project);
+    const commands = ecosystemConfigPath
+      ? [project.buildCommand, `pm2-runtime start --no-autorestart ${ecosystemConfigPath}`]
+      : this.buildDefaultProductionStartCommands(project, argv);
+
+    return this.buildProductionCommand(project, argv, commands);
+  }
+
+  protected buildDefaultProductionStartCommands(project: Project, argv: ScriptArgv): string[] {
+    return [
+      `YARN wb buildIfNeeded ${argv.verbose ? '--verbose' : ''}`.trim(),
+      `${project.isBunAvailable ? 'bun' : 'node'} dist/index.js ${argv.normalizedArgsText ?? ''}`.trim(),
+    ];
+  }
+
+  protected buildProductionCommand(project: Project, argv: ScriptArgv, commands: string[]): string {
     const migrationCommands = [
       ...(project.hasPrisma ? [prismaScripts.migrate(project)] : []),
       ...(project.hasDrizzle ? [drizzleScripts.migrate(project)] : []),
@@ -200,6 +215,14 @@ export abstract class BaseScripts {
     return `${this.waitApp(
       project
     )} || wait-on http-get://127.0.0.1:${port} && open-cli http://\${HOST:-localhost}:${port}`;
+  }
+}
+
+function findCustomProductionStartScriptPath(project: Project): string | undefined {
+  try {
+    return project.findFile('scripts/start-production.sh');
+  } catch {
+    return;
   }
 }
 

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -102,7 +102,7 @@ export abstract class BaseScripts {
 
   protected buildDefaultProductionStartCommands(project: Project, argv: ScriptArgv): string[] {
     return [
-      `YARN wb buildIfNeeded ${argv.verbose ? '--verbose' : ''}`.trim(),
+      project.buildCommand,
       `${project.isBunAvailable ? 'bun' : 'node'} dist/index.js ${argv.normalizedArgsText ?? ''}`.trim(),
     ];
   }

--- a/packages/wb/src/scripts/execution/nextScripts.ts
+++ b/packages/wb/src/scripts/execution/nextScripts.ts
@@ -15,6 +15,10 @@ class NextScripts extends BaseScripts {
   protected override startDevProtected(_: Project, argv: ScriptArgv): string {
     return `next dev --turbopack ${argv.normalizedArgsText ?? ''}`;
   }
+
+  protected override buildDefaultProductionStartCommands(project: Project, argv: ScriptArgv): string[] {
+    return [project.buildCommand, `next start ${argv.normalizedArgsText ?? ''}`.trim()];
+  }
 }
 
 export const nextScripts = new NextScripts();

--- a/packages/wb/test/scripts/execution/httpServerScripts.test.ts
+++ b/packages/wb/test/scripts/execution/httpServerScripts.test.ts
@@ -74,7 +74,7 @@ describe('HttpServerScripts.testE2E', () => {
         '--kill-others',
         '--success',
         'first',
-        'YARN wb buildIfNeeded && node dist/index.js && exit 1',
+        'echo "no build" && node dist/index.js && exit 1',
         `wait-on -t 600000 -i 2000 http-get://127.0.0.1:3000 && ${buildShellCommand([
           'YARN',
           'vitest',


### PR DESCRIPTION
## Summary

- Prefer `scripts/start-production.sh` over PM2 ecosystem config for production starts.
- Keep `ecosystem.config.cjs` as the legacy fallback path.
- Use `next start` as the Next.js production fallback when no custom script or ecosystem config exists.
- Reuse `project.buildCommand` in the default production start path.

## Why

This lets projects move app-specific production startup logic out of `ecosystem.config.cjs` without requiring `pm2-runtime`. Runtime restarts can then be delegated to the hosting platform, while `wb` still preserves existing PM2-based projects during migration.

## Testing

- `yarn workspace @willbooster/wb start start --working-dir /Users/exkazuu/ghq/github.com/WillBoosterLab/ai-game-builder --mode staging --dry-run`
- `yarn verify`
- GitHub Actions CI passed on the latest commit.
