### PR TITLE
feat: add gen-code command

### DIFF
--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -68,8 +68,11 @@ function getGenCodeScripts(project: Project, argv: GenCodeCommandArgv): string[]
     scripts.push(chakraTypegenScript);
   }
 
-  if (scripts.length === 0 && shouldRunDrizzleCheck(project)) {
-    scripts.push(`YARN drizzle-kit check --config ${getDrizzleConfigPath(project)} || true`);
+  const drizzleConfigPath = project.hasDrizzle ? getDrizzleConfigPath(project) : undefined;
+  // Existing Drizzle+Chakra repositories only generated Chakra types. Keep the
+  // Drizzle compatibility check limited to Drizzle-only gen-code scripts.
+  if (scripts.length === 0 && drizzleConfigPath) {
+    scripts.push(`YARN drizzle-kit check --config ${drizzleConfigPath} || true`);
   }
   return scripts;
 }
@@ -86,12 +89,7 @@ function getChakraTypegenScript(project: Project, useStrict: boolean): string | 
   return;
 }
 
-function shouldRunDrizzleCheck(project: Project): boolean {
-  return project.hasDrizzle && fs.existsSync(path.join(project.dirPath, getDrizzleConfigPath(project)));
-}
-
-function getDrizzleConfigPath(project: Project): string {
-  const defaultConfigPath = 'drizzle.config.ts';
-  const candidates = [defaultConfigPath, 'drizzle.config.mts', 'drizzle.config.js', 'drizzle.config.mjs'];
-  return candidates.find((filePath) => fs.existsSync(path.join(project.dirPath, filePath))) ?? defaultConfigPath;
+function getDrizzleConfigPath(project: Project): string | undefined {
+  const candidates = ['drizzle.config.ts', 'drizzle.config.mts', 'drizzle.config.js', 'drizzle.config.mjs'];
+  return candidates.find((filePath) => fs.existsSync(path.join(project.dirPath, filePath)));
 }

--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -80,11 +80,13 @@ function getGenCodeScripts(project: Project, argv: GenCodeCommandArgv): string[]
 function getChakraTypegenScript(project: Project, useStrict: boolean): string | undefined {
   if (!project.hasOwnDependency('@chakra-ui/cli')) return;
 
-  if (fs.existsSync(path.join(project.dirPath, 'src', 'core', 'theme.ts'))) {
-    return 'YARN chakra-cli tokens src/core/theme.ts';
+  const coreThemePath = 'src/core/theme.ts';
+  if (fs.existsSync(path.join(project.dirPath, coreThemePath))) {
+    return `YARN chakra-cli tokens ${coreThemePath}`;
   }
-  if (fs.existsSync(path.join(project.dirPath, 'src', 'theme.ts'))) {
-    return `YARN chakra typegen src/theme.ts${useStrict ? ' --strict' : ''}`;
+  const themePath = 'src/theme.ts';
+  if (fs.existsSync(path.join(project.dirPath, themePath))) {
+    return `YARN chakra typegen ${themePath}${useStrict ? ' --strict' : ''}`;
   }
   return;
 }

--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -53,32 +53,23 @@ function getGenCodeScripts(project: Project): string[] {
     scripts.push(chakraTypegenScript);
   }
 
-  scripts.push(...getDrizzleOnlyCompatibilityScripts(project, scripts));
+  const drizzleConfigPath = scripts.length === 0 && project.hasDrizzle ? getDrizzleConfigPath(project) : undefined;
+  if (drizzleConfigPath) {
+    scripts.push(`YARN drizzle-kit check --config ${drizzleConfigPath} || true`);
+  }
   return scripts;
 }
 
 function getChakraScript(project: Project): string | undefined {
   if (!project.hasOwnDependency('@chakra-ui/cli')) return;
 
-  const coreThemePath = 'src/core/theme.ts';
-  if (getDependencyMajor(project, '@chakra-ui/cli') === 2 && fileExists(project, coreThemePath)) {
-    return `YARN chakra-cli tokens ${coreThemePath}`;
+  if (getOwnDependencyMajor(project, '@chakra-ui/cli') === 2) {
+    return 'YARN chakra-cli tokens src/core/theme.ts';
   }
-  const themePath = 'src/theme.ts';
-  if (fileExists(project, themePath)) {
-    return `YARN chakra typegen ${themePath} --strict`;
-  }
-  if (fileExists(project, coreThemePath)) {
-    return `YARN chakra-cli tokens ${coreThemePath}`;
+  if (fileExists(project, 'src/theme.ts')) {
+    return 'YARN chakra typegen src/theme.ts --strict';
   }
   return;
-}
-
-function getDrizzleOnlyCompatibilityScripts(project: Project, alreadyGeneratedScripts: string[]): string[] {
-  if (alreadyGeneratedScripts.length > 0 || !project.hasDrizzle) return [];
-
-  const drizzleConfigPath = getDrizzleConfigPath(project);
-  return drizzleConfigPath ? [`YARN drizzle-kit check --config ${drizzleConfigPath} || true`] : [];
 }
 
 function getDrizzleConfigPath(project: Project): string | undefined {
@@ -86,20 +77,15 @@ function getDrizzleConfigPath(project: Project): string | undefined {
   return candidates.find((filePath) => fileExists(project, filePath));
 }
 
-function getDependencyMajor(project: Project, packageName: string): number | undefined {
-  const version = getOwnDependencyVersion(project, packageName);
-  const major = version?.match(/\d+/u)?.[0];
-  return major === undefined ? undefined : Number(major);
-}
-
-function getOwnDependencyVersion(project: Project, packageName: string): string | undefined {
+function getOwnDependencyMajor(project: Project, packageName: string): number | undefined {
   const packageJson = project.packageJson;
-  return (
+  const version =
     packageJson.dependencies?.[packageName] ??
     packageJson.devDependencies?.[packageName] ??
     packageJson.optionalDependencies?.[packageName] ??
-    packageJson.peerDependencies?.[packageName]
-  );
+    packageJson.peerDependencies?.[packageName];
+  const major = version?.match(/\d+/u)?.[0];
+  return major === undefined ? undefined : Number(major);
 }
 
 function fileExists(project: Project, filePath: string): boolean {

--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -17,6 +17,11 @@ const builder = {
     type: 'boolean',
     default: false,
   },
+  'drizzle-strict': {
+    description: 'Fail when drizzle-kit check fails.',
+    type: 'boolean',
+    default: false,
+  },
 } as const;
 
 type GenCodeCommandOptions = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>;
@@ -37,7 +42,9 @@ export const genCodeCommand: CommandModule<unknown, GenCodeCommandOptions> = {
     for (const project of prepareForRunningCommand('gen-code', projects.descendants)) {
       const scripts = getGenCodeScripts(project, argv);
       if (scripts.length === 0) {
-        console.info(chalk.yellow(`No code generation needed for ${project.name}.`));
+        if (argv.verbose) {
+          console.info(chalk.yellow(`No code generation needed for ${project.name}.`));
+        }
         continue;
       }
       generated = true;
@@ -72,7 +79,7 @@ function getGenCodeScripts(project: Project, argv: GenCodeCommandArgv): string[]
   // Existing Drizzle+Chakra repositories only generated Chakra types. Keep the
   // Drizzle compatibility check limited to Drizzle-only gen-code scripts.
   if (scripts.length === 0 && drizzleConfigPath) {
-    scripts.push(`YARN drizzle-kit check --config ${drizzleConfigPath} || true`);
+    scripts.push(`YARN drizzle-kit check --config ${drizzleConfigPath}${argv.drizzleStrict ? '' : ' || true'}`);
   }
   return scripts;
 }

--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import chalk from 'chalk';
+import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
+
+import type { Project } from '../project.js';
+import { findDescendantProjects } from '../project.js';
+import { runWithSpawn } from '../scripts/run.js';
+import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+
+import { prepareForRunningCommand } from './commandUtils.js';
+
+const builder = {
+  'chakra-strict': {
+    description: 'Pass --strict to Chakra UI v3 typegen.',
+    type: 'boolean',
+    default: false,
+  },
+} as const;
+
+type GenCodeCommandOptions = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>;
+type GenCodeCommandArgv = ArgumentsCamelCase<GenCodeCommandOptions>;
+
+export const genCodeCommand: CommandModule<unknown, GenCodeCommandOptions> = {
+  command: 'gen-code',
+  describe: 'Generate code for the current project',
+  builder,
+  async handler(argv) {
+    const projects = await findDescendantProjects(argv);
+    if (!projects) {
+      console.error(chalk.red('No project found.'));
+      process.exit(1);
+    }
+
+    let generated = false;
+    for (const project of prepareForRunningCommand('gen-code', projects.descendants)) {
+      const scripts = getGenCodeScripts(project, argv);
+      if (scripts.length === 0) {
+        console.info(chalk.yellow(`No code generation needed for ${project.name}.`));
+        continue;
+      }
+      generated = true;
+      for (const script of scripts) {
+        await runWithSpawn(script, project, argv);
+      }
+    }
+
+    if (!generated) {
+      console.info(chalk.green('No code generation needed.'));
+    }
+  },
+};
+
+function getGenCodeScripts(project: Project, argv: GenCodeCommandArgv): string[] {
+  const scripts: string[] = [];
+  if (project.hasOwnDependency('blitz')) {
+    scripts.push('YARN blitz codegen');
+    if (project.hasPrisma) {
+      scripts.push('YARN blitz prisma generate');
+    }
+  } else if (project.hasPrisma) {
+    scripts.push('PRISMA generate');
+  }
+
+  const chakraTypegenScript = getChakraTypegenScript(project, argv.chakraStrict);
+  if (chakraTypegenScript) {
+    scripts.push(chakraTypegenScript);
+  }
+
+  if (scripts.length === 0 && shouldRunDrizzleCheck(project)) {
+    scripts.push(`YARN drizzle-kit check --config ${getDrizzleConfigPath(project)} || true`);
+  }
+  return scripts;
+}
+
+function getChakraTypegenScript(project: Project, useStrict: boolean): string | undefined {
+  if (!project.hasOwnDependency('@chakra-ui/cli')) return;
+
+  if (fs.existsSync(path.join(project.dirPath, 'src', 'core', 'theme.ts'))) {
+    return 'YARN chakra-cli tokens src/core/theme.ts';
+  }
+  if (fs.existsSync(path.join(project.dirPath, 'src', 'theme.ts'))) {
+    return `YARN chakra typegen src/theme.ts${useStrict ? ' --strict' : ''}`;
+  }
+  return;
+}
+
+function shouldRunDrizzleCheck(project: Project): boolean {
+  return project.hasDrizzle && fs.existsSync(path.join(project.dirPath, getDrizzleConfigPath(project)));
+}
+
+function getDrizzleConfigPath(project: Project): string {
+  const defaultConfigPath = 'drizzle.config.ts';
+  const candidates = [defaultConfigPath, 'drizzle.config.mts', 'drizzle.config.js', 'drizzle.config.mjs'];
+  return candidates.find((filePath) => fs.existsSync(path.join(project.dirPath, filePath))) ?? defaultConfigPath;
+}

--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -2,32 +2,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import chalk from 'chalk';
-import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
+import type { CommandModule } from 'yargs';
 
 import type { Project } from '../project.js';
 import { findDescendantProjects } from '../project.js';
 import { runWithSpawn } from '../scripts/run.js';
-import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
-import { prepareForRunningCommand } from './commandUtils.js';
+const builder = {} as const;
 
-const builder = {
-  'chakra-strict': {
-    description: 'Pass --strict to Chakra UI v3 typegen.',
-    type: 'boolean',
-    default: false,
-  },
-  'drizzle-strict': {
-    description: 'Fail when drizzle-kit check fails.',
-    type: 'boolean',
-    default: false,
-  },
-} as const;
-
-type GenCodeCommandOptions = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>;
-type GenCodeCommandArgv = ArgumentsCamelCase<GenCodeCommandOptions>;
-
-export const genCodeCommand: CommandModule<unknown, GenCodeCommandOptions> = {
+export const genCodeCommand: CommandModule = {
   command: 'gen-code',
   describe: 'Generate code for the current project',
   builder,
@@ -38,28 +21,23 @@ export const genCodeCommand: CommandModule<unknown, GenCodeCommandOptions> = {
       process.exit(1);
     }
 
-    let generated = false;
-    for (const project of prepareForRunningCommand('gen-code', projects.descendants)) {
-      const scripts = getGenCodeScripts(project, argv);
-      if (scripts.length === 0) {
-        if (argv.verbose) {
-          console.info(chalk.yellow(`No code generation needed for ${project.name}.`));
-        }
-        continue;
-      }
-      generated = true;
+    const genCodeTargets = projects.descendants
+      .map((project) => ({ project, scripts: getGenCodeScripts(project) }))
+      .filter(({ scripts }) => scripts.length > 0);
+    if (genCodeTargets.length === 0) {
+      console.info(chalk.green('No code generation needed.'));
+      return;
+    }
+    for (const { project, scripts } of genCodeTargets) {
+      console.info(`Running "gen-code" for ${project.name} ...`);
       for (const script of scripts) {
         await runWithSpawn(script, project, argv);
       }
     }
-
-    if (!generated) {
-      console.info(chalk.green('No code generation needed.'));
-    }
   },
 };
 
-function getGenCodeScripts(project: Project, argv: GenCodeCommandArgv): string[] {
+function getGenCodeScripts(project: Project): string[] {
   const scripts: string[] = [];
   if (project.hasOwnDependency('blitz')) {
     scripts.push('YARN blitz codegen');
@@ -70,35 +48,60 @@ function getGenCodeScripts(project: Project, argv: GenCodeCommandArgv): string[]
     scripts.push('PRISMA generate');
   }
 
-  const chakraTypegenScript = getChakraTypegenScript(project, argv.chakraStrict);
+  const chakraTypegenScript = getChakraScript(project);
   if (chakraTypegenScript) {
     scripts.push(chakraTypegenScript);
   }
 
-  const drizzleConfigPath = project.hasDrizzle ? getDrizzleConfigPath(project) : undefined;
-  // Existing Drizzle+Chakra repositories only generated Chakra types. Keep the
-  // Drizzle compatibility check limited to Drizzle-only gen-code scripts.
-  if (scripts.length === 0 && drizzleConfigPath) {
-    scripts.push(`YARN drizzle-kit check --config ${drizzleConfigPath}${argv.drizzleStrict ? '' : ' || true'}`);
-  }
+  scripts.push(...getDrizzleOnlyCompatibilityScripts(project, scripts));
   return scripts;
 }
 
-function getChakraTypegenScript(project: Project, useStrict: boolean): string | undefined {
+function getChakraScript(project: Project): string | undefined {
   if (!project.hasOwnDependency('@chakra-ui/cli')) return;
 
   const coreThemePath = 'src/core/theme.ts';
-  if (fs.existsSync(path.join(project.dirPath, coreThemePath))) {
+  if (getDependencyMajor(project, '@chakra-ui/cli') === 2 && fileExists(project, coreThemePath)) {
     return `YARN chakra-cli tokens ${coreThemePath}`;
   }
   const themePath = 'src/theme.ts';
-  if (fs.existsSync(path.join(project.dirPath, themePath))) {
-    return `YARN chakra typegen ${themePath}${useStrict ? ' --strict' : ''}`;
+  if (fileExists(project, themePath)) {
+    return `YARN chakra typegen ${themePath} --strict`;
+  }
+  if (fileExists(project, coreThemePath)) {
+    return `YARN chakra-cli tokens ${coreThemePath}`;
   }
   return;
 }
 
+function getDrizzleOnlyCompatibilityScripts(project: Project, alreadyGeneratedScripts: string[]): string[] {
+  if (alreadyGeneratedScripts.length > 0 || !project.hasDrizzle) return [];
+
+  const drizzleConfigPath = getDrizzleConfigPath(project);
+  return drizzleConfigPath ? [`YARN drizzle-kit check --config ${drizzleConfigPath} || true`] : [];
+}
+
 function getDrizzleConfigPath(project: Project): string | undefined {
   const candidates = ['drizzle.config.ts', 'drizzle.config.mts', 'drizzle.config.js', 'drizzle.config.mjs'];
-  return candidates.find((filePath) => fs.existsSync(path.join(project.dirPath, filePath)));
+  return candidates.find((filePath) => fileExists(project, filePath));
+}
+
+function getDependencyMajor(project: Project, packageName: string): number | undefined {
+  const version = getOwnDependencyVersion(project, packageName);
+  const major = version?.match(/\d+/u)?.[0];
+  return major === undefined ? undefined : Number(major);
+}
+
+function getOwnDependencyVersion(project: Project, packageName: string): string | undefined {
+  const packageJson = project.packageJson;
+  return (
+    packageJson.dependencies?.[packageName] ??
+    packageJson.devDependencies?.[packageName] ??
+    packageJson.optionalDependencies?.[packageName] ??
+    packageJson.peerDependencies?.[packageName]
+  );
+}
+
+function fileExists(project: Project, filePath: string): boolean {
+  return fs.existsSync(path.join(project.dirPath, filePath));
 }

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -7,6 +7,7 @@ import { hideBin } from 'yargs/helpers';
 
 import { buildIfNeededCommand } from './commands/buildIfNeeded.js';
 import { concurrentlyCommand } from './commands/concurrently.js';
+import { genCodeCommand } from './commands/genCode.js';
 import { killPortIfNonCiCommand } from './commands/killPortIfNonCi.js';
 import { lintCommand } from './commands/lint.js';
 import { optimizeForDockerBuildCommand } from './commands/optimizeForDockerBuild.js';
@@ -36,6 +37,7 @@ await yargs(hideBin(process.argv))
   .command(verifyCodeCommand)
   .command(buildIfNeededCommand)
   .command(concurrentlyCommand)
+  .command(genCodeCommand)
   .command(killPortIfNonCiCommand)
   .command(lintCommand)
   .command(optimizeForDockerBuildCommand)

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -437,7 +437,7 @@ async function normalizePackageMetadata(
   }
 
   if (shouldGenerateWbGenCodeScript(config, jsonObj.scripts['gen-code'])) {
-    jsonObj.scripts['gen-code'] = generateWbGenCodeScript(jsonObj.scripts['gen-code']);
+    jsonObj.scripts['gen-code'] = 'wb gen-code';
   }
   addGenI18nTsPostinstallScript(config, jsonObj);
 
@@ -450,11 +450,8 @@ async function normalizePackageMetadata(
 function shouldGenerateWbGenCodeScript(config: PackageConfig, oldGenCodeScript: string | undefined): boolean {
   if (config.depending.blitz || config.depending.chakra || config.depending.prisma) return true;
   if (config.depending.drizzle && oldGenCodeScript?.includes('drizzle-kit check')) return true;
+  if (oldGenCodeScript?.includes('No code generation needed')) return true;
   return false;
-}
-
-function generateWbGenCodeScript(oldGenCodeScript: string | undefined): string {
-  return oldGenCodeScript?.includes('--strict') ? 'wb gen-code --chakra-strict' : 'wb gen-code';
 }
 
 function appendFormatCodeCommand(formatScript: string | undefined, config: PackageConfig): string {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -436,17 +436,8 @@ async function normalizePackageMetadata(
     jsonObj.repository = formatRepositoryForPackageJson(config.repository ?? jsonObj.repository, jsonObj.repository);
   }
 
-  if (config.depending.blitz) {
-    if (!jsonObj.scripts['gen-code']?.startsWith('blitz codegen')) {
-      jsonObj.scripts['gen-code'] = 'blitz codegen';
-    } else if (!jsonObj.scripts['gen-code'].includes('blitz prisma generate')) {
-      jsonObj.scripts['gen-code'] = jsonObj.scripts['gen-code'].replace(
-        'blitz codegen',
-        'blitz codegen && blitz prisma generate'
-      );
-    }
-  } else if (config.depending.prisma && !jsonObj.scripts['gen-code']?.startsWith('prisma generate')) {
-    jsonObj.scripts['gen-code'] = 'prisma generate';
+  if (shouldGenerateWbGenCodeScript(config, jsonObj.scripts['gen-code'])) {
+    jsonObj.scripts['gen-code'] = generateWbGenCodeScript(jsonObj.scripts['gen-code']);
   }
   addGenI18nTsPostinstallScript(config, jsonObj);
 
@@ -454,6 +445,16 @@ async function normalizePackageMetadata(
     // Because @types/prettier blocks prettier execution.
     delete jsonObj.devDependencies['@types/prettier'];
   }
+}
+
+function shouldGenerateWbGenCodeScript(config: PackageConfig, oldGenCodeScript: string | undefined): boolean {
+  if (config.depending.blitz || config.depending.chakra || config.depending.prisma) return true;
+  if (config.depending.drizzle && oldGenCodeScript?.includes('drizzle-kit check')) return true;
+  return false;
+}
+
+function generateWbGenCodeScript(oldGenCodeScript: string | undefined): string {
+  return oldGenCodeScript?.includes('--strict') ? 'wb gen-code --chakra-strict' : 'wb gen-code';
 }
 
 function appendFormatCodeCommand(formatScript: string | undefined, config: PackageConfig): string {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -451,9 +451,12 @@ async function normalizePackageMetadata(
 }
 
 function shouldGenerateWbGenCodeScript(config: PackageConfig, oldGenCodeScript: string | undefined): boolean {
-  if (config.depending.blitz || config.depending.chakra || config.depending.prisma) return true;
-  if (config.depending.drizzle && oldGenCodeScript?.includes('drizzle-kit check')) return true;
-  return false;
+  return (
+    config.depending.blitz ||
+    config.depending.chakra ||
+    config.depending.prisma ||
+    (config.depending.drizzle && !!oldGenCodeScript?.includes('drizzle-kit check'))
+  );
 }
 
 function appendFormatCodeCommand(formatScript: string | undefined, config: PackageConfig): string {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -436,7 +436,10 @@ async function normalizePackageMetadata(
     jsonObj.repository = formatRepositoryForPackageJson(config.repository ?? jsonObj.repository, jsonObj.repository);
   }
 
-  if (shouldGenerateWbGenCodeScript(config, jsonObj.scripts['gen-code'])) {
+  const genCodeScript = jsonObj.scripts['gen-code'];
+  if (genCodeScript?.includes('No code generation needed')) {
+    delete jsonObj.scripts['gen-code'];
+  } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
     jsonObj.scripts['gen-code'] = 'wb gen-code';
   }
   addGenI18nTsPostinstallScript(config, jsonObj);
@@ -450,7 +453,6 @@ async function normalizePackageMetadata(
 function shouldGenerateWbGenCodeScript(config: PackageConfig, oldGenCodeScript: string | undefined): boolean {
   if (config.depending.blitz || config.depending.chakra || config.depending.prisma) return true;
   if (config.depending.drizzle && oldGenCodeScript?.includes('drizzle-kit check')) return true;
-  if (oldGenCodeScript?.includes('No code generation needed')) return true;
   return false;
 }
 

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import fg from 'fast-glob';
 import { simpleGit } from 'simple-git';
-import toml from 'smol-toml';
+import { parse as parseToml } from 'smol-toml';
 import type { PackageJson } from 'type-fest';
 import { z } from 'zod';
 
@@ -60,6 +60,8 @@ export interface PackageConfig {
     semanticRelease: boolean;
     storybook: boolean;
     wb: boolean;
+    chakra: boolean;
+    drizzle: boolean;
   };
   release: {
     branches: string[];
@@ -201,6 +203,8 @@ export async function getPackageConfig(
       doesContainJavaInPackages: containsAny('packages/**/*.java', dirPath),
       depending: {
         blitz: !!dependencies.blitz,
+        chakra: !!devDependencies['@chakra-ui/cli'],
+        drizzle: !!dependencies['drizzle-orm'] || !!devDependencies['drizzle-kit'],
         firebase: !!devDependencies['firebase-tools'],
         genI18nTs: !!dependencies['gen-i18n-ts'] || !!devDependencies['gen-i18n-ts'],
         litestream: dockerfile.includes('install-litestream.sh'),
@@ -260,7 +264,7 @@ async function readMiseTasks(dirPath: string): Promise<Record<string, string>> {
   for (const fileName of ['mise.toml', '.mise.toml']) {
     const filePath = path.resolve(dirPath, fileName);
     try {
-      const settings = toml.parse(await fsp.readFile(filePath, 'utf8')) as { tasks?: Record<string, unknown> };
+      const settings = parseToml(await fsp.readFile(filePath, 'utf8')) as { tasks?: Record<string, unknown> };
       for (const [name, value] of Object.entries(settings.tasks ?? {})) {
         tasks[name] = readMiseTaskCommand(value);
       }

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -33,6 +33,8 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
     doesContainJavaInPackages: false,
     depending: {
       blitz: false,
+      chakra: false,
+      drizzle: false,
       firebase: false,
       genI18nTs: false,
       litestream: false,


### PR DESCRIPTION
## Summary

- Add `wb gen-code` as the single code-generation entry point for WillBooster project conventions.
- Infer existing repository behavior directly from dependencies and file layout: Blitz, Prisma, Chakra UI v2/v3, and the Drizzle-only compatibility check.
- Update `wbfy` to generate `gen-code: wb gen-code` only when code generation exists, and delete no-op `gen-code` scripts such as `echo 'No code generation needed'`.

## Why

- Existing repositories duplicated short `gen-code` command chains in `package.json`.
- The desired state is zero per-repository gen-code logic: repositories declare dependencies and files, while `wb` owns the convention.

## Testing

- `yarn workspace @willbooster/wb typecheck`
- `yarn workspace @willbooster/wbfy typecheck`
- `yarn verify`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBooster/gen-em gen-code --dry-run`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBooster/literacy-test gen-code --dry-run`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBooster/agent-sandbox-bbs gen-code --dry-run`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBooster/moti-ai gen-code --dry-run`
