### PR TITLE
fix: add node type references to generated configs

### DIFF
--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -39,7 +39,8 @@ function getConfigContent(config: PackageConfig): string {
   if (!config.isEsmPackage) {
     return `${managedConfigBlocks.getBlock(
       'base',
-      `// oxlint-disable typescript(TS2591), unicorn/prefer-module -- Oxfmt config files are only auto-discovered as .ts, and CommonJS avoids Node typeless ESM warnings.
+      `/// <reference types="node" />
+// oxlint-disable unicorn/prefer-module -- Oxfmt config files are only auto-discovered as .ts, and CommonJS avoids ESM package loading issues.
 const oxfmtConfig = require('@willbooster/oxfmt-config');
 
 const oxfmtResolvedConfig = oxfmtConfig.default ?? oxfmtConfig;`

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -75,7 +75,8 @@ function getConfigContent(config: PackageConfig): string {
   if (!config.isEsmPackage) {
     return `${managedConfigBlocks.getBlock(
       'base',
-      `// oxlint-disable typescript(TS2591), unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids Node typeless ESM warnings.
+      `/// <reference types="node" />
+// oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids ESM package loading issues.
 const oxlintBaseConfig = require('@willbooster/oxlint-config');
 
 ${getResolvedConfigContent('oxlintBaseConfig.default ?? oxlintBaseConfig', isRootConfig)}`


### PR DESCRIPTION
## Summary

- Add `/// <reference types="node" />` to CommonJS `oxlint.config.ts` and `oxfmt.config.ts` generated by wbfy.
- Remove now-unnecessary TS2591 oxlint suppression from those generated blocks.

## Why

- Repos migrated by wbfy can type-aware lint generated config files before Node globals are otherwise visible.
- The generated files should be self-contained instead of requiring every target repo to patch tsconfig manually.

## Testing

- `yarn verify`
