### PR TITLE
fix: normalize wb color environment handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint-fix": "yarn workspaces foreach --all --parallel --verbose run lint-fix",
     "prepare": "lefthook install || true",
     "release": "yarn multi-semantic-release --debug",
-    "test": "CI=1 FORCE_COLOR=3 yarn workspaces foreach --all --verbose run test",
+    "test": "CI=1 yarn workspaces foreach --all --verbose run test",
     "typecheck": "wb typecheck",
     "verify": "wb verify",
     "verify-full": "wb verify --full"

--- a/packages/wb/src/commands/concurrently.ts
+++ b/packages/wb/src/commands/concurrently.ts
@@ -42,7 +42,6 @@ interface RunConcurrentlyOptions {
   killOthersOnFail: boolean;
   success: 'all' | 'first';
   ci?: boolean;
-  forceColor?: boolean;
 }
 
 export const concurrentlyCommand: CommandModule<
@@ -78,7 +77,6 @@ export const concurrentlyCommand: CommandModule<
         killOthersOnFail: argv.killOthersOnFail ?? false,
         success: argv.success,
         ci: typeof argv.ci === 'boolean' ? argv.ci : undefined,
-        forceColor: typeof argv.forceColor === 'boolean' ? argv.forceColor : undefined,
       });
       process.exit(exitCode);
     } catch (error) {
@@ -93,7 +91,7 @@ export async function runConcurrently(options: RunConcurrentlyOptions): Promise<
     child_process.spawn(normalizeScript(command, options.project).runnable, {
       cwd: options.project.dirPath,
       detached: true,
-      env: configureEnv(options.project.env, { ci: options.ci, forceColor: options.forceColor }),
+      env: configureEnv(options.project.env, { ci: options.ci }),
       shell: true,
       stdio: 'inherit',
     })

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -216,7 +216,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
 
   const formatterCommands: LintRunCommand[] = [];
   const linterCommands: LintRunCommand[] = [];
-  const lintRunOptions = { exitIfFailed: false, forceColor: !argv.printAllOutput } as const;
+  const lintRunOptions = { exitIfFailed: false, preserveColor: !argv.printAllOutput } as const;
   const shouldRunFormatters = Boolean(argv.format);
   const shouldRunLinters = !argv.format || argv.fix;
   if (files.length > 0) {
@@ -289,7 +289,6 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
           'YARN',
           'prettier',
           '--cache',
-          '--color',
           '--no-error-on-unmatched-pattern',
           '--write',
           '--',

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -99,16 +99,14 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
     return 1;
   }
 
-  for (const project of projects.descendants) {
-    project.env.WB_ENV ||= 'test';
-  }
-
   // Get test targets from positional arguments
   const testTargets = (argv.targets ?? []) as string[];
   const forwardedPlaywrightArgs = argv['--'] ?? [];
   const { shouldRunE2e, shouldRunUnit } = resolveTestExecutionTargets(testTargets, forwardedPlaywrightArgs);
 
   for (const project of projects.descendants) {
+    project.env.WB_ENV ||= 'test';
+
     const deps = project.packageJson.dependencies ?? {};
     const devDeps = project.packageJson.devDependencies ?? {};
     let scripts: BaseScripts;

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -18,7 +18,7 @@ import { nextScripts } from '../scripts/execution/nextScripts.js';
 import { plainAppScripts } from '../scripts/execution/plainAppScripts.js';
 import { remixScripts } from '../scripts/execution/remixScripts.js';
 import { viteScripts } from '../scripts/execution/viteScripts.js';
-import { runWithSpawn } from '../scripts/run.js';
+import { configureColorEnv, runWithSpawn } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
 import { httpServerPackages } from './httpServerPackages.js';
@@ -99,8 +99,7 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
     return 1;
   }
 
-  process.env.FORCE_COLOR ||= '3';
-  delete process.env.NO_COLOR;
+  configureColorEnv(process.env, true);
   process.env.WB_ENV ||= 'test';
 
   // Get test targets from positional arguments

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -18,7 +18,7 @@ import { nextScripts } from '../scripts/execution/nextScripts.js';
 import { plainAppScripts } from '../scripts/execution/plainAppScripts.js';
 import { remixScripts } from '../scripts/execution/remixScripts.js';
 import { viteScripts } from '../scripts/execution/viteScripts.js';
-import { configureColorEnv, runWithSpawn } from '../scripts/run.js';
+import { runWithSpawn } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
 import { httpServerPackages } from './httpServerPackages.js';
@@ -99,7 +99,6 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
     return 1;
   }
 
-  configureColorEnv(process.env, true);
   process.env.WB_ENV ||= 'test';
 
   // Get test targets from positional arguments

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -99,7 +99,9 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
     return 1;
   }
 
-  process.env.WB_ENV ||= 'test';
+  for (const project of projects.descendants) {
+    project.env.WB_ENV ||= 'test';
+  }
 
   // Get test targets from positional arguments
   const testTargets = (argv.targets ?? []) as string[];

--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -47,8 +47,10 @@ export async function testOnCi(
     process.exit(1);
   }
 
-  process.env.CI ||= '1';
-  process.env.WB_ENV ||= 'test';
+  for (const project of projects.descendants) {
+    project.env.CI ||= '1';
+    project.env.WB_ENV ||= 'test';
+  }
 
   for (const project of projects.descendants) {
     const deps = project.packageJson.dependencies ?? {};

--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -14,7 +14,7 @@ import { nextScripts } from '../scripts/execution/nextScripts.js';
 import { plainAppScripts } from '../scripts/execution/plainAppScripts.js';
 import { remixScripts } from '../scripts/execution/remixScripts.js';
 import { viteScripts } from '../scripts/execution/viteScripts.js';
-import { runWithSpawn, runWithSpawnInParallel } from '../scripts/run.js';
+import { configureColorEnv, runWithSpawn, runWithSpawnInParallel } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { promisePool } from '../utils/promisePool.js';
 
@@ -48,7 +48,7 @@ export async function testOnCi(
   }
 
   process.env.CI ||= '1';
-  process.env.FORCE_COLOR ||= '3';
+  configureColorEnv(process.env, true);
   process.env.WB_ENV ||= 'test';
 
   for (const project of projects.descendants) {

--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -50,9 +50,7 @@ export async function testOnCi(
   for (const project of projects.descendants) {
     project.env.CI ||= '1';
     project.env.WB_ENV ||= 'test';
-  }
 
-  for (const project of projects.descendants) {
     const deps = project.packageJson.dependencies ?? {};
     const devDeps = project.packageJson.devDependencies ?? {};
     let scripts: BaseScripts;

--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -14,7 +14,7 @@ import { nextScripts } from '../scripts/execution/nextScripts.js';
 import { plainAppScripts } from '../scripts/execution/plainAppScripts.js';
 import { remixScripts } from '../scripts/execution/remixScripts.js';
 import { viteScripts } from '../scripts/execution/viteScripts.js';
-import { configureColorEnv, runWithSpawn, runWithSpawnInParallel } from '../scripts/run.js';
+import { runWithSpawn, runWithSpawnInParallel } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { promisePool } from '../utils/promisePool.js';
 
@@ -48,7 +48,6 @@ export async function testOnCi(
   }
 
   process.env.CI ||= '1';
-  configureColorEnv(process.env, true);
   process.env.WB_ENV ||= 'test';
 
   for (const project of projects.descendants) {

--- a/packages/wb/src/commands/typecheck.ts
+++ b/packages/wb/src/commands/typecheck.ts
@@ -44,7 +44,7 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
         // Disable interactive mode
         ci: projects.descendants.length > 1,
         exitIfFailed: false,
-        forceColor: true,
+        preserveColor: true,
       });
 
       // Re-try type checking after removing `.next` directory

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -131,7 +131,7 @@ async function runPackageCommand(
 
   const ret = await spawnAsync(command, undefined, {
     cwd: project.dirPath,
-    env: configureEnv(project.env, { forceColor: false }),
+    env: configureEnv(project.env, { preserveColor: false }),
     shell: true,
     stdio: 'pipe',
     mergeOutAndError: true,

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -182,7 +182,6 @@ export abstract class BaseScripts {
         'vitest',
         'run',
         ...(targets?.length ? targets : ['test/unit/']),
-        '--color',
         '--passWithNoTests',
         '--allowOnly',
         '--watch=false',

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -250,10 +250,20 @@ export function configureEnv(
   if (opts.ci) {
     newEnv.CI = '1';
   }
-  if (opts.forceColor) {
-    newEnv.FORCE_COLOR = '3';
-  }
+  configureColorEnv(newEnv, opts.forceColor);
   return newEnv;
+}
+
+export function configureColorEnv(env: Record<string, string | undefined>, forceColor?: boolean): void {
+  if (forceColor) {
+    env.FORCE_COLOR = '3';
+    delete env.NO_COLOR;
+    return;
+  }
+
+  if (env.NO_COLOR !== undefined && env.FORCE_COLOR !== undefined) {
+    delete env.FORCE_COLOR;
+  }
 }
 
 function fixBunCommand(command: string): string {

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -10,8 +10,8 @@ interface Options {
   ci?: boolean;
   exitIfFailed?: boolean;
   onSignal?: (signal: NodeJS.Signals | null) => void;
-  forceColor?: boolean;
   omitSilentStart?: boolean;
+  preserveColor?: boolean;
   processSilentOutput?: (output: string) => string;
   printRawOutput?: boolean;
   printSilentOutputOnFailureOnly?: boolean;
@@ -60,7 +60,7 @@ export async function runWithSpawn(
       : undefined;
   const ret = await spawnAsync(normalizedScript.runnable, undefined, {
     cwd: project.dirPath,
-    env: configureEnv(project.env, opts),
+    env: configureEnv(project.env, { ...opts, preserveColor: opts.preserveColor ?? Boolean(argv.silent) }),
     shell: true,
     stdio: argv.silent ? 'pipe' : 'inherit',
     timeout: opts.timeout,
@@ -114,7 +114,7 @@ export function runWithSpawnInParallel(
 
     const ret = await spawnAsync(normalizedScript.runnable, undefined, {
       cwd: project.dirPath,
-      env: configureEnv(project.env, opts),
+      env: configureEnv(project.env, { ...opts, preserveColor: opts.preserveColor ?? true }),
       shell: true,
       stdio: 'pipe',
       timeout: opts.timeout,
@@ -156,7 +156,7 @@ export function runWithSpawnInParallelBuffered(
 
     const ret = await spawnAsync(normalizedScript.runnable, undefined, {
       cwd: project.dirPath,
-      env: configureEnv(project.env, opts),
+      env: configureEnv(project.env, { ...opts, preserveColor: opts.preserveColor ?? true }),
       shell: true,
       stdio: 'pipe',
       timeout: opts.timeout,
@@ -250,19 +250,20 @@ export function configureEnv(
   if (opts.ci) {
     newEnv.CI = '1';
   }
-  configureColorEnv(newEnv, opts.forceColor);
+  configureColorEnv(newEnv, opts.preserveColor);
   return newEnv;
 }
 
-export function configureColorEnv(env: Record<string, string | undefined>, forceColor?: boolean): void {
-  if (forceColor) {
-    env.FORCE_COLOR = '3';
-    delete env.NO_COLOR;
+export function configureColorEnv(env: Record<string, string | undefined>, preserveColor?: boolean): void {
+  if (env.NO_COLOR !== undefined) {
+    // NO_COLOR is an explicit user preference. wb may preserve color lost through pipes, but it should not override this.
+    delete env.FORCE_COLOR;
     return;
   }
 
-  if (env.NO_COLOR !== undefined && env.FORCE_COLOR !== undefined) {
-    delete env.FORCE_COLOR;
+  if (preserveColor && process.stdout.isTTY) {
+    env.FORCE_COLOR ||= '3';
+    return;
   }
 }
 

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -60,7 +60,7 @@ export async function runWithSpawn(
       : undefined;
   const ret = await spawnAsync(normalizedScript.runnable, undefined, {
     cwd: project.dirPath,
-    env: configureEnv(project.env, { ...opts, preserveColor: opts.preserveColor ?? Boolean(argv.silent) }),
+    env: configureEnv(project.env, { ...opts, preserveColor: opts.preserveColor ?? (argv.silent ? true : undefined) }),
     shell: true,
     stdio: argv.silent ? 'pipe' : 'inherit',
     timeout: opts.timeout,

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -254,9 +254,15 @@ export function configureEnv(
   return newEnv;
 }
 
+/**
+ * Configures child-process color environment variables for wb-managed output.
+ *
+ * @param env The child-process environment to mutate.
+ * @param preserveColor Whether wb should preserve colors for output that it captures and reprints to an interactive TTY.
+ */
 export function configureColorEnv(env: Record<string, string | undefined>, preserveColor?: boolean): void {
-  if (env.NO_COLOR !== undefined) {
-    // NO_COLOR is an explicit user preference. wb may preserve color lost through pipes, but it should not override this.
+  if (env.NO_COLOR !== undefined || preserveColor === false) {
+    // NO_COLOR and preserveColor=false are explicit no-color choices, so inherited FORCE_COLOR must not leak through.
     delete env.FORCE_COLOR;
     return;
   }

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -264,12 +264,8 @@ export function configureColorEnv(env: Record<string, string | undefined>, prese
   if (env.NO_COLOR !== undefined || preserveColor === false) {
     // NO_COLOR and preserveColor=false are explicit no-color choices, so inherited FORCE_COLOR must not leak through.
     delete env.FORCE_COLOR;
-    return;
-  }
-
-  if (preserveColor && process.stdout.isTTY) {
+  } else if (preserveColor && process.stdout.isTTY) {
     env.FORCE_COLOR ||= '3';
-    return;
   }
 }
 

--- a/packages/wb/src/utils/output.ts
+++ b/packages/wb/src/utils/output.ts
@@ -9,20 +9,13 @@ export function printBufferedOutput(exitCode: number, output: string): void {
 }
 
 export function shouldPrintBufferedOutput(exitCode: number, output: string): boolean {
-  return exitCode !== 0 || hasWarningOutput(removeNoColorWarning(output));
+  return exitCode !== 0 || hasWarningOutput(output);
 }
 
 export function normalizeBufferedOutput(output: string): string {
-  return removeNoColorWarning(output).trim();
+  return output.trim();
 }
 
 function hasWarningOutput(output: string): boolean {
   return /\bwarn(?:ing)?s?\b/i.test(output.replaceAll(/\b(?:0|no) warnings?\b/gi, ''));
-}
-
-function removeNoColorWarning(output: string): string {
-  return output.replaceAll(
-    /\(node:\d+\) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set\.\n\(Use `node --trace-warnings \.\.\.` to show where the warning was created\)\n?/g,
-    ''
-  );
 }

--- a/packages/wb/test/concurrently.test.ts
+++ b/packages/wb/test/concurrently.test.ts
@@ -190,7 +190,7 @@ describe('runConcurrently', () => {
     expect(exitCode).toBe(0);
   });
 
-  it('passes ci and forceColor through to child environments', async () => {
+  it('passes ci through to child environments', async () => {
     const spawnMock = vi.spyOn(child_process, 'spawn').mockImplementation((_command, _options) => {
       const child = {
         once(event: string, listener: (...args: unknown[]) => void) {
@@ -213,14 +213,12 @@ describe('runConcurrently', () => {
         killOthersOnFail: false,
         success: 'all',
         ci: true,
-        forceColor: true,
       })
     ).resolves.toBe(0);
 
     expect(spawnMock).toHaveBeenCalledOnce();
     const spawnOptions = spawnMock.mock.calls[0]?.[1] as child_process.SpawnOptions;
     expect(spawnOptions.env?.CI).toBe('1');
-    expect(spawnOptions.env?.FORCE_COLOR).toBe('3');
   });
 
   it('returns failure when a child process emits an error', async () => {

--- a/packages/wb/test/scripts/execution/httpServerScripts.test.ts
+++ b/packages/wb/test/scripts/execution/httpServerScripts.test.ts
@@ -81,7 +81,6 @@ describe('HttpServerScripts.testE2E', () => {
           'run',
           `test/e2e/quo'te.spec.ts`,
           'test/e2e/space path.spec.ts',
-          '--color',
           '--passWithNoTests',
           '--allowOnly',
           '--watch=false',

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -993,9 +993,8 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
           format: `${scripts.format} && yarn workspaces foreach --all --parallel --verbose run format`,
           lint: `yarn workspaces foreach --all --parallel --verbose run lint`,
           'lint-fix': 'yarn workspaces foreach --all --parallel --verbose run lint-fix',
-          // CI=1 prevents vitest from enabling watch.
-          // FORCE_COLOR=3 make wb enable color output.
-          test: 'CI=1 FORCE_COLOR=3 yarn workspaces foreach --all --verbose run test',
+          // CI=1 prevents vitest from enabling watch. Color policy belongs to wb, not generated package scripts.
+          test: 'CI=1 yarn workspaces foreach --all --verbose run test',
           typecheck: 'yarn workspaces foreach --all --parallel --verbose run typecheck',
         }
       );

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -984,7 +984,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       typecheck: 'tsgo --noEmit',
     };
     if (hasJava) {
-      scripts.prettify = `prettier --cache --color --no-error-on-unmatched-pattern --write "**/{.*/,}*.{${extensions.prettierOnly.join(',')}}" "!**/test{-,/}fixtures/**"`;
+      scripts.prettify = `prettier --cache --no-error-on-unmatched-pattern --write "**/{.*/,}*.{${extensions.prettierOnly.join(',')}}" "!**/test{-,/}fixtures/**"`;
     }
     if (config.doesContainSubPackageJsons) {
       scripts = merge(
@@ -999,7 +999,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
         }
       );
       if (hasJava) {
-        scripts.prettify = `prettier --cache --color --no-error-on-unmatched-pattern --write "**/{.*/,}*.{${extensions.prettierOnly.join(
+        scripts.prettify = `prettier --cache --no-error-on-unmatched-pattern --write "**/{.*/,}*.{${extensions.prettierOnly.join(
           ','
         )}}" "!**/packages/**" "!**/test{-,/}fixtures/**"`;
       }


### PR DESCRIPTION
## Summary

- Centralize child-process color handling in `wb` with `configureColorEnv`.
- Preserve color only for wb-captured output that is reprinted to an interactive TTY.
- Respect explicit no-color paths by clearing inherited `FORCE_COLOR` when `NO_COLOR` is set or `preserveColor` is explicitly false.
- Keep direct `stdio: inherit` command paths from changing the caller's color environment.
- Move `wb test` and `wb test-on-ci` defaults from `process.env` to each project's `project.env`.
- Remove generated/script-level color forcing from `wbfy`, Prettier, and Vitest command construction.
- Stop filtering the NO_COLOR/FORCE_COLOR warning from buffered output.

## Why

Color policy should live at the `wb` process boundary, not in generated package scripts or individual tool flags. Direct child processes can detect TTY themselves and should inherit the caller's color environment unchanged. Piped child processes lose that context, so `wb` preserves color only when it captures output and reprints it to an interactive terminal. Agent/log-oriented output and explicit no-color preferences stay uncolored.

## Testing

- `yarn verify`
- `NO_COLOR=1 yarn workspace @willbooster/wb start --working-dir "$PWD" lint --fix --format`
- pre-commit cleanup hook
- pre-push check hook
- `bunx @willbooster/agent-skills@1.26.1 check-pr-ci`
- Resolved all review threads after applying Gemini feedback
