### PR TITLE
fix: keep runtime scripts in railway uploads

### DIFF
--- a/packages/wbfy/src/generators/railwayignore.ts
+++ b/packages/wbfy/src/generators/railwayignore.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+
+import { logger } from '../logger.js';
+import type { PackageConfig } from '../packageConfig.js';
+import { fsUtil } from '../utils/fsUtil.js';
+import { promisePool } from '../utils/promisePool.js';
+
+const managedScriptsBlock = `scripts/**
+!scripts/
+!scripts/*.sh`;
+
+export async function fixRailwayignore(config: PackageConfig): Promise<void> {
+  return logger.functionIgnoringException('fixRailwayignore', async () => {
+    const filePath = path.resolve(config.dirPath, '.railwayignore');
+    const content = await fsUtil.readFileIgnoringError(filePath);
+    if (!content) return;
+
+    const newContent = content.replace(/^scripts\/$/m, managedScriptsBlock);
+    if (newContent === content) return;
+
+    await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
+  });
+}

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -26,6 +26,7 @@ import { generateOxfmtConfig } from './generators/oxfmtConfig.js';
 import { generateOxlintConfig } from './generators/oxlintConfig.js';
 import { generatePrettierignore } from './generators/prettierignore.js';
 import { generatePyrightConfigJson } from './generators/pyrightConfig.js';
+import { fixRailwayignore } from './generators/railwayignore.js';
 import { generateReadme } from './generators/readme.js';
 import { generateReleaserc } from './generators/releaserc.js';
 import { generateRenovateJson } from './generators/renovateJson.js';
@@ -134,6 +135,7 @@ async function main(): Promise<void> {
       generateGitattributes(rootConfig),
       generateGitHubTemplates(rootConfig),
       generateIdeaSettings(rootConfig),
+      fixRailwayignore(rootConfig),
       generateRenovateJson(rootConfig),
       generateReleaserc(rootConfig),
       ...(shouldRunWorkflows ? [generateWorkflows(rootConfig)] : []),


### PR DESCRIPTION
## Summary

- Make wbfy preserve top-level runtime shell scripts in `.railwayignore`.
- Replace `scripts/` full exclusion with `scripts/**`, `!scripts/`, and `!scripts/*.sh` so Railway uploads Docker entrypoint/start scripts while still excluding non-runtime scripts.

## Why

Railway Docker builds fail when Dockerfile copies `scripts/docker-entrypoint.sh` or `scripts/start-production.sh` but `.railwayignore` excludes the whole `scripts/` directory.

## Testing

- `yarn workspace @willbooster/wbfy typecheck`
- `yarn verify`
