### PR TITLE
fix: normalize Railway CLI scripts

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -159,6 +159,7 @@ async function updateScripts(config: PackageConfig, jsonObj: WritablePackageJson
     scripts.prettify = (scripts.prettify ?? '') + (await generatePrettierSuffix(config.dirPath));
   }
   normalizeYarnWorkspaceForeachScripts(scripts);
+  normalizeRailwayCliScript(config, scripts);
 }
 
 function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
@@ -180,6 +181,12 @@ function normalizeYarnWorkspaceForeachScripts(scripts: PackageJson.Scripts): voi
       'yarn workspaces foreach --all'
     );
   }
+}
+
+function normalizeRailwayCliScript(config: PackageConfig, scripts: PackageJson.Scripts): void {
+  if (config.isBun || !scripts.railway?.includes('@railway/cli')) return;
+
+  scripts.railway = 'YARN_ENABLE_SCRIPTS=true yarn dlx @railway/cli';
 }
 
 async function applyPackageJsonConventions(


### PR DESCRIPTION
## Summary

- Normalize Yarn Railway CLI scripts to `YARN_ENABLE_SCRIPTS=true yarn dlx @railway/cli`.
- Keep Bun projects unchanged.

## Why

- Railway CLI depends on install-time setup when run through Yarn dlx.
- One existing deploy failed because its generated script disabled package scripts, so wbfy should converge Yarn repos onto the working pattern.

## Testing

- `yarn workspace @willbooster/wbfy typecheck`
- `yarn verify`
