### PR TITLE
fix: route code generation through wb

### DIFF
--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -6,6 +6,7 @@ import type { CommandModule } from 'yargs';
 
 import type { Project } from '../project.js';
 import { findDescendantProjects } from '../project.js';
+import { prismaScripts } from '../scripts/prismaScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
 
 const builder = {} as const;
@@ -42,10 +43,10 @@ function getGenCodeScripts(project: Project): string[] {
   if (project.hasOwnDependency('blitz')) {
     scripts.push('YARN blitz codegen');
     if (project.hasPrisma) {
-      scripts.push('YARN blitz prisma generate');
+      scripts.push(prismaScripts.generate(project));
     }
   } else if (project.hasPrisma) {
-    scripts.push('PRISMA generate');
+    scripts.push(prismaScripts.generate(project));
   }
 
   const chakraTypegenScript = getChakraScript(project);

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -28,6 +28,7 @@ export const prismaCommand: CommandModule = {
       .command(createLitestreamConfigCommand)
       .command(deployCommand)
       .command(deployForceCommand)
+      .command(generateCommand)
       .command(listBackupsCommand)
       .command(migrateCommand)
       .command(migrateDevCommand)
@@ -89,6 +90,19 @@ const deployForceCommand: CommandModule<unknown, InferredOptionTypes<typeof buil
     const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
     for (const { project } of prepareForRunningDatabaseOrmCommand('prisma deploy-force', allProjects)) {
       await runWithSpawn(prismaScripts.deployForce(project), project, argv);
+    }
+  },
+};
+
+const generateCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> = {
+  command: 'generate',
+  describe: 'Generate ORM client code',
+  builder,
+  async handler(argv) {
+    const allProjects = await findDatabaseOrmProjects(argv);
+    const unknownOptions = extractUnknownOptions(argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db generate', allProjects)) {
+      await runWithSpawn(getDatabaseOrmScripts(orm).generate(project, unknownOptions), project, argv);
     }
   },
 };

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -24,8 +24,12 @@ class DrizzleScripts {
     return `YARN drizzle-kit migrate ${additionalOptions}`;
   }
 
-  migrateDev(_project: Project, additionalOptions = ''): string {
+  generate(_project: Project, additionalOptions = ''): string {
     return `YARN drizzle-kit generate ${additionalOptions}`;
+  }
+
+  migrateDev(_project: Project, additionalOptions = ''): string {
+    return this.generate(_project, additionalOptions);
   }
 
   seed(project: Project, scriptPath?: string): string {

--- a/packages/wb/src/scripts/prismaScripts.ts
+++ b/packages/wb/src/scripts/prismaScripts.ts
@@ -29,6 +29,10 @@ class PrismaScripts {
     return `PRISMA migrate deploy ${additionalOptions}`;
   }
 
+  generate(_: Project, additionalOptions = ''): string {
+    return ['PRISMA generate', additionalOptions].filter(Boolean).join(' ');
+  }
+
   deployForce(project: Project): string {
     const dirPath = getDatabaseDirPath(project);
     const removeDbCommand = buildRemoveSqliteDbCommand(`${dirPath}/prod.sqlite3`);
@@ -44,7 +48,7 @@ class PrismaScripts {
   }
 
   migrate(project: Project, additionalOptions = ''): string {
-    return `PRISMA migrate deploy ${additionalOptions} && PRISMA generate && ${this.seed(project)}`;
+    return `PRISMA migrate deploy ${additionalOptions} && ${this.generate(project)} && ${this.seed(project)}`;
   }
 
   migrateDev(_: Project, additionalOptions = ''): string {

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -183,8 +183,8 @@ export function normalizeScript(script: string, project: Project): { printable: 
     .replaceAll('\n', '')
     .replaceAll(/\s\s+/g, ' ')
     .replaceAll(
-      'PRISMA generate ',
-      project.packageJson.dependencies?.blitz ? 'PRISMA generate ' : 'PRISMA generate --no-hints '
+      /PRISMA generate(?!\s+--no-hints)(?=\s|$)/gu,
+      project.packageJson.dependencies?.blitz ? 'PRISMA generate' : 'PRISMA generate --no-hints'
     )
     .replaceAll('PRISMA ', project.packageJson.dependencies?.blitz ? 'YARN blitz prisma ' : 'YARN prisma ')
     .replaceAll('BUN run ', project.usesBunPackageManager ? `${projectPackageManagerWithRun} ` : 'YARN run ')

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -446,8 +446,11 @@ async function normalizePackageMetadata(
   const genCodeScript = jsonObj.scripts['gen-code'];
   if (genCodeScript?.includes('No code generation needed')) {
     delete jsonObj.scripts['gen-code'];
-  } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
-    jsonObj.scripts['gen-code'] = 'wb gen-code';
+  } else {
+    const generatedGenCodeScript = getGeneratedGenCodeScript(config, genCodeScript);
+    if (generatedGenCodeScript) {
+      jsonObj.scripts['gen-code'] = generatedGenCodeScript;
+    }
   }
   addGenI18nTsPostinstallScript(config, jsonObj);
 
@@ -457,13 +460,20 @@ async function normalizePackageMetadata(
   }
 }
 
-function shouldGenerateWbGenCodeScript(config: PackageConfig, oldGenCodeScript: string | undefined): boolean {
-  return (
+function getGeneratedGenCodeScript(config: PackageConfig, oldGenCodeScript: string | undefined): string | undefined {
+  if (
     config.depending.blitz ||
     config.depending.chakra ||
-    config.depending.prisma ||
     (config.depending.drizzle && !!oldGenCodeScript?.includes('drizzle-kit check'))
-  );
+  ) {
+    return oldGenCodeScript;
+  }
+  if (config.depending.prisma) {
+    // The published wb versions used by generated projects expose Prisma through
+    // `wb prisma`, but do not consistently expose the aggregate `wb gen-code`.
+    return 'wb prisma generate';
+  }
+  return;
 }
 
 function appendFormatCodeCommand(formatScript: string | undefined, config: PackageConfig): string {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -446,11 +446,8 @@ async function normalizePackageMetadata(
   const genCodeScript = jsonObj.scripts['gen-code'];
   if (genCodeScript?.includes('No code generation needed')) {
     delete jsonObj.scripts['gen-code'];
-  } else {
-    const generatedGenCodeScript = getGeneratedGenCodeScript(config, genCodeScript);
-    if (generatedGenCodeScript) {
-      jsonObj.scripts['gen-code'] = generatedGenCodeScript;
-    }
+  } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
+    jsonObj.scripts['gen-code'] = `${config.isBun ? 'bun --bun ' : ''}wb gen-code`;
   }
   addGenI18nTsPostinstallScript(config, jsonObj);
 
@@ -460,20 +457,13 @@ async function normalizePackageMetadata(
   }
 }
 
-function getGeneratedGenCodeScript(config: PackageConfig, oldGenCodeScript: string | undefined): string | undefined {
-  if (
+function shouldGenerateWbGenCodeScript(config: PackageConfig, oldGenCodeScript: string | undefined): boolean {
+  return (
     config.depending.blitz ||
     config.depending.chakra ||
+    config.depending.prisma ||
     (config.depending.drizzle && !!oldGenCodeScript?.includes('drizzle-kit check'))
-  ) {
-    return oldGenCodeScript;
-  }
-  if (config.depending.prisma) {
-    // The published wb versions used by generated projects expose Prisma through
-    // `wb prisma`, but do not consistently expose the aggregate `wb gen-code`.
-    return 'wb prisma generate';
-  }
-  return;
+  );
 }
 
 function appendFormatCodeCommand(formatScript: string | undefined, config: PackageConfig): string {


### PR DESCRIPTION
## Summary

- make `wb prisma generate` an explicit `wb` command backed by the shared ORM script layer
- route `wb gen-code` Prisma generation through the same implementation
- keep wbfy generated scripts on the aggregate `wb gen-code` path instead of emitting Prisma-specific scripts
- use `bun --bun wb gen-code` for Bun projects and remove `No code generation needed` scripts

## Verification

- `yarn verify`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBoosterLab/llm-proxy/packages/server gen-code`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBoosterLab/llm-proxy/packages/server prisma generate`
