### PR TITLE
fix: use wbfy baseline for managed tool versions

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import merge from 'deepmerge';
 import fg from 'fast-glob';
@@ -29,9 +30,7 @@ const typescriptGoDependency = '@typescript/native-preview';
 const typescriptDependency = 'typescript';
 const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
-const wbfyPackageJson = JSON.parse(
-  fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
-) as PackageJson;
+const wbfyPackageJson = readWbfyPackageJson();
 const managedDependencyVersions = {
   ...wbfyPackageJson.dependencies,
   ...wbfyPackageJson.devDependencies,
@@ -832,6 +831,21 @@ function getManagedDependencyVersion(dependency: string): string | undefined {
   // baseline instead of live npm latest so generated lockfiles do not pull
   // unreviewed tool releases into every repository at runtime.
   return managedDependencyVersions[dependency];
+}
+
+function readWbfyPackageJson(): PackageJson {
+  let dirPath = path.dirname(fileURLToPath(import.meta.url));
+  while (true) {
+    const packageJsonPath = path.join(dirPath, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
+      if (packageJson.name === '@willbooster/wbfy') return packageJson;
+    }
+
+    const parentDirPath = path.dirname(dirPath);
+    if (parentDirPath === dirPath) throw new Error('Could not find @willbooster/wbfy package.json');
+    dirPath = parentDirPath;
+  }
 }
 
 function getDependencyVersionFromNpm(dependency: string): string {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -29,6 +29,15 @@ const typescriptGoDependency = '@typescript/native-preview';
 const typescriptDependency = 'typescript';
 const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
+const wbfyPackageJson = JSON.parse(
+  fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+) as PackageJson;
+const managedDependencyVersions = {
+  ...wbfyPackageJson.dependencies,
+  ...wbfyPackageJson.devDependencies,
+  ...wbfyPackageJson.peerDependencies,
+};
+const baselineManagedDependencies = new Set([wbDependency, buildTsDependency, ...oxlintDeps]);
 const willBoosterConfigsManagedDependencies = [
   '@willbooster/prettier-config',
   ...oxlintDeps.filter((dependency) => dependency.startsWith('@willbooster/')),
@@ -805,12 +814,24 @@ function getDependencySections(jsonObj: PackageJson): Partial<Record<string, str
 }
 
 function getLatestDependencyVersion(dependency: string): string {
+  const managedVersion = getManagedDependencyVersion(dependency);
+  if (managedVersion) return managedVersion;
+
   const cachedVersion = latestDependencyVersionCache.get(dependency);
   if (cachedVersion) return cachedVersion;
 
   const version = getDependencyVersionFromNpm(dependency);
   latestDependencyVersionCache.set(dependency, version);
   return version;
+}
+
+function getManagedDependencyVersion(dependency: string): string | undefined {
+  if (!baselineManagedDependencies.has(dependency)) return undefined;
+
+  // These tools often ship native binaries. Use wbfy's tested dependency
+  // baseline instead of live npm latest so generated lockfiles do not pull
+  // unreviewed tool releases into every repository at runtime.
+  return managedDependencyVersions[dependency];
 }
 
 function getDependencyVersionFromNpm(dependency: string): string {


### PR DESCRIPTION
## Summary

- Resolve managed tooling versions from `wbfy`'s own package baseline.
- Keep `@willbooster/wb`, `build-ts`, and oxlint/oxfmt tooling from drifting to live npm latest during generation.

## Why

- `wbfy` currently pulls fresh native/binary tool releases into every target repo at runtime.
- Those generated lockfile updates can fail dependency preflight before target verification runs.

## Testing

- `yarn verify`
