### PR TITLE
fix: install resolved managed dependency versions

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -581,9 +581,7 @@ function installNpmDependencies(
 
   const dependencySpecifiers = [
     ...new Set(
-      dependencies.map((dependency) =>
-        getInstallDependencySpecifier(dependency, packageJsonDependencies[dependency], packageManager)
-      )
+      dependencies.map((dependency) => getInstallDependencySpecifier(dependency, packageJsonDependencies[dependency]))
     ),
   ];
   spawnSync(
@@ -593,15 +591,11 @@ function installNpmDependencies(
   );
 }
 
-function getInstallDependencySpecifier(
-  dependency: string,
-  currentVersion: string | undefined,
-  packageManager: 'bun' | 'yarn'
-): string {
-  // Yarn prefers local workspaces when adding a bare package name. Passing the
-  // resolved version keeps managed tools as npm dependencies in config-package
-  // monorepos, where those package names can also exist as workspaces.
-  if (packageManager === 'yarn' && currentVersion && !isWorkspaceProtocolRange(currentVersion)) {
+function getInstallDependencySpecifier(dependency: string, currentVersion: string | undefined): string {
+  // Package managers resolve a bare add target against live registry state.
+  // Passing the resolved version keeps generated installs aligned with the
+  // package.json baseline we just wrote.
+  if (currentVersion && !isWorkspaceProtocolRange(currentVersion)) {
     return `${dependency}@${currentVersion}`;
   }
 


### PR DESCRIPTION
## Summary

- Pass resolved dependency specifiers to package-manager add commands.
- Prevent Bun from replacing the managed `wbfy` baseline with live npm latest during install.

## Why

- `package.json` was written with baseline versions, but `bun add <name>` still resolves against the registry latest tag.
- This keeps generated lockfiles consistent with the version policy added in the previous `wbfy` fix.

## Testing

- `yarn verify`
- `yarn test`
