### PR TITLE
fix: preserve newer managed dependency pins

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -913,9 +913,9 @@ function shouldUpdateExistingManagedDependency(dependency: string, currentVersio
   if (currentVersion === '*') return true;
   if (isWorkspaceProtocolRange(currentVersion)) return true;
   if (dependency === typescriptGoDependency) return isNewerManagedDependencyVersion(dependency, currentVersion);
-  // wbfy-managed tools must be kept current even when the package already pins
-  // a concrete version. In particular, build-ts owns declaration output paths.
-  return dependency === '@willbooster/wb' || dependency === buildTsDependency || oxlintDeps.includes(dependency);
+  // wbfy owns these tool baselines, but applying wbfy should not downgrade a
+  // repository that already pins a newer reviewed release.
+  return baselineManagedDependencies.has(dependency) && isNewerManagedDependencyVersion(dependency, currentVersion);
 }
 
 function isNewerManagedDependencyVersion(dependency: string, currentVersion: string): boolean {


### PR DESCRIPTION
## Summary

- Preserve existing concrete managed dependency versions when they are newer than `wbfy`'s tested baseline.
- Continue updating missing, wildcard, workspace, or older managed dependency pins to the managed baseline.

## Why

- Applying `wbfy` to a repo that already had a newer `@willbooster/wb` pin caused an unintended downgrade and dependency preflight rejection.
- This keeps baseline ownership while avoiding downgrade churn in target repositories.

## Testing

- `yarn verify`
- pre-push hook ran `oxlint` successfully
