### PR TITLE
fix: generate wb db scripts consistently

### DIFF
--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs/promises';
+
+import fg from 'fast-glob';
+
+import type { PackageConfig } from '../packageConfig.js';
+import { fsUtil } from '../utils/fsUtil.js';
+import { globIgnore } from '../utils/globUtil.js';
+import { promisePool } from '../utils/promisePool.js';
+
+const oldCommand = 'wb prisma';
+const newCommand = 'wb db';
+const maxTextFileBytes = 1024 * 1024;
+
+export async function fixWbDbCommand(rootConfig: PackageConfig): Promise<void> {
+  if (rootConfig.repoAuthor === 'WillBooster' && rootConfig.repoName === 'shared') return;
+
+  const filePaths = await fg('**/*', {
+    absolute: true,
+    cwd: rootConfig.dirPath,
+    dot: true,
+    ignore: ['**/.git/**', ...globIgnore],
+    onlyFiles: true,
+  });
+
+  await Promise.all(filePaths.map((filePath) => promisePool.run(() => replaceWbPrismaCommand(filePath))));
+}
+
+async function replaceWbPrismaCommand(filePath: string): Promise<void> {
+  const content = await readTextFile(filePath);
+  if (!content?.includes(oldCommand)) return;
+
+  // Temporary migration: remove this fixer after all repositories have been
+  // migrated from the legacy `wb prisma` spelling to `wb db`.
+  await fsUtil.generateFile(filePath, content.replaceAll(oldCommand, newCommand));
+}
+
+async function readTextFile(filePath: string): Promise<string | undefined> {
+  const stats = await fs.stat(filePath);
+  if (stats.size > maxTextFileBytes) return undefined;
+
+  const buffer = await fs.readFile(filePath);
+  if (buffer.includes(0)) return undefined;
+
+  return buffer.toString('utf8');
+}

--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -10,11 +10,26 @@ import { promisePool } from '../utils/promisePool.js';
 const oldCommand = 'wb prisma';
 const newCommand = 'wb db';
 const maxTextFileBytes = 1024 * 1024;
+const migrationTargets = [
+  '**/*.{cjs,cts,js,json,jsx,md,mdc,mjs,mts,sh,tsx,ts,toml,txt,yaml,yml}',
+  '**/.env',
+  '**/.env.*',
+  '**/.github/workflows/*',
+  '**/.gitignore',
+  '**/.dockerignore',
+  '**/Dockerfile',
+  '**/Dockerfile.*',
+  '**/Makefile',
+  '**/mise.toml',
+  '**/.mise.toml',
+  '**/lefthook.yml',
+  '**/package.json',
+];
 
 export async function fixWbDbCommand(rootConfig: PackageConfig): Promise<void> {
   if (rootConfig.repoAuthor === 'WillBooster' && rootConfig.repoName === 'shared') return;
 
-  const filePaths = await fg('**/*', {
+  const filePaths = await fg(migrationTargets, {
     absolute: true,
     cwd: rootConfig.dirPath,
     dot: true,

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -281,13 +281,6 @@ async function applyPackageJsonConventions(
   if (!isWbPackage(jsonObj)) {
     devDependencies.push(wbDependency);
   }
-  if (config.depending.wb || config.isBun) {
-    for (const [key, value] of Object.entries(jsonObj.scripts)) {
-      if (typeof value !== 'string') continue;
-      jsonObj.scripts[key] = value.replaceAll(/wb\s+db/gu, 'wb prisma');
-    }
-  }
-
   // build-ts owns TypeScript execution and declaration emit. wbfy must always
   // keep existing build-ts users current because older releases can emit .d.ts
   // files at paths that no longer match package exports.
@@ -999,6 +992,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       verify: 'bun --bun wb verify',
       'verify-full': 'bun --bun wb verify --full',
     };
+    applyDatabaseScripts(config, scripts, 'bun --bun wb db');
     applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
     if (!hasTypecheck) {
       delete scripts.typecheck;
@@ -1063,9 +1057,18 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       scripts.verify = 'wb verify';
       scripts['verify-full'] = 'wb verify --full';
     }
+    applyDatabaseScripts(config, scripts, 'wb db');
     applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
     return scripts;
   }
+}
+
+function applyDatabaseScripts(config: PackageConfig, scripts: Record<string, string>, wbDbCommand: string): void {
+  if (!config.depending.prisma && !config.depending.drizzle) return;
+
+  scripts['db-create-migration'] = `${wbDbCommand} migrate-dev`;
+  scripts['db-migrate'] = `${wbDbCommand} migrate --check-idempotency`;
+  scripts['db-view'] = `${wbDbCommand} studio`;
 }
 
 function isWbPackage(packageJson: PackageJson | undefined): boolean {

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -10,6 +10,7 @@ import { fixPrismaEnvFiles } from './fixers/prisma.js';
 import { fixTestDirectoriesUpdatingPackageJson } from './fixers/testDirectory.js';
 import { fixTypeDefinitions } from './fixers/typeDefinition.js';
 import { fixTypos } from './fixers/typos.js';
+import { fixWbDbCommand } from './fixers/wbDbCommand.js';
 import { generateAgentInstructions } from './generators/agents.js';
 import { generateBunfigToml } from './generators/bunfig.js';
 import { generateDockerignore } from './generators/dockerignore.js';
@@ -188,6 +189,7 @@ async function main(): Promise<void> {
     }
     await Promise.all(promises);
     await promisePool.promiseAll();
+    await fixWbDbCommand(rootConfig);
 
     const packageManager = rootConfig.isBun ? 'bun' : 'yarn';
     // Refresh lock files


### PR DESCRIPTION
## Summary
- generate database package scripts directly as `wb db ...`
- stop rewriting existing `wb db` scripts to `wb prisma`
- add a temporary migration fixer that rewrites `wb prisma` to `wb db` in typical source, script, config, workflow, env, and Dockerfile files
- skip the temporary migration fixer for `WillBooster/shared` itself

## Verification
- yarn verify in packages/wbfy
- pre-push oxlint hook
- reapplied wbfy to WillBooster/pkg-preflight
- inserted a temporary `wb prisma` README line in pkg-preflight, ran wbfy, and confirmed it became `wb db`; then removed the temporary line