### PR TITLE
fix: allow immediate bun type installs

### DIFF
--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -51,6 +51,10 @@ const minimumReleaseAgeExcludes = [
   '@typescript/native-preview-linux-x64',
   '@typescript/native-preview-win32-arm64',
   '@typescript/native-preview-win32-x64',
+  // Bun itself releases its first-party type packages in lockstep with the
+  // runtime, so generated Bun repos must be able to install them immediately.
+  '@types/bun',
+  'bun-types',
   'oxfmt',
   '@oxfmt/binding-android-arm-eabi',
   '@oxfmt/binding-android-arm64',


### PR DESCRIPTION
## 概要
- wbfy が生成する `bunfig.toml` の `minimumReleaseAgeExcludes` に `@types/bun` と `bun-types` を追加しました。
- Bun ランタイム更新直後でも、対応する型パッケージを即時 install できるようにします。

## 確認
- `yarn verify`
