### PR TITLE
feat: add wb maintenance server command

### DIFF
--- a/packages/wb/README.md
+++ b/packages/wb/README.md
@@ -16,6 +16,8 @@ Commands:
   wb kill-port-if-non-ci        Kill the port specified by PORT environment
                                 variable if non-CI.
   wb lint [files...]            Lint code
+  wb maintenance <action>       Start or stop a lightweight maintenance page
+                                server.
   wb optimizeForDockerBuild     Optimize configuration when building a Docker
                                 image
   wb prisma                     Run database commands              [aliases: db]

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -63,16 +63,14 @@ function getMaintenanceServerSource(port: number, pidPath: string): string {
 import fs from 'node:fs';
 import http from 'node:http';
 
-const port = ${port};
 const pidPath = ${JSON.stringify(pidPath)};
-const body = ${JSON.stringify(maintenanceHtml)};
 
 const server = http.createServer((_request, response) => {
   response.writeHead(503, {
     'cache-control': 'no-store',
     'content-type': 'text/html; charset=utf-8',
   });
-  response.end(body);
+  response.end(${JSON.stringify(maintenanceHtml)});
 });
 
 server.on('error', () => {
@@ -84,7 +82,7 @@ server.on('error', () => {
   process.exit(1);
 });
 
-server.listen(port, '0.0.0.0', () => {
+server.listen(${port}, '0.0.0.0', () => {
   fs.writeFileSync(pidPath, String(process.pid) + '\n');
 });
 `;

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -1,0 +1,213 @@
+import child_process from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+
+import chalk from 'chalk';
+import type { Argv, CommandModule, InferredOptionTypes } from 'yargs';
+
+import { findSelfProject, type Project } from '../project.js';
+import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+
+const builder = {} as const;
+const maintenanceHtml = `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>メンテナンス中</title>
+    <style>
+      body {
+        align-items: center;
+        background: #f8fafc;
+        color: #111827;
+        display: flex;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        justify-content: center;
+        margin: 0;
+        min-height: 100vh;
+      }
+
+      main {
+        padding: 24px;
+        text-align: center;
+      }
+
+      h1 {
+        font-size: 28px;
+        line-height: 1.4;
+        margin: 0 0 16px;
+      }
+
+      p {
+        font-size: 16px;
+        line-height: 1.8;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>現在メンテナンス中です</h1>
+      <p>皆様にはご不便をおかけしますが、メンテナンス終了までしばらくお待ちください。</p>
+    </main>
+  </body>
+</html>`;
+const maintenanceServerSource = String.raw`
+import http from 'node:http';
+
+const port = Number(process.env.PORT);
+if (!Number.isInteger(port) || port <= 0) {
+  console.error('PORT environment variable is invalid.');
+  process.exit(1);
+}
+
+const body = ${JSON.stringify(maintenanceHtml)};
+
+const server = http.createServer((_request, response) => {
+  response.writeHead(503, {
+    'cache-control': 'no-store',
+    'content-type': 'text/html; charset=utf-8',
+    'retry-after': '300',
+  });
+  response.end(body);
+});
+
+server.listen(port, '0.0.0.0');
+`;
+
+export const maintenanceCommand: CommandModule<
+  unknown,
+  InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>
+> = {
+  command: 'maintenance <action>',
+  describe: 'Start or stop a lightweight maintenance page server.',
+  builder: (yargs: Argv<unknown>) =>
+    yargs
+      .positional('action', {
+        choices: ['start', 'stop'] as const,
+        describe: 'Maintenance server action',
+        type: 'string',
+      })
+      .options(builder) as unknown as Argv<InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>>,
+  async handler(argv) {
+    const project = findSelfProject(argv);
+    if (!project) {
+      console.error(chalk.red('No project found.'));
+      process.exit(1);
+    }
+
+    const port = parsePort(project.env.PORT);
+    const action = String(argv.action);
+    if (action === 'start') {
+      await startMaintenanceServer(project, port);
+      return;
+    }
+    if (action === 'stop') {
+      stopMaintenanceServer(project, port);
+      return;
+    }
+
+    throw new Error(`Unknown maintenance action: ${action}`);
+  },
+};
+
+async function startMaintenanceServer(project: Project, port: number): Promise<void> {
+  const pidPath = getPidPath(project, port);
+  const existingPid = readPid(pidPath);
+  if (existingPid !== undefined && isProcessRunning(existingPid)) {
+    console.info(`Maintenance server is already running on port ${port}.`);
+    return;
+  }
+  removePidFile(pidPath);
+
+  await assertPortAvailable(port);
+  fs.mkdirSync(path.dirname(pidPath), { recursive: true });
+
+  const child = child_process.spawn(process.execPath, ['--input-type=module', '--eval', maintenanceServerSource], {
+    detached: true,
+    env: { ...process.env, PORT: String(port) },
+    stdio: 'ignore',
+  });
+  if (child.pid === undefined) {
+    throw new Error('Failed to start maintenance server.');
+  }
+
+  fs.writeFileSync(pidPath, `${child.pid}\n`);
+  child.unref();
+  console.info(`Started maintenance server on port ${port}.`);
+}
+
+function stopMaintenanceServer(project: Project, port: number): void {
+  const pidPath = getPidPath(project, port);
+  const pid = readPid(pidPath);
+  if (pid === undefined) {
+    console.info(`Maintenance server is not running on port ${port}.`);
+    return;
+  }
+
+  if (isProcessRunning(pid)) {
+    process.kill(pid, 'SIGTERM');
+  }
+  removePidFile(pidPath);
+  console.info(`Stopped maintenance server on port ${port}.`);
+}
+
+function parsePort(portEnv: string | undefined): number {
+  const port = Number(portEnv);
+  if (!Number.isInteger(port) || port <= 0) {
+    console.error(chalk.red(`PORT environment variable is invalid: ${portEnv}`));
+    process.exit(1);
+  }
+  return port;
+}
+
+async function assertPortAvailable(port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.once('listening', () => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+    server.listen(port, '0.0.0.0');
+  }).catch((error) => {
+    console.error(chalk.red(`Port ${port} is already in use.`));
+    throw error;
+  });
+}
+
+function getPidPath(project: Project, port: number): string {
+  return path.join(project.rootDirPath, '.tmp', `wb-maintenance-server-${port}.pid`);
+}
+
+function readPid(pidPath: string): number | undefined {
+  try {
+    const pid = Number(fs.readFileSync(pidPath, 'utf8').trim());
+    return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+  } catch {
+    return;
+  }
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function removePidFile(pidPath: string): void {
+  try {
+    fs.rmSync(pidPath, { force: true });
+  } catch {
+    // do nothing
+  }
+}

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -1,13 +1,14 @@
 import child_process from 'node:child_process';
 import fs from 'node:fs';
-import net from 'node:net';
 import path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 
 import chalk from 'chalk';
 import type { Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
 import { findSelfProject, type Project } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { isPortAvailable } from '../utils/port.js';
 
 const builder = {} as const;
 type MaintenanceArgv = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder> & {
@@ -138,7 +139,10 @@ async function startMaintenanceServer(project: Project, port: number): Promise<v
   }
   removePidFile(pidPath);
 
-  await assertPortAvailable(port);
+  if (!(await isPortAvailable(port))) {
+    console.error(chalk.red(`Port ${port} is already in use.`));
+    process.exit(1);
+  }
   fs.mkdirSync(path.dirname(pidPath), { recursive: true });
 
   const child = child_process.spawn(process.execPath, ['--input-type=module', '--eval', maintenanceServerSource], {
@@ -181,26 +185,6 @@ function parsePort(portEnv: string | undefined): number {
   return port;
 }
 
-async function assertPortAvailable(port: number): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const server = net.createServer();
-    server.once('error', reject);
-    server.once('listening', () => {
-      server.close((error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve();
-      });
-    });
-    server.listen(port, '0.0.0.0');
-  }).catch((error) => {
-    console.error(chalk.red(`Port ${port} is already in use.`));
-    throw error;
-  });
-}
-
 function getPidPath(project: Project, port: number): string {
   return path.join(project.rootDirPath, '.tmp', `wb-maintenance-server-${port}.pid`);
 }
@@ -236,15 +220,9 @@ async function waitForPidFile(pidPath: string, pid: number): Promise<void> {
   while (Date.now() < deadline) {
     if (readPid(pidPath) !== undefined) return;
     if (!isProcessRunning(pid)) break;
-    await sleep(50);
+    await setTimeout(50);
   }
 
   removePidFile(pidPath);
   throw new Error('Failed to start maintenance server.');
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -10,6 +10,9 @@ import { findSelfProject, type Project } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
 const builder = {} as const;
+type MaintenanceArgv = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder> & {
+  action: 'start' | 'stop';
+};
 const maintenanceHtml = `<!doctype html>
 <html lang="ja">
   <head>
@@ -54,11 +57,17 @@ const maintenanceHtml = `<!doctype html>
   </body>
 </html>`;
 const maintenanceServerSource = String.raw`
+import fs from 'node:fs';
 import http from 'node:http';
 
 const port = Number(process.env.PORT);
 if (!Number.isInteger(port) || port <= 0) {
   console.error('PORT environment variable is invalid.');
+  process.exit(1);
+}
+const pidPath = process.env.WB_MAINTENANCE_PID_PATH;
+if (!pidPath) {
+  console.error('WB_MAINTENANCE_PID_PATH environment variable is not set.');
   process.exit(1);
 }
 
@@ -73,13 +82,21 @@ const server = http.createServer((_request, response) => {
   response.end(body);
 });
 
-server.listen(port, '0.0.0.0');
+server.on('error', () => {
+  try {
+    fs.rmSync(pidPath, { force: true });
+  } catch {
+    // do nothing
+  }
+  process.exit(1);
+});
+
+server.listen(port, '0.0.0.0', () => {
+  fs.writeFileSync(pidPath, String(process.pid) + '\n');
+});
 `;
 
-export const maintenanceCommand: CommandModule<
-  unknown,
-  InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>
-> = {
+export const maintenanceCommand: CommandModule<unknown, MaintenanceArgv> = {
   command: 'maintenance <action>',
   describe: 'Start or stop a lightweight maintenance page server.',
   builder: (yargs: Argv<unknown>) =>
@@ -89,7 +106,7 @@ export const maintenanceCommand: CommandModule<
         describe: 'Maintenance server action',
         type: 'string',
       })
-      .options(builder) as unknown as Argv<InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>>,
+      .options(builder) as unknown as Argv<MaintenanceArgv>,
   async handler(argv) {
     const project = findSelfProject(argv);
     if (!project) {
@@ -98,7 +115,7 @@ export const maintenanceCommand: CommandModule<
     }
 
     const port = parsePort(project.env.PORT);
-    const action = String(argv.action);
+    const action = argv.action;
     if (action === 'start') {
       await startMaintenanceServer(project, port);
       return;
@@ -126,15 +143,15 @@ async function startMaintenanceServer(project: Project, port: number): Promise<v
 
   const child = child_process.spawn(process.execPath, ['--input-type=module', '--eval', maintenanceServerSource], {
     detached: true,
-    env: { ...process.env, PORT: String(port) },
+    env: { ...project.env, PORT: String(port), WB_MAINTENANCE_PID_PATH: pidPath },
     stdio: 'ignore',
   });
   if (child.pid === undefined) {
     throw new Error('Failed to start maintenance server.');
   }
 
-  fs.writeFileSync(pidPath, `${child.pid}\n`);
   child.unref();
+  await waitForPidFile(pidPath, child.pid);
   console.info(`Started maintenance server on port ${port}.`);
 }
 
@@ -146,8 +163,10 @@ function stopMaintenanceServer(project: Project, port: number): void {
     return;
   }
 
-  if (isProcessRunning(pid)) {
+  try {
     process.kill(pid, 'SIGTERM');
+  } catch {
+    // do nothing
   }
   removePidFile(pidPath);
   console.info(`Stopped maintenance server on port ${port}.`);
@@ -210,4 +229,22 @@ function removePidFile(pidPath: string): void {
   } catch {
     // do nothing
   }
+}
+
+async function waitForPidFile(pidPath: string, pid: number): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (readPid(pidPath) !== undefined) return;
+    if (!isProcessRunning(pid)) break;
+    await sleep(50);
+  }
+
+  removePidFile(pidPath);
+  throw new Error('Failed to start maintenance server.');
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -71,7 +71,6 @@ const server = http.createServer((_request, response) => {
   response.writeHead(503, {
     'cache-control': 'no-store',
     'content-type': 'text/html; charset=utf-8',
-    'retry-after': '300',
   });
   response.end(body);
 });

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -57,21 +57,14 @@ const maintenanceHtml = `<!doctype html>
     </main>
   </body>
 </html>`;
-const maintenanceServerSource = String.raw`
+
+function getMaintenanceServerSource(port: number, pidPath: string): string {
+  return String.raw`
 import fs from 'node:fs';
 import http from 'node:http';
 
-const port = Number(process.env.PORT);
-if (!Number.isInteger(port) || port <= 0) {
-  console.error('PORT environment variable is invalid.');
-  process.exit(1);
-}
-const pidPath = process.env.WB_MAINTENANCE_PID_PATH;
-if (!pidPath) {
-  console.error('WB_MAINTENANCE_PID_PATH environment variable is not set.');
-  process.exit(1);
-}
-
+const port = ${port};
+const pidPath = ${JSON.stringify(pidPath)};
 const body = ${JSON.stringify(maintenanceHtml)};
 
 const server = http.createServer((_request, response) => {
@@ -96,6 +89,7 @@ server.listen(port, '0.0.0.0', () => {
   fs.writeFileSync(pidPath, String(process.pid) + '\n');
 });
 `;
+}
 
 export const maintenanceCommand: CommandModule<unknown, MaintenanceArgv> = {
   command: 'maintenance <action>',
@@ -145,11 +139,15 @@ async function startMaintenanceServer(project: Project, port: number): Promise<v
   }
   fs.mkdirSync(path.dirname(pidPath), { recursive: true });
 
-  const child = child_process.spawn(process.execPath, ['--input-type=module', '--eval', maintenanceServerSource], {
-    detached: true,
-    env: { ...project.env, PORT: String(port), WB_MAINTENANCE_PID_PATH: pidPath },
-    stdio: 'ignore',
-  });
+  const child = child_process.spawn(
+    process.execPath,
+    ['--input-type=module', '--eval', getMaintenanceServerSource(port, pidPath)],
+    {
+      detached: true,
+      env: project.env,
+      stdio: 'ignore',
+    }
+  );
   if (child.pid === undefined) {
     throw new Error('Failed to start maintenance server.');
   }

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -1,4 +1,5 @@
 import child_process from 'node:child_process';
+import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
@@ -173,10 +174,7 @@ function stopMaintenanceServer(project: Project, port: number): void {
 
 function parsePort(portEnv: string | undefined): number {
   const port = Number(portEnv);
-  if (!Number.isInteger(port) || port <= 0) {
-    console.error(chalk.red(`PORT environment variable is invalid: ${portEnv}`));
-    process.exit(1);
-  }
+  assert.ok(Number.isInteger(port) && port > 0, `PORT environment variable is invalid: ${portEnv}`);
   return port;
 }
 

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -10,6 +10,7 @@ import { concurrentlyCommand } from './commands/concurrently.js';
 import { genCodeCommand } from './commands/genCode.js';
 import { killPortIfNonCiCommand } from './commands/killPortIfNonCi.js';
 import { lintCommand } from './commands/lint.js';
+import { maintenanceCommand } from './commands/maintenance.js';
 import { optimizeForDockerBuildCommand } from './commands/optimizeForDockerBuild.js';
 import { prismaCommand } from './commands/prisma.js';
 import { retryCommand } from './commands/retry.js';
@@ -40,6 +41,7 @@ await yargs(hideBin(process.argv))
   .command(genCodeCommand)
   .command(killPortIfNonCiCommand)
   .command(lintCommand)
+  .command(maintenanceCommand)
   .command(optimizeForDockerBuildCommand)
   .command(prismaCommand)
   .command(retryCommand)

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -36,7 +36,7 @@ const managedDependencyVersions = {
   ...wbfyPackageJson.devDependencies,
   ...wbfyPackageJson.peerDependencies,
 };
-const baselineManagedDependencies = new Set([wbDependency, buildTsDependency, ...oxlintDeps]);
+const baselineManagedDependencies = new Set([wbDependency, buildTsDependency, 'lefthook', ...oxlintDeps]);
 const willBoosterConfigsManagedDependencies = [
   '@willbooster/prettier-config',
   ...oxlintDeps.filter((dependency) => dependency.startsWith('@willbooster/')),


### PR DESCRIPTION
## 概要
- `wb maintenance start` / `wb maintenance stop` を追加
- `PORT` で指定されたポートに、標準 `node:http` ベースのメンテナンス表示サーバーを detached 起動
- repo 内 `.tmp` に PID ファイルを保存し、`stop` で該当 PID のみ停止
- 起動確認、PID ファイル cleanup、既存 port utility の利用で review 指摘に対応
- 親側で検証済みの `port` / `pidPath` を子プロセスの server source に渡す形へ整理
- 不要な `Retry-After` header を削除
- `PORT` 検証を `node:assert` に変更

## 確認
- `yarn workspace @willbooster/wb typecheck`
- `yarn workspace @willbooster/wb lint packages/wb/src/commands/maintenance.ts`
- `yarn workspace @willbooster/wbfy test test/cleanupIdempotency.test.ts`
- `PORT=49181 yarn workspace @willbooster/wb start maintenance start`
- `rtk curl -i http://127.0.0.1:49181/`
- `PORT=49181 yarn workspace @willbooster/wb start maintenance stop`
- `yarn verify`
<img width="400" alt="image" src="https://github.com/user-attachments/assets/2afc969b-6b70-448a-aba6-995dd16a3f48" />
