### PR TITLE
fix: skip maintenance server in test env

### DIFF
--- a/packages/wb/README.md
+++ b/packages/wb/README.md
@@ -18,6 +18,7 @@ Commands:
   wb lint [files...]            Lint code
   wb maintenance <action>       Start or stop a lightweight maintenance page
                                 server.
+                                Example: wb maintenance start
   wb optimizeForDockerBuild     Optimize configuration when building a Docker
                                 image
   wb prisma                     Run database commands              [aliases: db]

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -91,7 +91,7 @@ server.listen(${port}, '0.0.0.0', () => {
 
 export const maintenanceCommand: CommandModule<unknown, MaintenanceArgv> = {
   command: 'maintenance <action>',
-  describe: 'Start or stop a lightweight maintenance page server.',
+  describe: 'Start or stop a lightweight maintenance page server. Example: wb maintenance start',
   builder: (yargs: Argv<unknown>) =>
     yargs
       .positional('action', {
@@ -107,8 +107,13 @@ export const maintenanceCommand: CommandModule<unknown, MaintenanceArgv> = {
       process.exit(1);
     }
 
-    const port = parsePort(project.env.PORT);
     const action = argv.action;
+    if (project.env.WB_ENV === 'test') {
+      console.info(`Skip maintenance ${action} because WB_ENV is test.`);
+      return;
+    }
+
+    const port = parsePort(project.env.PORT);
     if (action === 'start') {
       await startMaintenanceServer(project, port);
       return;


### PR DESCRIPTION
## 概要
- `WB_ENV=test` のときは `wb maintenance start/stop` を skip するように変更
- Playwright がメンテナンスサーバー起動を通常の web server 起動と誤認しないようにする
- `wb --help` / README で `wb maintenance start` の例が見えるように追記

## 確認
- `yarn workspace @willbooster/wb typecheck`
- `yarn workspace @willbooster/wb lint packages/wb/src/commands/maintenance.ts`
- `WB_ENV=test yarn workspace @willbooster/wb start maintenance start --quiet-env`
- `yarn workspace @willbooster/wb start --help`
- `PORT=49183 yarn workspace @willbooster/wb start maintenance start`
- `rtk curl -i http://127.0.0.1:49183/`
- `PORT=49183 yarn workspace @willbooster/wb start maintenance stop`
- `yarn verify`
