### PR TITLE
feat: improve docker cleanup helper

### DIFF
--- a/packages/wb/docker/bash/cleanup-apt.sh
+++ b/packages/wb/docker/bash/cleanup-apt.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
-
-WB_KEEP_DOCKER_SCRIPTS=1 bash "${SCRIPT_DIR}/cleanup.sh"

--- a/packages/wb/docker/bash/cleanup-apt.sh
+++ b/packages/wb/docker/bash/cleanup-apt.sh
@@ -4,12 +4,4 @@ set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 
-if [ -f "${SCRIPT_DIR}/cleanup.sh" ]; then
-  WB_KEEP_DOCKER_SCRIPTS=1 bash "${SCRIPT_DIR}/cleanup.sh"
-  exit
-fi
-
-apt-get purge -qq -y curl wget || true
-apt-get autoremove -qq -y
-apt-get clean -qq
-rm -rf /var/lib/apt/lists/*
+WB_KEEP_DOCKER_SCRIPTS=1 bash "${SCRIPT_DIR}/cleanup.sh"

--- a/packages/wb/docker/bash/cleanup.sh
+++ b/packages/wb/docker/bash/cleanup.sh
@@ -4,12 +4,11 @@ set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 
-if [ -f "${SCRIPT_DIR}/cleanup.sh" ]; then
-  WB_KEEP_DOCKER_SCRIPTS=1 bash "${SCRIPT_DIR}/cleanup.sh"
-  exit
-fi
-
 apt-get purge -qq -y curl wget || true
 apt-get autoremove -qq -y
 apt-get clean -qq
 rm -rf /var/lib/apt/lists/*
+
+if [ -z "${WB_KEEP_DOCKER_SCRIPTS:-}" ] && [ "$(basename "${SCRIPT_DIR}")" = "bash" ]; then
+  rm -rf "${SCRIPT_DIR}"
+fi


### PR DESCRIPTION
## Summary

- add `cleanup.sh` as the Docker helper cleanup entry point
- make `cleanup.sh` remove apt artifacts and the copied `./bash` helper directory by default
- remove the old `cleanup-apt.sh` helper so downstream Dockerfiles use the broader cleanup name

## Why

- review feedback on downstream Dockerfiles showed that copied helper scripts should be removed by the generated cleanup helper where possible
- the old `cleanup-apt.sh` name no longer fits when cleanup also owns helper-script removal
- `wb optimizeForDockerBuild --outside` generates these helper files together, so downstreams can migrate directly to `cleanup.sh`

## Testing

- `bash -n packages/wb/docker/bash/cleanup.sh`
- `yarn workspace @willbooster/wb start --working-dir /tmp/wb-cleanup-script-check optimizeForDockerBuild --outside`
- confirmed `/tmp/wb-cleanup-script-check/dist/bash` includes `cleanup.sh`
- `yarn verify`
