### PR TITLE
feat: add explicit docker cleanup script retention

### DIFF
--- a/packages/wb/docker/bash/cleanup-apt.sh
+++ b/packages/wb/docker/bash/cleanup-apt.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
-
-WB_KEEP_DOCKER_SCRIPTS=1 bash "${SCRIPT_DIR}/cleanup.sh"

--- a/packages/wb/docker/bash/cleanup-apt.sh
+++ b/packages/wb/docker/bash/cleanup-apt.sh
@@ -4,12 +4,4 @@ set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 
-if [ -f "${SCRIPT_DIR}/cleanup.sh" ]; then
-  WB_KEEP_DOCKER_SCRIPTS=1 bash "${SCRIPT_DIR}/cleanup.sh"
-  exit
-fi
-
-apt-get purge -qq -y curl wget || true
-apt-get autoremove -qq -y
-apt-get clean -qq
-rm -rf /var/lib/apt/lists/*
+WB_KEEP_DOCKER_SCRIPTS=1 bash "${SCRIPT_DIR}/cleanup.sh"

--- a/packages/wb/docker/bash/cleanup.sh
+++ b/packages/wb/docker/bash/cleanup.sh
@@ -3,12 +3,25 @@
 set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+keep_scripts=0
+
+for arg in "$@"; do
+  case "${arg}" in
+    --keep-scripts)
+      keep_scripts=1
+      ;;
+    *)
+      echo "Usage: cleanup.sh [--keep-scripts]" >&2
+      exit 1
+      ;;
+  esac
+done
 
 apt-get purge -qq -y curl wget || true
 apt-get autoremove -qq -y
 apt-get clean -qq
 rm -rf /var/lib/apt/lists/*
 
-if [ -z "${WB_KEEP_DOCKER_SCRIPTS:-}" ] && [ "$(basename "${SCRIPT_DIR}")" = "bash" ]; then
+if [ "${keep_scripts}" = 0 ] && [ "$(basename "${SCRIPT_DIR}")" = "bash" ]; then
   rm -rf "${SCRIPT_DIR}"
 fi

--- a/packages/wb/docker/bash/cleanup.sh
+++ b/packages/wb/docker/bash/cleanup.sh
@@ -4,12 +4,11 @@ set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 
-if [ -f "${SCRIPT_DIR}/cleanup.sh" ]; then
-  WB_KEEP_DOCKER_SCRIPTS=1 bash "${SCRIPT_DIR}/cleanup.sh"
-  exit
-fi
-
 apt-get purge -qq -y curl wget || true
 apt-get autoremove -qq -y
 apt-get clean -qq
 rm -rf /var/lib/apt/lists/*
+
+if [ -z "${WB_KEEP_DOCKER_SCRIPTS:-}" ] && [ "$(basename "${SCRIPT_DIR}")" = "bash" ]; then
+  rm -rf "${SCRIPT_DIR}"
+fi

--- a/packages/wb/docker/bash/install-asdf.sh
+++ b/packages/wb/docker/bash/install-asdf.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# This script MUST NOT require superuser privileges; however, prepare-asdf.sh does require them.
-ASDF_VERSION=$(curl --silent "https://api.github.com/repos/asdf-vm/asdf/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/') \
-  && git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch ${ASDF_VERSION} \
-  && echo 'legacy_version_file = yes' > $HOME/.asdfrc

--- a/packages/wb/docker/bash/prepare-asdf-java.sh
+++ b/packages/wb/docker/bash/prepare-asdf-java.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-apt-get -qq install -y --no-install-recommends tar gpg

--- a/packages/wb/docker/bash/prepare-asdf-maven.sh
+++ b/packages/wb/docker/bash/prepare-asdf-maven.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-# do nothing

--- a/packages/wb/docker/bash/prepare-asdf-nodejs.sh
+++ b/packages/wb/docker/bash/prepare-asdf-nodejs.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-# do nothing

--- a/packages/wb/docker/bash/prepare-asdf-poetry.sh
+++ b/packages/wb/docker/bash/prepare-asdf-poetry.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-# do nothing

--- a/packages/wb/docker/bash/prepare-asdf-python.sh
+++ b/packages/wb/docker/bash/prepare-asdf-python.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# c.f. https://github.com/pyenv/pyenv/wiki#suggested-build-environment
-apt-get -qq install -y --no-install-recommends \
-  build-essential libssl-dev zlib1g-dev \
-  libbz2-dev libreadline-dev libsqlite3-dev curl \
-  libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev

--- a/packages/wb/docker/bash/prepare-asdf-ruby.sh
+++ b/packages/wb/docker/bash/prepare-asdf-ruby.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# cf. https://github.com/rbenv/ruby-build/wiki#ubuntudebianmint
-apt-get -qq install -y --no-install-recommends autoconf patch build-essential rustc libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libgmp-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev libdb-dev uuid-dev

--- a/packages/wb/docker/bash/prepare-asdf-yarn.sh
+++ b/packages/wb/docker/bash/prepare-asdf-yarn.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-apt-get -qq install -y --no-install-recommends gpg gpg-agent

--- a/packages/wb/docker/bash/prepare-asdf.sh
+++ b/packages/wb/docker/bash/prepare-asdf.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-apt-get -qq install -y --no-install-recommends curl git


### PR DESCRIPTION
## Summary

- update `cleanup.sh` to accept `--keep-scripts`
- keep plain `bash ./bash/cleanup.sh` as the final cleanup path that removes the copied `./bash` helper directory
- remove unused ASDF helper scripts from generated Docker helpers

## Why

- downstream Dockerfiles sometimes need apt cleanup before later generated helpers such as `configure-yarn.sh`
- the cleanup behavior should be visible in the Dockerfile command instead of relying on `WB_KEEP_DOCKER_SCRIPTS`
- unused helper scripts add noise to generated `dist/bash` output

## Testing

- `bash -n packages/wb/docker/bash/cleanup.sh`
- `rg "install-asdf\\.sh|prepare-asdf.*\\.sh|prepare-asdf\\.sh" packages/wb packages/wbfy -g '!node_modules' -g '!dist'`
- checked local WillBooster / WillBoosterLab Dockerfiles for helper usage
- `yarn verify`
