### PR TITLE
fix: grant PR read permission to test workflow

### DIFF
--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -125,6 +125,8 @@ const workflows = {
     permissions: {
       // for linter fix
       contents: 'write',
+      // for pkg-preflight PR file listing
+      'pull-requests': 'read',
     },
     jobs: {
       test: {


### PR DESCRIPTION
## 概要

- `wbfy` が生成する `test.yml` に `pull-requests: read` 権限を追加
- pkg-preflight が PR の変更ファイル一覧を取得する際の 403 を防ぐ

## 背景

`permissions` を明示した workflow では未指定権限が無効化されるため、`contents: write` だけだと reusable workflow に渡す `GITHUB_TOKEN` で `pulls/{number}/files` を読めない状態でした。

## 検証

- `yarn verify`
