### PR TITLE
fix: default wb test cascade env to test

### DIFF
--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -269,7 +269,7 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
   return 0;
 }
 
-function withDefaultTestCascadeEnv(argv: TestCommandArgv): TestCommandArgv {
+export function withDefaultTestCascadeEnv(argv: TestCommandArgv): TestCommandArgv {
   if (argv.env?.length || argv.cascadeEnv || argv.cascadeNodeEnv || argv.autoCascadeEnv === false) {
     return argv;
   }

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -93,7 +93,7 @@ export const testCommand: CommandModule<unknown, TestCommandOptions> = {
 };
 
 export async function test(argv: TestCommandArgv, options: TestRunOptions = {}): Promise<number> {
-  const projects = await findDescendantProjects(argv);
+  const projects = await findDescendantProjects(withDefaultTestCascadeEnv(argv));
   if (!projects) {
     console.error(chalk.red('No project found.'));
     return 1;
@@ -266,6 +266,13 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
     }
   }
   return 0;
+}
+
+function withDefaultTestCascadeEnv(argv: TestCommandArgv): TestCommandArgv {
+  if (argv.env?.length || argv.cascadeEnv || argv.cascadeNodeEnv || argv.autoCascadeEnv === false) {
+    return argv;
+  }
+  return { ...argv, cascadeEnv: 'test' };
 }
 
 function getDefaultUnitTargets(project: Project): string[] | false {

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -93,15 +93,16 @@ export const testCommand: CommandModule<unknown, TestCommandOptions> = {
 };
 
 export async function test(argv: TestCommandArgv, options: TestRunOptions = {}): Promise<number> {
-  const projects = await findDescendantProjects(withDefaultTestCascadeEnv(argv));
+  const testArgv = withDefaultTestCascadeEnv(argv);
+  const projects = await findDescendantProjects(testArgv);
   if (!projects) {
     console.error(chalk.red('No project found.'));
     return 1;
   }
 
   // Get test targets from positional arguments
-  const testTargets = (argv.targets ?? []) as string[];
-  const forwardedPlaywrightArgs = argv['--'] ?? [];
+  const testTargets = (testArgv.targets ?? []) as string[];
+  const forwardedPlaywrightArgs = testArgv['--'] ?? [];
   const { shouldRunE2e, shouldRunUnit } = resolveTestExecutionTargets(testTargets, forwardedPlaywrightArgs);
 
   for (const project of projects.descendants) {
@@ -132,10 +133,10 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
       const unitTargets = testTargets.filter((target) => target.includes('/unit'));
       const targets =
         unitTargets.length > 0 ? unitTargets : defaultUnitTargets.length > 0 ? defaultUnitTargets : undefined;
-      const unitArgv = { ...argv, targets };
-      const exitCode = await runUnitTestCommand(scripts.testUnit(project, unitArgv), project, argv, {
+      const unitArgv = { ...testArgv, targets };
+      const exitCode = await runUnitTestCommand(scripts.testUnit(project, unitArgv), project, testArgv, {
         exitIfFailed: options.exitIfFailed,
-        timeout: argv.unitTimeout,
+        timeout: testArgv.unitTimeout,
       });
       if (exitCode !== 0) {
         return exitCode;
@@ -148,9 +149,9 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
 
     // Get e2e targets for this project
     const e2eTargets = testTargets.filter((target) => target.includes('/e2e'));
-    const e2eArgv = { ...argv, targets: e2eTargets.length > 0 ? e2eTargets : undefined };
+    const e2eArgv = { ...testArgv, targets: e2eTargets.length > 0 ? e2eTargets : undefined };
 
-    switch (argv.e2e) {
+    switch (testArgv.e2e) {
       case 'headless': {
         const exitCode = await runTestCommand(
           await scripts.testE2EProduction(project, e2eArgv, {
@@ -158,7 +159,7 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
             forwardedPlaywrightArgs,
           }),
           project,
-          argv,
+          testArgv,
           { exitIfFailed: options.exitIfFailed }
         );
         if (exitCode !== 0) return exitCode;
@@ -171,7 +172,7 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
             forwardedPlaywrightArgs,
           }),
           project,
-          argv,
+          testArgv,
           { exitIfFailed: options.exitIfFailed }
         );
         if (exitCode !== 0) return exitCode;
@@ -203,7 +204,7 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
       }
     }
     if (deps.blitz || deps.next || devDeps['@remix-run/dev'] || devDeps.vite) {
-      switch (argv.e2e) {
+      switch (testArgv.e2e) {
         case 'headed': {
           const exitCode = await runTestCommand(
             await scripts.testE2EProduction(project, e2eArgv, {
@@ -211,7 +212,7 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
               forwardedPlaywrightArgs,
             }),
             project,
-            argv,
+            testArgv,
             { exitIfFailed: options.exitIfFailed }
           );
           if (exitCode !== 0) return exitCode;
@@ -224,7 +225,7 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
               forwardedPlaywrightArgs,
             }),
             project,
-            argv,
+            testArgv,
             { exitIfFailed: options.exitIfFailed }
           );
           if (exitCode !== 0) return exitCode;
@@ -237,7 +238,7 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
               forwardedPlaywrightArgs,
             }),
             project,
-            argv,
+            testArgv,
             { exitIfFailed: options.exitIfFailed }
           );
           if (exitCode !== 0) return exitCode;
@@ -249,14 +250,14 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
               playwrightArgs: ['codegen', `http://localhost:${project.env.PORT}`],
             }),
             project,
-            argv,
+            testArgv,
             { exitIfFailed: options.exitIfFailed }
           );
           if (exitCode !== 0) return exitCode;
           break;
         }
         case 'trace': {
-          const exitCode = await runTestCommand(`BUN playwright show-trace`, project, argv, {
+          const exitCode = await runTestCommand(`BUN playwright show-trace`, project, testArgv, {
             exitIfFailed: options.exitIfFailed,
           });
           if (exitCode !== 0) return exitCode;

--- a/packages/wb/test/testCommand.test.ts
+++ b/packages/wb/test/testCommand.test.ts
@@ -4,7 +4,13 @@ import { describe, expect, it } from 'vitest';
 import yargs from 'yargs';
 
 import { retryCommand } from '../src/commands/retry.js';
-import { buildPlaywrightArgsForE2E, resolveTestExecutionTargets, testCommand } from '../src/commands/test.js';
+import {
+  buildPlaywrightArgsForE2E,
+  resolveTestExecutionTargets,
+  testCommand,
+  type TestCommandArgv,
+  withDefaultTestCascadeEnv,
+} from '../src/commands/test.js';
 
 describe('buildPlaywrightArgsForE2E', () => {
   it('uses the default e2e directory when no explicit target is provided', () => {
@@ -83,5 +89,31 @@ describe('resolveTestExecutionTargets', () => {
       shouldRunUnit: true,
       shouldRunE2e: true,
     });
+  });
+});
+
+describe('withDefaultTestCascadeEnv', () => {
+  it('uses test cascade by default', () => {
+    expect(withDefaultTestCascadeEnv({} as TestCommandArgv)).toMatchObject({
+      cascadeEnv: 'test',
+    });
+  });
+
+  it('keeps explicit cascade env', () => {
+    const argv = { cascadeEnv: 'staging' } as TestCommandArgv;
+
+    expect(withDefaultTestCascadeEnv(argv)).toBe(argv);
+  });
+
+  it('keeps explicit env files', () => {
+    const argv = { env: ['.env.custom'] } as unknown as TestCommandArgv;
+
+    expect(withDefaultTestCascadeEnv(argv)).toBe(argv);
+  });
+
+  it('keeps disabled auto cascade env', () => {
+    const argv = { autoCascadeEnv: false } as TestCommandArgv;
+
+    expect(withDefaultTestCascadeEnv(argv)).toBe(argv);
   });
 });


### PR DESCRIPTION
## Summary

- `wb test` の通常実行時に、env cascade の既定を `test` に戻しました
- `--env` / `--cascade-env` / `--cascade-node-env` / `--auto-cascade-env=false` が明示された場合は既存の指定を尊重します
- `.env` の `WB_ENV=development` に引きずられて `yarn dotenv -c=development -- yarn playwright ...` が実行される regression を防ぎます

## Why

`fix: normalize wb color environment handling (#782)` 以降、`wb test` が `.env` の `WB_ENV=development` を拾い、test 用の `.env.test` ではなく development cascade で E2E を実行するケースがありました。
その結果、test 専用 API が 404 になったり、Playwright の固定 port と実サーバー port がずれて失敗していました。

## Testing

- `yarn workspace @willbooster/wb test`
- `yarn workspace @willbooster/wb start --working-dir /Users/haruto.kondo/ghq/github.com/WillBoosterLab/exercode test --dry-run`
  - `yarn dotenv -c=test -- yarn playwright test test/e2e/` になることを確認
- `yarn verify`
