### PR TITLE
fix: migrate wb prisma db commands correctly

### DIFF
--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -5,10 +5,10 @@ import fg from 'fast-glob';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
-import { promisePool } from '../utils/promisePool.js';
 
 const oldCommand = 'wb prisma';
 const newCommand = 'wb db';
+const oldPrismaDbCommand = 'wb prisma db';
 const maxTextFileBytes = 1024 * 1024;
 const migrationTargets = [
   '**/*.{cjs,cts,js,json,jsx,md,mdc,mjs,mts,sh,tsx,ts,toml,txt,yaml,yml}',
@@ -37,7 +37,7 @@ export async function fixWbDbCommand(rootConfig: PackageConfig): Promise<void> {
     onlyFiles: true,
   });
 
-  await Promise.all(filePaths.map((filePath) => promisePool.run(() => replaceWbPrismaCommand(filePath))));
+  await Promise.all(filePaths.map(replaceWbPrismaCommand));
 }
 
 async function replaceWbPrismaCommand(filePath: string): Promise<void> {
@@ -45,8 +45,13 @@ async function replaceWbPrismaCommand(filePath: string): Promise<void> {
   if (!content?.includes(oldCommand)) return;
 
   // Temporary migration: remove this fixer after all repositories have been
-  // migrated from the legacy `wb prisma` spelling to `wb db`.
-  await fsUtil.generateFile(filePath, content.replaceAll(oldCommand, newCommand));
+  // migrated from the legacy `wb prisma` spelling to `wb db`. Some repositories
+  // used `wb prisma db ...`, so the optional `db` segment must collapse instead
+  // of producing `wb db db ...`.
+  await fsUtil.generateFile(
+    filePath,
+    content.replaceAll(oldPrismaDbCommand, newCommand).replaceAll(oldCommand, newCommand)
+  );
 }
 
 async function readTextFile(filePath: string): Promise<string | undefined> {

--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 
 import fg from 'fast-glob';
+import { PromisePool } from 'minimal-promise-pool';
 
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
@@ -8,7 +9,7 @@ import { globIgnore } from '../utils/globUtil.js';
 
 const oldCommand = 'wb prisma';
 const newCommand = 'wb db';
-const oldPrismaDbCommand = 'wb prisma db';
+const oldCommandPattern = /\bwb\s+prisma(?:\s+db)?\b/g;
 const maxTextFileBytes = 1024 * 1024;
 const migrationTargets = [
   '**/*.{cjs,cts,js,json,jsx,md,mdc,mjs,mts,sh,tsx,ts,toml,txt,yaml,yml}',
@@ -37,7 +38,9 @@ export async function fixWbDbCommand(rootConfig: PackageConfig): Promise<void> {
     onlyFiles: true,
   });
 
-  await Promise.all(filePaths.map(replaceWbPrismaCommand));
+  const promisePool = new PromisePool<void>();
+  await Promise.all(filePaths.map((filePath) => promisePool.run(() => replaceWbPrismaCommand(filePath))));
+  await promisePool.promiseAll();
 }
 
 async function replaceWbPrismaCommand(filePath: string): Promise<void> {
@@ -48,10 +51,7 @@ async function replaceWbPrismaCommand(filePath: string): Promise<void> {
   // migrated from the legacy `wb prisma` spelling to `wb db`. Some repositories
   // used `wb prisma db ...`, so the optional `db` segment must collapse instead
   // of producing `wb db db ...`.
-  await fsUtil.generateFile(
-    filePath,
-    content.replaceAll(oldPrismaDbCommand, newCommand).replaceAll(oldCommand, newCommand)
-  );
+  await fsUtil.generateFile(filePath, content.replace(oldCommandPattern, newCommand));
 }
 
 async function readTextFile(filePath: string): Promise<string | undefined> {

--- a/packages/wbfy/test/wbDbCommand.test.ts
+++ b/packages/wbfy/test/wbDbCommand.test.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { fixWbDbCommand } from '../src/fixers/wbDbCommand.js';
+import { createConfig } from './testConfig.js';
+
+test('migrates legacy wb prisma commands without duplicating db', async () => {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-wb-db-command-'));
+  const dockerfilePath = path.join(dirPath, 'Dockerfile');
+  const packageJsonPath = path.join(dirPath, 'package.json');
+
+  await fs.writeFile(
+    dockerfilePath,
+    ['RUN yarn wb prisma db push', 'RUN yarn wb prisma create-litestream-config', 'RUN yarn wb prisma migrate'].join(
+      '\n'
+    )
+  );
+  await fs.writeFile(packageJsonPath, JSON.stringify({ scripts: { 'db-reset': 'wb prisma reset' } }));
+
+  try {
+    await fixWbDbCommand(createConfig({ dirPath, repoAuthor: 'WillBoosterLab', repoName: 'example' }));
+
+    await expect(fs.readFile(dockerfilePath, 'utf8')).resolves.toBe(
+      `${['RUN yarn wb db push', 'RUN yarn wb db create-litestream-config', 'RUN yarn wb db migrate'].join('\n')}\n`
+    );
+    await expect(fs.readFile(packageJsonPath, 'utf8')).resolves.toBe(
+      `${JSON.stringify({ scripts: { 'db-reset': 'wb db reset' } })}\n`
+    );
+  } finally {
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+});

--- a/packages/wbfy/test/wbDbCommand.test.ts
+++ b/packages/wbfy/test/wbDbCommand.test.ts
@@ -14,9 +14,9 @@ test('migrates legacy wb prisma commands without duplicating db', async () => {
 
   await fs.writeFile(
     dockerfilePath,
-    ['RUN yarn wb prisma db push', 'RUN yarn wb prisma create-litestream-config', 'RUN yarn wb prisma migrate'].join(
-      '\n'
-    )
+    `RUN yarn wb prisma db push
+RUN yarn wb prisma create-litestream-config
+RUN yarn wb prisma  db migrate`
   );
   await fs.writeFile(packageJsonPath, JSON.stringify({ scripts: { 'db-reset': 'wb prisma reset' } }));
 
@@ -24,7 +24,10 @@ test('migrates legacy wb prisma commands without duplicating db', async () => {
     await fixWbDbCommand(createConfig({ dirPath, repoAuthor: 'WillBoosterLab', repoName: 'example' }));
 
     await expect(fs.readFile(dockerfilePath, 'utf8')).resolves.toBe(
-      `${['RUN yarn wb db push', 'RUN yarn wb db create-litestream-config', 'RUN yarn wb db migrate'].join('\n')}\n`
+      `RUN yarn wb db push
+RUN yarn wb db create-litestream-config
+RUN yarn wb db migrate
+`
     );
     await expect(fs.readFile(packageJsonPath, 'utf8')).resolves.toBe(
       `${JSON.stringify({ scripts: { 'db-reset': 'wb db reset' } })}\n`


### PR DESCRIPTION
## 概要
- `wb prisma db ...` を `wb db ...` に移行するときに `wb db db ...` にならないよう修正
- `fixWbDbCommand` がファイル書き込み完了を待つように修正
- Dockerfile / package.json の移行回帰テストを追加

## 確認
- `yarn workspace @willbooster/wbfy verify`
- `yarn vitest test/wbDbCommand.test.ts`
