### PR TITLE
fix: preserve prisma db subcommands

### DIFF
--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -9,7 +9,7 @@ import { globIgnore } from '../utils/globUtil.js';
 
 const oldCommand = 'wb prisma';
 const newCommand = 'wb db';
-const oldCommandPattern = /\bwb\s+prisma(?:\s+db)?\b/g;
+const oldCommandPattern = /\bwb\s+prisma\b/g;
 const maxTextFileBytes = 1024 * 1024;
 const migrationTargets = [
   '**/*.{cjs,cts,js,json,jsx,md,mdc,mjs,mts,sh,tsx,ts,toml,txt,yaml,yml}',
@@ -48,9 +48,8 @@ async function replaceWbPrismaCommand(filePath: string): Promise<void> {
   if (!content?.includes(oldCommand)) return;
 
   // Temporary migration: remove this fixer after all repositories have been
-  // migrated from the legacy `wb prisma` spelling to `wb db`. Some repositories
-  // used `wb prisma db ...`, so the optional `db` segment must collapse instead
-  // of producing `wb db db ...`.
+  // migrated from the legacy `wb prisma` spelling to `wb db`. `wb db` is an
+  // alias for `wb prisma`, so `wb prisma db push` must become `wb db db push`.
   await fsUtil.generateFile(filePath, content.replace(oldCommandPattern, newCommand));
 }
 

--- a/packages/wbfy/test/wbDbCommand.test.ts
+++ b/packages/wbfy/test/wbDbCommand.test.ts
@@ -7,7 +7,7 @@ import { expect, test } from 'vitest';
 import { fixWbDbCommand } from '../src/fixers/wbDbCommand.js';
 import { createConfig } from './testConfig.js';
 
-test('migrates legacy wb prisma commands without duplicating db', async () => {
+test('migrates legacy wb prisma commands while preserving prisma subcommands', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-wb-db-command-'));
   const dockerfilePath = path.join(dirPath, 'Dockerfile');
   const packageJsonPath = path.join(dirPath, 'package.json');
@@ -16,7 +16,7 @@ test('migrates legacy wb prisma commands without duplicating db', async () => {
     dockerfilePath,
     `RUN yarn wb prisma db push
 RUN yarn wb prisma create-litestream-config
-RUN yarn wb prisma  db migrate`
+RUN yarn wb prisma db migrate`
   );
   await fs.writeFile(packageJsonPath, JSON.stringify({ scripts: { 'db-reset': 'wb prisma reset' } }));
 
@@ -24,9 +24,9 @@ RUN yarn wb prisma  db migrate`
     await fixWbDbCommand(createConfig({ dirPath, repoAuthor: 'WillBoosterLab', repoName: 'example' }));
 
     await expect(fs.readFile(dockerfilePath, 'utf8')).resolves.toBe(
-      `RUN yarn wb db push
+      `RUN yarn wb db db push
 RUN yarn wb db create-litestream-config
-RUN yarn wb db migrate
+RUN yarn wb db db migrate
 `
     );
     await expect(fs.readFile(packageJsonPath, 'utf8')).resolves.toBe(


### PR DESCRIPTION
## 概要
- `wb prisma` から `wb db` への移行時に Prisma の `db` サブコマンドを残すよう修正
- `wb prisma db push` が `wb db db push` になることを回帰テストで明示

## 背景
`wb db` は `wb prisma` の alias なので、`db push` の `db` は Prisma 側のサブコマンドとして残す必要があります。

## 確認
- `yarn workspace @willbooster/wbfy verify`
- `yarn vitest test/wbDbCommand.test.ts`
