### PR TITLE
fix: select wbfy database command by orm

### DIFF
--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -29,8 +29,8 @@ export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs =
   if (rootConfig.repoAuthor === 'WillBooster' && rootConfig.repoName === 'shared') return;
 
   const promisePool = new PromisePool<void>();
-  // `promiseAll()` only waits for tasks already admitted to the pool; awaiting
-  // these `run()` promises also covers tasks still waiting for capacity.
+  // `run()` resolves after a task enters the pool, while `promiseAll()` waits
+  // for admitted tasks to finish. Both waits are needed to cover queued work.
   const replacementPromises: Promise<void>[] = [];
   for (const config of packageConfigs) {
     const command = selectWbDatabaseCommand(config);

--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -7,9 +7,7 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
 
-const oldCommand = 'wb prisma';
-const newCommand = 'wb db';
-const oldCommandPattern = /\bwb\s+prisma\b/g;
+const wbDatabaseCommandPattern = /\bwb\s+(?:db|prisma)\b/g;
 const maxTextFileBytes = 1024 * 1024;
 const migrationTargets = [
   '**/*.{cjs,cts,js,json,jsx,md,mdc,mjs,mts,sh,tsx,ts,toml,txt,yaml,yml}',
@@ -27,30 +25,38 @@ const migrationTargets = [
   '**/package.json',
 ];
 
-export async function fixWbDbCommand(rootConfig: PackageConfig): Promise<void> {
+export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs = [rootConfig]): Promise<void> {
   if (rootConfig.repoAuthor === 'WillBooster' && rootConfig.repoName === 'shared') return;
 
-  const filePaths = await fg(migrationTargets, {
-    absolute: true,
-    cwd: rootConfig.dirPath,
-    dot: true,
-    ignore: ['**/.git/**', ...globIgnore],
-    onlyFiles: true,
-  });
-
   const promisePool = new PromisePool<void>();
-  await Promise.all(filePaths.map((filePath) => promisePool.run(() => replaceWbPrismaCommand(filePath))));
+  for (const config of packageConfigs) {
+    const command = selectWbDatabaseCommand(config);
+    if (!command) continue;
+
+    const filePaths = await fg(migrationTargets, {
+      absolute: true,
+      cwd: config.dirPath,
+      dot: true,
+      ignore: ['**/.git/**', ...(config.isRoot ? ['packages/**'] : []), ...globIgnore],
+      onlyFiles: true,
+    });
+    await Promise.all(filePaths.map((filePath) => promisePool.run(() => replaceWbDatabaseCommand(filePath, command))));
+  }
   await promisePool.promiseAll();
 }
 
-async function replaceWbPrismaCommand(filePath: string): Promise<void> {
-  const content = await readTextFile(filePath);
-  if (!content?.includes(oldCommand)) return;
+function selectWbDatabaseCommand(config: PackageConfig): 'wb db' | 'wb prisma' | undefined {
+  if (config.depending.prisma) return 'wb prisma';
+  if (config.depending.drizzle) return 'wb db';
+}
 
-  // Temporary migration: remove this fixer after all repositories have been
-  // migrated from the legacy `wb prisma` spelling to `wb db`. `wb db` is an
-  // alias for `wb prisma`, so `wb prisma db push` must become `wb db db push`.
-  await fsUtil.generateFile(filePath, content.replace(oldCommandPattern, newCommand));
+async function replaceWbDatabaseCommand(filePath: string, command: 'wb db' | 'wb prisma'): Promise<void> {
+  const content = await readTextFile(filePath);
+  if (!content || content.search(wbDatabaseCommandPattern) === -1) return;
+
+  // Temporary migration: normalize command spelling by ORM so Prisma keeps the
+  // native command name while Drizzle uses the generic database command.
+  await fsUtil.generateFile(filePath, content.replace(wbDatabaseCommandPattern, command));
 }
 
 async function readTextFile(filePath: string): Promise<string | undefined> {

--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -7,7 +7,7 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
 
-const wbDatabaseCommandPattern = String.raw`\bwb\s+(?:db|prisma)\b`;
+const wbDatabaseCommandRegex = /\bwb\s+(?:db|prisma)\b/gu;
 const maxTextFileBytes = 1024 * 1024;
 const migrationTargets = [
   '**/*.{cjs,cts,js,json,jsx,md,mdc,mjs,mts,sh,tsx,ts,toml,txt,yaml,yml}',
@@ -29,6 +29,8 @@ export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs =
   if (rootConfig.repoAuthor === 'WillBooster' && rootConfig.repoName === 'shared') return;
 
   const promisePool = new PromisePool<void>();
+  // `promiseAll()` only waits for tasks already admitted to the pool; awaiting
+  // these `run()` promises also covers tasks still waiting for capacity.
   const replacementPromises: Promise<void>[] = [];
   for (const config of packageConfigs) {
     const command = selectWbDatabaseCommand(config);
@@ -56,11 +58,11 @@ function selectWbDatabaseCommand(config: PackageConfig): 'wb db' | 'wb prisma' |
 
 async function replaceWbDatabaseCommand(filePath: string, command: 'wb db' | 'wb prisma'): Promise<void> {
   const content = await readTextFile(filePath);
-  if (!content || content.search(new RegExp(wbDatabaseCommandPattern, 'u')) === -1) return;
+  if (!content) return;
 
   // Temporary migration: normalize command spelling by ORM so Prisma keeps the
   // native command name while Drizzle uses the generic database command.
-  const newContent = content.replaceAll(new RegExp(wbDatabaseCommandPattern, 'gu'), command);
+  const newContent = content.replaceAll(wbDatabaseCommandRegex, command);
   if (newContent === content) return;
 
   await fsUtil.generateFile(filePath, newContent);

--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -7,7 +7,7 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
 
-const wbDatabaseCommandPattern = /\bwb\s+(?:db|prisma)\b/g;
+const wbDatabaseCommandPattern = String.raw`\bwb\s+(?:db|prisma)\b`;
 const maxTextFileBytes = 1024 * 1024;
 const migrationTargets = [
   '**/*.{cjs,cts,js,json,jsx,md,mdc,mjs,mts,sh,tsx,ts,toml,txt,yaml,yml}',
@@ -29,6 +29,7 @@ export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs =
   if (rootConfig.repoAuthor === 'WillBooster' && rootConfig.repoName === 'shared') return;
 
   const promisePool = new PromisePool<void>();
+  const replacementPromises: Promise<void>[] = [];
   for (const config of packageConfigs) {
     const command = selectWbDatabaseCommand(config);
     if (!command) continue;
@@ -40,8 +41,11 @@ export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs =
       ignore: ['**/.git/**', ...(config.isRoot ? ['packages/**'] : []), ...globIgnore],
       onlyFiles: true,
     });
-    await Promise.all(filePaths.map((filePath) => promisePool.run(() => replaceWbDatabaseCommand(filePath, command))));
+    for (const filePath of filePaths) {
+      replacementPromises.push(promisePool.run(() => replaceWbDatabaseCommand(filePath, command)));
+    }
   }
+  await Promise.all(replacementPromises);
   await promisePool.promiseAll();
 }
 
@@ -52,11 +56,14 @@ function selectWbDatabaseCommand(config: PackageConfig): 'wb db' | 'wb prisma' |
 
 async function replaceWbDatabaseCommand(filePath: string, command: 'wb db' | 'wb prisma'): Promise<void> {
   const content = await readTextFile(filePath);
-  if (!content || content.search(wbDatabaseCommandPattern) === -1) return;
+  if (!content || content.search(new RegExp(wbDatabaseCommandPattern, 'u')) === -1) return;
 
   // Temporary migration: normalize command spelling by ORM so Prisma keeps the
   // native command name while Drizzle uses the generic database command.
-  await fsUtil.generateFile(filePath, content.replace(wbDatabaseCommandPattern, command));
+  const newContent = content.replaceAll(new RegExp(wbDatabaseCommandPattern, 'gu'), command);
+  if (newContent === content) return;
+
+  await fsUtil.generateFile(filePath, newContent);
 }
 
 async function readTextFile(filePath: string): Promise<string | undefined> {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -993,7 +993,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       verify: 'bun --bun wb verify',
       'verify-full': 'bun --bun wb verify --full',
     };
-    applyDatabaseScripts(config, scripts, 'bun --bun wb db');
+    applyDatabaseScripts(config, scripts, `bun --bun ${getWbDatabaseCommand(config)}`);
     applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
     if (!hasTypecheck) {
       delete scripts.typecheck;
@@ -1058,7 +1058,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       scripts.verify = 'wb verify';
       scripts['verify-full'] = 'wb verify --full';
     }
-    applyDatabaseScripts(config, scripts, 'wb db');
+    applyDatabaseScripts(config, scripts, getWbDatabaseCommand(config));
     applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
     return scripts;
   }
@@ -1070,6 +1070,11 @@ function applyDatabaseScripts(config: PackageConfig, scripts: Record<string, str
   scripts['db-create-migration'] = `${wbDbCommand} migrate-dev`;
   scripts['db-migrate'] = `${wbDbCommand} migrate --check-idempotency`;
   scripts['db-view'] = `${wbDbCommand} studio`;
+}
+
+function getWbDatabaseCommand(config: PackageConfig): 'wb db' | 'wb prisma' {
+  if (config.depending.prisma) return 'wb prisma';
+  return 'wb db';
 }
 
 function isWbPackage(packageJson: PackageJson | undefined): boolean {

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -189,7 +189,7 @@ async function main(): Promise<void> {
     }
     await Promise.all(promises);
     await promisePool.promiseAll();
-    await fixWbDbCommand(rootConfig);
+    await fixWbDbCommand(rootConfig, allPackageConfigs);
 
     const packageManager = rootConfig.isBun ? 'bun' : 'yarn';
     // Refresh lock files

--- a/packages/wbfy/test/wbDbCommand.test.ts
+++ b/packages/wbfy/test/wbDbCommand.test.ts
@@ -7,7 +7,7 @@ import { expect, test } from 'vitest';
 import { fixWbDbCommand } from '../src/fixers/wbDbCommand.js';
 import { createConfig } from './testConfig.js';
 
-test('migrates legacy wb prisma commands while preserving prisma subcommands', async () => {
+test('uses wb prisma for prisma projects', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-wb-db-command-'));
   const dockerfilePath = path.join(dirPath, 'Dockerfile');
   const packageJsonPath = path.join(dirPath, 'package.json');
@@ -16,21 +16,93 @@ test('migrates legacy wb prisma commands while preserving prisma subcommands', a
     dockerfilePath,
     `RUN yarn wb prisma db push
 RUN yarn wb prisma create-litestream-config
-RUN yarn wb prisma db migrate`
+RUN yarn wb db db migrate`
   );
-  await fs.writeFile(packageJsonPath, JSON.stringify({ scripts: { 'db-reset': 'wb prisma reset' } }));
+  await fs.writeFile(packageJsonPath, JSON.stringify({ scripts: { 'db-reset': 'wb db reset' } }));
 
   try {
-    await fixWbDbCommand(createConfig({ dirPath, repoAuthor: 'WillBoosterLab', repoName: 'example' }));
+    await fixWbDbCommand(
+      createConfig({
+        dirPath,
+        depending: { ...createConfig().depending, prisma: true },
+        repoAuthor: 'WillBoosterLab',
+        repoName: 'example',
+      })
+    );
 
     await expect(fs.readFile(dockerfilePath, 'utf8')).resolves.toBe(
-      `RUN yarn wb db db push
-RUN yarn wb db create-litestream-config
-RUN yarn wb db db migrate
+      `RUN yarn wb prisma db push
+RUN yarn wb prisma create-litestream-config
+RUN yarn wb prisma db migrate
 `
     );
     await expect(fs.readFile(packageJsonPath, 'utf8')).resolves.toBe(
+      `${JSON.stringify({ scripts: { 'db-reset': 'wb prisma reset' } })}\n`
+    );
+  } finally {
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('uses wb db for drizzle projects', async () => {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-wb-db-command-'));
+  const packageJsonPath = path.join(dirPath, 'package.json');
+
+  await fs.writeFile(packageJsonPath, JSON.stringify({ scripts: { 'db-reset': 'wb prisma reset' } }));
+
+  try {
+    await fixWbDbCommand(
+      createConfig({
+        dirPath,
+        depending: { ...createConfig().depending, drizzle: true },
+        repoAuthor: 'WillBoosterLab',
+        repoName: 'example',
+      })
+    );
+
+    await expect(fs.readFile(packageJsonPath, 'utf8')).resolves.toBe(
       `${JSON.stringify({ scripts: { 'db-reset': 'wb db reset' } })}\n`
+    );
+  } finally {
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('normalizes monorepo packages independently', async () => {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-wb-db-command-'));
+  const prismaPackagePath = path.join(dirPath, 'packages', 'prisma-app');
+  const drizzlePackagePath = path.join(dirPath, 'packages', 'drizzle-app');
+
+  await fs.mkdir(prismaPackagePath, { recursive: true });
+  await fs.mkdir(drizzlePackagePath, { recursive: true });
+  await fs.writeFile(
+    path.join(prismaPackagePath, 'package.json'),
+    JSON.stringify({ scripts: { migrate: 'wb db db push' } })
+  );
+  await fs.writeFile(
+    path.join(drizzlePackagePath, 'package.json'),
+    JSON.stringify({ scripts: { migrate: 'wb prisma push' } })
+  );
+
+  try {
+    const rootConfig = createConfig({ dirPath, isRoot: true, repoAuthor: 'WillBoosterLab', repoName: 'example' });
+    await fixWbDbCommand(rootConfig, [
+      rootConfig,
+      createConfig({
+        dirPath: prismaPackagePath,
+        depending: { ...createConfig().depending, prisma: true },
+      }),
+      createConfig({
+        dirPath: drizzlePackagePath,
+        depending: { ...createConfig().depending, drizzle: true },
+      }),
+    ]);
+
+    await expect(fs.readFile(path.join(prismaPackagePath, 'package.json'), 'utf8')).resolves.toBe(
+      `${JSON.stringify({ scripts: { migrate: 'wb prisma db push' } })}\n`
+    );
+    await expect(fs.readFile(path.join(drizzlePackagePath, 'package.json'), 'utf8')).resolves.toBe(
+      `${JSON.stringify({ scripts: { migrate: 'wb db push' } })}\n`
     );
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });


### PR DESCRIPTION
## Summary

- Generate Prisma package database scripts with `wb prisma` instead of `wb db`
- Keep Drizzle package database scripts on `wb db`
- Normalize existing `wb db` and `wb prisma` references per package ORM, including monorepo packages
- Avoid redundant file writes when normalized command text is unchanged

## Why

- `wb db db push` is confusing for Prisma projects because `db` appears both as the `wb` alias and as a Prisma subcommand
- Prisma projects should keep the explicit `wb prisma` command while Drizzle projects use the generic `wb db` command

## Testing

- `yarn workspace @willbooster/wbfy test wbDbCommand`
- `yarn verify`
- PR CI passed
