### PR TITLE
fix: ignore drizzle sqlite files

### DIFF
--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -88,7 +88,6 @@ packaged.yaml
     if (rootConfig.depending.firebase || config.depending.firebase) {
       names.push('firebase');
     }
-    // Prisma and Drizzle commonly use local SQLite files for development and tests.
     if (config.depending.prisma || config.depending.drizzle) {
       headUserContent += `*.sqlite3*
 `;

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -88,7 +88,8 @@ packaged.yaml
     if (rootConfig.depending.firebase || config.depending.firebase) {
       names.push('firebase');
     }
-    if (config.depending.prisma) {
+    // Prisma and Drizzle commonly use local SQLite files for development and tests.
+    if (config.depending.prisma || config.depending.drizzle) {
       headUserContent += `*.sqlite3*
 `;
     }


### PR DESCRIPTION
## Summary
- Ignore SQLite files for Drizzle projects when generating `.gitignore`
- Keep local development and test database files out of generated Git status

## Verification
- `yarn verify`
