### PR TITLE
fix: grant actions permission to test workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,4 +21,4 @@ jobs:
       - run: yarn install
       - run: yarn run cleanup
       - run: yarn run build
-      - uses: autofix-ci/action@v1.3.4
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,4 +21,4 @@ jobs:
       - run: yarn install
       - run: yarn run cleanup
       - run: yarn run build
-      - uses: autofix-ci/action@v1
+      - uses: autofix-ci/action@v1.3.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 permissions:
+  actions: write
   contents: write
   pull-requests: read
 jobs:

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -123,6 +123,8 @@ const workflows = {
       'cancel-in-progress': true,
     },
     permissions: {
+      // for skip-duplicate-actions to cancel outdated runs
+      actions: 'write',
       // for linter fix
       contents: 'write',
       // for pkg-preflight PR file listing

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -443,7 +443,7 @@ function generateAutofixWorkflow(config: PackageConfig): Workflow {
   if (config.packageJson?.scripts?.build) {
     steps.push({ run: `${packageManager} run build` });
   }
-  steps.push({ uses: 'autofix-ci/action@v1' });
+  steps.push({ uses: 'autofix-ci/action@v1.3.4' });
 
   const autofixWorkflow = structuredClone(publicRepoAutofixWorkflow);
   const autofixJob = autofixWorkflow.jobs.autofix ?? { 'runs-on': 'ubuntu-latest' };

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -443,7 +443,7 @@ function generateAutofixWorkflow(config: PackageConfig): Workflow {
   if (config.packageJson?.scripts?.build) {
     steps.push({ run: `${packageManager} run build` });
   }
-  steps.push({ uses: 'autofix-ci/action@v1.3.4' });
+  steps.push({ uses: 'autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a' });
 
   const autofixWorkflow = structuredClone(publicRepoAutofixWorkflow);
   const autofixJob = autofixWorkflow.jobs.autofix ?? { 'runs-on': 'ubuntu-latest' };


### PR DESCRIPTION
## Summary
- Add `actions: write` to generated `test.yml` permissions so `fkirc/skip-duplicate-actions` can inspect/cancel workflow runs.
- Pin generated public `autofix.ci` workflows to `autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a`.
- Update this repo's generated workflow files accordingly.

## Inspection notes
- `fkirc/skip-duplicate-actions` still documents `actions: write` as part of its minimum permissions when default token permissions are read-only.
- `autofix-ci/action` latest named release `v1.3.4` resolves to `c5b2d67aa2274e7b5a18224e8171550871fc7e4a`, so the generated workflow now pins the commit hash directly.

## Verification
- `yarn verify`
