### PR TITLE
fix: install ca certificates for litestream download

### DIFF
--- a/packages/wb/docker/bash/install-litestream.sh
+++ b/packages/wb/docker/bash/install-litestream.sh
@@ -5,12 +5,12 @@ set -e
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 
 # Force to use 0.5.10 since the latest litestream is very unstable.
-apt-get -qq install -y --no-install-recommends curl \
+apt-get -qq install -y --no-install-recommends ca-certificates curl \
   && LITESTREAM_VERSION=$(curl --silent "https://api.github.com/repos/benbjohnson/litestream/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^v//') \
   && LITESTREAM_VERSION=0.5.10 \
   && DEB_FILE="litestream-${LITESTREAM_VERSION}-linux-${ARCH}.deb" \
   && echo "Installing Litestream: ${DEB_FILE}" \
-  && curl -sLO https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/${DEB_FILE} \
+  && curl -fsSLO https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/${DEB_FILE} \
   && dpkg-reconfigure debconf -f noninteractive -p critical \
   && dpkg -i ${DEB_FILE} \
   && cp "${SCRIPT_DIR}/run-litestream.sh" /usr/local/bin/run-litestream.sh \


### PR DESCRIPTION
## Summary

- `install-litestream.sh` で `curl` と一緒に `ca-certificates` を install するようにしました
- Litestream の `.deb` download を `curl -fsSLO` に変更し、download 失敗を明確にしました

## Why

- `oven/bun:1.3.14-slim` では `ca-certificates` が入っておらず、GitHub release から Litestream の `.deb` を download する `curl` が exit code 77 で失敗しました
- `install-litestream.sh` は単体で Litestream download に必要な CA 証明書を揃えるべきです
- Node image や他の prepare script に依存せず、Bun slim image でも同じ script が動くようにします

## Testing

- `docker run --rm -v "$PWD/packages/wb/docker/bash:/bash:ro" oven/bun:1.3.14-slim sh -lc 'export ARCH=arm64; apt-get -qq update >/dev/null && bash /bash/install-litestream.sh'`
- `yarn verify`
