### PR TITLE
fix: avoid maintenance port availability race

### DIFF
--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import http from 'node:http';
+import { setTimeout } from 'node:timers/promises';
 
 import chalk from 'chalk';
 import type { Argv, CommandModule, InferredOptionTypes } from 'yargs';
@@ -119,7 +120,7 @@ async function createAndListenMaintenanceServer(port: number): Promise<http.Serv
       await closeMaintenanceServer(server);
       const err = error as NodeJS.ErrnoException;
       if (err.code === 'EADDRINUSE' && attempt < maintenanceListenMaxAttempts) {
-        await sleep(maintenanceListenRetryDelayMs);
+        await setTimeout(maintenanceListenRetryDelayMs);
         continue;
       }
       handleMaintenanceStartupError(port, err);
@@ -186,8 +187,13 @@ async function waitForShutdown(server: http.Server): Promise<void> {
       process.off('SIGTERM', shutdown);
       process.off('SIGQUIT', shutdown);
       void (async () => {
-        await closeMaintenanceServer(server);
-        resolve();
+        try {
+          await closeMaintenanceServer(server);
+        } catch (error) {
+          console.error(chalk.red(`Failed to close maintenance server: ${(error as Error).message}`));
+        } finally {
+          resolve();
+        }
       })();
     };
     process.once('SIGINT', shutdown);
@@ -211,8 +217,4 @@ async function closeMaintenanceServer(server: http.Server): Promise<void> {
     });
     server.closeAllConnections();
   });
-}
-
-async function sleep(milliseconds: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, milliseconds));
 }

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -12,6 +12,8 @@ const builder = {} as const;
 type MaintenanceArgv = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder> & {
   action: 'start' | 'stop';
 };
+const maintenanceListenMaxAttempts = 5;
+const maintenanceListenRetryDelayMs = 100;
 const maintenanceHtml = `<!doctype html>
 <html lang="ja">
   <head>
@@ -102,20 +104,38 @@ function parsePort(portEnv: string | undefined): number {
 
 async function startMaintenanceServer(project: Project, port: number): Promise<void> {
   await killPortContainerAndProcess(port, project);
-  const server = createMaintenanceServer();
-  try {
-    await listenMaintenanceServer(server, port, handleRuntimeMaintenanceServerError);
-  } catch (error) {
-    const err = error as NodeJS.ErrnoException;
-    if (err.code === 'EADDRINUSE') {
-      console.error(chalk.red(`Port ${port} is already in use.`));
-    } else {
-      console.error(chalk.red(`Maintenance server error: ${err.message}`));
-    }
-    process.exit(1);
-  }
+  const server = await createAndListenMaintenanceServer(port);
   console.info(`Started maintenance server on port ${port}.`);
   await waitForShutdown(server);
+}
+
+async function createAndListenMaintenanceServer(port: number): Promise<http.Server> {
+  for (let attempt = 1; attempt <= maintenanceListenMaxAttempts; attempt++) {
+    const server = createMaintenanceServer();
+    try {
+      await listenMaintenanceServer(server, port, handleRuntimeMaintenanceServerError);
+      return server;
+    } catch (error) {
+      await closeMaintenanceServer(server);
+      const err = error as NodeJS.ErrnoException;
+      if (err.code === 'EADDRINUSE' && attempt < maintenanceListenMaxAttempts) {
+        await sleep(maintenanceListenRetryDelayMs);
+        continue;
+      }
+      handleMaintenanceStartupError(port, err);
+    }
+  }
+
+  throw new Error('Unreachable maintenance server startup state.');
+}
+
+function handleMaintenanceStartupError(port: number, error: NodeJS.ErrnoException): never {
+  if (error.code === 'EADDRINUSE') {
+    console.error(chalk.red(`Port ${port} is already in use.`));
+  } else {
+    console.error(chalk.red(`Maintenance server error: ${error.message}`));
+  }
+  process.exit(1);
 }
 
 function handleRuntimeMaintenanceServerError(error: Error): void {
@@ -165,13 +185,34 @@ async function waitForShutdown(server: http.Server): Promise<void> {
       process.off('SIGINT', shutdown);
       process.off('SIGTERM', shutdown);
       process.off('SIGQUIT', shutdown);
-      server.close(() => {
+      void (async () => {
+        await closeMaintenanceServer(server);
         resolve();
-      });
-      server.closeAllConnections();
+      })();
     };
     process.once('SIGINT', shutdown);
     process.once('SIGTERM', shutdown);
     process.once('SIGQUIT', shutdown);
   });
+}
+
+async function closeMaintenanceServer(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ERR_SERVER_NOT_RUNNING') {
+          resolve();
+          return;
+        }
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+    server.closeAllConnections();
+  });
+}
+
+async function sleep(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
 }

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -98,6 +98,9 @@ async function startMaintenanceServer(project: Project, port: number): Promise<v
   await killPortContainerAndProcess(port, project);
   const server = createMaintenanceServer();
   await listenMaintenanceServer(server, port);
+  server.on('error', (error) => {
+    console.error(chalk.red(`Maintenance server error: ${error.message}`));
+  });
   console.info(`Started maintenance server on port ${port}.`);
   await waitForShutdown(server);
 }
@@ -153,6 +156,7 @@ async function waitForShutdown(server: http.Server): Promise<void> {
       server.close(() => {
         resolve();
       });
+      server.closeAllConnections();
     };
     process.once('SIGINT', shutdown);
     process.once('SIGTERM', shutdown);

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -77,7 +77,7 @@ const server = http.createServer((_request, response) => {
 server.on('error', (error) => {
   try {
     fs.rmSync(pidPath, { force: true });
-    fs.writeFileSync(errorPath, error.code || error.message || 'UNKNOWN');
+    fs.writeFileSync(errorPath, error?.code || error?.message || 'UNKNOWN');
   } catch {
     // do nothing
   }
@@ -228,14 +228,6 @@ function removePidFile(pidPath: string): void {
   }
 }
 
-function removeErrorFile(errorPath: string): void {
-  try {
-    fs.rmSync(errorPath, { force: true });
-  } catch {
-    // do nothing
-  }
-}
-
 async function waitForMaintenanceServer(pidPath: string, errorPath: string, pid: number, port: number): Promise<void> {
   const deadline = Date.now() + 5000;
   while (Date.now() < deadline) {
@@ -243,17 +235,33 @@ async function waitForMaintenanceServer(pidPath: string, errorPath: string, pid:
     const error = readError(errorPath);
     if (error !== undefined) {
       removeErrorFile(errorPath);
-      if (error === 'EADDRINUSE') {
-        console.error(chalk.red(`Port ${port} is already in use.`));
-        process.exit(1);
-      }
-      throw new Error(`Failed to start maintenance server: ${error}`);
+      handleMaintenanceServerError(error, port);
     }
     if (!isProcessRunning(pid)) break;
     await setTimeout(50);
   }
 
+  const finalError = readError(errorPath);
   removePidFile(pidPath);
   removeErrorFile(errorPath);
+  if (finalError !== undefined) {
+    handleMaintenanceServerError(finalError, port);
+  }
   throw new Error('Failed to start maintenance server.');
+}
+
+function handleMaintenanceServerError(error: string, port: number): never {
+  if (error === 'EADDRINUSE') {
+    console.error(chalk.red(`Port ${port} is already in use.`));
+    process.exit(1);
+  }
+  throw new Error(`Failed to start maintenance server: ${error}`);
+}
+
+function removeErrorFile(errorPath: string): void {
+  try {
+    fs.rmSync(errorPath, { force: true });
+  } catch {
+    // do nothing
+  }
 }

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -125,8 +125,17 @@ function parsePort(portEnv: string | undefined): number {
 
 async function listenMaintenanceServer(server: http.Server, port: number): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(port, '0.0.0.0', resolve);
+    const onError = (error: Error): void => {
+      server.off('listening', onListening);
+      reject(error);
+    };
+    const onListening = (): void => {
+      server.off('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, '0.0.0.0');
   }).catch((error: NodeJS.ErrnoException) => {
     if (error.code === 'EADDRINUSE') {
       console.error(chalk.red(`Port ${port} is already in use.`));
@@ -139,6 +148,8 @@ async function listenMaintenanceServer(server: http.Server, port: number): Promi
 async function waitForShutdown(server: http.Server): Promise<void> {
   await new Promise<void>((resolve) => {
     const shutdown = (): void => {
+      process.off('SIGINT', shutdown);
+      process.off('SIGTERM', shutdown);
       server.close(() => {
         resolve();
       });

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert';
-import { once } from 'node:events';
 import http from 'node:http';
 
 import chalk from 'chalk';
@@ -104,18 +103,24 @@ function parsePort(portEnv: string | undefined): number {
 async function startMaintenanceServer(project: Project, port: number): Promise<void> {
   await killPortContainerAndProcess(port, project);
   const server = createMaintenanceServer();
-  server.on('error', (error) => {
+  try {
+    await listenMaintenanceServer(server, port, handleRuntimeMaintenanceServerError);
+  } catch (error) {
     const err = error as NodeJS.ErrnoException;
     if (err.code === 'EADDRINUSE') {
       console.error(chalk.red(`Port ${port} is already in use.`));
     } else {
-      console.error(chalk.red(`Maintenance server error: ${error.message}`));
+      console.error(chalk.red(`Maintenance server error: ${err.message}`));
     }
     process.exit(1);
-  });
-  await listenMaintenanceServer(server, port);
+  }
   console.info(`Started maintenance server on port ${port}.`);
   await waitForShutdown(server);
+}
+
+function handleRuntimeMaintenanceServerError(error: Error): void {
+  console.error(chalk.red(`Maintenance server error: ${error.message}`));
+  process.exit(1);
 }
 
 async function stopMaintenanceServer(project: Project, port: number): Promise<void> {
@@ -133,10 +138,25 @@ function createMaintenanceServer(): http.Server {
   });
 }
 
-async function listenMaintenanceServer(server: http.Server, port: number): Promise<void> {
-  const listening = once(server, 'listening');
-  server.listen(port, '0.0.0.0');
-  await listening;
+async function listenMaintenanceServer(
+  server: http.Server,
+  port: number,
+  onRuntimeError: (error: Error) => void
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onStartupError = (error: Error): void => {
+      server.off('listening', onListening);
+      reject(error);
+    };
+    const onListening = (): void => {
+      server.off('error', onStartupError);
+      server.on('error', onRuntimeError);
+      resolve();
+    };
+    server.once('error', onStartupError);
+    server.once('listening', onListening);
+    server.listen(port, '0.0.0.0');
+  });
 }
 
 async function waitForShutdown(server: http.Server): Promise<void> {

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -1,14 +1,12 @@
-import child_process from 'node:child_process';
 import assert from 'node:assert';
-import fs from 'node:fs';
-import path from 'node:path';
-import { setTimeout } from 'node:timers/promises';
+import http from 'node:http';
 
 import chalk from 'chalk';
 import type { Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
 import { findSelfProject, type Project } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { killPortContainerAndProcess } from '../utils/process.js';
 
 const builder = {} as const;
 type MaintenanceArgv = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder> & {
@@ -58,43 +56,6 @@ const maintenanceHtml = `<!doctype html>
   </body>
 </html>`;
 
-function getMaintenanceServerSource(port: number, pidPath: string, errorPath: string): string {
-  return String.raw`
-import fs from 'node:fs';
-import http from 'node:http';
-
-const pidPath = ${JSON.stringify(pidPath)};
-const errorPath = ${JSON.stringify(errorPath)};
-
-const server = http.createServer((_request, response) => {
-  response.writeHead(503, {
-    'cache-control': 'no-store',
-    'content-type': 'text/html; charset=utf-8',
-  });
-  response.end(${JSON.stringify(maintenanceHtml)});
-});
-
-server.on('error', (error) => {
-  try {
-    fs.rmSync(pidPath, { force: true });
-    fs.writeFileSync(errorPath, error?.code || error?.message || 'UNKNOWN');
-  } catch {
-    // do nothing
-  }
-  process.exit(1);
-});
-
-server.listen(${port}, '0.0.0.0', () => {
-  try {
-    fs.rmSync(errorPath, { force: true });
-  } catch {
-    // do nothing
-  }
-  fs.writeFileSync(pidPath, String(process.pid) + '\n');
-});
-`;
-}
-
 export const maintenanceCommand: CommandModule<unknown, MaintenanceArgv> = {
   command: 'maintenance <action>',
   describe: 'Start or stop a lightweight maintenance page server. Example: wb maintenance start',
@@ -125,7 +86,7 @@ export const maintenanceCommand: CommandModule<unknown, MaintenanceArgv> = {
       return;
     }
     if (action === 'stop') {
-      stopMaintenanceServer(project, port);
+      await stopMaintenanceServer(project, port);
       return;
     }
 
@@ -134,50 +95,26 @@ export const maintenanceCommand: CommandModule<unknown, MaintenanceArgv> = {
 };
 
 async function startMaintenanceServer(project: Project, port: number): Promise<void> {
-  const pidPath = getPidPath(project, port);
-  const errorPath = getErrorPath(project, port);
-  const existingPid = readPid(pidPath);
-  if (existingPid !== undefined && isProcessRunning(existingPid)) {
-    console.info(`Maintenance server is already running on port ${port}.`);
-    return;
-  }
-  removePidFile(pidPath);
-  removeErrorFile(errorPath);
-  fs.mkdirSync(path.dirname(pidPath), { recursive: true });
-
-  const child = child_process.spawn(
-    process.execPath,
-    ['--input-type=module', '--eval', getMaintenanceServerSource(port, pidPath, errorPath)],
-    {
-      detached: true,
-      env: project.env,
-      stdio: 'ignore',
-    }
-  );
-  if (child.pid === undefined) {
-    throw new Error('Failed to start maintenance server.');
-  }
-
-  child.unref();
-  await waitForMaintenanceServer(pidPath, errorPath, child.pid, port);
+  await killPortContainerAndProcess(port, project);
+  const server = createMaintenanceServer();
+  await listenMaintenanceServer(server, port);
   console.info(`Started maintenance server on port ${port}.`);
+  await waitForShutdown(server);
 }
 
-function stopMaintenanceServer(project: Project, port: number): void {
-  const pidPath = getPidPath(project, port);
-  const pid = readPid(pidPath);
-  if (pid === undefined) {
-    console.info(`Maintenance server is not running on port ${port}.`);
-    return;
-  }
-
-  try {
-    process.kill(pid, 'SIGTERM');
-  } catch {
-    // do nothing
-  }
-  removePidFile(pidPath);
+async function stopMaintenanceServer(project: Project, port: number): Promise<void> {
+  await killPortContainerAndProcess(port, project);
   console.info(`Stopped maintenance server on port ${port}.`);
+}
+
+function createMaintenanceServer(): http.Server {
+  return http.createServer((_request, response) => {
+    response.writeHead(503, {
+      'cache-control': 'no-store',
+      'content-type': 'text/html; charset=utf-8',
+    });
+    response.end(maintenanceHtml);
+  });
 }
 
 function parsePort(portEnv: string | undefined): number {
@@ -186,82 +123,27 @@ function parsePort(portEnv: string | undefined): number {
   return port;
 }
 
-function getPidPath(project: Project, port: number): string {
-  return path.join(project.rootDirPath, '.tmp', `wb-maintenance-server-${port}.pid`);
-}
-
-function getErrorPath(project: Project, port: number): string {
-  return path.join(project.rootDirPath, '.tmp', `wb-maintenance-server-${port}.error`);
-}
-
-function readPid(pidPath: string): number | undefined {
-  try {
-    const pid = Number(fs.readFileSync(pidPath, 'utf8').trim());
-    return Number.isInteger(pid) && pid > 0 ? pid : undefined;
-  } catch {
-    return;
-  }
-}
-
-function readError(errorPath: string): string | undefined {
-  try {
-    return fs.readFileSync(errorPath, 'utf8').trim() || undefined;
-  } catch {
-    return;
-  }
-}
-
-function isProcessRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function removePidFile(pidPath: string): void {
-  try {
-    fs.rmSync(pidPath, { force: true });
-  } catch {
-    // do nothing
-  }
-}
-
-async function waitForMaintenanceServer(pidPath: string, errorPath: string, pid: number, port: number): Promise<void> {
-  const deadline = Date.now() + 5000;
-  while (Date.now() < deadline) {
-    if (readPid(pidPath) !== undefined) return;
-    const error = readError(errorPath);
-    if (error !== undefined) {
-      removeErrorFile(errorPath);
-      handleMaintenanceServerError(error, port);
+async function listenMaintenanceServer(server: http.Server, port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '0.0.0.0', resolve);
+  }).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'EADDRINUSE') {
+      console.error(chalk.red(`Port ${port} is already in use.`));
+      process.exit(1);
     }
-    if (!isProcessRunning(pid)) break;
-    await setTimeout(50);
-  }
-
-  const finalError = readError(errorPath);
-  removePidFile(pidPath);
-  removeErrorFile(errorPath);
-  if (finalError !== undefined) {
-    handleMaintenanceServerError(finalError, port);
-  }
-  throw new Error('Failed to start maintenance server.');
+    throw error;
+  });
 }
 
-function handleMaintenanceServerError(error: string, port: number): never {
-  if (error === 'EADDRINUSE') {
-    console.error(chalk.red(`Port ${port} is already in use.`));
-    process.exit(1);
-  }
-  throw new Error(`Failed to start maintenance server: ${error}`);
-}
-
-function removeErrorFile(errorPath: string): void {
-  try {
-    fs.rmSync(errorPath, { force: true });
-  } catch {
-    // do nothing
-  }
+async function waitForShutdown(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      server.close(() => {
+        resolve();
+      });
+    };
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+  });
 }

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -100,6 +100,7 @@ async function startMaintenanceServer(project: Project, port: number): Promise<v
   await listenMaintenanceServer(server, port);
   server.on('error', (error) => {
     console.error(chalk.red(`Maintenance server error: ${error.message}`));
+    process.exit(1);
   });
   console.info(`Started maintenance server on port ${port}.`);
   await waitForShutdown(server);

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { once } from 'node:events';
 import http from 'node:http';
 
 import chalk from 'chalk';
@@ -128,25 +129,18 @@ function parsePort(portEnv: string | undefined): number {
 }
 
 async function listenMaintenanceServer(server: http.Server, port: number): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const onError = (error: Error): void => {
-      server.off('listening', onListening);
-      reject(error);
-    };
-    const onListening = (): void => {
-      server.off('error', onError);
-      resolve();
-    };
-    server.once('error', onError);
-    server.once('listening', onListening);
+  try {
+    const listening = once(server, 'listening');
     server.listen(port, '0.0.0.0');
-  }).catch((error: NodeJS.ErrnoException) => {
-    if (error.code === 'EADDRINUSE') {
+    await listening;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'EADDRINUSE') {
       console.error(chalk.red(`Port ${port} is already in use.`));
       process.exit(1);
     }
     throw error;
-  });
+  }
 }
 
 async function waitForShutdown(server: http.Server): Promise<void> {
@@ -154,6 +148,7 @@ async function waitForShutdown(server: http.Server): Promise<void> {
     const shutdown = (): void => {
       process.off('SIGINT', shutdown);
       process.off('SIGTERM', shutdown);
+      process.off('SIGQUIT', shutdown);
       server.close(() => {
         resolve();
       });
@@ -161,5 +156,6 @@ async function waitForShutdown(server: http.Server): Promise<void> {
     };
     process.once('SIGINT', shutdown);
     process.once('SIGTERM', shutdown);
+    process.once('SIGQUIT', shutdown);
   });
 }

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -95,14 +95,25 @@ export const maintenanceCommand: CommandModule<unknown, MaintenanceArgv> = {
   },
 };
 
+function parsePort(portEnv: string | undefined): number {
+  const port = Number(portEnv);
+  assert.ok(Number.isInteger(port) && port > 0, `PORT environment variable is invalid: ${portEnv}`);
+  return port;
+}
+
 async function startMaintenanceServer(project: Project, port: number): Promise<void> {
   await killPortContainerAndProcess(port, project);
   const server = createMaintenanceServer();
-  await listenMaintenanceServer(server, port);
   server.on('error', (error) => {
-    console.error(chalk.red(`Maintenance server error: ${error.message}`));
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'EADDRINUSE') {
+      console.error(chalk.red(`Port ${port} is already in use.`));
+    } else {
+      console.error(chalk.red(`Maintenance server error: ${error.message}`));
+    }
     process.exit(1);
   });
+  await listenMaintenanceServer(server, port);
   console.info(`Started maintenance server on port ${port}.`);
   await waitForShutdown(server);
 }
@@ -122,25 +133,10 @@ function createMaintenanceServer(): http.Server {
   });
 }
 
-function parsePort(portEnv: string | undefined): number {
-  const port = Number(portEnv);
-  assert.ok(Number.isInteger(port) && port > 0, `PORT environment variable is invalid: ${portEnv}`);
-  return port;
-}
-
 async function listenMaintenanceServer(server: http.Server, port: number): Promise<void> {
-  try {
-    const listening = once(server, 'listening');
-    server.listen(port, '0.0.0.0');
-    await listening;
-  } catch (error) {
-    const err = error as NodeJS.ErrnoException;
-    if (err.code === 'EADDRINUSE') {
-      console.error(chalk.red(`Port ${port} is already in use.`));
-      process.exit(1);
-    }
-    throw error;
-  }
+  const listening = once(server, 'listening');
+  server.listen(port, '0.0.0.0');
+  await listening;
 }
 
 async function waitForShutdown(server: http.Server): Promise<void> {

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -9,7 +9,6 @@ import type { Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
 import { findSelfProject, type Project } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
-import { isPortAvailable } from '../utils/port.js';
 
 const builder = {} as const;
 type MaintenanceArgv = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder> & {
@@ -59,12 +58,13 @@ const maintenanceHtml = `<!doctype html>
   </body>
 </html>`;
 
-function getMaintenanceServerSource(port: number, pidPath: string): string {
+function getMaintenanceServerSource(port: number, pidPath: string, errorPath: string): string {
   return String.raw`
 import fs from 'node:fs';
 import http from 'node:http';
 
 const pidPath = ${JSON.stringify(pidPath)};
+const errorPath = ${JSON.stringify(errorPath)};
 
 const server = http.createServer((_request, response) => {
   response.writeHead(503, {
@@ -74,9 +74,10 @@ const server = http.createServer((_request, response) => {
   response.end(${JSON.stringify(maintenanceHtml)});
 });
 
-server.on('error', () => {
+server.on('error', (error) => {
   try {
     fs.rmSync(pidPath, { force: true });
+    fs.writeFileSync(errorPath, error.code || error.message || 'UNKNOWN');
   } catch {
     // do nothing
   }
@@ -84,6 +85,11 @@ server.on('error', () => {
 });
 
 server.listen(${port}, '0.0.0.0', () => {
+  try {
+    fs.rmSync(errorPath, { force: true });
+  } catch {
+    // do nothing
+  }
   fs.writeFileSync(pidPath, String(process.pid) + '\n');
 });
 `;
@@ -129,22 +135,19 @@ export const maintenanceCommand: CommandModule<unknown, MaintenanceArgv> = {
 
 async function startMaintenanceServer(project: Project, port: number): Promise<void> {
   const pidPath = getPidPath(project, port);
+  const errorPath = getErrorPath(project, port);
   const existingPid = readPid(pidPath);
   if (existingPid !== undefined && isProcessRunning(existingPid)) {
     console.info(`Maintenance server is already running on port ${port}.`);
     return;
   }
   removePidFile(pidPath);
-
-  if (!(await isPortAvailable(port))) {
-    console.error(chalk.red(`Port ${port} is already in use.`));
-    process.exit(1);
-  }
+  removeErrorFile(errorPath);
   fs.mkdirSync(path.dirname(pidPath), { recursive: true });
 
   const child = child_process.spawn(
     process.execPath,
-    ['--input-type=module', '--eval', getMaintenanceServerSource(port, pidPath)],
+    ['--input-type=module', '--eval', getMaintenanceServerSource(port, pidPath, errorPath)],
     {
       detached: true,
       env: project.env,
@@ -156,7 +159,7 @@ async function startMaintenanceServer(project: Project, port: number): Promise<v
   }
 
   child.unref();
-  await waitForPidFile(pidPath, child.pid);
+  await waitForMaintenanceServer(pidPath, errorPath, child.pid, port);
   console.info(`Started maintenance server on port ${port}.`);
 }
 
@@ -187,10 +190,22 @@ function getPidPath(project: Project, port: number): string {
   return path.join(project.rootDirPath, '.tmp', `wb-maintenance-server-${port}.pid`);
 }
 
+function getErrorPath(project: Project, port: number): string {
+  return path.join(project.rootDirPath, '.tmp', `wb-maintenance-server-${port}.error`);
+}
+
 function readPid(pidPath: string): number | undefined {
   try {
     const pid = Number(fs.readFileSync(pidPath, 'utf8').trim());
     return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+  } catch {
+    return;
+  }
+}
+
+function readError(errorPath: string): string | undefined {
+  try {
+    return fs.readFileSync(errorPath, 'utf8').trim() || undefined;
   } catch {
     return;
   }
@@ -213,14 +228,32 @@ function removePidFile(pidPath: string): void {
   }
 }
 
-async function waitForPidFile(pidPath: string, pid: number): Promise<void> {
+function removeErrorFile(errorPath: string): void {
+  try {
+    fs.rmSync(errorPath, { force: true });
+  } catch {
+    // do nothing
+  }
+}
+
+async function waitForMaintenanceServer(pidPath: string, errorPath: string, pid: number, port: number): Promise<void> {
   const deadline = Date.now() + 5000;
   while (Date.now() < deadline) {
     if (readPid(pidPath) !== undefined) return;
+    const error = readError(errorPath);
+    if (error !== undefined) {
+      removeErrorFile(errorPath);
+      if (error === 'EADDRINUSE') {
+        console.error(chalk.red(`Port ${port} is already in use.`));
+        process.exit(1);
+      }
+      throw new Error(`Failed to start maintenance server: ${error}`);
+    }
     if (!isProcessRunning(pid)) break;
     await setTimeout(50);
   }
 
   removePidFile(pidPath);
+  removeErrorFile(errorPath);
   throw new Error('Failed to start maintenance server.');
 }

--- a/packages/wb/src/utils/process.ts
+++ b/packages/wb/src/utils/process.ts
@@ -27,7 +27,7 @@ export async function killPortProcessImmediatelyAndOnExit(port: number, project:
   }
 }
 
-async function killPortContainerAndProcess(port: number, project: Project): Promise<void> {
+export async function killPortContainerAndProcess(port: number, project: Project): Promise<void> {
   // We should stop Docker containers first because `kill-port` may fail to stop Docker containers.
   await stopDockerContainerByPort(port, project);
   try {

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -3,11 +3,13 @@ import { once } from 'node:events';
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type * as projectModule from '../src/project.js';
+
 const findSelfProjectMock = vi.fn();
 const killPortContainerAndProcessMock = vi.fn();
 
 vi.mock('../src/project.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../src/project.js')>()),
+  ...(await importOriginal<typeof projectModule>()),
   findSelfProject: findSelfProjectMock,
 }));
 
@@ -54,7 +56,7 @@ describe('maintenanceCommand', () => {
     await maintenanceCommand.handler({ action: 'stop' } as never);
 
     expect(killPortContainerAndProcessMock).toHaveBeenCalledOnce();
-    expect(killPortContainerAndProcessMock).toHaveBeenCalledWith(32123, project);
+    expect(killPortContainerAndProcessMock).toHaveBeenCalledWith(32_123, project);
   });
 });
 

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -1,0 +1,98 @@
+import http from 'node:http';
+import { once } from 'node:events';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const findSelfProjectMock = vi.fn();
+const killPortContainerAndProcessMock = vi.fn();
+
+vi.mock('../src/project.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/project.js')>()),
+  findSelfProject: findSelfProjectMock,
+}));
+
+vi.mock('../src/utils/process.js', () => ({
+  killPortContainerAndProcess: killPortContainerAndProcessMock,
+}));
+
+const { maintenanceCommand } = await import('../src/commands/maintenance.js');
+
+describe('maintenanceCommand', () => {
+  beforeEach(() => {
+    findSelfProjectMock.mockReset();
+    killPortContainerAndProcessMock.mockReset();
+    killPortContainerAndProcessMock.mockResolvedValue(undefined);
+  });
+
+  it('runs the maintenance server in the foreground until SIGTERM', async () => {
+    const port = await findAvailablePort();
+    findSelfProjectMock.mockReturnValue({
+      env: { PORT: String(port), WB_ENV: 'development' },
+    });
+
+    if (!maintenanceCommand.handler) throw new Error('maintenanceCommand.handler is undefined.');
+
+    const handlerPromise = maintenanceCommand.handler({ action: 'start' } as never);
+    await waitForHttpStatus(port, 503);
+
+    process.emit('SIGTERM', 'SIGTERM');
+    await expect(handlerPromise).resolves.toBeUndefined();
+    expect(killPortContainerAndProcessMock).toHaveBeenCalledWith(
+      port,
+      expect.objectContaining({ env: expect.anything() })
+    );
+  });
+
+  it('stops maintenance by killing the configured port without requiring a pid file', async () => {
+    const project = {
+      env: { PORT: '32123', WB_ENV: 'development' },
+    };
+    findSelfProjectMock.mockReturnValue(project);
+
+    if (!maintenanceCommand.handler) throw new Error('maintenanceCommand.handler is undefined.');
+
+    await maintenanceCommand.handler({ action: 'stop' } as never);
+
+    expect(killPortContainerAndProcessMock).toHaveBeenCalledOnce();
+    expect(killPortContainerAndProcessMock).toHaveBeenCalledWith(32123, project);
+  });
+});
+
+async function findAvailablePort(): Promise<number> {
+  const server = http.createServer();
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Failed to find an available port.');
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+  return address.port;
+}
+
+async function waitForHttpStatus(port: number, expectedStatus: number): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const status = await fetchStatus(port);
+    if (status === expectedStatus) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for HTTP ${expectedStatus} on port ${port}.`);
+}
+
+async function fetchStatus(port: number): Promise<number | undefined> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}`);
+    return response.status;
+  } catch {
+    return;
+  }
+}

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -63,7 +63,6 @@ function spawnNodeServer(port: number): childProcess.ChildProcess {
         import http from 'node:http';
         const server = http.createServer((_request, response) => response.end('ok'));
         server.listen(${JSON.stringify(port)}, '0.0.0.0');
-        setInterval(() => {}, 1000);
       `,
     ],
     {

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -1,64 +1,100 @@
+import childProcess from 'node:child_process';
 import http from 'node:http';
 import { once } from 'node:events';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import type * as projectModule from '../src/project.js';
-
-const findSelfProjectMock = vi.fn();
-const killPortContainerAndProcessMock = vi.fn();
-
-vi.mock('../src/project.js', async (importOriginal) => ({
-  ...(await importOriginal<typeof projectModule>()),
-  findSelfProject: findSelfProjectMock,
-}));
-
-vi.mock('../src/utils/process.js', () => ({
-  killPortContainerAndProcess: killPortContainerAndProcessMock,
-}));
-
-const { maintenanceCommand } = await import('../src/commands/maintenance.js');
-
-describe('maintenanceCommand', () => {
-  beforeEach(() => {
-    findSelfProjectMock.mockReset();
-    killPortContainerAndProcessMock.mockReset();
-    killPortContainerAndProcessMock.mockResolvedValue(undefined);
-  });
-
-  it('runs the maintenance server in the foreground until SIGTERM', async () => {
+describe.skipIf(process.platform === 'win32')('wb maintenance', () => {
+  it('runs start in the foreground until SIGTERM', async () => {
     const port = await findAvailablePort();
-    findSelfProjectMock.mockReturnValue({
-      env: { PORT: String(port), WB_ENV: 'development' },
-    });
+    const maintenance = spawnWbMaintenance('start', port);
 
-    if (!maintenanceCommand.handler) throw new Error('maintenanceCommand.handler is undefined.');
+    try {
+      await waitForHttpStatus(port, 503);
+    } finally {
+      terminateProcessGroup(maintenance);
+      await waitForExit(maintenance);
+    }
+  }, 20_000);
 
-    const handlerPromise = maintenanceCommand.handler({ action: 'start' } as never);
-    await waitForHttpStatus(port, 503);
+  it('stops a listener on the configured port without relying on a pid file', async () => {
+    const port = await findAvailablePort();
+    const server = spawnNodeServer(port);
 
-    process.emit('SIGTERM', 'SIGTERM');
-    await expect(handlerPromise).resolves.toBeUndefined();
-    expect(killPortContainerAndProcessMock).toHaveBeenCalledWith(
-      port,
-      expect.objectContaining({ env: expect.anything() })
-    );
-  });
+    try {
+      await waitForHttpStatus(port, 200);
 
-  it('stops maintenance by killing the configured port without requiring a pid file', async () => {
-    const project = {
-      env: { PORT: '32123', WB_ENV: 'development' },
-    };
-    findSelfProjectMock.mockReturnValue(project);
+      const result = childProcess.spawnSync(
+        'yarn',
+        ['workspace', '@willbooster/wb', 'start', 'maintenance', 'stop', '--quiet-env'],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf8',
+          env: { ...process.env, PORT: String(port), WB_ENV: 'development' },
+          timeout: 20_000,
+        }
+      );
 
-    if (!maintenanceCommand.handler) throw new Error('maintenanceCommand.handler is undefined.');
-
-    await maintenanceCommand.handler({ action: 'stop' } as never);
-
-    expect(killPortContainerAndProcessMock).toHaveBeenCalledOnce();
-    expect(killPortContainerAndProcessMock).toHaveBeenCalledWith(32_123, project);
-  });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(`Stopped maintenance server on port ${port}.`);
+      await waitForExit(server);
+    } finally {
+      terminateProcessGroup(server);
+    }
+  }, 30_000);
 });
+
+function spawnWbMaintenance(action: 'start' | 'stop', port: number): childProcess.ChildProcess {
+  return childProcess.spawn('yarn', ['workspace', '@willbooster/wb', 'start', 'maintenance', action, '--quiet-env'], {
+    cwd: process.cwd(),
+    detached: true,
+    env: { ...process.env, PORT: String(port), WB_ENV: 'development' },
+    stdio: 'ignore',
+  });
+}
+
+function spawnNodeServer(port: number): childProcess.ChildProcess {
+  return childProcess.spawn(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `
+        import http from 'node:http';
+        const server = http.createServer((_request, response) => response.end('ok'));
+        server.listen(${JSON.stringify(port)}, '0.0.0.0');
+        setInterval(() => {}, 1000);
+      `,
+    ],
+    {
+      detached: true,
+      stdio: 'ignore',
+    }
+  );
+}
+
+function terminateProcessGroup(child: childProcess.ChildProcess): void {
+  if (child.exitCode !== null || child.pid === undefined) return;
+
+  try {
+    process.kill(-child.pid, 'SIGTERM');
+  } catch {
+    // do nothing
+  }
+}
+
+async function waitForExit(child: childProcess.ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return;
+
+  await Promise.race([
+    once(child, 'exit').then(() => {}),
+    new Promise<void>((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Timed out waiting for process ${child.pid ?? '<unknown>'} to exit.`));
+      }, 10_000);
+    }),
+  ]);
+}
 
 async function findAvailablePort(): Promise<number> {
   const server = http.createServer();
@@ -81,11 +117,11 @@ async function findAvailablePort(): Promise<number> {
 }
 
 async function waitForHttpStatus(port: number, expectedStatus: number): Promise<void> {
-  const deadline = Date.now() + 5000;
+  const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
     const status = await fetchStatus(port);
     if (status === expectedStatus) return;
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error(`Timed out waiting for HTTP ${expectedStatus} on port ${port}.`);
 }

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -87,7 +87,7 @@ async function waitForExit(child: childProcess.ChildProcess): Promise<void> {
   if (child.exitCode !== null) return;
 
   await Promise.race([
-    once(child, 'exit').then(() => {}),
+    once(child, 'exit'),
     new Promise<void>((_resolve, reject) => {
       setTimeout(() => {
         reject(new Error(`Timed out waiting for process ${child.pid ?? '<unknown>'} to exit.`));

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -4,7 +4,7 @@ import { once } from 'node:events';
 
 import { describe, expect, it } from 'vitest';
 
-describe.skipIf(process.platform === 'win32')('wb maintenance', () => {
+describe('wb maintenance', () => {
   it('runs start in the foreground until SIGTERM', async () => {
     const port = await findAvailablePort();
     const maintenance = spawnWbMaintenance('start', port);
@@ -86,14 +86,21 @@ function terminateProcessGroup(child: childProcess.ChildProcess): void {
 async function waitForExit(child: childProcess.ChildProcess): Promise<void> {
   if (child.exitCode !== null) return;
 
-  await Promise.race([
-    once(child, 'exit'),
-    new Promise<void>((_resolve, reject) => {
-      setTimeout(() => {
-        reject(new Error(`Timed out waiting for process ${child.pid ?? '<unknown>'} to exit.`));
-      }, 10_000);
-    }),
-  ]);
+  let timeoutId: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      once(child, 'exit'),
+      new Promise<void>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`Timed out waiting for process ${child.pid ?? '<unknown>'} to exit.`));
+        }, 10_000);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
 async function findAvailablePort(): Promise<number> {

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -73,7 +73,7 @@ function spawnNodeServer(port: number): childProcess.ChildProcess {
 }
 
 function terminateProcessGroup(child: childProcess.ChildProcess): void {
-  if (child.exitCode !== null || child.pid === undefined) return;
+  if (child.exitCode !== null || child.signalCode !== null || child.pid === undefined) return;
 
   try {
     process.kill(-child.pid, 'SIGTERM');
@@ -83,7 +83,7 @@ function terminateProcessGroup(child: childProcess.ChildProcess): void {
 }
 
 async function waitForExit(child: childProcess.ChildProcess): Promise<void> {
-  if (child.exitCode !== null) return;
+  if (child.exitCode !== null || child.signalCode !== null) return;
 
   let timeoutId: NodeJS.Timeout | undefined;
   try {


### PR DESCRIPTION
## Summary

- Remove the pre-listen `isPortAvailable()` check from `wb maintenance start`.
- Run `wb maintenance start` as the foreground maintenance HTTP server instead of daemonizing a detached child process.
- Make `wb maintenance stop` clear the configured port through the existing `kill-port` based flow instead of relying on pid files.
- Retry maintenance server listen briefly after port cleanup to tolerate delayed port release.

## Why

`isPortAvailable()` performs a separate temporary listen before the real maintenance server starts. That check is inherently racy: the port can become unavailable between the successful probe and the real `listen()` call.

The previous detached-child implementation also required pid/error files and made `wb` act as a small process manager. The new model is simpler: callers that need the maintenance server in the background should run `wb maintenance start &`, and `wb maintenance stop` clears the configured port before the real server starts.

## Reproduction

This reproduces the underlying race: an `isPortAvailable()`-style probe returns `true`, but the subsequent real `listen('0.0.0.0')` fails with `EADDRINUSE`.

```bash
cat > .tmp/repro-maintenance-port-race.mjs <<'NODE'
import { createServer } from 'node:net';
import { setTimeout as sleep } from 'node:timers/promises';

const port = Number(process.env.PORT || 26123);
const iterations = Number(process.env.ITERATIONS || 200);
const concurrency = Number(process.env.CONCURRENCY || 2);
const holdMs = Number(process.env.HOLD_MS || 100);

let attempts = 0;
let falsePositives = 0;
let unavailable = 0;
let otherErrors = 0;

async function main() {
  console.log(
    JSON.stringify({
      runtime: process.versions.bun ? `bun ${process.versions.bun}` : `node ${process.version}`,
      port,
      iterations,
      concurrency,
      holdMs,
    })
  );

  await Promise.all(Array.from({ length: concurrency }, (_, worker) => runWorker(worker)));

  console.log(JSON.stringify({ attempts, falsePositives, unavailable, otherErrors }));

  process.exit(falsePositives > 0 ? 2 : 0);
}

async function runWorker(worker) {
  for (let i = worker; i < iterations; i += concurrency) {
    attempts += 1;
    const available = await isPortAvailableLikeWb(port);
    if (!available) {
      unavailable += 1;
      continue;
    }

    const result = await listenLikeMaintenance(port);
    if (result !== 'ok') {
      falsePositives += 1;
      console.log(`false positive at iteration=${i}: ${result}`);
      return;
    }
  }
}

async function isPortAvailableLikeWb(targetPort) {
  for (const host of ['127.0.0.1', '::']) {
    const available = await probePort(host, targetPort);
    if (!available) return false;
  }
  return true;
}

async function probePort(host, targetPort) {
  return new Promise((resolve) => {
    const server = createServer();
    server.once('error', (error) => {
      if (error.code === 'EADDRINUSE') {
        resolve(false);
        return;
      }
      if (error.code === 'EAFNOSUPPORT') {
        resolve(true);
        return;
      }
      otherErrors += 1;
      console.log(`probe ${host} error: ${error.code || error.message}`);
      resolve(false);
    });
    server.once('listening', () => {
      server.close(() => resolve(true));
    });
    server.listen(targetPort, host);
  });
}

async function listenLikeMaintenance(targetPort) {
  return new Promise((resolve) => {
    const server = createServer();
    server.once('error', (error) => resolve(error.code || error.message || 'UNKNOWN'));
    server.once('listening', async () => {
      if (holdMs > 0) await sleep(holdMs);
      server.close(() => resolve('ok'));
    });
    server.listen(targetPort, '0.0.0.0');
  });
}

await main();
NODE

CONCURRENCY=2 ITERATIONS=200 HOLD_MS=100 bun .tmp/repro-maintenance-port-race.mjs
```

Example output:

```text
{"runtime":"bun 1.3.14","port":26123,"iterations":200,"concurrency":2,"holdMs":100}
false positive at iteration=3: EADDRINUSE
{"attempts":102,"falsePositives":1,"unavailable":1,"otherErrors":0}
```

## Testing

- Added `packages/wb/test/maintenanceCommand.test.ts` to verify foreground `start` behavior and port-based `stop` behavior.
- `yarn workspace @willbooster/wb typecheck`
- `yarn run cleanup`
- GitHub Actions passed on the latest commit.
