### PR TITLE
fix: install lsof in Docker prep scripts

### DIFF
--- a/packages/wb/docker/bash/prepare-blitz.sh
+++ b/packages/wb/docker/bash/prepare-blitz.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# Blitz.js requires libssl-dev. wb requires procps.
+# Blitz.js requires libssl-dev. wb requires lsof and procps.
 # TODO: merge this with bash/prepare-node-web.sh
-apt-get -qq install -y --no-install-recommends ca-certificates libssl3 procps tzdata
+apt-get -qq install -y --no-install-recommends ca-certificates libssl3 lsof procps tzdata

--- a/packages/wb/docker/bash/prepare-node-web.sh
+++ b/packages/wb/docker/bash/prepare-node-web.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# Web server requires libssl-dev. wb requires git and procps.
-apt-get -qq install -y --no-install-recommends ca-certificates git libssl-dev procps tzdata
+# Web server requires libssl-dev. wb requires git, lsof, and procps.
+apt-get -qq install -y --no-install-recommends ca-certificates git libssl-dev lsof procps tzdata


### PR DESCRIPTION
## Summary

- Add `lsof` to `prepare-node-web.sh`.
- Add `lsof` to `prepare-blitz.sh`.

## Why

`wb maintenance stop` uses `kill-port`, and `kill-port` depends on `lsof` on Linux. Docker images generated from these shared prep scripts need `lsof` available so port-based maintenance shutdown can actually stop the process occupying the app port.

## Testing

- `yarn verify`
