### PR TITLE
fix: stop granting actions write in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 permissions:
-  actions: write
   contents: write
   pull-requests: read
 jobs:

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -123,8 +123,6 @@ const workflows = {
       'cancel-in-progress': true,
     },
     permissions: {
-      // for skip-duplicate-actions to cancel outdated runs
-      actions: 'write',
       // for linter fix
       contents: 'write',
       // for pkg-preflight PR file listing
@@ -327,6 +325,8 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
     }
     case 'test': {
       // Don't use `paths-ignore` for test because GitHub's Branch Protection and Rulesets require job running.
+      // The reusable test workflow no longer needs Actions write access.
+      delete newSettings.permissions?.actions;
       if (newSettings.on?.pull_request) {
         delete newSettings.on.pull_request['paths-ignore'];
       }


### PR DESCRIPTION
## Summary

- Remove `actions: write` from wbfy's generated `test.yml` permissions.
- Ensure wbfy deletes an existing `permissions.actions` entry when regenerating `test.yml`.
- Apply wbfy to this repository so `.github/workflows/test.yml` no longer grants Actions write access.

## Why

- The reusable test workflow no longer needs Actions write permission.
- The cleanup path keeps repositories from retaining the recently generated permission after future wbfy runs.

## Testing

- `yarn start /Users/exkazuu/ghq/github.com/WillBooster/shared` from `packages/wbfy`
- `rg -n "actions:\\s*write" .github/workflows/test.yml packages/wbfy/src/generators/workflow.ts`
- `yarn verify`
