### PR TITLE
fix: delay maintenance server startup

### DIFF
--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -117,15 +117,39 @@ async function startMaintenanceServer(project: Project, port: number, delayMs: n
   assert.ok(Number.isFinite(delayMs) && delayMs >= 0, `delay-ms must be greater than or equal to 0: ${delayMs}`);
 
   const pidFilePath = await writeMaintenancePidFile(project, port);
+  const abortController = new AbortController();
+  const cleanup = async (): Promise<void> => {
+    await removeMaintenancePidFile(pidFilePath, process.pid);
+  };
+  const handleSignal = (): void => {
+    abortController.abort();
+    void cleanup().finally(() => process.exit(0));
+  };
+  const removeSignalHandlers = (): void => {
+    process.off('SIGINT', handleSignal);
+    process.off('SIGTERM', handleSignal);
+    process.off('SIGQUIT', handleSignal);
+  };
+
+  process.once('SIGINT', handleSignal);
+  process.once('SIGTERM', handleSignal);
+  process.once('SIGQUIT', handleSignal);
+
   try {
-    await setTimeout(delayMs);
+    await setTimeout(delayMs, undefined, { signal: abortController.signal });
+    removeSignalHandlers();
     const server = await createAndListenMaintenanceServer(port);
     if (!server) return;
 
     console.info(`Started maintenance server on port ${port}.`);
     await waitForShutdown(server);
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') return;
+
+    throw error;
   } finally {
-    await removeMaintenancePidFile(pidFilePath, process.pid);
+    removeSignalHandlers();
+    await cleanup();
   }
 }
 
@@ -253,7 +277,7 @@ async function writeMaintenancePidFile(project: Project, port: number): Promise<
 async function killMaintenanceProcess(project: Project, port: number): Promise<void> {
   const pidFilePath = maintenancePidFilePath(project, port);
   const pid = await readMaintenancePidFile(pidFilePath);
-  if (pid !== undefined) {
+  if (pid !== undefined && pid !== process.pid) {
     try {
       treeKill(pid, 'SIGTERM');
     } catch {
@@ -283,5 +307,9 @@ async function removeMaintenancePidFile(pidFilePath: string, expectedPid?: numbe
 }
 
 function maintenancePidFilePath(project: Project, port: number): string {
-  return path.join(project.rootDirPath, maintenancePidDirectoryName, `maintenance-${port}.pid`);
+  return getMaintenancePidFilePath(project.rootDirPath, port);
+}
+
+export function getMaintenancePidFilePath(rootDirPath: string, port: number): string {
+  return path.join(rootDirPath, maintenancePidDirectoryName, `maintenance-${port}.pid`);
 }

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -125,7 +125,7 @@ async function startMaintenanceServer(project: Project, port: number, delayMs: n
     console.info(`Started maintenance server on port ${port}.`);
     await waitForShutdown(server);
   } finally {
-    await removeMaintenancePidFile(pidFilePath);
+    await removeMaintenancePidFile(pidFilePath, process.pid);
   }
 }
 
@@ -274,7 +274,11 @@ async function readMaintenancePidFile(pidFilePath: string): Promise<number | und
   }
 }
 
-async function removeMaintenancePidFile(pidFilePath: string): Promise<void> {
+async function removeMaintenancePidFile(pidFilePath: string, expectedPid?: number): Promise<void> {
+  if (expectedPid !== undefined) {
+    const pid = await readMaintenancePidFile(pidFilePath);
+    if (pid !== expectedPid) return;
+  }
   await fs.rm(pidFilePath, { force: true });
 }
 

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -1,20 +1,30 @@
 import assert from 'node:assert';
+import fs from 'node:fs/promises';
 import http from 'node:http';
+import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
+import { treeKill } from '@willbooster/shared-lib-node/src';
 import chalk from 'chalk';
 import type { Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
 import { findSelfProject, type Project } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
-import { killPortContainerAndProcess } from '../utils/process.js';
+import { killPortContainerAndProcess, removeStaleProcess } from '../utils/process.js';
 
-const builder = {} as const;
+const builder = {
+  'delay-ms': {
+    default: 5000,
+    describe: 'Delay before starting the maintenance page server.',
+    type: 'number',
+  },
+} as const;
 type MaintenanceArgv = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder> & {
   action: 'start' | 'stop';
 };
 const maintenanceListenMaxAttempts = 5;
 const maintenanceListenRetryDelayMs = 100;
+const maintenancePidDirectoryName = '.wb';
 const maintenanceHtml = `<!doctype html>
 <html lang="ja">
   <head>
@@ -85,7 +95,7 @@ export const maintenanceCommand: CommandModule<unknown, MaintenanceArgv> = {
 
     const port = parsePort(project.env.PORT);
     if (action === 'start') {
-      await startMaintenanceServer(project, port);
+      await startMaintenanceServer(project, port, argv.delayMs);
       return;
     }
     if (action === 'stop') {
@@ -103,14 +113,23 @@ function parsePort(portEnv: string | undefined): number {
   return port;
 }
 
-async function startMaintenanceServer(project: Project, port: number): Promise<void> {
-  await killPortContainerAndProcess(port, project);
-  const server = await createAndListenMaintenanceServer(port);
-  console.info(`Started maintenance server on port ${port}.`);
-  await waitForShutdown(server);
+async function startMaintenanceServer(project: Project, port: number, delayMs: number): Promise<void> {
+  assert.ok(Number.isFinite(delayMs) && delayMs >= 0, `delay-ms must be greater than or equal to 0: ${delayMs}`);
+
+  const pidFilePath = await writeMaintenancePidFile(project, port);
+  try {
+    await setTimeout(delayMs);
+    const server = await createAndListenMaintenanceServer(port);
+    if (!server) return;
+
+    console.info(`Started maintenance server on port ${port}.`);
+    await waitForShutdown(server);
+  } finally {
+    await removeMaintenancePidFile(pidFilePath);
+  }
 }
 
-async function createAndListenMaintenanceServer(port: number): Promise<http.Server> {
+async function createAndListenMaintenanceServer(port: number): Promise<http.Server | undefined> {
   for (let attempt = 1; attempt <= maintenanceListenMaxAttempts; attempt++) {
     const server = createMaintenanceServer();
     try {
@@ -122,6 +141,10 @@ async function createAndListenMaintenanceServer(port: number): Promise<http.Serv
       if (err.code === 'EADDRINUSE' && attempt < maintenanceListenMaxAttempts) {
         await setTimeout(maintenanceListenRetryDelayMs);
         continue;
+      }
+      if (err.code === 'EADDRINUSE') {
+        console.info(`Skip maintenance server because port ${port} is already in use.`);
+        return undefined;
       }
       handleMaintenanceStartupError(port, err);
     }
@@ -145,6 +168,7 @@ function handleRuntimeMaintenanceServerError(error: Error): void {
 }
 
 async function stopMaintenanceServer(project: Project, port: number): Promise<void> {
+  await killMaintenanceProcess(project, port);
   await killPortContainerAndProcess(port, project);
   console.info(`Stopped maintenance server on port ${port}.`);
 }
@@ -217,4 +241,43 @@ async function closeMaintenanceServer(server: http.Server): Promise<void> {
     });
     server.closeAllConnections();
   });
+}
+
+async function writeMaintenancePidFile(project: Project, port: number): Promise<string> {
+  const pidFilePath = maintenancePidFilePath(project, port);
+  await fs.mkdir(path.dirname(pidFilePath), { recursive: true });
+  await fs.writeFile(pidFilePath, `${process.pid}\n`, 'utf8');
+  return pidFilePath;
+}
+
+async function killMaintenanceProcess(project: Project, port: number): Promise<void> {
+  const pidFilePath = maintenancePidFilePath(project, port);
+  const pid = await readMaintenancePidFile(pidFilePath);
+  if (pid !== undefined) {
+    try {
+      treeKill(pid, 'SIGTERM');
+    } catch {
+      // do nothing
+    }
+    await removeStaleProcess(pid);
+  }
+  await removeMaintenancePidFile(pidFilePath);
+}
+
+async function readMaintenancePidFile(pidFilePath: string): Promise<number | undefined> {
+  try {
+    const pidText = await fs.readFile(pidFilePath, 'utf8');
+    const pid = Number(pidText.trim());
+    return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function removeMaintenancePidFile(pidFilePath: string): Promise<void> {
+  await fs.rm(pidFilePath, { force: true });
+}
+
+function maintenancePidFilePath(project: Project, port: number): string {
+  return path.join(project.rootDirPath, maintenancePidDirectoryName, `maintenance-${port}.pid`);
 }

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -123,7 +123,6 @@ async function startMaintenanceServer(project: Project, port: number, delayMs: n
   };
   const handleSignal = (): void => {
     abortController.abort();
-    void cleanup().finally(() => process.exit(0));
   };
   const removeSignalHandlers = (): void => {
     process.off('SIGINT', handleSignal);
@@ -288,6 +287,14 @@ async function killMaintenanceProcess(project: Project, port: number): Promise<v
   await removeMaintenancePidFile(pidFilePath);
 }
 
+async function removeMaintenancePidFile(pidFilePath: string, expectedPid?: number): Promise<void> {
+  if (expectedPid !== undefined) {
+    const pid = await readMaintenancePidFile(pidFilePath);
+    if (pid !== expectedPid) return;
+  }
+  await fs.rm(pidFilePath, { force: true });
+}
+
 async function readMaintenancePidFile(pidFilePath: string): Promise<number | undefined> {
   try {
     const pidText = await fs.readFile(pidFilePath, 'utf8');
@@ -296,14 +303,6 @@ async function readMaintenancePidFile(pidFilePath: string): Promise<number | und
   } catch {
     return undefined;
   }
-}
-
-async function removeMaintenancePidFile(pidFilePath: string, expectedPid?: number): Promise<void> {
-  if (expectedPid !== undefined) {
-    const pid = await readMaintenancePidFile(pidFilePath);
-    if (pid !== expectedPid) return;
-  }
-  await fs.rm(pidFilePath, { force: true });
 }
 
 function maintenancePidFilePath(project: Project, port: number): string {

--- a/packages/wb/src/commands/maintenance.ts
+++ b/packages/wb/src/commands/maintenance.ts
@@ -24,6 +24,7 @@ type MaintenanceArgv = InferredOptionTypes<typeof builder & typeof sharedOptions
 };
 const maintenanceListenMaxAttempts = 5;
 const maintenanceListenRetryDelayMs = 100;
+const maxTimeoutDelayMs = 2_147_483_647;
 const maintenancePidDirectoryName = '.wb';
 const maintenanceHtml = `<!doctype html>
 <html lang="ja">
@@ -114,7 +115,10 @@ function parsePort(portEnv: string | undefined): number {
 }
 
 async function startMaintenanceServer(project: Project, port: number, delayMs: number): Promise<void> {
-  assert.ok(Number.isFinite(delayMs) && delayMs >= 0, `delay-ms must be greater than or equal to 0: ${delayMs}`);
+  assert.ok(
+    Number.isFinite(delayMs) && delayMs >= 0 && delayMs <= maxTimeoutDelayMs,
+    `delay-ms must be between 0 and ${maxTimeoutDelayMs}: ${delayMs}`
+  );
 
   const pidFilePath = await writeMaintenancePidFile(project, port);
   const abortController = new AbortController();
@@ -284,7 +288,7 @@ async function killMaintenanceProcess(project: Project, port: number): Promise<v
     }
     await removeStaleProcess(pid);
   }
-  await removeMaintenancePidFile(pidFilePath);
+  await removeMaintenancePidFile(pidFilePath, pid);
 }
 
 async function removeMaintenancePidFile(pidFilePath: string, expectedPid?: number): Promise<void> {

--- a/packages/wb/src/utils/process.ts
+++ b/packages/wb/src/utils/process.ts
@@ -2,7 +2,6 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { setTimeout } from 'node:timers/promises';
 
 import { spawnAsync } from '@willbooster/shared-lib-node/src';
-import killPortProcess from 'kill-port';
 
 import type { Project } from '../project.js';
 import { printFinishedAndExitIfNeeded, printStart } from '../scripts/run.js';
@@ -10,7 +9,8 @@ import { printFinishedAndExitIfNeeded, printStart } from '../scripts/run.js';
 import { isPortAvailable } from './port.js';
 
 const killed = new Set<number | string>();
-const staleProcessWaitMs = 1000;
+const staleProcessPollIntervalMs = 100;
+const staleProcessMaxPolls = 10;
 
 export async function killPortProcessImmediatelyAndOnExit(port: number, project: Project): Promise<void> {
   const available = await isPortAvailable(port);
@@ -30,18 +30,8 @@ export async function killPortProcessImmediatelyAndOnExit(port: number, project:
 }
 
 export async function killPortContainerAndProcess(port: number, project: Project): Promise<void> {
-  // We should stop Docker containers first because `kill-port` may fail to stop Docker containers.
   await stopDockerContainerByPort(port, project);
-  if (process.platform !== 'win32') {
-    killListeningProcessesByPort(port);
-    return;
-  }
-
-  try {
-    await killPortProcess(port);
-  } catch {
-    // do nothing
-  }
+  killListeningProcessesByPort(port);
 }
 
 function killListeningProcessesByPort(port: number): void {
@@ -71,11 +61,13 @@ function listListeningProcessIds(port: number): number[] {
 }
 
 export async function removeStaleProcess(pid: number): Promise<void> {
-  await setTimeout(staleProcessWaitMs);
-  try {
-    process.kill(pid, 0);
-  } catch {
-    return;
+  for (let i = 0; i < staleProcessMaxPolls; i++) {
+    await setTimeout(staleProcessPollIntervalMs);
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
   }
 
   try {

--- a/packages/wb/src/utils/process.ts
+++ b/packages/wb/src/utils/process.ts
@@ -1,4 +1,5 @@
-import { spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { setTimeout } from 'node:timers/promises';
 
 import { spawnAsync } from '@willbooster/shared-lib-node/src';
 import killPortProcess from 'kill-port';
@@ -9,6 +10,7 @@ import { printFinishedAndExitIfNeeded, printStart } from '../scripts/run.js';
 import { isPortAvailable } from './port.js';
 
 const killed = new Set<number | string>();
+const staleProcessWaitMs = 1000;
 
 export async function killPortProcessImmediatelyAndOnExit(port: number, project: Project): Promise<void> {
   const available = await isPortAvailable(port);
@@ -30,8 +32,54 @@ export async function killPortProcessImmediatelyAndOnExit(port: number, project:
 export async function killPortContainerAndProcess(port: number, project: Project): Promise<void> {
   // We should stop Docker containers first because `kill-port` may fail to stop Docker containers.
   await stopDockerContainerByPort(port, project);
+  if (process.platform !== 'win32') {
+    killListeningProcessesByPort(port);
+    return;
+  }
+
   try {
     await killPortProcess(port);
+  } catch {
+    // do nothing
+  }
+}
+
+function killListeningProcessesByPort(port: number): void {
+  for (const pid of listListeningProcessIds(port)) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // do nothing
+    }
+  }
+}
+
+function listListeningProcessIds(port: number): number[] {
+  try {
+    const stdout = execFileSync('lsof', ['-ti', `tcp:${port}`, '-sTCP:LISTEN'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    });
+    return stdout
+      .split(/\s+/)
+      .map((pid) => Number(pid.trim()))
+      .filter((pid) => Number.isInteger(pid) && pid > 0 && pid !== process.pid);
+  } catch {
+    return [];
+  }
+}
+
+export async function removeStaleProcess(pid: number): Promise<void> {
+  await setTimeout(staleProcessWaitMs);
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return;
+  }
+
+  try {
+    process.kill(pid, 'SIGKILL');
   } catch {
     // do nothing
   }

--- a/packages/wb/src/utils/process.ts
+++ b/packages/wb/src/utils/process.ts
@@ -65,8 +65,8 @@ export async function removeStaleProcess(pid: number): Promise<void> {
     await setTimeout(staleProcessPollIntervalMs);
     try {
       process.kill(pid, 0);
-    } catch {
-      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ESRCH') return;
     }
   }
 

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -201,7 +201,8 @@ async function removePidFile(port: number): Promise<void> {
 }
 
 function maintenancePidFilePath(port: number): string {
-  return path.join(process.cwd(), '..', '..', '.wb', `maintenance-${port}.pid`);
+  const rootDir = process.cwd().endsWith('packages/wb') ? path.resolve(process.cwd(), '../..') : process.cwd();
+  return path.join(rootDir, '.wb', `maintenance-${port}.pid`);
 }
 
 async function fetchStatus(port: number): Promise<number | undefined> {

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { getMaintenancePidFilePath } from '../src/commands/maintenance.js';
+
 describe('wb maintenance', () => {
   it('runs start in the foreground until SIGTERM', async () => {
     const port = await findAvailablePort();
@@ -202,7 +204,7 @@ async function removePidFile(port: number): Promise<void> {
 
 function maintenancePidFilePath(port: number): string {
   const rootDir = process.cwd().endsWith('packages/wb') ? path.resolve(process.cwd(), '../..') : process.cwd();
-  return path.join(rootDir, '.wb', `maintenance-${port}.pid`);
+  return getMaintenancePidFilePath(rootDir, port);
 }
 
 async function fetchStatus(port: number): Promise<number | undefined> {

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -1,13 +1,15 @@
 import childProcess from 'node:child_process';
 import http from 'node:http';
 import { once } from 'node:events';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 describe('wb maintenance', () => {
   it('runs start in the foreground until SIGTERM', async () => {
     const port = await findAvailablePort();
-    const maintenance = spawnWbMaintenance('start', port);
+    const maintenance = spawnWbMaintenance('start', port, ['--delay-ms', '0']);
 
     try {
       await waitForHttpStatus(port, 503);
@@ -17,23 +19,53 @@ describe('wb maintenance', () => {
     }
   }, 20_000);
 
+  it('stops delayed start before it starts listening', async () => {
+    const port = await findAvailablePort();
+    await removePidFile(port);
+    const maintenance = spawnWbMaintenance('start', port, ['--delay-ms', '10000']);
+
+    try {
+      await waitForPidFile(port);
+      const result = runWbMaintenanceStop(port);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(`Stopped maintenance server on port ${port}.`);
+      await waitForExit(maintenance);
+      await expect(fetchStatus(port)).resolves.toBeUndefined();
+    } finally {
+      terminateProcessGroup(maintenance);
+    }
+  }, 30_000);
+
+  it('does not start maintenance when the app already listens after the delay', async () => {
+    const port = await findAvailablePort();
+    await removePidFile(port);
+    const maintenance = spawnWbMaintenance('start', port, ['--delay-ms', '100']);
+    let server: childProcess.ChildProcess | undefined;
+
+    try {
+      await waitForPidFile(port);
+      server = spawnNodeServer(port);
+      await waitForHttpStatus(port, 200);
+      await waitForExit(maintenance);
+      await expect(fetchStatus(port)).resolves.toBe(200);
+    } finally {
+      terminateProcessGroup(maintenance);
+      if (server) {
+        terminateProcessGroup(server);
+      }
+    }
+  }, 30_000);
+
   it('stops a listener on the configured port without relying on a pid file', async () => {
     const port = await findAvailablePort();
+    await removePidFile(port);
     const server = spawnNodeServer(port);
 
     try {
       await waitForHttpStatus(port, 200);
 
-      const result = childProcess.spawnSync(
-        'yarn',
-        ['workspace', '@willbooster/wb', 'start', 'maintenance', 'stop', '--quiet-env'],
-        {
-          cwd: process.cwd(),
-          encoding: 'utf8',
-          env: { ...process.env, PORT: String(port), WB_ENV: 'development' },
-          timeout: 20_000,
-        }
-      );
+      const result = runWbMaintenanceStop(port);
 
       expect(result.status).toBe(0);
       expect(result.stdout).toContain(`Stopped maintenance server on port ${port}.`);
@@ -44,13 +76,30 @@ describe('wb maintenance', () => {
   }, 30_000);
 });
 
-function spawnWbMaintenance(action: 'start' | 'stop', port: number): childProcess.ChildProcess {
-  return childProcess.spawn('yarn', ['workspace', '@willbooster/wb', 'start', 'maintenance', action, '--quiet-env'], {
-    cwd: process.cwd(),
-    detached: true,
-    env: { ...process.env, PORT: String(port), WB_ENV: 'development' },
-    stdio: 'ignore',
-  });
+function spawnWbMaintenance(action: 'start' | 'stop', port: number, args: string[] = []): childProcess.ChildProcess {
+  return childProcess.spawn(
+    'yarn',
+    ['workspace', '@willbooster/wb', 'start', 'maintenance', action, '--quiet-env', ...args],
+    {
+      cwd: process.cwd(),
+      detached: true,
+      env: { ...process.env, PORT: String(port), WB_ENV: 'development' },
+      stdio: 'ignore',
+    }
+  );
+}
+
+function runWbMaintenanceStop(port: number): childProcess.SpawnSyncReturns<string> {
+  return childProcess.spawnSync(
+    'yarn',
+    ['workspace', '@willbooster/wb', 'start', 'maintenance', 'stop', '--quiet-env'],
+    {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: { ...process.env, PORT: String(port), WB_ENV: 'development' },
+      timeout: 20_000,
+    }
+  );
 }
 
 function spawnNodeServer(port: number): childProcess.ChildProcess {
@@ -130,6 +179,29 @@ async function waitForHttpStatus(port: number, expectedStatus: number): Promise<
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new Error(`Timed out waiting for HTTP ${expectedStatus} on port ${port}.`);
+}
+
+async function waitForPidFile(port: number): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  const pidFilePath = maintenancePidFilePath(port);
+  while (Date.now() < deadline) {
+    try {
+      await fs.access(pidFilePath);
+      return;
+    } catch {
+      // continue waiting
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${pidFilePath}.`);
+}
+
+async function removePidFile(port: number): Promise<void> {
+  await fs.rm(maintenancePidFilePath(port), { force: true });
+}
+
+function maintenancePidFilePath(port: number): string {
+  return path.join(process.cwd(), '..', '..', '.wb', `maintenance-${port}.pid`);
 }
 
 async function fetchStatus(port: number): Promise<number | undefined> {

--- a/packages/wb/test/maintenanceCommand.test.ts
+++ b/packages/wb/test/maintenanceCommand.test.ts
@@ -42,7 +42,7 @@ describe('wb maintenance', () => {
   it('does not start maintenance when the app already listens after the delay', async () => {
     const port = await findAvailablePort();
     await removePidFile(port);
-    const maintenance = spawnWbMaintenance('start', port, ['--delay-ms', '100']);
+    const maintenance = spawnWbMaintenance('start', port, ['--delay-ms', '2000']);
     let server: childProcess.ChildProcess | undefined;
 
     try {


### PR DESCRIPTION
## Summary
- delay `wb maintenance start` by default so short startup tasks do not briefly serve the maintenance page
- add `--delay-ms` to make the delay configurable
- record the maintenance process PID so `wb maintenance stop` can terminate a delayed startup before it begins listening
- treat `EADDRINUSE` after the delay as the app already owning the port, and skip starting maintenance

## Why Delay
- Without a delay, `wb maintenance start` can immediately serve the maintenance page even when the real application starts successfully a few seconds later.
- In that short window, users accessing `/` may receive a temporary maintenance page instead of the application.
- Search crawlers may also observe the maintenance response during short deployments, which creates an unnecessary SEO concern.
- Delaying startup avoids showing maintenance for fast/no-op startup tasks while still showing it for genuinely long startup work.

## Verification
- `yarn workspace @willbooster/wb test test/maintenanceCommand.test.ts`
- `yarn verify`
