### PR TITLE
feat: add setup-private-packages command

### DIFF
--- a/packages/wb/README.md
+++ b/packages/wb/README.md
@@ -25,6 +25,7 @@ Commands:
   wb retry [command] [args...]  Retry the given command until it succeeds
   wb setup                      Setup development environment. .env files are
                                 ignored.
+  wb setup-private-packages     Copy private git dependencies for Docker builds
   wb start [args..]             Start app
   wb test [targets...]          Test project. If you pass no arguments, it will
                                 run all tests.

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -24,7 +24,7 @@ const builder = {
   },
 } as const;
 
-export const setupPrivatePackagesCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> = {
+export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, InferredOptionTypes<typeof builder>> = {
   command: 'setup-private-packages',
   describe: 'Copy private git dependencies for Docker builds',
   builder,
@@ -69,6 +69,7 @@ async function collectPrivatePackages(
 
   for (let index = 0; index < packageNamesToCopy.length; index++) {
     const packageName = packageNamesToCopy[index];
+    if (!packageName) continue;
     if (copiedPackages.has(packageName)) continue;
 
     const privatePackage = buildPrivatePackage(rootDirPath, outDirPath, packageName);
@@ -126,7 +127,7 @@ async function replacePrivateGitDependencies(
   for (const privatePackage of copiedPackages.values()) {
     for (const packageJsonPath of await findPackageJsonPaths(privatePackage.targetDirPath)) {
       const packageJson = readPackageJson(packageJsonPath);
-      if (!replacePackageJsonDependencies(packageJson, copiedPackages)) continue;
+      if (!replacePackageJsonDependencies(packageJsonPath, packageJson, copiedPackages)) continue;
 
       await fs.promises.writeFile(packageJsonPath, `${JSON.stringify(packageJson, undefined, 2)}\n`, 'utf8');
       console.info(`Rewrote private dependencies in ${path.relative(outDirPath, packageJsonPath)}`);
@@ -135,6 +136,7 @@ async function replacePrivateGitDependencies(
 }
 
 function replacePackageJsonDependencies(
+  packageJsonPath: string,
   packageJson: PackageJson,
   copiedPackages: Map<string, PrivatePackage>
 ): boolean {
@@ -145,9 +147,10 @@ function replacePackageJsonDependencies(
 
     for (const [name, value] of Object.entries(dependencies)) {
       if (!isPrivateGitDependency(value)) continue;
-      if (!copiedPackages.has(name)) continue;
+      const targetPackage = copiedPackages.get(name);
+      if (!targetPackage) continue;
 
-      dependencies[name] = `file:../${toUnscopedPackageName(name)}`;
+      dependencies[name] = `file:${path.relative(path.dirname(packageJsonPath), targetPackage.targetDirPath)}`;
       changed = true;
     }
   }
@@ -157,7 +160,7 @@ function replacePackageJsonDependencies(
 async function findPackageJsonPaths(dirPath: string): Promise<string[]> {
   const packageJsonPaths: string[] = [];
   for (const dirent of await fs.promises.readdir(dirPath, { withFileTypes: true })) {
-    if (dirent.name === 'node_modules') continue;
+    if (dirent.name === 'node_modules' || dirent.name === '.git') continue;
 
     const childPath = path.join(dirPath, dirent.name);
     if (dirent.isDirectory()) {

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -36,6 +36,7 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     }
 
     const outDirPath = path.resolve(projects.root.dirPath, argv.outDir);
+    assertSubdirectory(projects.root.dirPath, outDirPath);
     const copiedPackages = await collectPrivatePackages(projects.root.dirPath, projects.root.packageJson, outDirPath);
 
     if (argv.dryRun) {
@@ -71,6 +72,7 @@ async function collectPrivatePackages(
   const copiedPackages = new Map<string, PrivatePackage>();
   // Start from the root package.json by design; workspace package dependencies are outside this command's target.
   const packageNamesToCopy = findPrivateGitDependencyNames(rootPackageJson);
+  const queuedPackageNames = new Set(packageNamesToCopy);
 
   for (let index = 0; index < packageNamesToCopy.length; index++) {
     const packageName = packageNamesToCopy[index];
@@ -83,7 +85,8 @@ async function collectPrivatePackages(
     for (const packageJsonPath of await findPackageJsonPaths(privatePackage.sourceDirPath)) {
       const packageJson = await readPackageJson(packageJsonPath);
       for (const nestedPackageName of findPrivateGitDependencyNames(packageJson)) {
-        if (!copiedPackages.has(nestedPackageName) && !packageNamesToCopy.includes(nestedPackageName)) {
+        if (!queuedPackageNames.has(nestedPackageName)) {
+          queuedPackageNames.add(nestedPackageName);
           packageNamesToCopy.push(nestedPackageName);
         }
       }
@@ -91,6 +94,14 @@ async function collectPrivatePackages(
   }
 
   return copiedPackages;
+}
+
+function assertSubdirectory(rootDirPath: string, outDirPath: string): void {
+  const relativePath = path.relative(rootDirPath, outDirPath);
+  if (relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)) return;
+
+  console.error(chalk.red(`Output directory must be a subdirectory of the project root: ${outDirPath}`));
+  process.exit(1);
 }
 
 function buildPrivatePackage(rootDirPath: string, outDirPath: string, packageName: string): PrivatePackage {

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -49,6 +49,10 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       await fs.promises.cp(privatePackage.sourceDirPath, privatePackage.targetDirPath, {
         recursive: true,
         force: true,
+        filter: (src) => {
+          const segments = path.relative(privatePackage.sourceDirPath, src).split(path.sep);
+          return !segments.includes('node_modules') && !segments.includes('.git');
+        },
       });
       console.info(
         `Copied ${privatePackage.name} to ${path.relative(projects.root.dirPath, privatePackage.targetDirPath)}`
@@ -65,6 +69,7 @@ async function collectPrivatePackages(
   outDirPath: string
 ): Promise<Map<string, PrivatePackage>> {
   const copiedPackages = new Map<string, PrivatePackage>();
+  // Start from the root package.json by design; workspace package dependencies are outside this command's target.
   const packageNamesToCopy = findPrivateGitDependencyNames(rootPackageJson);
 
   for (let index = 0; index < packageNamesToCopy.length; index++) {
@@ -76,7 +81,7 @@ async function collectPrivatePackages(
     copiedPackages.set(packageName, privatePackage);
 
     for (const packageJsonPath of await findPackageJsonPaths(privatePackage.sourceDirPath)) {
-      const packageJson = readPackageJson(packageJsonPath);
+      const packageJson = await readPackageJson(packageJsonPath);
       for (const nestedPackageName of findPrivateGitDependencyNames(packageJson)) {
         if (!copiedPackages.has(nestedPackageName) && !packageNamesToCopy.includes(nestedPackageName)) {
           packageNamesToCopy.push(nestedPackageName);
@@ -126,7 +131,7 @@ async function replacePrivateGitDependencies(
 ): Promise<void> {
   for (const privatePackage of copiedPackages.values()) {
     for (const packageJsonPath of await findPackageJsonPaths(privatePackage.targetDirPath)) {
-      const packageJson = readPackageJson(packageJsonPath);
+      const packageJson = await readPackageJson(packageJsonPath);
       if (!replacePackageJsonDependencies(packageJsonPath, packageJson, copiedPackages)) continue;
 
       await fs.promises.writeFile(packageJsonPath, `${JSON.stringify(packageJson, undefined, 2)}\n`, 'utf8');
@@ -174,8 +179,8 @@ async function findPackageJsonPaths(dirPath: string): Promise<string[]> {
   return packageJsonPaths;
 }
 
-function readPackageJson(packageJsonPath: string): PackageJson {
-  return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
+async function readPackageJson(packageJsonPath: string): Promise<PackageJson> {
+  return JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf8')) as PackageJson;
 }
 
 function isPrivateGitDependency(value: unknown): value is string {

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -1,0 +1,192 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import chalk from 'chalk';
+import type { PackageJson } from 'type-fest';
+import type { CommandModule, InferredOptionTypes } from 'yargs';
+
+import { findRootAndSelfProjects } from '../project.js';
+
+interface PrivatePackage {
+  name: string;
+  sourceDirPath: string;
+  targetDirPath: string;
+}
+
+const dependencyKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
+const privateGitDependencyPattern = /^git@github\.com:(?:WillBooster|WillBoosterLab)\/[^/#]+(?:\.git)?(?:#.*)?$/;
+
+const builder = {
+  'out-dir': {
+    description: 'Directory to copy private packages into',
+    type: 'string',
+    default: '@willbooster',
+  },
+} as const;
+
+export const setupPrivatePackagesCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> = {
+  command: 'setup-private-packages',
+  describe: 'Copy private git dependencies for Docker builds',
+  builder,
+  async handler(argv) {
+    const projects = findRootAndSelfProjects(argv, false);
+    if (!projects) {
+      console.error(chalk.red('No project found.'));
+      process.exit(1);
+    }
+
+    const outDirPath = path.resolve(projects.root.dirPath, argv.outDir);
+    const copiedPackages = await collectPrivatePackages(projects.root.dirPath, projects.root.packageJson, outDirPath);
+
+    if (argv.dryRun) {
+      printDryRunResult(outDirPath, copiedPackages);
+      return;
+    }
+
+    await fs.promises.rm(outDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(outDirPath, { recursive: true });
+    for (const privatePackage of copiedPackages.values()) {
+      await fs.promises.cp(privatePackage.sourceDirPath, privatePackage.targetDirPath, {
+        recursive: true,
+        force: true,
+      });
+      console.info(
+        `Copied ${privatePackage.name} to ${path.relative(projects.root.dirPath, privatePackage.targetDirPath)}`
+      );
+    }
+
+    await replacePrivateGitDependencies(outDirPath, copiedPackages);
+  },
+};
+
+async function collectPrivatePackages(
+  rootDirPath: string,
+  rootPackageJson: PackageJson,
+  outDirPath: string
+): Promise<Map<string, PrivatePackage>> {
+  const copiedPackages = new Map<string, PrivatePackage>();
+  const packageNamesToCopy = findPrivateGitDependencyNames(rootPackageJson);
+
+  for (let index = 0; index < packageNamesToCopy.length; index++) {
+    const packageName = packageNamesToCopy[index];
+    if (copiedPackages.has(packageName)) continue;
+
+    const privatePackage = buildPrivatePackage(rootDirPath, outDirPath, packageName);
+    copiedPackages.set(packageName, privatePackage);
+
+    for (const packageJsonPath of await findPackageJsonPaths(privatePackage.sourceDirPath)) {
+      const packageJson = readPackageJson(packageJsonPath);
+      for (const nestedPackageName of findPrivateGitDependencyNames(packageJson)) {
+        if (!copiedPackages.has(nestedPackageName) && !packageNamesToCopy.includes(nestedPackageName)) {
+          packageNamesToCopy.push(nestedPackageName);
+        }
+      }
+    }
+  }
+
+  return copiedPackages;
+}
+
+function buildPrivatePackage(rootDirPath: string, outDirPath: string, packageName: string): PrivatePackage {
+  const unscopedPackageName = toUnscopedPackageName(packageName);
+  const sourceDirPath = path.join(rootDirPath, 'node_modules', '@willbooster', unscopedPackageName);
+  if (!fs.existsSync(path.join(sourceDirPath, 'package.json'))) {
+    throw new Error(`Private package is not installed: ${packageName} (${sourceDirPath})`);
+  }
+
+  return {
+    name: packageName,
+    sourceDirPath,
+    targetDirPath: path.join(outDirPath, unscopedPackageName),
+  };
+}
+
+function findPrivateGitDependencyNames(packageJson: PackageJson): string[] {
+  const packageNames: string[] = [];
+  for (const key of dependencyKeys) {
+    const dependencies = packageJson[key];
+    if (!dependencies) continue;
+
+    for (const [name, value] of Object.entries(dependencies)) {
+      if (!isPrivateGitDependency(value)) continue;
+
+      if (!name.startsWith('@willbooster/')) {
+        throw new Error(`Private git dependency must be an @willbooster package: ${name}`);
+      }
+      packageNames.push(name);
+    }
+  }
+  return [...new Set(packageNames)];
+}
+
+async function replacePrivateGitDependencies(
+  outDirPath: string,
+  copiedPackages: Map<string, PrivatePackage>
+): Promise<void> {
+  for (const privatePackage of copiedPackages.values()) {
+    for (const packageJsonPath of await findPackageJsonPaths(privatePackage.targetDirPath)) {
+      const packageJson = readPackageJson(packageJsonPath);
+      if (!replacePackageJsonDependencies(packageJson, copiedPackages)) continue;
+
+      await fs.promises.writeFile(packageJsonPath, `${JSON.stringify(packageJson, undefined, 2)}\n`, 'utf8');
+      console.info(`Rewrote private dependencies in ${path.relative(outDirPath, packageJsonPath)}`);
+    }
+  }
+}
+
+function replacePackageJsonDependencies(
+  packageJson: PackageJson,
+  copiedPackages: Map<string, PrivatePackage>
+): boolean {
+  let changed = false;
+  for (const key of dependencyKeys) {
+    const dependencies = packageJson[key];
+    if (!dependencies) continue;
+
+    for (const [name, value] of Object.entries(dependencies)) {
+      if (!isPrivateGitDependency(value)) continue;
+      if (!copiedPackages.has(name)) continue;
+
+      dependencies[name] = `file:../${toUnscopedPackageName(name)}`;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+async function findPackageJsonPaths(dirPath: string): Promise<string[]> {
+  const packageJsonPaths: string[] = [];
+  for (const dirent of await fs.promises.readdir(dirPath, { withFileTypes: true })) {
+    if (dirent.name === 'node_modules') continue;
+
+    const childPath = path.join(dirPath, dirent.name);
+    if (dirent.isDirectory()) {
+      packageJsonPaths.push(...(await findPackageJsonPaths(childPath)));
+      continue;
+    }
+    if (dirent.isFile() && dirent.name === 'package.json') {
+      packageJsonPaths.push(childPath);
+    }
+  }
+  return packageJsonPaths;
+}
+
+function readPackageJson(packageJsonPath: string): PackageJson {
+  return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
+}
+
+function isPrivateGitDependency(value: unknown): value is string {
+  return typeof value === 'string' && privateGitDependencyPattern.test(value);
+}
+
+function toUnscopedPackageName(packageName: string): string {
+  return packageName.replace(/^@willbooster\//, '');
+}
+
+function printDryRunResult(outDirPath: string, copiedPackages: Map<string, PrivatePackage>): void {
+  console.info(`[dry-run] Would recreate ${outDirPath}`);
+  for (const privatePackage of copiedPackages.values()) {
+    console.info(`[dry-run] Would copy ${privatePackage.name}: ${privatePackage.sourceDirPath}`);
+  }
+  console.info(`[dry-run] Would rewrite copied private git dependencies to file:../<name>`);
+}

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -15,6 +15,7 @@ import { optimizeForDockerBuildCommand } from './commands/optimizeForDockerBuild
 import { prismaCommand } from './commands/prisma.js';
 import { retryCommand } from './commands/retry.js';
 import { setupCommand } from './commands/setup.js';
+import { setupPrivatePackagesCommand } from './commands/setupPrivatePackages.js';
 import { startCommand } from './commands/start.js';
 import { testCommand } from './commands/test.js';
 import { testOnCiCommand } from './commands/testOnCi.js';
@@ -46,6 +47,7 @@ await yargs(hideBin(process.argv))
   .command(prismaCommand)
   .command(retryCommand)
   .command(setupCommand)
+  .command(setupPrivatePackagesCommand)
   .command(startCommand)
   .command(testCommand)
   .command(testOnCiCommand)


### PR DESCRIPTION
## Summary

- Add `wb setup-private-packages` to copy WillBooster private git dependencies into a Docker build context.
- Resolve nested private dependencies to a fixed point by scanning copied package trees and rewrite copied package references to local `file:` paths.
- Add `--out-dir` and existing `--dry-run` support.
- Exclude nested `node_modules` and `.git` from copied packages, validate `--out-dir`, and keep nested file references relative to each rewritten `package.json`.

## Why

- Docker builds should not need SSH access to fetch private git dependencies.
- The command prepares the private package tree expected by `wb optimizeForDockerBuild --outside` generated package metadata.

## Testing

- `yarn verify`
- `yarn workspace @willbooster/wb start -- setup-private-packages --dry-run`
