### PR TITLE
feat: setup GitHub main ruleset in wbfy

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -236,7 +236,9 @@ async function applyPackageJsonConventions(
     devDependencies.push(lefthookDependency);
 
     if (config.depending.semanticRelease) {
-      if (
+      if (doesReleaseScriptInstallSemanticRelease(jsonObj.scripts.release)) {
+        delete jsonObj.devDependencies['semantic-release'];
+      } else if (
         !jsonObj.devDependencies['semantic-release'] &&
         !jsonObj.devDependencies['multi-semantic-release'] &&
         !jsonObj.devDependencies['@qiwi/multi-semantic-release']
@@ -333,6 +335,11 @@ async function applyPackageJsonConventions(
   }
 
   return { dependencies, devDependencies, pythonDevDependencies };
+}
+
+function doesReleaseScriptInstallSemanticRelease(script: unknown): boolean {
+  if (typeof script !== 'string') return false;
+  return /\b(?:bunx|npx|pnpm\s+dlx|yarn\s+dlx)\s+semantic-release(?:@\S+)?\b/u.test(script);
 }
 
 function moveManagedToolDependenciesToDevDependencies(jsonObj: WritablePackageJson): void {

--- a/packages/wbfy/src/github/ruleset.ts
+++ b/packages/wbfy/src/github/ruleset.ts
@@ -196,6 +196,7 @@ async function findRepositoryRuleset(
 }
 
 function isGitHubPermissionOrVisibilityError(error: unknown): boolean {
-  if (!error || typeof error !== 'object' || !('status' in error)) return false;
-  return error.status === 401 || error.status === 403 || error.status === 404;
+  if (!error || typeof error !== 'object') return false;
+  const status = (error as { status?: number }).status;
+  return status === 401 || status === 403 || status === 404;
 }

--- a/packages/wbfy/src/github/ruleset.ts
+++ b/packages/wbfy/src/github/ruleset.ts
@@ -120,7 +120,7 @@ export async function setupRepositoryRulesets(config: PackageConfig): Promise<vo
   return logger.functionIgnoringException('setupRepositoryRulesets', async () => {
     const [owner, repo] = gitHubUtil.getOrgAndName(config.repository ?? '');
     if (!owner || !repo) return;
-    if (owner !== 'WillBooster' && owner !== 'WillBoosterLab') return;
+    if (owner !== 'WillBooster') return;
     if (!hasGitHubToken(owner)) return;
 
     const octokit = getOctokit(owner);

--- a/packages/wbfy/src/github/ruleset.ts
+++ b/packages/wbfy/src/github/ruleset.ts
@@ -1,0 +1,201 @@
+import type { Octokit } from '@octokit/core';
+import { withRetry } from '@willbooster/shared-lib/src';
+
+import { logger } from '../logger.js';
+import type { PackageConfig } from '../packageConfig.js';
+import { getOctokit, gitHubUtil, hasGitHubToken } from '../utils/githubUtil.js';
+
+interface RepositoryRulesetPayload {
+  name: string;
+  target: 'branch';
+  enforcement: 'active';
+  conditions: {
+    ref_name: {
+      include: string[];
+      exclude: string[];
+    };
+  };
+  rules: (
+    | {
+        type: 'deletion' | 'non_fast_forward';
+      }
+    | {
+        type: 'required_status_checks';
+        parameters: {
+          strict_required_status_checks_policy: boolean;
+          do_not_enforce_on_create: boolean;
+          required_status_checks: {
+            context: string;
+            integration_id: number;
+          }[];
+        };
+      }
+    | {
+        type: 'pull_request';
+        parameters: {
+          required_approving_review_count: number;
+          dismiss_stale_reviews_on_push: boolean;
+          required_reviewers: [];
+          require_code_owner_review: boolean;
+          require_last_push_approval: boolean;
+          required_review_thread_resolution: boolean;
+          allowed_merge_methods: ['squash'];
+        };
+      }
+  )[];
+  bypass_actors: {
+    actor_id: number;
+    actor_type: 'Team';
+    bypass_mode: 'pull_request';
+  }[];
+}
+
+interface RepositoryRulesetSummary {
+  id?: number;
+  name?: string;
+  source_type?: string;
+}
+
+const GITHUB_API_VERSION_HEADER = {
+  'X-GitHub-Api-Version': '2022-11-28',
+} as const;
+
+const PROTECT_MAIN_RULESET: RepositoryRulesetPayload = {
+  name: 'Protect main',
+  target: 'branch',
+  enforcement: 'active',
+  conditions: {
+    ref_name: {
+      exclude: [],
+      include: ['~DEFAULT_BRANCH'],
+    },
+  },
+  rules: [
+    {
+      type: 'deletion',
+    },
+    {
+      type: 'required_status_checks',
+      parameters: {
+        strict_required_status_checks_policy: false,
+        do_not_enforce_on_create: true,
+        required_status_checks: [
+          {
+            context: 'test / test',
+            integration_id: 15_368,
+          },
+          {
+            context: 'semantic-pr / semantic-pr',
+            integration_id: 15_368,
+          },
+        ],
+      },
+    },
+    {
+      type: 'non_fast_forward',
+    },
+    {
+      type: 'pull_request',
+      parameters: {
+        required_approving_review_count: 0,
+        dismiss_stale_reviews_on_push: false,
+        required_reviewers: [],
+        require_code_owner_review: false,
+        require_last_push_approval: false,
+        required_review_thread_resolution: false,
+        allowed_merge_methods: ['squash'],
+      },
+    },
+  ],
+  bypass_actors: [
+    {
+      actor_id: 17_777_495,
+      actor_type: 'Team',
+      bypass_mode: 'pull_request',
+    },
+  ],
+};
+
+export async function setupRepositoryRulesets(config: PackageConfig): Promise<void> {
+  return logger.functionIgnoringException('setupRepositoryRulesets', async () => {
+    const [owner, repo] = gitHubUtil.getOrgAndName(config.repository ?? '');
+    if (!owner || !repo) return;
+    if (owner !== 'WillBooster' && owner !== 'WillBoosterLab') return;
+    if (!hasGitHubToken(owner)) return;
+
+    const octokit = getOctokit(owner);
+
+    try {
+      await upsertProtectMainRuleset(octokit, owner, repo);
+    } catch (error) {
+      if (!isGitHubPermissionOrVisibilityError(error)) throw error;
+
+      // Repository rulesets require administration permission, which local runs
+      // may not have even when file-generation and pushes are allowed.
+      console.warn('Skip setupRepositoryRulesets due to:', (error as Error | undefined)?.stack ?? error);
+    }
+  });
+}
+
+async function upsertProtectMainRuleset(octokit: Octokit, owner: string, repo: string): Promise<void> {
+  const existingRuleset = await findRepositoryRuleset(octokit, owner, repo, PROTECT_MAIN_RULESET.name);
+
+  const existingRulesetId = existingRuleset?.id;
+  if (existingRulesetId) {
+    await withRetry(
+      () =>
+        octokit.request('PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}', {
+          owner,
+          repo,
+          ruleset_id: existingRulesetId,
+          ...PROTECT_MAIN_RULESET,
+          headers: GITHUB_API_VERSION_HEADER,
+        }),
+      {
+        shouldRetry: (error) => !isGitHubPermissionOrVisibilityError(error),
+      }
+    );
+    return;
+  }
+
+  await withRetry(
+    () =>
+      octokit.request('POST /repos/{owner}/{repo}/rulesets', {
+        owner,
+        repo,
+        ...PROTECT_MAIN_RULESET,
+        headers: GITHUB_API_VERSION_HEADER,
+      }),
+    {
+      shouldRetry: (error) => !isGitHubPermissionOrVisibilityError(error),
+    }
+  );
+}
+
+async function findRepositoryRuleset(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  rulesetName: string
+): Promise<RepositoryRulesetSummary | undefined> {
+  const response = await withRetry(
+    () =>
+      octokit.request('GET /repos/{owner}/{repo}/rulesets', {
+        owner,
+        repo,
+        includes_parents: false,
+        targets: 'branch',
+        headers: GITHUB_API_VERSION_HEADER,
+      }),
+    {
+      shouldRetry: (error) => !isGitHubPermissionOrVisibilityError(error),
+    }
+  );
+  const rulesets = response.data as RepositoryRulesetSummary[];
+  return rulesets.find((ruleset) => ruleset.name === rulesetName && ruleset.source_type === 'Repository');
+}
+
+function isGitHubPermissionOrVisibilityError(error: unknown): boolean {
+  if (!error || typeof error !== 'object' || !('status' in error)) return false;
+  return error.status === 401 || error.status === 403 || error.status === 404;
+}

--- a/packages/wbfy/src/github/ruleset.ts
+++ b/packages/wbfy/src/github/ruleset.ts
@@ -139,33 +139,28 @@ export async function setupRepositoryRulesets(config: PackageConfig): Promise<vo
 
 async function upsertProtectMainRuleset(octokit: Octokit, owner: string, repo: string): Promise<void> {
   const existingRuleset = await findRepositoryRuleset(octokit, owner, repo, PROTECT_MAIN_RULESET.name);
-
   const existingRulesetId = existingRuleset?.id;
-  if (existingRulesetId) {
-    await withRetry(
-      () =>
-        octokit.request('PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}', {
+
+  await withRetry(
+    async () => {
+      if (existingRulesetId) {
+        await octokit.request('PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}', {
           owner,
           repo,
           ruleset_id: existingRulesetId,
           ...PROTECT_MAIN_RULESET,
           headers: GITHUB_API_VERSION_HEADER,
-        }),
-      {
-        shouldRetry: (error) => !isGitHubPermissionOrVisibilityError(error),
+        });
+        return;
       }
-    );
-    return;
-  }
 
-  await withRetry(
-    () =>
-      octokit.request('POST /repos/{owner}/{repo}/rulesets', {
+      await octokit.request('POST /repos/{owner}/{repo}/rulesets', {
         owner,
         repo,
         ...PROTECT_MAIN_RULESET,
         headers: GITHUB_API_VERSION_HEADER,
-      }),
+      });
+    },
     {
       shouldRetry: (error) => !isGitHubPermissionOrVisibilityError(error),
     }
@@ -191,7 +186,8 @@ async function findRepositoryRuleset(
       shouldRetry: (error) => !isGitHubPermissionOrVisibilityError(error),
     }
   );
-  const rulesets = response.data as RepositoryRulesetSummary[];
+  const rulesets = response.data;
+  if (!Array.isArray(rulesets)) return;
   return rulesets.find((ruleset) => ruleset.name === rulesetName && ruleset.source_type === 'Repository');
 }
 

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -37,6 +37,7 @@ import { generateVscodeSettings } from './generators/vscodeSettings.js';
 import { generateWorkflows, isReusableWorkflowsRepo } from './generators/workflow.js';
 import { generateYarnrcYml } from './generators/yarnrc.js';
 import { setupLabels } from './github/label.js';
+import { setupRepositoryRulesets } from './github/ruleset.js';
 import { setupSecrets } from './github/secret.js';
 import { setupGitHubSettings } from './github/settings.js';
 import { generateGitHubTemplates } from './github/template.js';
@@ -141,6 +142,7 @@ async function main(): Promise<void> {
       generateReleaserc(rootConfig),
       ...(shouldRunWorkflows ? [generateWorkflows(rootConfig)] : []),
       setupLabels(rootConfig),
+      setupRepositoryRulesets(rootConfig),
       setupSecrets(rootConfig),
       setupGitHubSettings(rootConfig),
       generateLefthookUpdatingPackageJson(rootConfig),


### PR DESCRIPTION
## Summary

- Add a wbfy GitHub setup step that upserts the repository-level `Protect main` branch ruleset for `WillBooster` repositories only.
- Configure the ruleset from the exported `/Users/exkazuu/Downloads/Protect main.json` shape: deletion protection, required `test / test` and `semantic-pr / semantic-pr` checks, non-fast-forward protection, squash-only PR merges, and the WillBooster bypass team.
- Keep repository ruleset setup idempotent by updating an existing repository-sourced `Protect main` ruleset instead of creating duplicates.
- Respect explicit package-manager semantic-release scripts such as `bunx semantic-release@25.0.3`, so wbfy does not force a local `semantic-release` devDependency and large lockfile expansion.

## Why

- wbfy already standardizes GitHub repository settings, labels, secrets, and templates for WillBooster repositories.
- Branch protection should be converged through the same automation path for WillBooster repositories.
- The ruleset is intentionally not applied to `WillBoosterLab` repositories.
- The semantic-release script handling was needed after validating the new wbfy behavior on `WillBooster/ranked-aa`, where a reusable release workflow can use an explicit script without adding semantic-release to the repo lockfile.

## Testing

- `yarn workspace @willbooster/wbfy typecheck`
- `yarn workspace @willbooster/wbfy verify`
- `yarn verify`
- Ran local updated wbfy against `/Users/exkazuu/ghq/github.com/WillBooster/ranked-aa`
- Confirmed `WillBooster/ranked-aa` has repository ruleset `Protect main` with `enforcement: active`
- Confirmed PR CI is green for this PR and `WillBooster/ranked-aa#1`
