### PR TITLE
fix: avoid rewriting oxlint self config import

### DIFF
--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -67,6 +67,7 @@ function replaceLegacyConfigReferences(content: string): string {
 
 function getConfigContent(config: PackageConfig): string {
   const isRootConfig = config.isRoot;
+  const oxlintBaseConfigModule = getOxlintBaseConfigModule(config);
 
   // Do not collapse this to a static import for every package. CommonJS packages
   // type-check auto-discovered oxlint.config.ts as CommonJS, so importing the ESM
@@ -88,13 +89,17 @@ ${managedConfigBlocks.getBlock('export', 'module.exports = oxlintResolvedConfig;
 
   return `${managedConfigBlocks.getBlock(
     'base',
-    `import oxlintBaseConfig from '@willbooster/oxlint-config';
+    `import oxlintBaseConfig from '${oxlintBaseConfigModule}';
 
 ${getResolvedConfigContent('oxlintBaseConfig', isRootConfig)}`
   )}
 
 ${managedConfigBlocks.getBlock('export', 'export default oxlintResolvedConfig;')}
 `;
+}
+
+function getOxlintBaseConfigModule(config: PackageConfig): string {
+  return config.packageJson?.name === '@willbooster/oxlint-config' ? './config.mjs' : '@willbooster/oxlint-config';
 }
 
 function getResolvedConfigContent(baseConfigName: string, isRootConfig: boolean): string {

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -62,7 +62,7 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
 }
 
 function replaceLegacyConfigReferences(content: string): string {
-  return content.replaceAll('config.', 'oxlintResolvedConfig.');
+  return content.replaceAll(/(?<![./])\bconfig\./gu, 'oxlintResolvedConfig.');
 }
 
 function getConfigContent(config: PackageConfig): string {


### PR DESCRIPTION
## Summary

- Keep `@willbooster/oxlint-config` package-local `oxlint.config.ts` imports pointed at `./config.mjs`.
- Continue generating `@willbooster/oxlint-config` imports for other packages.

## Why

- `willbooster-configs` publishes `@willbooster/oxlint-config` itself, so rewriting that package's self-lint config to import `@willbooster/oxlint-config` can reintroduce a self-reference that release tooling treats as a package graph edge.
- The package should consume its local config file when linting itself, while downstream packages should consume the published package name.

## Testing

- `yarn verify`
- pre-push hook
