### PR TITLE
fix: update agent workflows bun exclude

### DIFF
--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -20,6 +20,7 @@ interface BunfigToml {
 const minimumReleaseAgeExcludes = [
   // ---------- START: We believe our packages are safe ----------
   '@exercode/problem-utils',
+  '@willbooster/agent-skills',
   '@willbooster/agent-workflows',
   '@willbooster/babel-configs',
   '@willbooster/monaco-loader',

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -20,7 +20,7 @@ interface BunfigToml {
 const minimumReleaseAgeExcludes = [
   // ---------- START: We believe our packages are safe ----------
   '@exercode/problem-utils',
-  '@willbooster/agent-skills',
+  '@willbooster/agent-workflows',
   '@willbooster/babel-configs',
   '@willbooster/monaco-loader',
   '@willbooster/monaco-react',


### PR DESCRIPTION
## Summary

- Update the wbfy generated `bunfig.toml` minimum release age exclude list from `@willbooster/agent-skills` to `@willbooster/agent-workflows`.
- Rebuilt `@willbooster/wbfy` to confirm the generated bundle already reflects the source change or has no tracked delta.

## Why

- `agent-skills` has been merged into `agent-workflows`, so generated Bun projects should exclude the unified package from the 5-day minimum release age window.

## Testing

- `yarn workspace @willbooster/wbfy build`
- `yarn verify`
