### PR TITLE
fix: ignore antigravity cli artifacts

### DIFF
--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -14,6 +14,7 @@ const defaultNames = ['windows', 'macos', 'linux', 'jetbrains', 'visualstudiocod
 
 const commonContent = `
 !.keep
+.antigravitycli/
 .aider*
 .env.production
 */mount/*.hash

--- a/packages/wbfy/src/utils/globUtil.ts
+++ b/packages/wbfy/src/utils/globUtil.ts
@@ -1,5 +1,6 @@
 export const globIgnore = [
   '**/node_modules/**',
+  '**/.antigravitycli/**',
   '**/.venv/**',
   '**/test-fixtures/**',
   '**/test/fixtures/**',


### PR DESCRIPTION
## Summary

- Add `.antigravitycli/` to wbfy's common generated `.gitignore` entries.
- Exclude `.antigravitycli` directories from wbfy's internal fast-glob scans.

## Why

- `.antigravitycli/` contains local Antigravity CLI artifacts and should be ignored consistently by generated ignore files and by wbfy's repository scans.

## Testing

- `yarn verify`
- GitHub Actions passed for commit `9d92ac7`
