### PR TITLE
fix: print lint warnings during verify

### DIFF
--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -9,7 +9,7 @@ import { findDescendantProjects } from '../project.js';
 import type { BufferedRunResult } from '../scripts/run.js';
 import { normalizeScript, runWithSpawnInParallel, runWithSpawnInParallelBuffered } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
-import { printBufferedOutput } from '../utils/output.js';
+import { printBufferedOutput, shouldPrintBufferedOutput } from '../utils/output.js';
 import { buildShellCommand } from '../utils/shell.js';
 
 const builder = {
@@ -356,7 +356,9 @@ function printSilentLintOutputs(
   argv: Pick<LintCommandArgv, 'printAllOutput' | 'silent'>
 ): void {
   const printableResults =
-    argv.silent && !argv.printAllOutput ? results.filter((result) => result.exitCode !== 0) : results;
+    argv.silent && !argv.printAllOutput
+      ? results.filter((result) => 'output' in result && shouldPrintBufferedOutput(result.exitCode, result.output))
+      : results;
   if (printableResults.length === 0) return;
 
   for (const result of printableResults) {

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -68,8 +68,6 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
         _: ['lint'],
         fix: true,
         format: true,
-        printAllOutput: true,
-        quiet: true,
         silent: true,
       } as unknown as LintCommandArgv),
     { silent: true }


### PR DESCRIPTION
## Summary

- Keep `wb verify` and `wb verify-full` quiet for successful commands unless lint output contains warnings.
- Stop invoking lint in quiet mode from verify so Oxlint warning diagnostics can be surfaced.

## Why

- `wb verify` previously reported warning counts without the warning details, making successful lint warnings hard to address.
- Reusing the existing buffered-output warning detector preserves compact output while still showing actionable lint diagnostics.

## Testing

- `yarn verify`
- `yarn workspace @willbooster/wb typecheck`
- `yarn workspace @willbooster/wb start --working-dir "$PWD" verify`
- Manual silent lint warning probe with `yarn workspace @willbooster/wb start --working-dir "$PWD" lint packages/wb/src/verifyWarningProbe.ts --silent`
- Compared before/after `wb verify` output on `/Users/exkazuu/ghq/github.com/WillBoosterLab/exercode`
