### PR TITLE
docs: clarify oxlint ignore guidance

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -69,7 +69,7 @@ function generateAgentInstruction(
   - Fix the actual root cause instead of applying workarounds.
 - After making code changes, run \`${packageManager} verify-full\` to execute all tests (takes up to 1 hour), or \`${packageManager} verify\` for only type checking and linting (takes up to 10 minutes).
   - If you are confident that your changes will not break any tests, you may use \`verify\`.
-  - Use \`oxlint\` ignore comments with reasons (e.g., \`// oxlint-disable-next-line <rule> -- <reason>\`) if lint errors or warnings cannot be fixed (e.g., prisma requires null values which are disallowed).
+  - Use \`oxlint\` ignore comments with reasons (e.g., \`// oxlint-disable-next-line <rule> -- <reason>\`) if lint errors or warnings cannot be fixed (e.g., Prisma requires \`null\`).
 - Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via \`gh\`.
   - Follow the conventional commits; your commit message should start with \`feat:\`, \`fix:\`, etc.
   - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -69,7 +69,7 @@ function generateAgentInstruction(
   - Fix the actual root cause instead of applying workarounds.
 - After making code changes, run \`${packageManager} verify-full\` to execute all tests (takes up to 1 hour), or \`${packageManager} verify\` for only type checking and linting (takes up to 10 minutes).
   - If you are confident that your changes will not break any tests, you may use \`verify\`.
-  - Use \`oxlint\` ignore comments with reasons (e.g., \`// oxlint-disable-next-line <rule> -- <reason>\`) if lint errors or warnings cannot be fixed.
+  - Use \`oxlint\` ignore comments with reasons (e.g., \`// oxlint-disable-next-line <rule> -- <reason>\`) if lint errors or warnings cannot be fixed (e.g., prisma requires null values which are disallowed).
 - Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via \`gh\`.
   - Follow the conventional commits; your commit message should start with \`feat:\`, \`fix:\`, etc.
   - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.


### PR DESCRIPTION
## Customer Summary

- Clarifies generated agent instructions for cases where `oxlint` ignore comments are acceptable.
- Makes it explicit that unavoidable library/API requirements, such as Prisma requiring `null`, can justify an ignore comment with a reason.
- No runtime behavior, compatibility, or migration impact.

## Technical Summary

- Updates `packages/wbfy/src/generators/agents.ts` so generated AGENTS.md guidance includes a concrete Prisma `null` example.
- Scope is limited to generated instruction text.
- No dependency, configuration, or architecture changes.

## Why

- Agents need clear guidance for rare cases where lint warnings cannot be fixed directly.
- A concrete example reduces ambiguity while preserving the requirement to document the reason for each ignore.

## Testing

- `yarn verify`
- Pre-commit hook ran `oxfmt` and `oxlint` for the changed file.
- Pre-push hook ran package `oxlint` checks.
