### PR TITLE
fix: preserve Verdaccio npm token in wbfy

### DIFF
--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -360,8 +360,10 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
 function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   job.with ??= {};
   job.secrets ??= {};
-  // Use trusted publishing instead of NPM_TOKEN
-  delete job.secrets.NPM_TOKEN;
+  // Public npm releases use trusted publishing, but private Verdaccio releases still require NPM_TOKEN.
+  if (kind === 'release' && config.isPublicRepo) {
+    delete job.secrets.NPM_TOKEN;
+  }
 
   if (kind === 'test' || kind === 'release') {
     job.secrets.GH_TOKEN = '${{ secrets.GITHUB_TOKEN }}';


### PR DESCRIPTION
## Summary

- Keep `NPM_TOKEN` when wbfy normalizes private release workflows.
- Continue removing `NPM_TOKEN` only for public release workflows that use npm trusted publishing.

## Why

- Private Verdaccio releases still require an explicit npm token.
- The previous unconditional deletion broke repositories publishing to the private Verdaccio registry.

## Testing

- `rtk err yarn verify`
