### PR TITLE
fix: preserve npm token for private repos

### DIFF
--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -360,8 +360,10 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
 function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   job.with ??= {};
   job.secrets ??= {};
-  // Use trusted publishing instead of NPM_TOKEN
-  delete job.secrets.NPM_TOKEN;
+  if (config.isPublicRepo) {
+    // Private registries such as Verdaccio still require NPM_TOKEN.
+    delete job.secrets.NPM_TOKEN;
+  }
 
   if (kind === 'test' || kind === 'release') {
     job.secrets.GH_TOKEN = '${{ secrets.GITHUB_TOKEN }}';

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -360,10 +360,6 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
 function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   job.with ??= {};
   job.secrets ??= {};
-  if (config.isPublicRepo) {
-    // Private registries such as Verdaccio still require NPM_TOKEN.
-    delete job.secrets.NPM_TOKEN;
-  }
 
   if (kind === 'test' || kind === 'release') {
     job.secrets.GH_TOKEN = '${{ secrets.GITHUB_TOKEN }}';


### PR DESCRIPTION
## Summary
- preserve `NPM_TOKEN` in reusable release workflows for private repositories
- continue removing `NPM_TOKEN` for public repositories that can use trusted publishing

## Verification
- `yarn verify`
