### PR TITLE
fix: support drizzle litestream config generation

### DIFF
--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -63,6 +63,11 @@ const createLitestreamConfigCommand: CommandModule<unknown, InferredOptionTypes<
   builder,
   async handler(argv) {
     const allProjects = await findDatabaseOrmProjects(argv);
+    if (allProjects.length > 1) {
+      throw new Error(
+        'Creating Litestream configuration for multiple projects at once is not supported because they would overwrite each other.'
+      );
+    }
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db create-litestream-config', allProjects)) {
       createLitestreamConfig(project, orm);
     }

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -353,7 +353,9 @@ function getFileDatabaseUrlPath(project: Project): string | undefined {
   const dbUrl = project.env.DATABASE_URL;
   if (!dbUrl?.startsWith('file:')) return;
 
-  return dbUrl.slice('file:'.length).replace(/[?#].*$/, '') || undefined;
+  const rawPath = dbUrl.slice('file:'.length).replace(/[?#].*$/, '');
+  const normalizedPath = rawPath.startsWith('//') ? rawPath.slice(2) : rawPath;
+  return normalizedPath || undefined;
 }
 
 interface DatabaseOrmProject {

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
 import type { DatabaseOrm, Project } from '../project.js';
-import { findDescendantProjects, isProjectEnvironment } from '../project.js';
+import { findDescendantProjects, getFileDatabaseUrlPath, isProjectEnvironment } from '../project.js';
 import { drizzleScripts } from '../scripts/drizzleScripts.js';
 import { prismaScripts } from '../scripts/prismaScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
@@ -347,15 +347,6 @@ function getLitestreamDbPath(project: Project, orm: DatabaseOrm): string {
     throw new Error('wb db create-litestream-config for Drizzle requires DATABASE_PATH or file: DATABASE_URL.');
   }
   return dbPath;
-}
-
-function getFileDatabaseUrlPath(project: Project): string | undefined {
-  const dbUrl = project.env.DATABASE_URL;
-  if (!dbUrl?.startsWith('file:')) return;
-
-  const rawPath = dbUrl.slice('file:'.length).replace(/[?#].*$/, '');
-  const normalizedPath = rawPath.startsWith('//') ? rawPath.slice(2) : rawPath;
-  return normalizedPath || undefined;
 }
 
 interface DatabaseOrmProject {

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -353,9 +353,7 @@ function getFileDatabaseUrlPath(project: Project): string | undefined {
   const dbUrl = project.env.DATABASE_URL;
   if (!dbUrl?.startsWith('file:')) return;
 
-  const dbPath = dbUrl.slice('file:'.length).replace(/[?#].*$/, '');
-  if (!dbPath) return;
-  return dbPath;
+  return dbUrl.slice('file:'.length).replace(/[?#].*$/, '') || undefined;
 }
 
 interface DatabaseOrmProject {

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -62,9 +62,9 @@ const createLitestreamConfigCommand: CommandModule<unknown, InferredOptionTypes<
   describe: 'Create Litestream configuration file',
   builder,
   async handler(argv) {
-    const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
-    for (const { project } of prepareForRunningDatabaseOrmCommand('prisma create-litestream-config', allProjects)) {
-      createLitestreamConfig(project);
+    const allProjects = await findDatabaseOrmProjects(argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db create-litestream-config', allProjects)) {
+      createLitestreamConfig(project, orm);
     }
   },
 };
@@ -292,9 +292,8 @@ const defaultCommand: CommandModule<unknown, InferredOptionTypes<typeof defaultC
   },
 };
 
-function createLitestreamConfig(project: Project): void {
-  const dirName = project.packageJson.dependencies?.blitz ? 'db' : 'prisma';
-  const dbPath = `${dirName}/mount/prod.sqlite3`;
+function createLitestreamConfig(project: Project, orm: DatabaseOrm): void {
+  const dbPath = getLitestreamDbPath(project, orm);
   const requiredEnvVars = {
     CLOUDFLARE_R2_LITESTREAM_ACCOUNT_ID: project.env.CLOUDFLARE_R2_LITESTREAM_ACCOUNT_ID,
     CLOUDFLARE_R2_LITESTREAM_BUCKET_NAME: project.env.CLOUDFLARE_R2_LITESTREAM_BUCKET_NAME,
@@ -335,6 +334,28 @@ function createLitestreamConfig(project: Project): void {
       cause: error,
     });
   }
+}
+
+function getLitestreamDbPath(project: Project, orm: DatabaseOrm): string {
+  if (orm === 'prisma') {
+    const dirName = project.packageJson.dependencies?.blitz ? 'db' : 'prisma';
+    return `${dirName}/mount/prod.sqlite3`;
+  }
+
+  const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
+  if (!dbPath) {
+    throw new Error('wb db create-litestream-config for Drizzle requires DATABASE_PATH or file: DATABASE_URL.');
+  }
+  return dbPath;
+}
+
+function getFileDatabaseUrlPath(project: Project): string | undefined {
+  const dbUrl = project.env.DATABASE_URL;
+  if (!dbUrl?.startsWith('file:')) return;
+
+  const dbPath = dbUrl.slice('file:'.length).replace(/[?#].*$/, '');
+  if (!dbPath) return;
+  return dbPath;
 }
 
 interface DatabaseOrmProject {

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -11,7 +11,7 @@ import { isCI } from './utils/ci.js';
 
 export type DatabaseOrm = 'prisma' | 'drizzle';
 
-const FILE_SCHEMA = 'file:';
+export const FILE_SCHEMA = 'file:';
 
 export class Project {
   private readonly argv: EnvReaderOptions;

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -11,6 +11,8 @@ import { isCI } from './utils/ci.js';
 
 export type DatabaseOrm = 'prisma' | 'drizzle';
 
+const FILE_SCHEMA = 'file:';
+
 export class Project {
   private readonly argv: EnvReaderOptions;
   private readonly loadEnv: boolean;
@@ -288,6 +290,15 @@ export class Project {
       return;
     }
   }
+}
+
+export function getFileDatabaseUrlPath(project: Pick<Project, 'env'>): string | undefined {
+  const dbUrl = project.env.DATABASE_URL;
+  if (!dbUrl?.startsWith(FILE_SCHEMA)) return;
+
+  const rawPath = dbUrl.slice(FILE_SCHEMA.length).replace(/[?#].*$/, '');
+  const normalizedPath = rawPath.startsWith('//') ? rawPath.slice(2) : rawPath;
+  return normalizedPath || undefined;
 }
 
 export interface FoundProjects {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -1,8 +1,6 @@
 import path from 'node:path';
 
-import { isProjectEnvironment, type Project } from '../project.js';
-
-const FILE_SCHEMA = 'file:';
+import { getFileDatabaseUrlPath, isProjectEnvironment, type Project } from '../project.js';
 
 class DrizzleScripts {
   reset(project: Project, additionalOptions = ''): string {
@@ -60,16 +58,6 @@ function buildRemoveSqliteDbCommand(project: Project): string | undefined {
 
   const absolutePath = path.isAbsolute(dbPath) ? dbPath : path.resolve(project.dirPath, dbPath);
   return `rm -f "${absolutePath}" "${absolutePath}-wal" "${absolutePath}-shm"`;
-}
-
-function getFileDatabaseUrlPath(project: Project): string | undefined {
-  const dbUrl = project.env.DATABASE_URL;
-  if (!dbUrl?.startsWith(FILE_SCHEMA)) return;
-
-  const rawDbPath = dbUrl.slice(FILE_SCHEMA.length).replace(/[?#].*$/, '');
-  if (!rawDbPath) return;
-
-  return rawDbPath;
 }
 
 export const drizzleScripts = new DrizzleScripts();

--- a/packages/wb/src/scripts/prismaScripts.ts
+++ b/packages/wb/src/scripts/prismaScripts.ts
@@ -2,9 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type { Project } from '../project.js';
-import { getFileDatabaseUrlPath } from '../project.js';
+import { FILE_SCHEMA, getFileDatabaseUrlPath } from '../project.js';
 
-const FILE_SCHEMA = 'file:';
 const LITESTREAM_CONFIG_FILE_NAME = 'litestream.yml';
 const DEFAULT_LITESTREAM_CONFIG_PATH = '/etc/litestream.yml';
 

--- a/packages/wb/src/scripts/prismaScripts.ts
+++ b/packages/wb/src/scripts/prismaScripts.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type { Project } from '../project.js';
+import { getFileDatabaseUrlPath } from '../project.js';
 
 const FILE_SCHEMA = 'file:';
 const LITESTREAM_CONFIG_FILE_NAME = 'litestream.yml';
@@ -131,10 +132,7 @@ function buildWalCheckpointAndRemoveSqliteSidecarFilesCommand(dbPath: string): s
 }
 
 export function cleanUpSqliteDbIfNeeded(project: Project): string | undefined {
-  const dbUrl = project.env.DATABASE_URL;
-  if (!dbUrl?.startsWith(FILE_SCHEMA)) return;
-
-  const rawDbPath = dbUrl.slice(FILE_SCHEMA.length).replace(/[?#].*$/, '');
+  const rawDbPath = getFileDatabaseUrlPath(project);
   if (!rawDbPath) return;
 
   const baseDir = getPrismaBaseDir(project);


### PR DESCRIPTION
## Customer Summary

- `wb db create-litestream-config` now works for Drizzle projects as well as Prisma projects.
- Drizzle applications can use the standard Docker/Litestream setup instead of carrying custom config generation.
- The command now fails fast when multiple database projects would try to write one global Litestream config.

## Technical Summary

- Detect all supported database ORMs for `create-litestream-config` instead of filtering to Prisma only.
- Resolve Drizzle Litestream database paths from `DATABASE_PATH` or `file:` `DATABASE_URL`.
- Centralize `file:` URL parsing and `FILE_SCHEMA` in `project.ts`, reusing them from Prisma and Drizzle scripts.
- Normalize `file://` paths before resolving SQLite sidecar cleanup paths.

## Why

- WillBooster app Dockerfiles should be able to use the standard `wb db create-litestream-config` flow regardless of Prisma or Drizzle.
- Centralizing file URL parsing keeps command behavior consistent across migration, cleanup, and Litestream config code.

## Testing

- `yarn verify`
- `yarn workspace @willbooster/wb start --working-dir /Users/exkazuu/ghq/github.com/WillBooster/ranked-aa db create-litestream-config` reached Drizzle config generation; local execution stopped at `/etc/litestream.yml` permissions because Docker runs this command as root.
- PR CI passed.
