### PR TITLE
fix: support drizzle litestream operations

### DIFF
--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -50,9 +50,9 @@ const cleanUpLitestreamCommand: CommandModule<unknown, InferredOptionTypes<typeo
   describe: 'Clean up temporal Litestream files',
   builder,
   async handler(argv) {
-    const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
-    for (const { project } of prepareForRunningDatabaseOrmCommand('prisma cleanup-litestream', allProjects)) {
-      await runWithSpawn(prismaScripts.cleanUpLitestream(project), project, argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db cleanup-litestream', allProjects)) {
+      await runWithSpawn(getDatabaseOrmScripts(orm).cleanUpLitestream(project), project, argv);
     }
   },
 };
@@ -92,9 +92,9 @@ const deployForceCommand: CommandModule<unknown, InferredOptionTypes<typeof buil
   describe: "Force to apply migration to DB utilizing Litestream's backup without initializing it",
   builder,
   async handler(argv) {
-    const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
-    for (const { project } of prepareForRunningDatabaseOrmCommand('prisma deploy-force', allProjects)) {
-      await runWithSpawn(prismaScripts.deployForce(project), project, argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db deploy-force', allProjects)) {
+      await runWithSpawn(getDatabaseOrmScripts(orm).deployForce(project), project, argv);
     }
   },
 };

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -1,8 +1,18 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
 import { getFileDatabaseUrlPath, isProjectEnvironment, type Project } from '../project.js';
 
+const LITESTREAM_CONFIG_FILE_NAME = 'litestream.yml';
+const DEFAULT_LITESTREAM_CONFIG_PATH = '/etc/litestream.yml';
+
 class DrizzleScripts {
+  cleanUpLitestream(project: Project): string {
+    const dbPath = getSqliteDbPathOrError(project, 'cleanup-litestream');
+    const walCheckpointCommand = `if [ -f "${dbPath}" ] && command -v sqlite3 >/dev/null; then printf 'PRAGMA wal_checkpoint(TRUNCATE);' | sqlite3 "${dbPath}" && rm -f "${dbPath}-wal" "${dbPath}-shm"; fi`;
+    return `${walCheckpointCommand}; rm -f "${dbPath}".* "${dbPath}"-litestream*; rm -Rf "${path.dirname(dbPath)}/.${path.basename(dbPath)}"* || true`;
+  }
+
   reset(project: Project, additionalOptions = ''): string {
     const removeCommand = buildRemoveSqliteDbCommand(project);
     if (!removeCommand) {
@@ -29,6 +39,14 @@ class DrizzleScripts {
     return `YARN drizzle-kit migrate ${additionalOptions}`;
   }
 
+  deployForce(project: Project): string {
+    const dbPath = getSqliteDbPathOrError(project, 'deploy-force');
+    const removeDbCommand = buildRemoveSqliteDbFamilyCommand(dbPath);
+    const litestreamConfigOption = getLitestreamConfigOption(project);
+    return `${removeDbCommand}; ${this.deploy(project)} && ${removeDbCommand}
+      && litestream restore ${litestreamConfigOption} -o "${dbPath}" "${dbPath}" && ls -ahl "${dbPath}" && ALLOW_TO_SKIP_SEED=0 ${this.deploy(project)}`;
+  }
+
   generate(_project: Project, additionalOptions = ''): string {
     return `YARN drizzle-kit generate ${additionalOptions}`;
   }
@@ -53,11 +71,38 @@ class DrizzleScripts {
 }
 
 function buildRemoveSqliteDbCommand(project: Project): string | undefined {
-  const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
+  const dbPath = getSqliteDbPath(project);
   if (!dbPath) return;
 
   const absolutePath = path.isAbsolute(dbPath) ? dbPath : path.resolve(project.dirPath, dbPath);
-  return `rm -f "${absolutePath}" "${absolutePath}-wal" "${absolutePath}-shm"`;
+  return buildRemoveSqliteDbCommandForPath(absolutePath);
+}
+
+function buildRemoveSqliteDbCommandForPath(dbPath: string): string {
+  return `rm -f "${dbPath}" "${dbPath}-wal" "${dbPath}-shm"`;
+}
+
+function buildRemoveSqliteDbFamilyCommand(dbPath: string): string {
+  return `rm -Rf "${dbPath}"*`;
+}
+
+function getSqliteDbPathOrError(project: Project, commandName: string): string {
+  const dbPath = getSqliteDbPath(project);
+  if (!dbPath) {
+    throw new Error(`wb db ${commandName} supports Drizzle only when DATABASE_PATH or file: DATABASE_URL is set.`);
+  }
+  return dbPath;
+}
+
+function getSqliteDbPath(project: Project): string | undefined {
+  return project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
+}
+
+function getLitestreamConfigOption(project: Project): string {
+  const localConfigPath = path.join(project.dirPath, LITESTREAM_CONFIG_FILE_NAME);
+  if (fs.existsSync(localConfigPath)) return `-config ./${LITESTREAM_CONFIG_FILE_NAME}`;
+  if (fs.existsSync(DEFAULT_LITESTREAM_CONFIG_PATH)) return `-config ${DEFAULT_LITESTREAM_CONFIG_PATH}`;
+  return `-config ./${LITESTREAM_CONFIG_FILE_NAME}`;
 }
 
 export const drizzleScripts = new DrizzleScripts();

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -8,9 +8,9 @@ const DEFAULT_LITESTREAM_CONFIG_PATH = '/etc/litestream.yml';
 
 class DrizzleScripts {
   cleanUpLitestream(project: Project): string {
-    const dbPath = getSqliteDbPathOrError(project, 'cleanup-litestream');
-    const walCheckpointCommand = `if [ -f "${dbPath}" ] && command -v sqlite3 >/dev/null; then printf 'PRAGMA wal_checkpoint(TRUNCATE);' | sqlite3 "${dbPath}" && rm -f "${dbPath}-wal" "${dbPath}-shm"; fi`;
-    return `${walCheckpointCommand}; rm -f "${dbPath}".* "${dbPath}"-litestream*; rm -Rf "${path.dirname(dbPath)}/.${path.basename(dbPath)}"* || true`;
+    const dbPath = getAbsoluteSqliteDbPath(project, 'cleanup-litestream');
+    const walCheckpointCommand = `if [ -f "${dbPath}" ] && command -v sqlite3 >/dev/null; then printf 'PRAGMA wal_checkpoint(TRUNCATE);' | sqlite3 "${dbPath}"; fi`;
+    return `${walCheckpointCommand}; rm -f "${dbPath}".* "${dbPath}"-*; rm -Rf "${path.dirname(dbPath)}/.${path.basename(dbPath)}"* || true`;
   }
 
   reset(project: Project, additionalOptions = ''): string {
@@ -40,7 +40,7 @@ class DrizzleScripts {
   }
 
   deployForce(project: Project): string {
-    const dbPath = getSqliteDbPathOrError(project, 'deploy-force');
+    const dbPath = getAbsoluteSqliteDbPath(project, 'deploy-force');
     const removeDbCommand = buildRemoveSqliteDbFamilyCommand(dbPath);
     const litestreamConfigOption = getLitestreamConfigOption(project);
     return `${removeDbCommand}; ${this.deploy(project)} && ${removeDbCommand}
@@ -92,6 +92,11 @@ function getSqliteDbPathOrError(project: Project, commandName: string): string {
     throw new Error(`wb db ${commandName} supports Drizzle only when DATABASE_PATH or file: DATABASE_URL is set.`);
   }
   return dbPath;
+}
+
+function getAbsoluteSqliteDbPath(project: Project, commandName: string): string {
+  const dbPath = getSqliteDbPathOrError(project, commandName);
+  return path.isAbsolute(dbPath) ? dbPath : path.resolve(project.dirPath, dbPath);
 }
 
 function getSqliteDbPath(project: Project): string | undefined {


### PR DESCRIPTION
## Customer Summary

- Enables Drizzle-based projects to use the same `wb db` Litestream startup and restore operations as Prisma projects.
- Lets apps standardize Docker entrypoints around `cleanup-litestream` and `deploy-force` without custom Drizzle-specific shell logic.

## Technical Summary

- Routes `wb db cleanup-litestream` and `wb db deploy-force` through the detected ORM implementation instead of requiring Prisma.
- Adds Drizzle implementations for Litestream cleanup and force deploy.
- Resolves SQLite paths from `DATABASE_PATH` or `file:` `DATABASE_URL`, normalizing Litestream operation paths to absolute paths.

## Why

- `ranked-aa` uses Drizzle and needs to follow the standard WillBooster Docker/Litestream structure.
- Keeping the behavior in `wb` avoids duplicating Litestream restore and cleanup logic in each application repo.

## Testing

- `yarn verify`
- Dry-ran Drizzle `cleanup-litestream` and `deploy-force` against WillBooster/ranked-aa development and production environments.
