### PR TITLE
feat: add fast wb dotenv command

### DIFF
--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -1,0 +1,208 @@
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { config } from 'dotenv';
+import { expand } from 'dotenv-expand';
+
+export function runDotenvCommand(args) {
+  const { command, options } = parseDotenvArgs(args);
+  if (command.length === 0) {
+    console.error('Usage: wb dotenv [-c <environment>] [--env <file>] -- <command> [args...]');
+    process.exit(1);
+  }
+
+  const cwd = path.resolve(options.workingDir ?? process.cwd());
+  if (options.workingDir) {
+    process.chdir(cwd);
+  }
+  if (options.cascadeEnv) {
+    process.env.WB_ENV ||= options.cascadeEnv;
+  }
+  readAndApplyEnvironmentVariables(options, cwd);
+  removeNpmAndYarnEnvironmentVariables(process.env);
+
+  const child = childProcess.spawn(command[0], command.slice(1), {
+    cwd,
+    env: process.env,
+    stdio: 'inherit',
+  });
+  child.on('error', (error) => {
+    console.error(error);
+    process.exit(1);
+  });
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
+}
+
+function readAndApplyEnvironmentVariables(options, cwd) {
+  const envVars = readEnvironmentVariables(options, cwd);
+  for (const [key, value] of Object.entries(envVars)) {
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function readEnvironmentVariables(options, cwd) {
+  let envPaths = (options.env ?? []).map((envPath) => path.resolve(cwd, envPath));
+  if (options.cascadeEnv) {
+    if (envPaths.length === 0) {
+      envPaths.push(path.join(cwd, '.env'));
+      if (options.includeRootEnv ?? true) {
+        const rootPath = path.resolve(cwd, '..', '..');
+        if (fs.existsSync(path.join(rootPath, 'package.json'))) {
+          envPaths.push(path.join(rootPath, '.env'));
+        }
+      }
+    }
+    envPaths = envPaths.flatMap((envPath) => [
+      `${envPath}.${options.cascadeEnv}.local`,
+      `${envPath}.local`,
+      `${envPath}.${options.cascadeEnv}`,
+      envPath,
+    ]);
+  }
+  const envVars = {};
+  for (const envPath of envPaths) {
+    if (!fs.existsSync(envPath)) continue;
+
+    for (const [key, value] of Object.entries(readEnvFile(envPath))) {
+      if (!(key in envVars) && !(key in process.env)) {
+        envVars[key] = value;
+      }
+    }
+  }
+  Object.assign(envVars, readMiseEnvironmentVariables(cwd, options.cascadeEnv, envVars));
+  if (options.checkEnv) {
+    const missingKeys = Object.keys(readEnvFile(path.join(cwd, options.checkEnv))).filter(
+      (key) => !(key in envVars) && !(key in process.env)
+    );
+    if (missingKeys.length > 0) {
+      throw new Error(`Missing environment variables: [${missingKeys.join(', ')}]`);
+    }
+  }
+  return expand({ parsed: envVars, processEnv: {} }).parsed ?? envVars;
+}
+
+function readMiseEnvironmentVariables(cwd, cascadeEnv, currentEnvVars) {
+  if (!hasProjectMiseConfig(cwd)) return {};
+
+  const args = ['env', '--json', '--cd', cwd];
+  if (cascadeEnv) {
+    args.push('--env', cascadeEnv);
+  }
+  const result = childProcess.spawnSync('mise', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.error || result.status !== 0 || !result.stdout?.trim()) return {};
+
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+
+  const envVars = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value !== 'string') continue;
+    if (key in currentEnvVars || process.env[key] === value) continue;
+    envVars[key] = value;
+  }
+  return envVars;
+}
+
+function hasProjectMiseConfig(cwd) {
+  for (let currentPath = path.resolve(cwd); ; currentPath = path.dirname(currentPath)) {
+    if (fs.existsSync(path.join(currentPath, 'mise.toml')) || fs.existsSync(path.join(currentPath, '.mise.toml'))) {
+      return true;
+    }
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) return false;
+  }
+}
+
+function readEnvFile(filePath) {
+  return config({ path: path.resolve(filePath), processEnv: {}, quiet: true }).parsed ?? {};
+}
+
+function removeNpmAndYarnEnvironmentVariables(envVars) {
+  if (envVars.PATH && envVars.BERRY_BIN_FOLDER) {
+    envVars.PATH = envVars.PATH.replace(`${envVars.BERRY_BIN_FOLDER}:`, '')
+      .replaceAll(/\/private\/var\/folders\/[^:]+:/g, '')
+      .replaceAll(/\/var\/tmp\/[^:]+:/g, '')
+      .replaceAll(/\/tmp\/[^:]+:/g, '');
+  }
+  for (const key of Object.keys(envVars)) {
+    const upperKey = key.toUpperCase();
+    if (
+      upperKey.startsWith('NPM_') ||
+      upperKey.startsWith('YARN_') ||
+      upperKey.startsWith('BERRY_') ||
+      upperKey === 'PROJECT_CWD' ||
+      upperKey === 'INIT_CWD'
+    ) {
+      delete envVars[key];
+    }
+  }
+}
+
+function parseDotenvArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--') {
+      return normalizeParsedDotenvArgs({ command: args.slice(index + 1), options });
+    }
+    if (!arg.startsWith('-')) {
+      return normalizeParsedDotenvArgs({ command: args.slice(index), options });
+    }
+
+    const nextValue = () => {
+      const value = args[++index];
+      if (!value) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      return value;
+    };
+    if (arg === '-c' || arg === '--cascade-env') {
+      options.cascadeEnv = nextValue();
+    } else if (arg.startsWith('--cascade-env=')) {
+      options.cascadeEnv = arg.slice('--cascade-env='.length);
+    } else if (arg === '-e' || arg === '--env') {
+      options.env = [...(options.env ?? []), nextValue()];
+    } else if (arg.startsWith('--env=')) {
+      options.env = [...(options.env ?? []), arg.slice('--env='.length)];
+    } else if (arg === '--check-env') {
+      options.checkEnv = nextValue();
+    } else if (arg.startsWith('--check-env=')) {
+      options.checkEnv = arg.slice('--check-env='.length);
+    } else if (arg === '--include-root-env') {
+      options.includeRootEnv = true;
+    } else if (arg === '--no-include-root-env') {
+      options.includeRootEnv = false;
+    } else if (arg === '--working-dir') {
+      options.workingDir = nextValue();
+    } else if (arg.startsWith('--working-dir=')) {
+      options.workingDir = arg.slice('--working-dir='.length);
+    } else {
+      throw new Error(`Unknown wb dotenv option: ${arg}`);
+    }
+  }
+  return normalizeParsedDotenvArgs({ command: [], options });
+}
+
+function normalizeParsedDotenvArgs(parsed) {
+  if (!parsed.options.cascadeEnv && !parsed.options.env) {
+    parsed.options.env = ['.env'];
+  }
+  return parsed;
+}

--- a/packages/wb/bin/index.js
+++ b/packages/wb/bin/index.js
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
 
-import '../dist/index.js';
+if (process.argv[2] === 'dotenv') {
+  const { runDotenvCommand } = await import('./dotenv.js');
+  await runDotenvCommand(process.argv.slice(3));
+} else {
+  await import('../dist/index.js');
+}

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -1,0 +1,178 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+import {
+  readAndApplyEnvironmentVariables,
+  removeNpmAndYarnEnvironmentVariables,
+} from '@willbooster/shared-lib-node/src';
+import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
+
+interface DotenvOptions {
+  cascadeEnv?: string;
+  checkEnv?: string;
+  env?: string[];
+  includeRootEnv?: boolean;
+  quietEnv?: boolean;
+  verbose?: boolean;
+  workingDir?: string;
+}
+
+interface ParsedDotenvArgs {
+  command: string[];
+  options: DotenvOptions;
+}
+
+export const dotenvCommand: CommandModule = {
+  command: 'dotenv [args..]',
+  describe: 'Load .env files and run a command.',
+  builder: (yargs: Argv<unknown>) =>
+    yargs
+      .parserConfiguration({ 'populate--': true })
+      .option('cascade-env', {
+        alias: 'c',
+        description: 'Environment to load cascading .env files.',
+        type: 'string',
+      })
+      .option('env', {
+        alias: 'e',
+        description: '.env files to be loaded.',
+        type: 'array',
+      })
+      .option('check-env', {
+        description: 'Check whether loaded env keys match the given .env file.',
+        type: 'string',
+      })
+      .option('quiet-env', {
+        description: 'Suppress .env file loading information.',
+        type: 'boolean',
+      }),
+  async handler(argv) {
+    await runParsedDotenvCommand(getParsedDotenvArgsFromYargs(argv));
+  },
+};
+
+export async function runDotenvCommand(args: string[]): Promise<void> {
+  await runParsedDotenvCommand(parseDotenvArgs(args));
+}
+
+async function runParsedDotenvCommand({ command, options }: ParsedDotenvArgs): Promise<void> {
+  if (command.length === 0) {
+    console.error('Usage: wb dotenv [-c <environment>] [--env <file>] -- <command> [args...]');
+    process.exit(1);
+  }
+
+  const cwd = path.resolve(options.workingDir ?? process.cwd());
+  if (options.workingDir) {
+    process.chdir(cwd);
+  }
+  if (options.cascadeEnv) {
+    process.env.WB_ENV ||= options.cascadeEnv;
+  }
+  readAndApplyEnvironmentVariables(
+    {
+      autoCascadeEnv: false,
+      cascadeEnv: options.cascadeEnv,
+      checkEnv: options.checkEnv,
+      env: options.env,
+      includeRootEnv: options.includeRootEnv ?? true,
+      quietEnv: options.quietEnv ?? true,
+      verbose: options.verbose,
+    },
+    cwd
+  );
+  removeNpmAndYarnEnvironmentVariables(process.env);
+
+  const child = spawn(command[0]!, command.slice(1), {
+    cwd,
+    env: process.env,
+    stdio: 'inherit',
+  });
+  child.on('error', (error) => {
+    console.error(error);
+    process.exit(1);
+  });
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
+}
+
+function getParsedDotenvArgsFromYargs(argv: ArgumentsCamelCase): ParsedDotenvArgs {
+  const command = [
+    ...((argv.args as unknown[] | undefined) ?? []).map(String),
+    ...((argv['--'] as unknown[] | undefined) ?? []).map(String),
+  ];
+  return normalizeParsedDotenvArgs({
+    command,
+    options: {
+      cascadeEnv: typeof argv.cascadeEnv === 'string' ? argv.cascadeEnv : undefined,
+      checkEnv: process.argv.some((arg) => arg === '--check-env' || arg.startsWith('--check-env='))
+        ? String(argv.checkEnv)
+        : undefined,
+      env: Array.isArray(argv.env) ? argv.env.map(String) : undefined,
+      includeRootEnv: typeof argv.includeRootEnv === 'boolean' ? argv.includeRootEnv : undefined,
+      quietEnv: typeof argv.quietEnv === 'boolean' ? argv.quietEnv : undefined,
+      verbose: typeof argv.verbose === 'boolean' ? argv.verbose : undefined,
+      workingDir: typeof argv.workingDir === 'string' ? argv.workingDir : undefined,
+    },
+  });
+}
+
+function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
+  const options: DotenvOptions = {};
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]!;
+    if (arg === '--') {
+      return normalizeParsedDotenvArgs({ command: args.slice(index + 1), options });
+    }
+    if (!arg.startsWith('-')) {
+      return normalizeParsedDotenvArgs({ command: args.slice(index), options });
+    }
+
+    const nextValue = (): string => {
+      const value = args[++index];
+      if (!value) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      return value;
+    };
+    if (arg === '-c' || arg === '--cascade-env') {
+      options.cascadeEnv = nextValue();
+    } else if (arg.startsWith('--cascade-env=')) {
+      options.cascadeEnv = arg.slice('--cascade-env='.length);
+    } else if (arg === '-e' || arg === '--env') {
+      options.env = [...(options.env ?? []), nextValue()];
+    } else if (arg.startsWith('--env=')) {
+      options.env = [...(options.env ?? []), arg.slice('--env='.length)];
+    } else if (arg === '--check-env') {
+      options.checkEnv = nextValue();
+    } else if (arg.startsWith('--check-env=')) {
+      options.checkEnv = arg.slice('--check-env='.length);
+    } else if (arg === '--include-root-env') {
+      options.includeRootEnv = true;
+    } else if (arg === '--no-include-root-env') {
+      options.includeRootEnv = false;
+    } else if (arg === '--quiet' || arg === '--quiet-env') {
+      options.quietEnv = true;
+    } else if (arg === '--verbose' || arg === '-v') {
+      options.verbose = true;
+    } else if (arg === '--working-dir') {
+      options.workingDir = nextValue();
+    } else if (arg.startsWith('--working-dir=')) {
+      options.workingDir = arg.slice('--working-dir='.length);
+    } else {
+      throw new Error(`Unknown wb dotenv option: ${arg}`);
+    }
+  }
+  return normalizeParsedDotenvArgs({ command: [], options });
+}
+
+function normalizeParsedDotenvArgs(parsed: ParsedDotenvArgs): ParsedDotenvArgs {
+  if (!parsed.options.cascadeEnv && !parsed.options.env) {
+    parsed.options.env = ['.env'];
+  }
+  return parsed;
+}

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -7,6 +7,7 @@ import { hideBin } from 'yargs/helpers';
 
 import { buildIfNeededCommand } from './commands/buildIfNeeded.js';
 import { concurrentlyCommand } from './commands/concurrently.js';
+import { dotenvCommand } from './commands/dotenv.js';
 import { genCodeCommand } from './commands/genCode.js';
 import { killPortIfNonCiCommand } from './commands/killPortIfNonCi.js';
 import { lintCommand } from './commands/lint.js';
@@ -39,6 +40,7 @@ await yargs(hideBin(process.argv))
   .command(verifyCodeCommand)
   .command(buildIfNeededCommand)
   .command(concurrentlyCommand)
+  .command(dotenvCommand)
   .command(genCodeCommand)
   .command(killPortIfNonCiCommand)
   .command(lintCommand)


### PR DESCRIPTION
## Summary
- add `wb dotenv` for loading cascading env files and running a command without `dotenv-cli`
- fast-path `wb dotenv` in the package bin so it skips loading the full wb command graph
- keep the normal yargs command available for help/direct dist usage

## Verification
- `yarn verify`
- `/Users/exkazuu/ghq/github.com/WillBooster/shared/packages/wb/bin/index.js dotenv -c test -- node -e 'console.log(process.env.PORT + ":" + process.env.NAME + ":" + process.env.WB_ENV)'`
