### PR TITLE
fix: simplify wb dotenv

### DIFF
--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -51,14 +51,7 @@ function readAndApplyEnvironmentVariables(options, cwd) {
 
 function readEnvironmentVariables(options, cwd) {
   let envPaths = (options.env ?? []).map((envPath) => path.resolve(cwd, envPath));
-  const cascade =
-    options.cascadeEnv ??
-    (options.cascadeNodeEnv
-      ? process.env.NODE_ENV || 'development'
-      : options.autoCascadeEnv
-        ? process.env.WB_ENV || process.env.NODE_ENV || 'development'
-        : undefined);
-  if (cascade) {
+  if (options.cascadeEnv) {
     if (envPaths.length === 0) {
       envPaths.push(path.join(cwd, '.env'));
       if (options.includeRootEnv ?? true) {
@@ -69,9 +62,9 @@ function readEnvironmentVariables(options, cwd) {
       }
     }
     envPaths = envPaths.flatMap((envPath) => [
-      `${envPath}.${cascade}.local`,
+      `${envPath}.${options.cascadeEnv}.local`,
       `${envPath}.local`,
-      `${envPath}.${cascade}`,
+      `${envPath}.${options.cascadeEnv}`,
       envPath,
     ]);
   }
@@ -85,7 +78,7 @@ function readEnvironmentVariables(options, cwd) {
       }
     }
   }
-  Object.assign(envVars, readMiseEnvironmentVariables(cwd, cascade, envVars));
+  Object.assign(envVars, readMiseEnvironmentVariables(cwd, options.cascadeEnv, envVars));
   if (options.checkEnv) {
     const missingKeys = Object.keys(readEnvFile(path.join(cwd, options.checkEnv))).filter(
       (key) => !(key in envVars) && !(key in process.env)
@@ -186,14 +179,6 @@ function parseDotenvArgs(args) {
       options.cascadeEnv = arg.slice('-c='.length);
     } else if (arg.startsWith('--cascade-env=')) {
       options.cascadeEnv = arg.slice('--cascade-env='.length);
-    } else if (arg === '--cascade-node-env') {
-      options.cascadeNodeEnv = true;
-    } else if (arg === '--cascade-node-env=false' || arg === '--no-cascade-node-env') {
-      options.cascadeNodeEnv = false;
-    } else if (arg === '--auto-cascade-env') {
-      options.autoCascadeEnv = true;
-    } else if (arg === '--auto-cascade-env=false' || arg === '--no-auto-cascade-env') {
-      options.autoCascadeEnv = false;
     } else if (arg === '-e' || arg === '--env') {
       options.env = [...(options.env ?? []), nextValue()];
     } else if (arg.startsWith('--env=')) {
@@ -222,7 +207,7 @@ function parseDotenvArgs(args) {
 }
 
 function normalizeParsedDotenvArgs(parsed) {
-  if (!parsed.options.cascadeEnv && !parsed.options.cascadeNodeEnv && !parsed.options.autoCascadeEnv && !parsed.options.env) {
+  if (!parsed.options.cascadeEnv && !parsed.options.env) {
     parsed.options.env = ['.env'];
   }
   return parsed;

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -1,25 +1,18 @@
 import childProcess from 'node:child_process';
-import fs from 'node:fs';
 import path from 'node:path';
 
 import { config } from 'dotenv';
 import { expand } from 'dotenv-expand';
 
 export function runDotenvCommand(args) {
-  const { command, options } = parseDotenvArgs(args);
+  const { command } = parseDotenvArgs(args);
   if (command.length === 0) {
-    console.error('Usage: wb dotenv [-c <environment>] [--env <file>] -- <command> [args...]');
+    console.error('Usage: wb dotenv -- <command> [args...]');
     process.exit(1);
   }
 
-  const cwd = path.resolve(options.workingDir ?? process.cwd());
-  if (options.workingDir) {
-    process.chdir(cwd);
-  }
-  if (options.cascadeEnv) {
-    process.env.WB_ENV ||= options.cascadeEnv;
-  }
-  readAndApplyEnvironmentVariables(options, cwd);
+  const cwd = path.resolve(process.cwd());
+  readAndApplyEnvironmentVariables(cwd);
   removeNpmAndYarnEnvironmentVariables(process.env);
 
   const child = childProcess.spawn(command[0], command.slice(1), {
@@ -40,8 +33,8 @@ export function runDotenvCommand(args) {
   });
 }
 
-function readAndApplyEnvironmentVariables(options, cwd) {
-  const envVars = readEnvironmentVariables(options, cwd);
+function readAndApplyEnvironmentVariables(cwd) {
+  const envVars = readEnvFile(path.join(cwd, '.env'));
   for (const [key, value] of Object.entries(envVars)) {
     if (!(key in process.env)) {
       process.env[key] = value;
@@ -49,89 +42,9 @@ function readAndApplyEnvironmentVariables(options, cwd) {
   }
 }
 
-function readEnvironmentVariables(options, cwd) {
-  let envPaths = (options.env ?? []).map((envPath) => path.resolve(cwd, envPath));
-  if (options.cascadeEnv) {
-    if (envPaths.length === 0) {
-      envPaths.push(path.join(cwd, '.env'));
-      if (options.includeRootEnv ?? true) {
-        const rootPath = path.resolve(cwd, '..', '..');
-        if (fs.existsSync(path.join(rootPath, 'package.json'))) {
-          envPaths.push(path.join(rootPath, '.env'));
-        }
-      }
-    }
-    envPaths = envPaths.flatMap((envPath) => [
-      `${envPath}.${options.cascadeEnv}.local`,
-      `${envPath}.local`,
-      `${envPath}.${options.cascadeEnv}`,
-      envPath,
-    ]);
-  }
-  const envVars = {};
-  for (const envPath of envPaths) {
-    if (!fs.existsSync(envPath)) continue;
-
-    for (const [key, value] of Object.entries(readEnvFile(envPath))) {
-      if (!(key in envVars) && !(key in process.env)) {
-        envVars[key] = value;
-      }
-    }
-  }
-  Object.assign(envVars, readMiseEnvironmentVariables(cwd, options.cascadeEnv, envVars));
-  if (options.checkEnv) {
-    const missingKeys = Object.keys(readEnvFile(path.join(cwd, options.checkEnv))).filter(
-      (key) => !(key in envVars) && !(key in process.env)
-    );
-    if (missingKeys.length > 0) {
-      throw new Error(`Missing environment variables: [${missingKeys.join(', ')}]`);
-    }
-  }
-  return expand({ parsed: envVars, processEnv: {} }).parsed ?? envVars;
-}
-
-function readMiseEnvironmentVariables(cwd, cascadeEnv, currentEnvVars) {
-  if (!hasProjectMiseConfig(cwd)) return {};
-
-  const args = ['env', '--json', '--cd', cwd];
-  if (cascadeEnv) {
-    args.push('--env', cascadeEnv);
-  }
-  const result = childProcess.spawnSync('mise', args, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (result.error || result.status !== 0 || !result.stdout?.trim()) return {};
-
-  let parsed;
-  try {
-    parsed = JSON.parse(result.stdout);
-  } catch {
-    return {};
-  }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
-
-  const envVars = {};
-  for (const [key, value] of Object.entries(parsed)) {
-    if (typeof value !== 'string') continue;
-    if (key in currentEnvVars || process.env[key] === value) continue;
-    envVars[key] = value;
-  }
-  return envVars;
-}
-
-function hasProjectMiseConfig(cwd) {
-  for (let currentPath = path.resolve(cwd); ; currentPath = path.dirname(currentPath)) {
-    if (fs.existsSync(path.join(currentPath, 'mise.toml')) || fs.existsSync(path.join(currentPath, '.mise.toml'))) {
-      return true;
-    }
-    const parentPath = path.dirname(currentPath);
-    if (parentPath === currentPath) return false;
-  }
-}
-
 function readEnvFile(filePath) {
-  return config({ path: path.resolve(filePath), processEnv: {}, quiet: true }).parsed ?? {};
+  const parsed = config({ path: path.resolve(filePath), processEnv: {}, quiet: true }).parsed ?? {};
+  return expand({ parsed, processEnv: {} }).parsed ?? parsed;
 }
 
 function removeNpmAndYarnEnvironmentVariables(envVars) {
@@ -156,59 +69,6 @@ function removeNpmAndYarnEnvironmentVariables(envVars) {
 }
 
 function parseDotenvArgs(args) {
-  const options = {};
-  for (let index = 0; index < args.length; index++) {
-    const arg = args[index];
-    if (arg === '--') {
-      return normalizeParsedDotenvArgs({ command: args.slice(index + 1), options });
-    }
-    if (!arg.startsWith('-')) {
-      return normalizeParsedDotenvArgs({ command: args.slice(index), options });
-    }
-
-    const nextValue = () => {
-      const value = args[++index];
-      if (!value) {
-        throw new Error(`Missing value for ${arg}`);
-      }
-      return value;
-    };
-    if (arg === '-c' || arg === '--cascade-env') {
-      options.cascadeEnv = nextValue();
-    } else if (arg.startsWith('-c=')) {
-      options.cascadeEnv = arg.slice('-c='.length);
-    } else if (arg.startsWith('--cascade-env=')) {
-      options.cascadeEnv = arg.slice('--cascade-env='.length);
-    } else if (arg === '-e' || arg === '--env') {
-      options.env = [...(options.env ?? []), nextValue()];
-    } else if (arg.startsWith('--env=')) {
-      options.env = [...(options.env ?? []), arg.slice('--env='.length)];
-    } else if (arg === '--check-env') {
-      options.checkEnv = nextValue();
-    } else if (arg.startsWith('--check-env=')) {
-      options.checkEnv = arg.slice('--check-env='.length);
-    } else if (arg === '--include-root-env') {
-      options.includeRootEnv = true;
-    } else if (arg === '--include-root-env=false' || arg === '--no-include-root-env') {
-      options.includeRootEnv = false;
-    } else if (arg === '--quiet' || arg === '--quiet-env') {
-      options.quietEnv = true;
-    } else if (arg === '--verbose' || arg === '-v') {
-      options.verbose = true;
-    } else if (arg === '--working-dir') {
-      options.workingDir = nextValue();
-    } else if (arg.startsWith('--working-dir=')) {
-      options.workingDir = arg.slice('--working-dir='.length);
-    } else {
-      throw new Error(`Unknown wb dotenv option: ${arg}`);
-    }
-  }
-  return normalizeParsedDotenvArgs({ command: [], options });
-}
-
-function normalizeParsedDotenvArgs(parsed) {
-  if (!parsed.options.cascadeEnv && !parsed.options.env) {
-    parsed.options.env = ['.env'];
-  }
-  return parsed;
+  const separatorIndex = args.indexOf('--');
+  return { command: separatorIndex === -1 ? args : args.slice(separatorIndex + 1) };
 }

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -51,7 +51,14 @@ function readAndApplyEnvironmentVariables(options, cwd) {
 
 function readEnvironmentVariables(options, cwd) {
   let envPaths = (options.env ?? []).map((envPath) => path.resolve(cwd, envPath));
-  if (options.cascadeEnv) {
+  const cascade =
+    options.cascadeEnv ??
+    (options.cascadeNodeEnv
+      ? process.env.NODE_ENV || 'development'
+      : options.autoCascadeEnv
+        ? process.env.WB_ENV || process.env.NODE_ENV || 'development'
+        : undefined);
+  if (cascade) {
     if (envPaths.length === 0) {
       envPaths.push(path.join(cwd, '.env'));
       if (options.includeRootEnv ?? true) {
@@ -62,9 +69,9 @@ function readEnvironmentVariables(options, cwd) {
       }
     }
     envPaths = envPaths.flatMap((envPath) => [
-      `${envPath}.${options.cascadeEnv}.local`,
+      `${envPath}.${cascade}.local`,
       `${envPath}.local`,
-      `${envPath}.${options.cascadeEnv}`,
+      `${envPath}.${cascade}`,
       envPath,
     ]);
   }
@@ -78,7 +85,7 @@ function readEnvironmentVariables(options, cwd) {
       }
     }
   }
-  Object.assign(envVars, readMiseEnvironmentVariables(cwd, options.cascadeEnv, envVars));
+  Object.assign(envVars, readMiseEnvironmentVariables(cwd, cascade, envVars));
   if (options.checkEnv) {
     const missingKeys = Object.keys(readEnvFile(path.join(cwd, options.checkEnv))).filter(
       (key) => !(key in envVars) && !(key in process.env)
@@ -175,8 +182,18 @@ function parseDotenvArgs(args) {
     };
     if (arg === '-c' || arg === '--cascade-env') {
       options.cascadeEnv = nextValue();
+    } else if (arg.startsWith('-c=')) {
+      options.cascadeEnv = arg.slice('-c='.length);
     } else if (arg.startsWith('--cascade-env=')) {
       options.cascadeEnv = arg.slice('--cascade-env='.length);
+    } else if (arg === '--cascade-node-env') {
+      options.cascadeNodeEnv = true;
+    } else if (arg === '--cascade-node-env=false' || arg === '--no-cascade-node-env') {
+      options.cascadeNodeEnv = false;
+    } else if (arg === '--auto-cascade-env') {
+      options.autoCascadeEnv = true;
+    } else if (arg === '--auto-cascade-env=false' || arg === '--no-auto-cascade-env') {
+      options.autoCascadeEnv = false;
     } else if (arg === '-e' || arg === '--env') {
       options.env = [...(options.env ?? []), nextValue()];
     } else if (arg.startsWith('--env=')) {
@@ -187,8 +204,12 @@ function parseDotenvArgs(args) {
       options.checkEnv = arg.slice('--check-env='.length);
     } else if (arg === '--include-root-env') {
       options.includeRootEnv = true;
-    } else if (arg === '--no-include-root-env') {
+    } else if (arg === '--include-root-env=false' || arg === '--no-include-root-env') {
       options.includeRootEnv = false;
+    } else if (arg === '--quiet' || arg === '--quiet-env') {
+      options.quietEnv = true;
+    } else if (arg === '--verbose' || arg === '-v') {
+      options.verbose = true;
     } else if (arg === '--working-dir') {
       options.workingDir = nextValue();
     } else if (arg.startsWith('--working-dir=')) {
@@ -201,7 +222,7 @@ function parseDotenvArgs(args) {
 }
 
 function normalizeParsedDotenvArgs(parsed) {
-  if (!parsed.options.cascadeEnv && !parsed.options.env) {
+  if (!parsed.options.cascadeEnv && !parsed.options.cascadeNodeEnv && !parsed.options.autoCascadeEnv && !parsed.options.env) {
     parsed.options.env = ['.env'];
   }
   return parsed;

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -8,7 +8,9 @@ import {
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 
 interface DotenvOptions {
+  autoCascadeEnv?: boolean;
   cascadeEnv?: string;
+  cascadeNodeEnv?: boolean;
   checkEnv?: string;
   env?: string[];
   includeRootEnv?: boolean;
@@ -109,6 +111,8 @@ function getParsedDotenvArgsFromYargs(argv: ArgumentsCamelCase): ParsedDotenvArg
     command,
     options: {
       cascadeEnv: typeof argv.cascadeEnv === 'string' ? argv.cascadeEnv : undefined,
+      cascadeNodeEnv: typeof argv.cascadeNodeEnv === 'boolean' ? argv.cascadeNodeEnv : undefined,
+      autoCascadeEnv: typeof argv.autoCascadeEnv === 'boolean' ? argv.autoCascadeEnv : undefined,
       checkEnv: process.argv.some((arg) => arg === '--check-env' || arg.startsWith('--check-env='))
         ? String(argv.checkEnv)
         : undefined,
@@ -141,8 +145,18 @@ function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
     };
     if (arg === '-c' || arg === '--cascade-env') {
       options.cascadeEnv = nextValue();
+    } else if (arg.startsWith('-c=')) {
+      options.cascadeEnv = arg.slice('-c='.length);
     } else if (arg.startsWith('--cascade-env=')) {
       options.cascadeEnv = arg.slice('--cascade-env='.length);
+    } else if (arg === '--cascade-node-env') {
+      options.cascadeNodeEnv = true;
+    } else if (arg === '--cascade-node-env=false' || arg === '--no-cascade-node-env') {
+      options.cascadeNodeEnv = false;
+    } else if (arg === '--auto-cascade-env') {
+      options.autoCascadeEnv = true;
+    } else if (arg === '--auto-cascade-env=false' || arg === '--no-auto-cascade-env') {
+      options.autoCascadeEnv = false;
     } else if (arg === '-e' || arg === '--env') {
       options.env = [...(options.env ?? []), nextValue()];
     } else if (arg.startsWith('--env=')) {
@@ -153,7 +167,7 @@ function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
       options.checkEnv = arg.slice('--check-env='.length);
     } else if (arg === '--include-root-env') {
       options.includeRootEnv = true;
-    } else if (arg === '--no-include-root-env') {
+    } else if (arg === '--include-root-env=false' || arg === '--no-include-root-env') {
       options.includeRootEnv = false;
     } else if (arg === '--quiet' || arg === '--quiet-env') {
       options.quietEnv = true;
@@ -171,7 +185,12 @@ function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
 }
 
 function normalizeParsedDotenvArgs(parsed: ParsedDotenvArgs): ParsedDotenvArgs {
-  if (!parsed.options.cascadeEnv && !parsed.options.env) {
+  if (
+    !parsed.options.cascadeEnv &&
+    !parsed.options.cascadeNodeEnv &&
+    !parsed.options.autoCascadeEnv &&
+    !parsed.options.env
+  ) {
     parsed.options.env = ['.env'];
   }
   return parsed;

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -8,9 +8,7 @@ import {
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 
 interface DotenvOptions {
-  autoCascadeEnv?: boolean;
   cascadeEnv?: string;
-  cascadeNodeEnv?: boolean;
   checkEnv?: string;
   env?: string[];
   includeRootEnv?: boolean;
@@ -111,8 +109,6 @@ function getParsedDotenvArgsFromYargs(argv: ArgumentsCamelCase): ParsedDotenvArg
     command,
     options: {
       cascadeEnv: typeof argv.cascadeEnv === 'string' ? argv.cascadeEnv : undefined,
-      cascadeNodeEnv: typeof argv.cascadeNodeEnv === 'boolean' ? argv.cascadeNodeEnv : undefined,
-      autoCascadeEnv: typeof argv.autoCascadeEnv === 'boolean' ? argv.autoCascadeEnv : undefined,
       checkEnv: process.argv.some((arg) => arg === '--check-env' || arg.startsWith('--check-env='))
         ? String(argv.checkEnv)
         : undefined,
@@ -149,14 +145,6 @@ function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
       options.cascadeEnv = arg.slice('-c='.length);
     } else if (arg.startsWith('--cascade-env=')) {
       options.cascadeEnv = arg.slice('--cascade-env='.length);
-    } else if (arg === '--cascade-node-env') {
-      options.cascadeNodeEnv = true;
-    } else if (arg === '--cascade-node-env=false' || arg === '--no-cascade-node-env') {
-      options.cascadeNodeEnv = false;
-    } else if (arg === '--auto-cascade-env') {
-      options.autoCascadeEnv = true;
-    } else if (arg === '--auto-cascade-env=false' || arg === '--no-auto-cascade-env') {
-      options.autoCascadeEnv = false;
     } else if (arg === '-e' || arg === '--env') {
       options.env = [...(options.env ?? []), nextValue()];
     } else if (arg.startsWith('--env=')) {
@@ -185,12 +173,7 @@ function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
 }
 
 function normalizeParsedDotenvArgs(parsed: ParsedDotenvArgs): ParsedDotenvArgs {
-  if (
-    !parsed.options.cascadeEnv &&
-    !parsed.options.cascadeNodeEnv &&
-    !parsed.options.autoCascadeEnv &&
-    !parsed.options.env
-  ) {
+  if (!parsed.options.cascadeEnv && !parsed.options.env) {
     parsed.options.env = ['.env'];
   }
   return parsed;

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -1,51 +1,19 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 
-import {
-  readAndApplyEnvironmentVariables,
-  removeNpmAndYarnEnvironmentVariables,
-} from '@willbooster/shared-lib-node/src';
+import { removeNpmAndYarnEnvironmentVariables } from '@willbooster/shared-lib-node/src';
+import { config } from 'dotenv';
+import { expand } from 'dotenv-expand';
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
-
-interface DotenvOptions {
-  cascadeEnv?: string;
-  checkEnv?: string;
-  env?: string[];
-  includeRootEnv?: boolean;
-  quietEnv?: boolean;
-  verbose?: boolean;
-  workingDir?: string;
-}
 
 interface ParsedDotenvArgs {
   command: string[];
-  options: DotenvOptions;
 }
 
 export const dotenvCommand: CommandModule = {
   command: 'dotenv [args..]',
   describe: 'Load .env files and run a command.',
-  builder: (yargs: Argv<unknown>) =>
-    yargs
-      .parserConfiguration({ 'populate--': true })
-      .option('cascade-env', {
-        alias: 'c',
-        description: 'Environment to load cascading .env files.',
-        type: 'string',
-      })
-      .option('env', {
-        alias: 'e',
-        description: '.env files to be loaded.',
-        type: 'array',
-      })
-      .option('check-env', {
-        description: 'Check whether loaded env keys match the given .env file.',
-        type: 'string',
-      })
-      .option('quiet-env', {
-        description: 'Suppress .env file loading information.',
-        type: 'boolean',
-      }),
+  builder: (yargs: Argv<unknown>) => yargs.parserConfiguration({ 'populate--': true }),
   async handler(argv) {
     await runParsedDotenvCommand(getParsedDotenvArgsFromYargs(argv));
   },
@@ -55,31 +23,14 @@ export async function runDotenvCommand(args: string[]): Promise<void> {
   await runParsedDotenvCommand(parseDotenvArgs(args));
 }
 
-async function runParsedDotenvCommand({ command, options }: ParsedDotenvArgs): Promise<void> {
+async function runParsedDotenvCommand({ command }: ParsedDotenvArgs): Promise<void> {
   if (command.length === 0) {
-    console.error('Usage: wb dotenv [-c <environment>] [--env <file>] -- <command> [args...]');
+    console.error('Usage: wb dotenv -- <command> [args...]');
     process.exit(1);
   }
 
-  const cwd = path.resolve(options.workingDir ?? process.cwd());
-  if (options.workingDir) {
-    process.chdir(cwd);
-  }
-  if (options.cascadeEnv) {
-    process.env.WB_ENV ||= options.cascadeEnv;
-  }
-  readAndApplyEnvironmentVariables(
-    {
-      autoCascadeEnv: false,
-      cascadeEnv: options.cascadeEnv,
-      checkEnv: options.checkEnv,
-      env: options.env,
-      includeRootEnv: options.includeRootEnv ?? true,
-      quietEnv: options.quietEnv ?? true,
-      verbose: options.verbose,
-    },
-    cwd
-  );
+  const cwd = path.resolve(process.cwd());
+  readAndApplyEnvironmentVariables(cwd);
   removeNpmAndYarnEnvironmentVariables(process.env);
 
   const child = spawn(command[0]!, command.slice(1), {
@@ -101,80 +52,25 @@ async function runParsedDotenvCommand({ command, options }: ParsedDotenvArgs): P
 }
 
 function getParsedDotenvArgsFromYargs(argv: ArgumentsCamelCase): ParsedDotenvArgs {
-  const command = [
-    ...((argv.args as unknown[] | undefined) ?? []).map(String),
-    ...((argv['--'] as unknown[] | undefined) ?? []).map(String),
-  ];
-  return normalizeParsedDotenvArgs({
-    command,
-    options: {
-      cascadeEnv: typeof argv.cascadeEnv === 'string' ? argv.cascadeEnv : undefined,
-      checkEnv: process.argv.some((arg) => arg === '--check-env' || arg.startsWith('--check-env='))
-        ? String(argv.checkEnv)
-        : undefined,
-      env: Array.isArray(argv.env) ? argv.env.map(String) : undefined,
-      includeRootEnv: typeof argv.includeRootEnv === 'boolean' ? argv.includeRootEnv : undefined,
-      quietEnv: typeof argv.quietEnv === 'boolean' ? argv.quietEnv : undefined,
-      verbose: typeof argv.verbose === 'boolean' ? argv.verbose : undefined,
-      workingDir: typeof argv.workingDir === 'string' ? argv.workingDir : undefined,
-    },
-  });
+  return {
+    command: [
+      ...((argv.args as unknown[] | undefined) ?? []).map(String),
+      ...((argv['--'] as unknown[] | undefined) ?? []).map(String),
+    ],
+  };
 }
 
 function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
-  const options: DotenvOptions = {};
-  for (let index = 0; index < args.length; index++) {
-    const arg = args[index]!;
-    if (arg === '--') {
-      return normalizeParsedDotenvArgs({ command: args.slice(index + 1), options });
-    }
-    if (!arg.startsWith('-')) {
-      return normalizeParsedDotenvArgs({ command: args.slice(index), options });
-    }
-
-    const nextValue = (): string => {
-      const value = args[++index];
-      if (!value) {
-        throw new Error(`Missing value for ${arg}`);
-      }
-      return value;
-    };
-    if (arg === '-c' || arg === '--cascade-env') {
-      options.cascadeEnv = nextValue();
-    } else if (arg.startsWith('-c=')) {
-      options.cascadeEnv = arg.slice('-c='.length);
-    } else if (arg.startsWith('--cascade-env=')) {
-      options.cascadeEnv = arg.slice('--cascade-env='.length);
-    } else if (arg === '-e' || arg === '--env') {
-      options.env = [...(options.env ?? []), nextValue()];
-    } else if (arg.startsWith('--env=')) {
-      options.env = [...(options.env ?? []), arg.slice('--env='.length)];
-    } else if (arg === '--check-env') {
-      options.checkEnv = nextValue();
-    } else if (arg.startsWith('--check-env=')) {
-      options.checkEnv = arg.slice('--check-env='.length);
-    } else if (arg === '--include-root-env') {
-      options.includeRootEnv = true;
-    } else if (arg === '--include-root-env=false' || arg === '--no-include-root-env') {
-      options.includeRootEnv = false;
-    } else if (arg === '--quiet' || arg === '--quiet-env') {
-      options.quietEnv = true;
-    } else if (arg === '--verbose' || arg === '-v') {
-      options.verbose = true;
-    } else if (arg === '--working-dir') {
-      options.workingDir = nextValue();
-    } else if (arg.startsWith('--working-dir=')) {
-      options.workingDir = arg.slice('--working-dir='.length);
-    } else {
-      throw new Error(`Unknown wb dotenv option: ${arg}`);
-    }
-  }
-  return normalizeParsedDotenvArgs({ command: [], options });
+  const separatorIndex = args.indexOf('--');
+  return { command: separatorIndex === -1 ? args : args.slice(separatorIndex + 1) };
 }
 
-function normalizeParsedDotenvArgs(parsed: ParsedDotenvArgs): ParsedDotenvArgs {
-  if (!parsed.options.cascadeEnv && !parsed.options.env) {
-    parsed.options.env = ['.env'];
+function readAndApplyEnvironmentVariables(cwd: string): void {
+  const parsed = config({ path: path.join(cwd, '.env'), processEnv: {}, quiet: true }).parsed ?? {};
+  const envVars = expand({ parsed, processEnv: {} }).parsed ?? parsed;
+  for (const [key, value] of Object.entries(envVars)) {
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
   }
-  return parsed;
 }

--- a/packages/wb/src/scripts/run.ts
+++ b/packages/wb/src/scripts/run.ts
@@ -209,10 +209,8 @@ export function normalizeScript(script: string, project: Project): { printable: 
         !project.usesBunPackageManager && project.binExists ? '' : `${projectPackageManagerWithRun} `
       )
   );
-  // Add cascade option when WB_ENV is defined
-  const cascadeOption = project.env.WB_ENV ? ` -c=${project.env.WB_ENV || 'development'}` : '';
   return {
-    printable: `${projectPackageManagerWithRun} dotenv${cascadeOption} -- ${printableScript}`,
+    printable: `${projectPackageManagerWithRun} dotenv -- ${printableScript}`,
     runnable: runnableScript,
   };
 }

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -326,8 +326,8 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
     );
   } else if (config.depending.prisma) {
     postMergeCommands.push(
-      String.raw`run_if_changed ".*\.prisma" "node node_modules/.bin/dotenv -c development -- node node_modules/.bin/prisma migrate deploy"`,
-      String.raw`run_if_changed ".*\.prisma" "node node_modules/.bin/dotenv -c development -- node node_modules/.bin/prisma generate"`
+      String.raw`run_if_changed ".*\.prisma" "node node_modules/.bin/wb prisma deploy"`,
+      String.raw`run_if_changed ".*\.prisma" "node node_modules/.bin/wb prisma generate"`
     );
   }
   const genI18nTsCommand = getGenI18nTsCommand(config, config.packageJson?.scripts);


### PR DESCRIPTION
## Summary
- make `wb dotenv` command-only: `wb dotenv -- <command> [args...]`
- remove dotenv option parsing and unused cascade/check/mise paths from the fast bin
- make nested command display use `wb dotenv -- ...` without env options
- stop generating `dotenv-cli -c development` Prisma hooks; use `wb prisma` so normal project env loading handles the development cascade

## Confirmation
- Current repo call sites only use optionless `wb dotenv`
- `ai-game-builder` and `exercode` production scripts now call `wb dotenv -- ...`
- `exercode` direct script usage is `WB_ENV=test yarn wb dotenv -- ...`, which only needs `.env` plus already-set `WB_ENV`
- `llm-proxy` does not use `wb dotenv`; its runtime still uses Bun `--env-file`

## Verification
- `yarn verify`
- `yarn workspace @willbooster/wbfy test`
- `node packages/wb/bin/index.js dotenv -- node -e "console.log('ok')"`
- `node packages/wb/bin/index.js dotenv node -e "console.log('ok')"`
