### PR TITLE
fix: load wb env dotenv file

### DIFF
--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -34,7 +34,11 @@ export function runDotenvCommand(args) {
 }
 
 function readAndApplyEnvironmentVariables(cwd) {
-  const envVars = readEnvFile(path.join(cwd, '.env'));
+  const parsed = {
+    ...readEnvFile(path.join(cwd, '.env')),
+    ...(process.env.WB_ENV ? readEnvFile(path.join(cwd, `.env.${process.env.WB_ENV}`)) : {}),
+  };
+  const envVars = expand({ parsed, processEnv: {} }).parsed ?? parsed;
   for (const [key, value] of Object.entries(envVars)) {
     if (!(key in process.env)) {
       process.env[key] = value;
@@ -43,8 +47,7 @@ function readAndApplyEnvironmentVariables(cwd) {
 }
 
 function readEnvFile(filePath) {
-  const parsed = config({ path: path.resolve(filePath), processEnv: {}, quiet: true }).parsed ?? {};
-  return expand({ parsed, processEnv: {} }).parsed ?? parsed;
+  return config({ path: path.resolve(filePath), processEnv: {}, quiet: true }).parsed ?? {};
 }
 
 function removeNpmAndYarnEnvironmentVariables(envVars) {

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -66,7 +66,12 @@ function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
 }
 
 function readAndApplyEnvironmentVariables(cwd: string): void {
-  const parsed = config({ path: path.join(cwd, '.env'), processEnv: {}, quiet: true }).parsed ?? {};
+  const parsed = {
+    ...config({ path: path.join(cwd, '.env'), processEnv: {}, quiet: true }).parsed,
+    ...(process.env.WB_ENV
+      ? (config({ path: path.join(cwd, `.env.${process.env.WB_ENV}`), processEnv: {}, quiet: true }).parsed ?? {})
+      : {}),
+  };
   const envVars = expand({ parsed, processEnv: {} }).parsed ?? parsed;
   for (const [key, value] of Object.entries(envVars)) {
     if (!(key in process.env)) {


### PR DESCRIPTION
## Customer Summary

- Keeps `wb dotenv ...` optionless while restoring support for environment-specific `.env.$WB_ENV` files.
- Fixes CI/runtime cases where Dockerized test apps need `.env.test` values.

## Technical Summary

- Loads `.env` first, then `.env.$WB_ENV` when `WB_ENV` is set, so environment-specific values override defaults.
- Applies the same behavior to both the TypeScript command source and the fast `bin/dotenv.js` path.

## Why

- The previous `dotenv-cli -c "$WB_ENV"` usage in downstream apps loaded `.env.test` in CI.
- The simplified `wb dotenv` implementation only loaded `.env`, which broke Dockerized e2e tests.

## Testing

- `yarn verify`
- `WB_ENV=test packages/wb/bin/index.js dotenv -- node -e '...'` smoke check returning `.env.test` values
