### PR TITLE
feat: add sqlite pragma runners

### DIFF
--- a/packages/shared-lib/src/index.ts
+++ b/packages/shared-lib/src/index.ts
@@ -5,13 +5,7 @@ export { mailTemplates } from './mail.js';
 export { parseCommandLineArgs } from './parseCommandLineArgs.js';
 export { shuffle } from './shuffle.js';
 export { sleep } from './sleep.js';
-export {
-  getConnectionLevelSqlitePragmas,
-  getPersistentSqlitePragmas,
-  runConnectionLevelSqlitePragmas,
-  runPersistentSqlitePragmas,
-  runSqlitePragmas,
-} from './sqlite.js';
+export { getConnectionLevelSqlitePragmas, getPersistentSqlitePragmas, runSqlitePragmas } from './sqlite.js';
 export { zenkakuAlphanumericalsToHankaku } from './zenkaku.js';
 
 export type { RetryOptions } from './error.js';

--- a/packages/shared-lib/src/index.ts
+++ b/packages/shared-lib/src/index.ts
@@ -5,7 +5,14 @@ export { mailTemplates } from './mail.js';
 export { parseCommandLineArgs } from './parseCommandLineArgs.js';
 export { shuffle } from './shuffle.js';
 export { sleep } from './sleep.js';
-export { getConnectionLevelSqlitePragmas, getPersistentSqlitePragmas } from './sqlite.js';
+export {
+  getConnectionLevelSqlitePragmas,
+  getPersistentSqlitePragmas,
+  runConnectionLevelSqlitePragmas,
+  runPersistentSqlitePragmas,
+  runSqlitePragmas,
+} from './sqlite.js';
 export { zenkakuAlphanumericalsToHankaku } from './zenkaku.js';
 
 export type { RetryOptions } from './error.js';
+export type { RunSqlitePragmasOptions, SqlitePragmaExecutor } from './sqlite.js';

--- a/packages/shared-lib/src/sqlite.ts
+++ b/packages/shared-lib/src/sqlite.ts
@@ -6,17 +6,6 @@ export interface RunSqlitePragmasOptions {
   ignoreBusy?: boolean;
 }
 
-export function runConnectionLevelSqlitePragmas(executor: SqlitePragmaExecutor): void {
-  runSqlitePragmas(executor, getConnectionLevelSqlitePragmas());
-}
-
-export function runPersistentSqlitePragmas(
-  executor: SqlitePragmaExecutor,
-  options: RunSqlitePragmasOptions = {}
-): void {
-  runSqlitePragmas(executor, getPersistentSqlitePragmas(), options);
-}
-
 export function runSqlitePragmas(
   executor: SqlitePragmaExecutor,
   pragmas: string,

--- a/packages/shared-lib/src/sqlite.ts
+++ b/packages/shared-lib/src/sqlite.ts
@@ -1,3 +1,35 @@
+export interface SqlitePragmaExecutor {
+  exec(sql: string): unknown;
+}
+
+export interface RunSqlitePragmasOptions {
+  ignoreBusy?: boolean;
+}
+
+export function runConnectionLevelSqlitePragmas(executor: SqlitePragmaExecutor): void {
+  runSqlitePragmas(executor, getConnectionLevelSqlitePragmas());
+}
+
+export function runPersistentSqlitePragmas(
+  executor: SqlitePragmaExecutor,
+  options: RunSqlitePragmasOptions = {}
+): void {
+  runSqlitePragmas(executor, getPersistentSqlitePragmas(), options);
+}
+
+export function runSqlitePragmas(
+  executor: SqlitePragmaExecutor,
+  pragmas: string,
+  options: RunSqlitePragmasOptions = {}
+): void {
+  try {
+    executor.exec(pragmas);
+  } catch (error) {
+    if (options.ignoreBusy && isSqliteBusyError(error)) return;
+    throw error;
+  }
+}
+
 export function getConnectionLevelSqlitePragmas(): string {
   // cf. https://github.com/benbjohnson/litestream/issues/724#issue-3367254318
   // cf. https://github.com/benbjohnson/litestream/blob/9bd72348b7e7b1b3b8cf1e8befbee3b2c17444f7/.claude/agents/performance-optimizer.md?plain=1#L225-L232
@@ -6,4 +38,8 @@ export function getConnectionLevelSqlitePragmas(): string {
 
 export function getPersistentSqlitePragmas(): string {
   return 'PRAGMA journal_mode = WAL;';
+}
+
+function isSqliteBusyError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'SQLITE_BUSY';
 }


### PR DESCRIPTION
## Summary
- Add shared helpers to execute SQLite PRAGMA strings through any connection exposing `exec(sql)`.
- Add wrappers for connection-level and persistent PRAGMAs.
- Allow callers to ignore `SQLITE_BUSY` for lock-prone persistent PRAGMA setup such as WAL initialization.

## Verification
- `yarn verify`
