### PR TITLE
fix: keep docker optimized dev deps in place

### DIFF
--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -12,10 +12,6 @@ import { packageManager } from '../utils/runtime.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
 
-// These tools are declared as devDependencies in source repos, but optimized Docker
-// package.json files still need them for in-image codegen/build steps.
-const runtimeDevDependencies = ['@willbooster/wb', 'build-ts'];
-
 const builder = {
   outside: {
     description: 'Whether the optimization is executed outside a docker container or not',
@@ -101,10 +97,9 @@ function findDockerShellScriptsDirPath(): string {
 }
 
 function optimizeDevDependencies(argv: InferredOptionTypes<typeof builder>, packageJson: PackageJson): void {
-  promoteRuntimeDevDependencies(packageJson);
   if (argv.outside) {
     // Outside optimization writes dist/package.json before Docker builds the app.
-    // Keep build-time packages for that later in-image build and remove only known non-build tooling.
+    // Keep dependency sections aligned with the source lockfile and remove only known non-build tooling.
     removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson);
     return;
   }
@@ -150,25 +145,6 @@ function removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson: Pack
     }
   }
   console.info('Removed devDependencies:', removedDeps.join(', ') || 'none');
-}
-
-function promoteRuntimeDevDependencies(packageJson: PackageJson): void {
-  const devDeps = packageJson.devDependencies ?? {};
-  const dependencies = packageJson.dependencies ?? {};
-  const promotedDeps: string[] = [];
-  for (const name of runtimeDevDependencies) {
-    const version = devDeps[name];
-    if (!version) continue;
-    if (!dependencies[name]) {
-      dependencies[name] = version;
-      promotedDeps.push(name);
-    }
-    delete devDeps[name];
-  }
-  if (promotedDeps.length > 0) {
-    packageJson.dependencies = dependencies;
-  }
-  console.info('Promoted runtime devDependencies:', promotedDeps.join(', ') || 'none');
 }
 
 function optimizeScripts(packageJson: PackageJson): void {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -37,7 +37,13 @@ const managedDependencyVersions = {
   ...wbfyPackageJson.devDependencies,
   ...wbfyPackageJson.peerDependencies,
 };
-const baselineManagedDependencies = new Set([wbDependency, buildTsDependency, lefthookDependency, ...oxlintDeps]);
+const baselineManagedDependencies = new Set([
+  wbDependency,
+  buildTsDependency,
+  lefthookDependency,
+  'sort-package-json',
+  ...oxlintDeps,
+]);
 const willBoosterConfigsManagedDependencies = [
   '@willbooster/prettier-config',
   ...oxlintDeps.filter((dependency) => dependency.startsWith('@willbooster/')),


### PR DESCRIPTION
## Summary
- stop promoting selected devDependencies to dependencies during `wb optimizeForDockerBuild`
- keep optimized Docker package manifests aligned with the source lockfile dependency sections

## Verification
- `yarn verify`
