### PR TITLE
feat: generate pruned docker lockfiles

### DIFF
--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -234,6 +234,7 @@ async function writePrunedBunLockfile(project: Project, packageJson: PackageJson
   const workspace = await prepareLockfileWorkspace(project, packageJson, [
     path.basename(sourceLockfilePath),
     'bunfig.toml',
+    '.tool-versions',
   ]);
   try {
     const result = child_process.spawnSync('bun', ['install', '--lockfile-only'], {
@@ -260,7 +261,12 @@ async function writePrunedYarnLockfile(project: Project, packageJson: PackageJso
     return;
   }
 
-  const workspace = await prepareLockfileWorkspace(project, packageJson, ['yarn.lock', '.yarnrc.yml', '.yarn']);
+  const workspace = await prepareLockfileWorkspace(project, packageJson, [
+    'yarn.lock',
+    '.yarnrc.yml',
+    '.yarn',
+    '.tool-versions',
+  ]);
   try {
     const result = child_process.spawnSync('yarn', ['install', '--mode=update-lockfile'], {
       cwd: workspace.installDirPath,

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -50,7 +50,7 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
     const prunedLockfileRequests: PrunedLockfileRequest[] = [];
     for (const project of prepareForRunningCommand('optimizeForDockerBuild', projects.descendants)) {
       const packageJson: PackageJson = project.packageJson;
-      const rewrittenDependencies = rewritePrivateGitHubDependencies(packageJson);
+      const rewrittenDependencies = rewritePrivateGitHubDependencies(project, packageJson);
       const prunedDependencies = optimizeDevDependencies(argv, packageJson);
 
       optimizeScripts(packageJson);
@@ -66,6 +66,8 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
         await writeDockerShellScripts(path.join(distDirPath, 'bash'));
         if (prunedDependencies.length > 0 || rewrittenDependencies.length > 0) {
           prunedLockfileRequests.push({ distDirPath, packageJson, project });
+        } else {
+          await copySourceLockfile(project, distDirPath);
         }
       }
     }
@@ -81,7 +83,7 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
   },
 };
 
-function rewritePrivateGitHubDependencies(packageJson: PackageJson): string[] {
+function rewritePrivateGitHubDependencies(project: Project, packageJson: PackageJson): string[] {
   const rewrittenDependencies: string[] = [];
   for (const key of dependencySectionKeys) {
     const deps = packageJson[key] ?? {};
@@ -89,13 +91,23 @@ function rewritePrivateGitHubDependencies(packageJson: PackageJson): string[] {
       if (value?.startsWith('git@github.com:')) {
         // Docker builds cannot access private SSH URLs unless credentials are forwarded.
         // The Dockerfile copies those workspace packages into the image instead.
-        deps[name] = `./${name}`;
+        deps[name] = getPrivatePackageDockerSpecifier(project, name);
         rewrittenDependencies.push(`${key}.${name}`);
       }
     }
   }
   console.info('Rewrote private GitHub dependencies:', rewrittenDependencies.join(', ') || 'none');
   return rewrittenDependencies;
+}
+
+function getPrivatePackageDockerSpecifier(project: Project, packageName: string): string {
+  const privatePackageDirPath = path.join(project.rootDirPath, '@willbooster', toUnscopedPackageName(packageName));
+  const relativePath = path.relative(project.dirPath, privatePackageDirPath);
+  return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
+}
+
+function toUnscopedPackageName(packageName: string): string {
+  return packageName.replace(/^@willbooster\//, '');
 }
 
 async function writeDockerShellScripts(dirPath: string): Promise<void> {
@@ -183,6 +195,17 @@ async function writePrunedLockfile(project: Project, packageJson: PackageJson, d
   await lockfileWriter(project, packageJson, distDirPath);
 }
 
+async function copySourceLockfile(project: Project, distDirPath: string): Promise<void> {
+  const sourceLockfilePath = project.usesBunPackageManager
+    ? findFirstExistingProjectFile(project, ['bun.lock', 'bun.lockb'])
+    : findFirstExistingProjectFile(project, ['yarn.lock']);
+  if (!sourceLockfilePath) return;
+
+  const targetLockfilePath = path.join(distDirPath, path.basename(sourceLockfilePath));
+  await fs.promises.copyFile(sourceLockfilePath, targetLockfilePath);
+  console.info(`Copied Docker lockfile: ${path.relative(process.cwd(), targetLockfilePath)}`);
+}
+
 async function writePrunedBunLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
   const sourceLockfilePath = findFirstExistingProjectFile(project, ['bun.lock', 'bun.lockb']);
   if (!sourceLockfilePath) {
@@ -241,25 +264,30 @@ async function prepareLockfileWorkspace(
   packageManagerFiles: string[]
 ): Promise<LockfileWorkspace> {
   const tempDirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-docker-lock-'));
-  const relativeProjectDirPath = path.relative(project.rootDirPath, project.dirPath);
-  const tempProjectDirPath = path.resolve(tempDirPath, relativeProjectDirPath);
+  try {
+    const relativeProjectDirPath = path.relative(project.rootDirPath, project.dirPath);
+    const tempProjectDirPath = path.resolve(tempDirPath, relativeProjectDirPath);
 
-  await copyRootPackageJson(project, tempDirPath);
-  await fs.promises.mkdir(tempProjectDirPath, { recursive: true });
-  await fs.promises.writeFile(path.join(tempProjectDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
+    await copyRootPackageJson(project, tempDirPath);
+    await fs.promises.mkdir(tempProjectDirPath, { recursive: true });
+    await fs.promises.writeFile(path.join(tempProjectDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
 
-  for (const fileName of packageManagerFiles) {
-    const sourcePath = path.join(project.rootDirPath, fileName);
-    if (!fs.existsSync(sourcePath)) continue;
+    for (const fileName of packageManagerFiles) {
+      const sourcePath = path.join(project.rootDirPath, fileName);
+      if (!fs.existsSync(sourcePath)) continue;
 
-    const targetPath = path.join(tempDirPath, fileName);
-    await fs.promises.mkdir(path.dirname(targetPath), { recursive: true });
-    await fs.promises.cp(sourcePath, targetPath, { recursive: true });
+      const targetPath = path.join(tempDirPath, fileName);
+      await fs.promises.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.promises.cp(sourcePath, targetPath, { recursive: true });
+    }
+
+    await copyLocalPackageReferences(project, packageJson, tempProjectDirPath, tempDirPath);
+    await copyWorkspacePackageReferences(project, packageJson, tempDirPath);
+    return { installDirPath: tempProjectDirPath, rootDirPath: tempDirPath };
+  } catch (error) {
+    await fs.promises.rm(tempDirPath, { recursive: true, force: true });
+    throw error;
   }
-
-  await copyLocalPackageReferences(project, packageJson, tempProjectDirPath, tempDirPath);
-  await copyWorkspacePackageReferences(project, packageJson, tempDirPath);
-  return { installDirPath: tempProjectDirPath, rootDirPath: tempDirPath };
 }
 
 async function copyRootPackageJson(project: Project, tempDirPath: string): Promise<void> {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -48,12 +48,16 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       process.exit(1);
     }
 
+    const changedRootDirPaths = new Set<string>();
     const dockerLockfileRequests: DockerLockfileRequest[] = [];
     for (const project of prepareForRunningCommand('optimizeForDockerBuild', projects.descendants)) {
       const packageJson: PackageJson = project.packageJson;
       const rewrittenDependencies = rewritePrivateGitHubDependencies(project, packageJson);
       const prunedDependencies = optimizeDevDependencies(argv, packageJson);
       const dependenciesChanged = prunedDependencies.length > 0 || rewrittenDependencies.length > 0;
+      if (dependenciesChanged) {
+        changedRootDirPaths.add(project.rootDirPath);
+      }
 
       optimizeScripts(packageJson);
 
@@ -66,14 +70,13 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       await fs.promises.writeFile(path.join(distDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
       if (argv.outside) {
         await writeDockerShellScripts(path.join(distDirPath, 'bash'));
-        dockerLockfileRequests.push({ dependenciesChanged, distDirPath, packageJson, project });
+        // Docker lockfile output is intentionally root-only. wb assumes monorepos are rooted by package.json and use
+        // packages/*; package dist manifests are installed through the root Docker context, not as standalone projects.
+        if (project.dirPath === project.rootDirPath) {
+          dockerLockfileRequests.push({ dependenciesChanged, distDirPath, packageJson, project });
+        }
       }
     }
-    const changedRootDirPaths = new Set(
-      dockerLockfileRequests
-        .filter((request) => request.dependenciesChanged)
-        .map((request) => request.project.rootDirPath)
-    );
     for (const request of dockerLockfileRequests) {
       const writeLockfile =
         request.dependenciesChanged || changedRootDirPaths.has(request.project.dirPath)
@@ -456,15 +459,7 @@ function usesBunPackageManager(rootDirPath: string): boolean {
   if (['bun.lock', 'bun.lockb'].some((fileName) => fs.existsSync(path.join(rootDirPath, fileName)))) return true;
 
   const rootPackageJson = getRootPackageJson(rootDirPath);
-  if (typeof rootPackageJson?.packageManager === 'string' && rootPackageJson.packageManager.startsWith('bun@')) {
-    return true;
-  }
-
-  try {
-    return /(^|\n)bun\s/.test(fs.readFileSync(path.join(rootDirPath, '.tool-versions'), 'utf8'));
-  } catch {
-    return false;
-  }
+  return typeof rootPackageJson?.packageManager === 'string' && rootPackageJson.packageManager.startsWith('bun@');
 }
 
 function throwIfCommandFailed(result: child_process.SpawnSyncReturns<Buffer>, command: string): void {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -91,6 +91,14 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
 };
 
 function rewritePrivateGitHubDependencies(project: Project, packageJson: PackageJson): string[] {
+  return rewritePrivateGitHubDependenciesForDir(project.rootDirPath, project.dirPath, packageJson);
+}
+
+function rewritePrivateGitHubDependenciesForDir(
+  rootDirPath: string,
+  packageDirPath: string,
+  packageJson: PackageJson
+): string[] {
   const rewrittenDependencies: string[] = [];
   for (const key of dependencySectionKeys) {
     const deps = packageJson[key] ?? {};
@@ -98,7 +106,7 @@ function rewritePrivateGitHubDependencies(project: Project, packageJson: Package
       if (value?.startsWith('git@github.com:')) {
         // Docker builds cannot access private SSH URLs unless credentials are forwarded.
         // The Dockerfile copies those workspace packages into the image instead.
-        deps[name] = getPrivatePackageDockerSpecifier(project, name);
+        deps[name] = getPrivatePackageDockerSpecifier(rootDirPath, packageDirPath, name);
         rewrittenDependencies.push(`${key}.${name}`);
       }
     }
@@ -107,9 +115,9 @@ function rewritePrivateGitHubDependencies(project: Project, packageJson: Package
   return rewrittenDependencies;
 }
 
-function getPrivatePackageDockerSpecifier(project: Project, packageName: string): string {
-  const privatePackageDirPath = path.join(project.rootDirPath, '@willbooster', toUnscopedPackageName(packageName));
-  const relativePath = path.relative(project.dirPath, privatePackageDirPath);
+function getPrivatePackageDockerSpecifier(rootDirPath: string, packageDirPath: string, packageName: string): string {
+  const privatePackageDirPath = path.join(rootDirPath, '@willbooster', toUnscopedPackageName(packageName));
+  const relativePath = path.relative(packageDirPath, privatePackageDirPath);
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
 }
 
@@ -298,10 +306,21 @@ async function prepareLockfileWorkspace(
 }
 
 async function copyRootPackageJson(project: Project, tempDirPath: string): Promise<void> {
-  const sourcePackageJsonPath = path.join(project.rootDirPath, 'package.json');
+  const optimizedPackageJsonPath = path.join(project.rootDirPath, 'dist', 'package.json');
+  const sourcePackageJsonPath = fs.existsSync(optimizedPackageJsonPath)
+    ? optimizedPackageJsonPath
+    : path.join(project.rootDirPath, 'package.json');
   if (!fs.existsSync(sourcePackageJsonPath)) return;
 
-  await fs.promises.copyFile(sourcePackageJsonPath, path.join(tempDirPath, 'package.json'));
+  if (sourcePackageJsonPath === optimizedPackageJsonPath) {
+    await fs.promises.copyFile(sourcePackageJsonPath, path.join(tempDirPath, 'package.json'));
+    return;
+  }
+
+  const rootPackageJson = JSON.parse(await fs.promises.readFile(sourcePackageJsonPath, 'utf8')) as PackageJson;
+  rewritePrivateGitHubDependenciesForDir(project.rootDirPath, project.rootDirPath, rootPackageJson);
+  removeUnnecessaryDevDependenciesForOutsideDockerBuild(rootPackageJson);
+  await fs.promises.writeFile(path.join(tempDirPath, 'package.json'), JSON.stringify(rootPackageJson), 'utf8');
 }
 
 async function copyLocalPackageReferences(

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -23,6 +23,11 @@ interface PrunedLockfileRequest {
   project: Project;
 }
 
+interface LockfileWorkspace {
+  installDirPath: string;
+  rootDirPath: string;
+}
+
 const builder = {
   outside: {
     description: 'Whether the optimization is executed outside a docker container or not',
@@ -45,17 +50,7 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
     const prunedLockfileRequests: PrunedLockfileRequest[] = [];
     for (const project of prepareForRunningCommand('optimizeForDockerBuild', projects.descendants)) {
       const packageJson: PackageJson = project.packageJson;
-      for (const key of dependencySectionKeys) {
-        const deps = packageJson[key] ?? {};
-        for (const [name, value] of Object.entries(deps)) {
-          if (value?.startsWith('git@github.com:')) {
-            // Docker builds cannot access private SSH URLs unless credentials are forwarded.
-            // The Dockerfile copies those workspace packages into the image instead.
-            deps[name] = `./${name}`;
-          }
-        }
-      }
-
+      const rewrittenDependencies = rewritePrivateGitHubDependencies(packageJson);
       const prunedDependencies = optimizeDevDependencies(argv, packageJson);
 
       optimizeScripts(packageJson);
@@ -69,7 +64,7 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       await fs.promises.writeFile(path.join(distDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
       if (argv.outside) {
         await writeDockerShellScripts(path.join(distDirPath, 'bash'));
-        if (prunedDependencies.length > 0) {
+        if (prunedDependencies.length > 0 || rewrittenDependencies.length > 0) {
           prunedLockfileRequests.push({ distDirPath, packageJson, project });
         }
       }
@@ -85,6 +80,23 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
     }
   },
 };
+
+function rewritePrivateGitHubDependencies(packageJson: PackageJson): string[] {
+  const rewrittenDependencies: string[] = [];
+  for (const key of dependencySectionKeys) {
+    const deps = packageJson[key] ?? {};
+    for (const [name, value] of Object.entries(deps)) {
+      if (value?.startsWith('git@github.com:')) {
+        // Docker builds cannot access private SSH URLs unless credentials are forwarded.
+        // The Dockerfile copies those workspace packages into the image instead.
+        deps[name] = `./${name}`;
+        rewrittenDependencies.push(`${key}.${name}`);
+      }
+    }
+  }
+  console.info('Rewrote private GitHub dependencies:', rewrittenDependencies.join(', ') || 'none');
+  return rewrittenDependencies;
+}
 
 async function writeDockerShellScripts(dirPath: string): Promise<void> {
   const sourceDirPath = findDockerShellScriptsDirPath();
@@ -172,54 +184,54 @@ async function writePrunedLockfile(project: Project, packageJson: PackageJson, d
 }
 
 async function writePrunedBunLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
-  const sourceLockfilePath = findFirstExistingFile(project.dirPath, ['bun.lock', 'bun.lockb']);
+  const sourceLockfilePath = findFirstExistingProjectFile(project, ['bun.lock', 'bun.lockb']);
   if (!sourceLockfilePath) {
     console.info('Skipped pruned Bun lockfile generation because no Bun lockfile was found.');
     return;
   }
 
-  const tempDirPath = await prepareLockfileWorkspace(project, packageJson, [
+  const workspace = await prepareLockfileWorkspace(project, packageJson, [
     path.basename(sourceLockfilePath),
     'bunfig.toml',
   ]);
   try {
     const result = child_process.spawnSync('bun', ['install', '--lockfile-only'], {
-      cwd: tempDirPath,
+      cwd: workspace.installDirPath,
       stdio: 'inherit',
     });
-    if (result.status !== 0) throw new Error(`bun install --lockfile-only exited with status ${result.status}`);
+    throwIfCommandFailed(result, 'bun install --lockfile-only');
 
-    const generatedLockfilePath = findFirstExistingFile(tempDirPath, ['bun.lock', 'bun.lockb']);
+    const generatedLockfilePath = findFirstExistingFile(workspace.rootDirPath, ['bun.lock', 'bun.lockb']);
     if (!generatedLockfilePath) throw new Error('bun install --lockfile-only did not generate a lockfile.');
 
     const targetLockfilePath = path.join(distDirPath, path.basename(generatedLockfilePath));
     await fs.promises.copyFile(generatedLockfilePath, targetLockfilePath);
     console.info(`Generated pruned Bun lockfile: ${path.relative(process.cwd(), targetLockfilePath)}`);
   } finally {
-    await fs.promises.rm(tempDirPath, { recursive: true, force: true });
+    await fs.promises.rm(workspace.rootDirPath, { recursive: true, force: true });
   }
 }
 
 async function writePrunedYarnLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
-  const sourceLockfilePath = path.join(project.dirPath, 'yarn.lock');
-  if (!fs.existsSync(sourceLockfilePath)) {
+  const sourceLockfilePath = findFirstExistingProjectFile(project, ['yarn.lock']);
+  if (!sourceLockfilePath) {
     console.info('Skipped pruned Yarn lockfile generation because no yarn.lock was found.');
     return;
   }
 
-  const tempDirPath = await prepareLockfileWorkspace(project, packageJson, ['yarn.lock', '.yarnrc.yml', '.yarn']);
+  const workspace = await prepareLockfileWorkspace(project, packageJson, ['yarn.lock', '.yarnrc.yml', '.yarn']);
   try {
     const result = child_process.spawnSync('yarn', ['install', '--mode=update-lockfile'], {
-      cwd: tempDirPath,
+      cwd: workspace.installDirPath,
       stdio: 'inherit',
     });
-    if (result.status !== 0) throw new Error(`yarn install --mode=update-lockfile exited with status ${result.status}`);
+    throwIfCommandFailed(result, 'yarn install --mode=update-lockfile');
 
     const targetLockfilePath = path.join(distDirPath, 'yarn.lock');
-    await fs.promises.copyFile(path.join(tempDirPath, 'yarn.lock'), targetLockfilePath);
+    await fs.promises.copyFile(path.join(workspace.rootDirPath, 'yarn.lock'), targetLockfilePath);
     console.info(`Generated pruned Yarn lockfile: ${path.relative(process.cwd(), targetLockfilePath)}`);
   } finally {
-    await fs.promises.rm(tempDirPath, { recursive: true, force: true });
+    await fs.promises.rm(workspace.rootDirPath, { recursive: true, force: true });
   }
 }
 
@@ -227,12 +239,17 @@ async function prepareLockfileWorkspace(
   project: Project,
   packageJson: PackageJson,
   packageManagerFiles: string[]
-): Promise<string> {
+): Promise<LockfileWorkspace> {
   const tempDirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-docker-lock-'));
-  await fs.promises.writeFile(path.join(tempDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
+  const relativeProjectDirPath = path.relative(project.rootDirPath, project.dirPath);
+  const tempProjectDirPath = path.resolve(tempDirPath, relativeProjectDirPath);
+
+  await copyRootPackageJson(project, tempDirPath);
+  await fs.promises.mkdir(tempProjectDirPath, { recursive: true });
+  await fs.promises.writeFile(path.join(tempProjectDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
 
   for (const fileName of packageManagerFiles) {
-    const sourcePath = path.join(project.dirPath, fileName);
+    const sourcePath = path.join(project.rootDirPath, fileName);
     if (!fs.existsSync(sourcePath)) continue;
 
     const targetPath = path.join(tempDirPath, fileName);
@@ -240,15 +257,23 @@ async function prepareLockfileWorkspace(
     await fs.promises.cp(sourcePath, targetPath, { recursive: true });
   }
 
-  await copyLocalPackageReferences(project, packageJson, tempDirPath);
+  await copyLocalPackageReferences(project, packageJson, tempProjectDirPath, tempDirPath);
   await copyWorkspacePackageReferences(project, packageJson, tempDirPath);
-  return tempDirPath;
+  return { installDirPath: tempProjectDirPath, rootDirPath: tempDirPath };
+}
+
+async function copyRootPackageJson(project: Project, tempDirPath: string): Promise<void> {
+  const sourcePackageJsonPath = path.join(project.rootDirPath, 'package.json');
+  if (!fs.existsSync(sourcePackageJsonPath)) return;
+
+  await fs.promises.copyFile(sourcePackageJsonPath, path.join(tempDirPath, 'package.json'));
 }
 
 async function copyLocalPackageReferences(
   project: Project,
   packageJson: PackageJson,
-  tempDirPath: string
+  tempProjectDirPath: string,
+  tempRootDirPath: string
 ): Promise<void> {
   for (const dependencies of dependencySectionKeys.map((sectionKey) => packageJson[sectionKey] ?? {})) {
     for (const dependencySpecifier of Object.values(dependencies)) {
@@ -257,7 +282,7 @@ async function copyLocalPackageReferences(
 
       await copyLocalPackageDirectory(
         path.resolve(project.dirPath, relativePackagePath),
-        path.resolve(tempDirPath, relativePackagePath)
+        getSafeTempPackagePath(tempRootDirPath, tempProjectDirPath, relativePackagePath)
       );
     }
   }
@@ -268,17 +293,17 @@ async function copyWorkspacePackageReferences(
   packageJson: PackageJson,
   tempDirPath: string
 ): Promise<void> {
-  const workspacePatterns = getWorkspacePatterns(packageJson);
+  const workspacePatterns = getWorkspacePatterns(getRootPackageJson(project) ?? packageJson);
   if (workspacePatterns.length === 0) return;
 
   const workspacePackageJsonPaths = await globby(
     workspacePatterns.map((pattern) => `${pattern.replace(/\/$/, '')}/package.json`),
-    { cwd: project.dirPath, onlyFiles: true }
+    { cwd: project.rootDirPath, onlyFiles: true }
   );
   for (const packageJsonPath of workspacePackageJsonPaths) {
     const relativePackageDirPath = path.dirname(packageJsonPath);
     await copyLocalPackageDirectory(
-      path.resolve(project.dirPath, relativePackageDirPath),
+      path.resolve(project.rootDirPath, relativePackageDirPath),
       path.resolve(tempDirPath, relativePackageDirPath)
     );
     await copyOptimizedWorkspacePackageJson(project, relativePackageDirPath, tempDirPath);
@@ -290,7 +315,7 @@ async function copyOptimizedWorkspacePackageJson(
   relativePackageDirPath: string,
   tempDirPath: string
 ): Promise<void> {
-  const optimizedPackageJsonPath = path.resolve(project.dirPath, relativePackageDirPath, 'dist/package.json');
+  const optimizedPackageJsonPath = path.resolve(project.rootDirPath, relativePackageDirPath, 'dist/package.json');
   if (!fs.existsSync(optimizedPackageJsonPath)) return;
 
   await fs.promises.copyFile(
@@ -308,8 +333,27 @@ async function copyLocalPackageDirectory(sourceDirPath: string, targetDirPath: s
   await fs.promises.mkdir(path.dirname(targetDirPath), { recursive: true });
   await fs.promises.cp(sourceDirPath, targetDirPath, {
     recursive: true,
-    filter: (sourcePath) => !sourcePath.split(path.sep).some((part) => localPackageCopyIgnoredDirNames.has(part)),
+    filter: (sourcePath) => shouldCopyLocalPackagePath(sourceDirPath, sourcePath),
   });
+}
+
+function shouldCopyLocalPackagePath(sourceDirPath: string, sourcePath: string): boolean {
+  const relativePath = path.relative(sourceDirPath, sourcePath);
+  if (!relativePath) return true;
+
+  return !relativePath.split(path.sep).some((part) => localPackageCopyIgnoredDirNames.has(part));
+}
+
+function getSafeTempPackagePath(
+  tempRootDirPath: string,
+  tempProjectDirPath: string,
+  relativePackagePath: string
+): string {
+  const targetDirPath = path.resolve(tempProjectDirPath, relativePackagePath);
+  if (targetDirPath !== tempRootDirPath && !targetDirPath.startsWith(`${tempRootDirPath}${path.sep}`)) {
+    throw new Error(`Local package path escapes the temporary lockfile workspace: ${relativePackagePath}`);
+  }
+  return targetDirPath;
 }
 
 function getWorkspacePatterns(packageJson: PackageJson): string[] {
@@ -334,6 +378,27 @@ function findFirstExistingFile(dirPath: string, fileNames: string[]): string | u
     const filePath = path.join(dirPath, fileName);
     if (fs.existsSync(filePath)) return filePath;
   }
+  return undefined;
+}
+
+function findFirstExistingProjectFile(project: Project, fileNames: string[]): string | undefined {
+  for (const fileName of fileNames) {
+    const filePath = path.join(project.rootDirPath, fileName);
+    if (fs.existsSync(filePath)) return filePath;
+  }
+  return undefined;
+}
+
+function getRootPackageJson(project: Project): PackageJson | undefined {
+  const packageJsonPath = path.join(project.rootDirPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) return undefined;
+
+  return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
+}
+
+function throwIfCommandFailed(result: child_process.SpawnSyncReturns<Buffer>, command: string): void {
+  if (result.error) throw new Error(`${command} failed: ${result.error.message}`);
+  if (result.status !== 0) throw new Error(`${command} exited with status ${result.status}`);
 }
 
 function optimizeScripts(packageJson: PackageJson): void {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -22,6 +22,7 @@ interface DockerLockfileRequest {
   distDirPath: string;
   packageJson: PackageJson;
   project: Project;
+  rootDirPath: string;
 }
 
 interface LockfileWorkspace {
@@ -49,9 +50,10 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
     }
 
     const dockerLockfileRequests: DockerLockfileRequest[] = [];
+    const rootDirPath = projects.root.dirPath;
     for (const project of prepareForRunningCommand('optimizeForDockerBuild', projects.descendants)) {
       const packageJson: PackageJson = project.packageJson;
-      const rewrittenDependencies = rewritePrivateGitHubDependencies(project, packageJson);
+      const rewrittenDependencies = rewritePrivateGitHubDependencies(rootDirPath, project.dirPath, packageJson);
       const prunedDependencies = optimizeDevDependencies(argv, packageJson);
       const dependenciesChanged = prunedDependencies.length > 0 || rewrittenDependencies.length > 0;
 
@@ -66,20 +68,18 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       await fs.promises.writeFile(path.join(distDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
       if (argv.outside) {
         await writeDockerShellScripts(path.join(distDirPath, 'bash'));
-        dockerLockfileRequests.push({ dependenciesChanged, distDirPath, packageJson, project });
+        dockerLockfileRequests.push({ dependenciesChanged, distDirPath, packageJson, project, rootDirPath });
       }
     }
     const changedRootDirPaths = new Set(
-      dockerLockfileRequests
-        .filter((request) => request.dependenciesChanged)
-        .map((request) => request.project.rootDirPath)
+      dockerLockfileRequests.filter((request) => request.dependenciesChanged).map((request) => request.rootDirPath)
     );
     for (const request of dockerLockfileRequests) {
       const writeLockfile =
         request.dependenciesChanged || changedRootDirPaths.has(request.project.dirPath)
           ? writePrunedLockfile
           : copySourceLockfile;
-      await writeLockfile(request.project, request.packageJson, request.distDirPath);
+      await writeLockfile(request.rootDirPath, request.project, request.packageJson, request.distDirPath);
     }
     if (!argv.dryRun && !argv.outside) {
       child_process.spawnSync(packageManager, ['install'], {
@@ -90,8 +90,12 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
   },
 };
 
-function rewritePrivateGitHubDependencies(project: Project, packageJson: PackageJson): string[] {
-  return rewritePrivateGitHubDependenciesForDir(project.rootDirPath, project.dirPath, packageJson);
+function rewritePrivateGitHubDependencies(
+  rootDirPath: string,
+  packageDirPath: string,
+  packageJson: PackageJson
+): string[] {
+  return rewritePrivateGitHubDependenciesForDir(rootDirPath, packageDirPath, packageJson);
 }
 
 function rewritePrivateGitHubDependenciesForDir(
@@ -205,15 +209,25 @@ function removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson: Pack
   return removedDeps;
 }
 
-async function writePrunedLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
+async function writePrunedLockfile(
+  rootDirPath: string,
+  project: Project,
+  packageJson: PackageJson,
+  distDirPath: string
+): Promise<void> {
   const lockfileWriter = project.usesBunPackageManager ? writePrunedBunLockfile : writePrunedYarnLockfile;
-  await lockfileWriter(project, packageJson, distDirPath);
+  await lockfileWriter(rootDirPath, project, packageJson, distDirPath);
 }
 
-async function copySourceLockfile(project: Project, _packageJson: PackageJson, distDirPath: string): Promise<void> {
+async function copySourceLockfile(
+  rootDirPath: string,
+  project: Project,
+  _packageJson: PackageJson,
+  distDirPath: string
+): Promise<void> {
   const sourceLockfilePath = project.usesBunPackageManager
-    ? findFirstExistingProjectFile(project, ['bun.lock', 'bun.lockb'])
-    : findFirstExistingProjectFile(project, ['yarn.lock']);
+    ? findFirstExistingProjectFile(rootDirPath, ['bun.lock', 'bun.lockb'])
+    : findFirstExistingProjectFile(rootDirPath, ['yarn.lock']);
   if (!sourceLockfilePath) return;
 
   const targetLockfilePath = path.join(distDirPath, path.basename(sourceLockfilePath));
@@ -221,14 +235,19 @@ async function copySourceLockfile(project: Project, _packageJson: PackageJson, d
   console.info(`Copied Docker lockfile: ${path.relative(process.cwd(), targetLockfilePath)}`);
 }
 
-async function writePrunedBunLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
-  const sourceLockfilePath = findFirstExistingProjectFile(project, ['bun.lock', 'bun.lockb']);
+async function writePrunedBunLockfile(
+  rootDirPath: string,
+  project: Project,
+  packageJson: PackageJson,
+  distDirPath: string
+): Promise<void> {
+  const sourceLockfilePath = findFirstExistingProjectFile(rootDirPath, ['bun.lock', 'bun.lockb']);
   if (!sourceLockfilePath) {
     console.info('Skipped pruned Bun lockfile generation because no Bun lockfile was found.');
     return;
   }
 
-  const workspace = await prepareLockfileWorkspace(project, packageJson, [
+  const workspace = await prepareLockfileWorkspace(rootDirPath, project, packageJson, [
     path.basename(sourceLockfilePath),
     'bunfig.toml',
   ]);
@@ -250,14 +269,23 @@ async function writePrunedBunLockfile(project: Project, packageJson: PackageJson
   }
 }
 
-async function writePrunedYarnLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
-  const sourceLockfilePath = findFirstExistingProjectFile(project, ['yarn.lock']);
+async function writePrunedYarnLockfile(
+  rootDirPath: string,
+  project: Project,
+  packageJson: PackageJson,
+  distDirPath: string
+): Promise<void> {
+  const sourceLockfilePath = findFirstExistingProjectFile(rootDirPath, ['yarn.lock']);
   if (!sourceLockfilePath) {
     console.info('Skipped pruned Yarn lockfile generation because no yarn.lock was found.');
     return;
   }
 
-  const workspace = await prepareLockfileWorkspace(project, packageJson, ['yarn.lock', '.yarnrc.yml', '.yarn']);
+  const workspace = await prepareLockfileWorkspace(rootDirPath, project, packageJson, [
+    'yarn.lock',
+    '.yarnrc.yml',
+    '.yarn',
+  ]);
   try {
     const result = child_process.spawnSync('yarn', ['install', '--mode=update-lockfile'], {
       cwd: workspace.installDirPath,
@@ -274,21 +302,22 @@ async function writePrunedYarnLockfile(project: Project, packageJson: PackageJso
 }
 
 async function prepareLockfileWorkspace(
+  rootDirPath: string,
   project: Project,
   packageJson: PackageJson,
   packageManagerFiles: string[]
 ): Promise<LockfileWorkspace> {
   const tempDirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-docker-lock-'));
   try {
-    const relativeProjectDirPath = path.relative(project.rootDirPath, project.dirPath);
+    const relativeProjectDirPath = path.relative(rootDirPath, project.dirPath);
     const tempProjectDirPath = path.resolve(tempDirPath, relativeProjectDirPath);
 
-    await copyRootPackageJson(project, tempDirPath);
+    await copyRootPackageJson(rootDirPath, tempDirPath);
     await fs.promises.mkdir(tempProjectDirPath, { recursive: true });
     await fs.promises.writeFile(path.join(tempProjectDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
 
     for (const fileName of packageManagerFiles) {
-      const sourcePath = path.join(project.rootDirPath, fileName);
+      const sourcePath = path.join(rootDirPath, fileName);
       if (!fs.existsSync(sourcePath)) continue;
 
       const targetPath = path.join(tempDirPath, fileName);
@@ -297,7 +326,7 @@ async function prepareLockfileWorkspace(
     }
 
     await copyLocalPackageReferences(project, packageJson, tempProjectDirPath, tempDirPath);
-    await copyWorkspacePackageReferences(project, packageJson, tempDirPath);
+    await copyWorkspacePackageReferences(rootDirPath, packageJson, tempDirPath);
     return { installDirPath: tempProjectDirPath, rootDirPath: tempDirPath };
   } catch (error) {
     await fs.promises.rm(tempDirPath, { recursive: true, force: true });
@@ -305,11 +334,11 @@ async function prepareLockfileWorkspace(
   }
 }
 
-async function copyRootPackageJson(project: Project, tempDirPath: string): Promise<void> {
-  const optimizedPackageJsonPath = path.join(project.rootDirPath, 'dist', 'package.json');
+async function copyRootPackageJson(rootDirPath: string, tempDirPath: string): Promise<void> {
+  const optimizedPackageJsonPath = path.join(rootDirPath, 'dist', 'package.json');
   const sourcePackageJsonPath = fs.existsSync(optimizedPackageJsonPath)
     ? optimizedPackageJsonPath
-    : path.join(project.rootDirPath, 'package.json');
+    : path.join(rootDirPath, 'package.json');
   if (!fs.existsSync(sourcePackageJsonPath)) return;
 
   if (sourcePackageJsonPath === optimizedPackageJsonPath) {
@@ -318,7 +347,7 @@ async function copyRootPackageJson(project: Project, tempDirPath: string): Promi
   }
 
   const rootPackageJson = JSON.parse(await fs.promises.readFile(sourcePackageJsonPath, 'utf8')) as PackageJson;
-  rewritePrivateGitHubDependenciesForDir(project.rootDirPath, project.rootDirPath, rootPackageJson);
+  rewritePrivateGitHubDependenciesForDir(rootDirPath, rootDirPath, rootPackageJson);
   removeUnnecessaryDevDependenciesForOutsideDockerBuild(rootPackageJson);
   await fs.promises.writeFile(path.join(tempDirPath, 'package.json'), JSON.stringify(rootPackageJson), 'utf8');
 }
@@ -343,33 +372,33 @@ async function copyLocalPackageReferences(
 }
 
 async function copyWorkspacePackageReferences(
-  project: Project,
+  rootDirPath: string,
   packageJson: PackageJson,
   tempDirPath: string
 ): Promise<void> {
-  const workspacePatterns = getWorkspacePatterns(getRootPackageJson(project) ?? packageJson);
+  const workspacePatterns = getWorkspacePatterns(getRootPackageJson(rootDirPath) ?? packageJson);
   if (workspacePatterns.length === 0) return;
 
   const workspacePackageJsonPaths = await globby(
     workspacePatterns.map((pattern) => `${pattern.replace(/\/$/, '')}/package.json`),
-    { cwd: project.rootDirPath, onlyFiles: true }
+    { cwd: rootDirPath, onlyFiles: true }
   );
   for (const packageJsonPath of workspacePackageJsonPaths) {
     const relativePackageDirPath = path.dirname(packageJsonPath);
     await copyLocalPackageDirectory(
-      path.resolve(project.rootDirPath, relativePackageDirPath),
+      path.resolve(rootDirPath, relativePackageDirPath),
       path.resolve(tempDirPath, relativePackageDirPath)
     );
-    await copyOptimizedWorkspacePackageJson(project, relativePackageDirPath, tempDirPath);
+    await copyOptimizedWorkspacePackageJson(rootDirPath, relativePackageDirPath, tempDirPath);
   }
 }
 
 async function copyOptimizedWorkspacePackageJson(
-  project: Project,
+  rootDirPath: string,
   relativePackageDirPath: string,
   tempDirPath: string
 ): Promise<void> {
-  const optimizedPackageJsonPath = path.resolve(project.rootDirPath, relativePackageDirPath, 'dist/package.json');
+  const optimizedPackageJsonPath = path.resolve(rootDirPath, relativePackageDirPath, 'dist/package.json');
   if (!fs.existsSync(optimizedPackageJsonPath)) return;
 
   await fs.promises.copyFile(
@@ -435,16 +464,16 @@ function findFirstExistingFile(dirPath: string, fileNames: string[]): string | u
   return undefined;
 }
 
-function findFirstExistingProjectFile(project: Project, fileNames: string[]): string | undefined {
+function findFirstExistingProjectFile(rootDirPath: string, fileNames: string[]): string | undefined {
   for (const fileName of fileNames) {
-    const filePath = path.join(project.rootDirPath, fileName);
+    const filePath = path.join(rootDirPath, fileName);
     if (fs.existsSync(filePath)) return filePath;
   }
   return undefined;
 }
 
-function getRootPackageJson(project: Project): PackageJson | undefined {
-  const packageJsonPath = path.join(project.rootDirPath, 'package.json');
+function getRootPackageJson(rootDirPath: string): PackageJson | undefined {
+  const packageJsonPath = path.join(rootDirPath, 'package.json');
   if (!fs.existsSync(packageJsonPath)) return undefined;
 
   return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -1,16 +1,27 @@
 import child_process from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import chalk from 'chalk';
+import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
-import { findDescendantProjects } from '../project.js';
+import { findDescendantProjects, type Project } from '../project.js';
 import { packageManager } from '../utils/runtime.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
+
+const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
+const localPackageCopyIgnoredDirNames = new Set(['.git', '.tmp', 'node_modules']);
+
+interface PrunedLockfileRequest {
+  distDirPath: string;
+  packageJson: PackageJson;
+  project: Project;
+}
 
 const builder = {
   outside: {
@@ -31,10 +42,10 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       process.exit(1);
     }
 
+    const prunedLockfileRequests: PrunedLockfileRequest[] = [];
     for (const project of prepareForRunningCommand('optimizeForDockerBuild', projects.descendants)) {
       const packageJson: PackageJson = project.packageJson;
-      const keys = ['dependencies', 'devDependencies'] as const;
-      for (const key of keys) {
+      for (const key of dependencySectionKeys) {
         const deps = packageJson[key] ?? {};
         for (const [name, value] of Object.entries(deps)) {
           if (value?.startsWith('git@github.com:')) {
@@ -45,7 +56,7 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
         }
       }
 
-      optimizeDevDependencies(argv, packageJson);
+      const prunedDependencies = optimizeDevDependencies(argv, packageJson);
 
       optimizeScripts(packageJson);
 
@@ -58,7 +69,13 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       await fs.promises.writeFile(path.join(distDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
       if (argv.outside) {
         await writeDockerShellScripts(path.join(distDirPath, 'bash'));
+        if (prunedDependencies.length > 0) {
+          prunedLockfileRequests.push({ distDirPath, packageJson, project });
+        }
       }
+    }
+    for (const request of prunedLockfileRequests) {
+      await writePrunedLockfile(request.project, request.packageJson, request.distDirPath);
     }
     if (!argv.dryRun && !argv.outside) {
       child_process.spawnSync(packageManager, ['install'], {
@@ -96,16 +113,227 @@ function findDockerShellScriptsDirPath(): string {
   }
 }
 
-function optimizeDevDependencies(argv: InferredOptionTypes<typeof builder>, packageJson: PackageJson): void {
+function optimizeDevDependencies(argv: InferredOptionTypes<typeof builder>, packageJson: PackageJson): string[] {
   if (argv.outside) {
-    // Outside optimization writes dist/package.json before Docker builds the app. Keep dependency sections aligned with
-    // the source lockfile so package managers can install with frozen lockfiles in the later Docker build.
-    return;
+    // Outside optimization writes dist/package.json before Docker builds the app.
+    // Keep build-time dependencies and remove only known non-build tooling.
+    return removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson);
   }
 
   // Inside Docker, codegen/build has already finished, so production install should not see dev tooling.
+  const removedDependencies = Object.keys(packageJson.devDependencies ?? {});
   delete packageJson.devDependencies;
   console.info('Removed all devDependencies.');
+  return removedDependencies;
+}
+
+function removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson: PackageJson): string[] {
+  const devDeps = packageJson.devDependencies ?? {};
+  // In --outside mode, Docker still runs codegen/build before a second in-image optimization.
+  // Remove only tooling that is not needed for that build phase.
+  const nameWordsToBeRemoved = [
+    'artillery',
+    'concurrently',
+    'conventional-changelog-conventionalcommits',
+    'husky',
+    'imagemin',
+    'jest',
+    'kill-port',
+    'lint-staged',
+    'open-cli',
+    'playwright',
+    'prettier',
+    'pinst',
+    'railway',
+    'semantic-release',
+    'sort-package-json',
+    'wait-on',
+    'vitest',
+  ];
+  const removedDeps: string[] = [];
+  for (const name of Object.keys(devDeps)) {
+    if (
+      nameWordsToBeRemoved.some((word) => name.includes(word)) ||
+      // Shared config packages are needed only for lint/format/test commands, not Docker builds.
+      (name.includes('willbooster') && name.includes('config'))
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete devDeps[name];
+      removedDeps.push(name);
+    }
+  }
+  console.info('Removed devDependencies:', removedDeps.join(', ') || 'none');
+  return removedDeps;
+}
+
+async function writePrunedLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
+  const lockfileWriter = project.usesBunPackageManager ? writePrunedBunLockfile : writePrunedYarnLockfile;
+  await lockfileWriter(project, packageJson, distDirPath);
+}
+
+async function writePrunedBunLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
+  const sourceLockfilePath = findFirstExistingFile(project.dirPath, ['bun.lock', 'bun.lockb']);
+  if (!sourceLockfilePath) {
+    console.info('Skipped pruned Bun lockfile generation because no Bun lockfile was found.');
+    return;
+  }
+
+  const tempDirPath = await prepareLockfileWorkspace(project, packageJson, [
+    path.basename(sourceLockfilePath),
+    'bunfig.toml',
+  ]);
+  try {
+    const result = child_process.spawnSync('bun', ['install', '--lockfile-only'], {
+      cwd: tempDirPath,
+      stdio: 'inherit',
+    });
+    if (result.status !== 0) throw new Error(`bun install --lockfile-only exited with status ${result.status}`);
+
+    const generatedLockfilePath = findFirstExistingFile(tempDirPath, ['bun.lock', 'bun.lockb']);
+    if (!generatedLockfilePath) throw new Error('bun install --lockfile-only did not generate a lockfile.');
+
+    const targetLockfilePath = path.join(distDirPath, path.basename(generatedLockfilePath));
+    await fs.promises.copyFile(generatedLockfilePath, targetLockfilePath);
+    console.info(`Generated pruned Bun lockfile: ${path.relative(process.cwd(), targetLockfilePath)}`);
+  } finally {
+    await fs.promises.rm(tempDirPath, { recursive: true, force: true });
+  }
+}
+
+async function writePrunedYarnLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
+  const sourceLockfilePath = path.join(project.dirPath, 'yarn.lock');
+  if (!fs.existsSync(sourceLockfilePath)) {
+    console.info('Skipped pruned Yarn lockfile generation because no yarn.lock was found.');
+    return;
+  }
+
+  const tempDirPath = await prepareLockfileWorkspace(project, packageJson, ['yarn.lock', '.yarnrc.yml', '.yarn']);
+  try {
+    const result = child_process.spawnSync('yarn', ['install', '--mode=update-lockfile'], {
+      cwd: tempDirPath,
+      stdio: 'inherit',
+    });
+    if (result.status !== 0) throw new Error(`yarn install --mode=update-lockfile exited with status ${result.status}`);
+
+    const targetLockfilePath = path.join(distDirPath, 'yarn.lock');
+    await fs.promises.copyFile(path.join(tempDirPath, 'yarn.lock'), targetLockfilePath);
+    console.info(`Generated pruned Yarn lockfile: ${path.relative(process.cwd(), targetLockfilePath)}`);
+  } finally {
+    await fs.promises.rm(tempDirPath, { recursive: true, force: true });
+  }
+}
+
+async function prepareLockfileWorkspace(
+  project: Project,
+  packageJson: PackageJson,
+  packageManagerFiles: string[]
+): Promise<string> {
+  const tempDirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-docker-lock-'));
+  await fs.promises.writeFile(path.join(tempDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
+
+  for (const fileName of packageManagerFiles) {
+    const sourcePath = path.join(project.dirPath, fileName);
+    if (!fs.existsSync(sourcePath)) continue;
+
+    const targetPath = path.join(tempDirPath, fileName);
+    await fs.promises.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.promises.cp(sourcePath, targetPath, { recursive: true });
+  }
+
+  await copyLocalPackageReferences(project, packageJson, tempDirPath);
+  await copyWorkspacePackageReferences(project, packageJson, tempDirPath);
+  return tempDirPath;
+}
+
+async function copyLocalPackageReferences(
+  project: Project,
+  packageJson: PackageJson,
+  tempDirPath: string
+): Promise<void> {
+  for (const dependencies of dependencySectionKeys.map((sectionKey) => packageJson[sectionKey] ?? {})) {
+    for (const dependencySpecifier of Object.values(dependencies)) {
+      const relativePackagePath = getLocalPackageRelativePath(dependencySpecifier);
+      if (!relativePackagePath) continue;
+
+      await copyLocalPackageDirectory(
+        path.resolve(project.dirPath, relativePackagePath),
+        path.resolve(tempDirPath, relativePackagePath)
+      );
+    }
+  }
+}
+
+async function copyWorkspacePackageReferences(
+  project: Project,
+  packageJson: PackageJson,
+  tempDirPath: string
+): Promise<void> {
+  const workspacePatterns = getWorkspacePatterns(packageJson);
+  if (workspacePatterns.length === 0) return;
+
+  const workspacePackageJsonPaths = await globby(
+    workspacePatterns.map((pattern) => `${pattern.replace(/\/$/, '')}/package.json`),
+    { cwd: project.dirPath, onlyFiles: true }
+  );
+  for (const packageJsonPath of workspacePackageJsonPaths) {
+    const relativePackageDirPath = path.dirname(packageJsonPath);
+    await copyLocalPackageDirectory(
+      path.resolve(project.dirPath, relativePackageDirPath),
+      path.resolve(tempDirPath, relativePackageDirPath)
+    );
+    await copyOptimizedWorkspacePackageJson(project, relativePackageDirPath, tempDirPath);
+  }
+}
+
+async function copyOptimizedWorkspacePackageJson(
+  project: Project,
+  relativePackageDirPath: string,
+  tempDirPath: string
+): Promise<void> {
+  const optimizedPackageJsonPath = path.resolve(project.dirPath, relativePackageDirPath, 'dist/package.json');
+  if (!fs.existsSync(optimizedPackageJsonPath)) return;
+
+  await fs.promises.copyFile(
+    optimizedPackageJsonPath,
+    path.resolve(tempDirPath, relativePackageDirPath, 'package.json')
+  );
+}
+
+async function copyLocalPackageDirectory(sourceDirPath: string, targetDirPath: string): Promise<void> {
+  if (!fs.existsSync(sourceDirPath)) {
+    throw new Error(`Local package directory not found: ${sourceDirPath}`);
+  }
+  if (fs.existsSync(targetDirPath)) return;
+
+  await fs.promises.mkdir(path.dirname(targetDirPath), { recursive: true });
+  await fs.promises.cp(sourceDirPath, targetDirPath, {
+    recursive: true,
+    filter: (sourcePath) => !sourcePath.split(path.sep).some((part) => localPackageCopyIgnoredDirNames.has(part)),
+  });
+}
+
+function getWorkspacePatterns(packageJson: PackageJson): string[] {
+  if (Array.isArray(packageJson.workspaces)) return packageJson.workspaces;
+  if (Array.isArray(packageJson.workspaces?.packages)) return packageJson.workspaces.packages;
+  return [];
+}
+
+function getLocalPackageRelativePath(dependencySpecifier: string | undefined): string | undefined {
+  if (!dependencySpecifier) return;
+
+  const specifier = dependencySpecifier.startsWith('file:')
+    ? dependencySpecifier.slice('file:'.length)
+    : dependencySpecifier;
+  if (!specifier.startsWith('./') && !specifier.startsWith('../')) return;
+
+  return specifier;
+}
+
+function findFirstExistingFile(dirPath: string, fileNames: string[]): string | undefined {
+  for (const fileName of fileNames) {
+    const filePath = path.join(dirPath, fileName);
+    if (fs.existsSync(filePath)) return filePath;
+  }
 }
 
 function optimizeScripts(packageJson: PackageJson): void {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -175,14 +175,18 @@ function removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson: Pack
   // Remove only tooling that is not needed for that build phase.
   const nameWordsToBeRemoved = [
     'artillery',
+    'biome',
     'concurrently',
     'conventional-changelog-conventionalcommits',
+    'eslint',
     'husky',
     'imagemin',
     'jest',
     'kill-port',
     'lint-staged',
     'open-cli',
+    'oxfmt',
+    'oxlint',
     'playwright',
     'prettier',
     'pinst',

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -215,7 +215,7 @@ async function writePrunedLockfile(
   packageJson: PackageJson,
   distDirPath: string
 ): Promise<void> {
-  const lockfileWriter = project.usesBunPackageManager ? writePrunedBunLockfile : writePrunedYarnLockfile;
+  const lockfileWriter = usesBunPackageManager(rootDirPath) ? writePrunedBunLockfile : writePrunedYarnLockfile;
   await lockfileWriter(rootDirPath, project, packageJson, distDirPath);
 }
 
@@ -225,7 +225,7 @@ async function copySourceLockfile(
   _packageJson: PackageJson,
   distDirPath: string
 ): Promise<void> {
-  const sourceLockfilePath = project.usesBunPackageManager
+  const sourceLockfilePath = usesBunPackageManager(rootDirPath)
     ? findFirstExistingProjectFile(rootDirPath, ['bun.lock', 'bun.lockb'])
     : findFirstExistingProjectFile(rootDirPath, ['yarn.lock']);
   if (!sourceLockfilePath) return;
@@ -477,6 +477,21 @@ function getRootPackageJson(rootDirPath: string): PackageJson | undefined {
   if (!fs.existsSync(packageJsonPath)) return undefined;
 
   return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson;
+}
+
+function usesBunPackageManager(rootDirPath: string): boolean {
+  if (['bun.lock', 'bun.lockb'].some((fileName) => fs.existsSync(path.join(rootDirPath, fileName)))) return true;
+
+  const rootPackageJson = getRootPackageJson(rootDirPath);
+  if (typeof rootPackageJson?.packageManager === 'string' && rootPackageJson.packageManager.startsWith('bun@')) {
+    return true;
+  }
+
+  try {
+    return /(^|\n)bun\s/.test(fs.readFileSync(path.join(rootDirPath, '.tool-versions'), 'utf8'));
+  } catch {
+    return false;
+  }
 }
 
 function throwIfCommandFailed(result: child_process.SpawnSyncReturns<Buffer>, command: string): void {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -17,7 +17,8 @@ import { prepareForRunningCommand } from './commandUtils.js';
 const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
 const localPackageCopyIgnoredDirNames = new Set(['.git', '.tmp', 'node_modules']);
 
-interface PrunedLockfileRequest {
+interface DockerLockfileRequest {
+  dependenciesChanged: boolean;
   distDirPath: string;
   packageJson: PackageJson;
   project: Project;
@@ -47,11 +48,12 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       process.exit(1);
     }
 
-    const prunedLockfileRequests: PrunedLockfileRequest[] = [];
+    const dockerLockfileRequests: DockerLockfileRequest[] = [];
     for (const project of prepareForRunningCommand('optimizeForDockerBuild', projects.descendants)) {
       const packageJson: PackageJson = project.packageJson;
       const rewrittenDependencies = rewritePrivateGitHubDependencies(project, packageJson);
       const prunedDependencies = optimizeDevDependencies(argv, packageJson);
+      const dependenciesChanged = prunedDependencies.length > 0 || rewrittenDependencies.length > 0;
 
       optimizeScripts(packageJson);
 
@@ -64,15 +66,20 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       await fs.promises.writeFile(path.join(distDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
       if (argv.outside) {
         await writeDockerShellScripts(path.join(distDirPath, 'bash'));
-        if (prunedDependencies.length > 0 || rewrittenDependencies.length > 0) {
-          prunedLockfileRequests.push({ distDirPath, packageJson, project });
-        } else {
-          await copySourceLockfile(project, distDirPath);
-        }
+        dockerLockfileRequests.push({ dependenciesChanged, distDirPath, packageJson, project });
       }
     }
-    for (const request of prunedLockfileRequests) {
-      await writePrunedLockfile(request.project, request.packageJson, request.distDirPath);
+    const changedRootDirPaths = new Set(
+      dockerLockfileRequests
+        .filter((request) => request.dependenciesChanged)
+        .map((request) => request.project.rootDirPath)
+    );
+    for (const request of dockerLockfileRequests) {
+      const writeLockfile =
+        request.dependenciesChanged || changedRootDirPaths.has(request.project.dirPath)
+          ? writePrunedLockfile
+          : copySourceLockfile;
+      await writeLockfile(request.project, request.packageJson, request.distDirPath);
     }
     if (!argv.dryRun && !argv.outside) {
       child_process.spawnSync(packageManager, ['install'], {
@@ -195,7 +202,7 @@ async function writePrunedLockfile(project: Project, packageJson: PackageJson, d
   await lockfileWriter(project, packageJson, distDirPath);
 }
 
-async function copySourceLockfile(project: Project, distDirPath: string): Promise<void> {
+async function copySourceLockfile(project: Project, _packageJson: PackageJson, distDirPath: string): Promise<void> {
   const sourceLockfilePath = project.usesBunPackageManager
     ? findFirstExistingProjectFile(project, ['bun.lock', 'bun.lockb'])
     : findFirstExistingProjectFile(project, ['yarn.lock']);

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -22,7 +22,6 @@ interface DockerLockfileRequest {
   distDirPath: string;
   packageJson: PackageJson;
   project: Project;
-  rootDirPath: string;
 }
 
 interface LockfileWorkspace {
@@ -50,10 +49,9 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
     }
 
     const dockerLockfileRequests: DockerLockfileRequest[] = [];
-    const rootDirPath = projects.root.dirPath;
     for (const project of prepareForRunningCommand('optimizeForDockerBuild', projects.descendants)) {
       const packageJson: PackageJson = project.packageJson;
-      const rewrittenDependencies = rewritePrivateGitHubDependencies(rootDirPath, project.dirPath, packageJson);
+      const rewrittenDependencies = rewritePrivateGitHubDependencies(project, packageJson);
       const prunedDependencies = optimizeDevDependencies(argv, packageJson);
       const dependenciesChanged = prunedDependencies.length > 0 || rewrittenDependencies.length > 0;
 
@@ -68,18 +66,20 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       await fs.promises.writeFile(path.join(distDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
       if (argv.outside) {
         await writeDockerShellScripts(path.join(distDirPath, 'bash'));
-        dockerLockfileRequests.push({ dependenciesChanged, distDirPath, packageJson, project, rootDirPath });
+        dockerLockfileRequests.push({ dependenciesChanged, distDirPath, packageJson, project });
       }
     }
     const changedRootDirPaths = new Set(
-      dockerLockfileRequests.filter((request) => request.dependenciesChanged).map((request) => request.rootDirPath)
+      dockerLockfileRequests
+        .filter((request) => request.dependenciesChanged)
+        .map((request) => request.project.rootDirPath)
     );
     for (const request of dockerLockfileRequests) {
       const writeLockfile =
         request.dependenciesChanged || changedRootDirPaths.has(request.project.dirPath)
           ? writePrunedLockfile
           : copySourceLockfile;
-      await writeLockfile(request.rootDirPath, request.project, request.packageJson, request.distDirPath);
+      await writeLockfile(request.project, request.packageJson, request.distDirPath);
     }
     if (!argv.dryRun && !argv.outside) {
       child_process.spawnSync(packageManager, ['install'], {
@@ -90,12 +90,8 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
   },
 };
 
-function rewritePrivateGitHubDependencies(
-  rootDirPath: string,
-  packageDirPath: string,
-  packageJson: PackageJson
-): string[] {
-  return rewritePrivateGitHubDependenciesForDir(rootDirPath, packageDirPath, packageJson);
+function rewritePrivateGitHubDependencies(project: Project, packageJson: PackageJson): string[] {
+  return rewritePrivateGitHubDependenciesForDir(project.rootDirPath, project.dirPath, packageJson);
 }
 
 function rewritePrivateGitHubDependenciesForDir(
@@ -209,25 +205,15 @@ function removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson: Pack
   return removedDeps;
 }
 
-async function writePrunedLockfile(
-  rootDirPath: string,
-  project: Project,
-  packageJson: PackageJson,
-  distDirPath: string
-): Promise<void> {
-  const lockfileWriter = usesBunPackageManager(rootDirPath) ? writePrunedBunLockfile : writePrunedYarnLockfile;
-  await lockfileWriter(rootDirPath, project, packageJson, distDirPath);
+async function writePrunedLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
+  const lockfileWriter = usesBunPackageManager(project.rootDirPath) ? writePrunedBunLockfile : writePrunedYarnLockfile;
+  await lockfileWriter(project, packageJson, distDirPath);
 }
 
-async function copySourceLockfile(
-  rootDirPath: string,
-  project: Project,
-  _packageJson: PackageJson,
-  distDirPath: string
-): Promise<void> {
-  const sourceLockfilePath = usesBunPackageManager(rootDirPath)
-    ? findFirstExistingProjectFile(rootDirPath, ['bun.lock', 'bun.lockb'])
-    : findFirstExistingProjectFile(rootDirPath, ['yarn.lock']);
+async function copySourceLockfile(project: Project, _packageJson: PackageJson, distDirPath: string): Promise<void> {
+  const sourceLockfilePath = usesBunPackageManager(project.rootDirPath)
+    ? findFirstExistingProjectFile(project.rootDirPath, ['bun.lock', 'bun.lockb'])
+    : findFirstExistingProjectFile(project.rootDirPath, ['yarn.lock']);
   if (!sourceLockfilePath) return;
 
   const targetLockfilePath = path.join(distDirPath, path.basename(sourceLockfilePath));
@@ -235,19 +221,14 @@ async function copySourceLockfile(
   console.info(`Copied Docker lockfile: ${path.relative(process.cwd(), targetLockfilePath)}`);
 }
 
-async function writePrunedBunLockfile(
-  rootDirPath: string,
-  project: Project,
-  packageJson: PackageJson,
-  distDirPath: string
-): Promise<void> {
-  const sourceLockfilePath = findFirstExistingProjectFile(rootDirPath, ['bun.lock', 'bun.lockb']);
+async function writePrunedBunLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
+  const sourceLockfilePath = findFirstExistingProjectFile(project.rootDirPath, ['bun.lock', 'bun.lockb']);
   if (!sourceLockfilePath) {
     console.info('Skipped pruned Bun lockfile generation because no Bun lockfile was found.');
     return;
   }
 
-  const workspace = await prepareLockfileWorkspace(rootDirPath, project, packageJson, [
+  const workspace = await prepareLockfileWorkspace(project, packageJson, [
     path.basename(sourceLockfilePath),
     'bunfig.toml',
   ]);
@@ -269,23 +250,14 @@ async function writePrunedBunLockfile(
   }
 }
 
-async function writePrunedYarnLockfile(
-  rootDirPath: string,
-  project: Project,
-  packageJson: PackageJson,
-  distDirPath: string
-): Promise<void> {
-  const sourceLockfilePath = findFirstExistingProjectFile(rootDirPath, ['yarn.lock']);
+async function writePrunedYarnLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {
+  const sourceLockfilePath = findFirstExistingProjectFile(project.rootDirPath, ['yarn.lock']);
   if (!sourceLockfilePath) {
     console.info('Skipped pruned Yarn lockfile generation because no yarn.lock was found.');
     return;
   }
 
-  const workspace = await prepareLockfileWorkspace(rootDirPath, project, packageJson, [
-    'yarn.lock',
-    '.yarnrc.yml',
-    '.yarn',
-  ]);
+  const workspace = await prepareLockfileWorkspace(project, packageJson, ['yarn.lock', '.yarnrc.yml', '.yarn']);
   try {
     const result = child_process.spawnSync('yarn', ['install', '--mode=update-lockfile'], {
       cwd: workspace.installDirPath,
@@ -302,22 +274,23 @@ async function writePrunedYarnLockfile(
 }
 
 async function prepareLockfileWorkspace(
-  rootDirPath: string,
   project: Project,
   packageJson: PackageJson,
   packageManagerFiles: string[]
 ): Promise<LockfileWorkspace> {
   const tempDirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-docker-lock-'));
   try {
-    const relativeProjectDirPath = path.relative(rootDirPath, project.dirPath);
+    // Keep this simple: wb Docker optimization assumes monorepos are rooted by package.json and use packages/*.
+    // Project.rootDirPath intentionally mirrors that convention and does not support arbitrary nested workspace roots.
+    const relativeProjectDirPath = path.relative(project.rootDirPath, project.dirPath);
     const tempProjectDirPath = path.resolve(tempDirPath, relativeProjectDirPath);
 
-    await copyRootPackageJson(rootDirPath, tempDirPath);
+    await copyRootPackageJson(project.rootDirPath, tempDirPath);
     await fs.promises.mkdir(tempProjectDirPath, { recursive: true });
     await fs.promises.writeFile(path.join(tempProjectDirPath, 'package.json'), JSON.stringify(packageJson), 'utf8');
 
     for (const fileName of packageManagerFiles) {
-      const sourcePath = path.join(rootDirPath, fileName);
+      const sourcePath = path.join(project.rootDirPath, fileName);
       if (!fs.existsSync(sourcePath)) continue;
 
       const targetPath = path.join(tempDirPath, fileName);
@@ -326,7 +299,7 @@ async function prepareLockfileWorkspace(
     }
 
     await copyLocalPackageReferences(project, packageJson, tempProjectDirPath, tempDirPath);
-    await copyWorkspacePackageReferences(rootDirPath, packageJson, tempDirPath);
+    await copyWorkspacePackageReferences(project.rootDirPath, packageJson, tempDirPath);
     return { installDirPath: tempProjectDirPath, rootDirPath: tempDirPath };
   } catch (error) {
     await fs.promises.rm(tempDirPath, { recursive: true, force: true });


### PR DESCRIPTION
## Customer Summary

- Docker builds now install fewer unnecessary development packages while still using a lockfile.
- Outside-Docker optimization keeps build-time dependencies, but removes known lint, format, test, release, and local workflow tooling such as ESLint, Oxlint, Oxfmt, Biome, Playwright, Prettier, Vitest, and similar packages.
- For supported monorepos, the Docker lockfile is generated at the repository root and used by the root Docker build context.

## Technical Summary

- `wb optimizeForDockerBuild --outside` now writes an optimized `dist/package.json` and a matching root Docker lockfile.
- Bun projects generate a pruned `bun.lock`/`bun.lockb`; Yarn projects generate a pruned `yarn.lock`; unchanged manifests copy the source lockfile.
- The implementation assumes a root `package.json` and monorepo packages under `packages/<sub package name>`.
- Private GitHub dependencies are rewritten to local Docker paths before pruned lockfile generation.
- Temporary lockfile workspaces copy package-manager files, workspace package references, and `.tool-versions` for mise shim compatibility without using `.tool-versions` for package-manager detection.

## Why

- Docker builds were spending time installing packages that are only needed for local linting, formatting, tests, releases, or developer workflows.
- Generating a manifest and lockfile together preserves reproducible installs while reducing no-cache Docker install work.
- Keeping lockfile output root-only matches the supported repository layout and avoids standalone child package lockfiles that do not represent the Docker install context.

## Testing

- `yarn verify`
- `exercode`: `optimizeForDockerBuild --outside` generated `dist/yarn.lock`, then a temporary Docker-context style install passed with `yarn install --immutable --mode=skip-build`.
- `llm-proxy`: `optimizeForDockerBuild --outside` generated `dist/bun.lock`, then a temporary Docker-context style install passed with `bun install --omit=dev --frozen-lockfile`.
- Latest PR CI passed.
