### PR TITLE
fix: stabilize pruned bun docker lockfiles

### DIFF
--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -247,7 +247,7 @@ async function writePrunedBunLockfile(project: Project, packageJson: PackageJson
     runBunPrunedLockfileInstall(workspace.installDirPath, project.env);
 
     const generatedLockfilePath = findFirstExistingFile(workspace.rootDirPath, ['bun.lock', 'bun.lockb']);
-    if (!generatedLockfilePath) throw new Error('bun install --lockfile-only did not generate a lockfile.');
+    if (!generatedLockfilePath) throw new Error('bun install --omit=dev --ignore-scripts did not generate a lockfile.');
 
     const targetLockfilePath = path.join(distDirPath, path.basename(generatedLockfilePath));
     await fs.promises.copyFile(generatedLockfilePath, targetLockfilePath);

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -241,11 +241,10 @@ async function writePrunedBunLockfile(project: Project, packageJson: PackageJson
     '.tool-versions',
   ]);
   try {
-    const result = child_process.spawnSync('bun', ['install', '--lockfile-only'], {
-      cwd: workspace.installDirPath,
-      stdio: 'inherit',
-    });
-    throwIfCommandFailed(result, 'bun install --lockfile-only');
+    runBunPrunedLockfileInstall(workspace.installDirPath);
+    // Bun can leave stale transitive resolutions after the first omit-mode install. A second pass stabilizes the
+    // generated lockfile so Docker can later run `bun install --omit=dev --frozen-lockfile` without rewriting it.
+    runBunPrunedLockfileInstall(workspace.installDirPath);
 
     const generatedLockfilePath = findFirstExistingFile(workspace.rootDirPath, ['bun.lock', 'bun.lockb']);
     if (!generatedLockfilePath) throw new Error('bun install --lockfile-only did not generate a lockfile.');
@@ -256,6 +255,14 @@ async function writePrunedBunLockfile(project: Project, packageJson: PackageJson
   } finally {
     await fs.promises.rm(workspace.rootDirPath, { recursive: true, force: true });
   }
+}
+
+function runBunPrunedLockfileInstall(installDirPath: string): void {
+  const result = child_process.spawnSync('bun', ['install', '--omit=dev', '--ignore-scripts'], {
+    cwd: installDirPath,
+    stdio: 'inherit',
+  });
+  throwIfCommandFailed(result, 'bun install --omit=dev --ignore-scripts');
 }
 
 async function writePrunedYarnLockfile(project: Project, packageJson: PackageJson, distDirPath: string): Promise<void> {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -241,10 +241,10 @@ async function writePrunedBunLockfile(project: Project, packageJson: PackageJson
     '.tool-versions',
   ]);
   try {
-    runBunPrunedLockfileInstall(workspace.installDirPath);
+    runBunPrunedLockfileInstall(workspace.installDirPath, project.env);
     // Bun can leave stale transitive resolutions after the first omit-mode install. A second pass stabilizes the
     // generated lockfile so Docker can later run `bun install --omit=dev --frozen-lockfile` without rewriting it.
-    runBunPrunedLockfileInstall(workspace.installDirPath);
+    runBunPrunedLockfileInstall(workspace.installDirPath, project.env);
 
     const generatedLockfilePath = findFirstExistingFile(workspace.rootDirPath, ['bun.lock', 'bun.lockb']);
     if (!generatedLockfilePath) throw new Error('bun install --lockfile-only did not generate a lockfile.');
@@ -257,9 +257,10 @@ async function writePrunedBunLockfile(project: Project, packageJson: PackageJson
   }
 }
 
-function runBunPrunedLockfileInstall(installDirPath: string): void {
+function runBunPrunedLockfileInstall(installDirPath: string, env: Record<string, string | undefined>): void {
   const result = child_process.spawnSync('bun', ['install', '--omit=dev', '--ignore-scripts'], {
     cwd: installDirPath,
+    env,
     stdio: 'inherit',
   });
   throwIfCommandFailed(result, 'bun install --omit=dev --ignore-scripts');


### PR DESCRIPTION
## Customer Summary

- Docker builds that use wb-generated pruned Bun lockfiles can keep using frozen production installs.
- Projects with private package copies and omitted dev dependencies avoid Docker install failures caused by Bun rewriting the generated lockfile.
- No customer migration is required beyond using the released wb version that contains this fix.

## Technical Summary

- Generate pruned Bun Docker lockfiles with temporary `bun install --omit=dev --ignore-scripts` passes instead of `--lockfile-only`.
- Run a second omit-mode pass to stabilize stale transitive lockfile resolutions before copying the Docker lockfile.
- Pass `project.env` to the Bun subprocess so wb-loaded environment variables remain available.

## Why

- `bun install --lockfile-only` can emit a lockfile that `bun install --omit=dev --frozen-lockfile` later rejects as needing changes.
- The generator should produce the same lockfile shape expected by Docker's production install command.

## Testing

- `yarn verify`
- Regenerated `WillBooster/openclaw-railway` `dist/bun.lock` with the local wb change.
- Confirmed `bun install --omit=dev --frozen-lockfile` succeeds against that generated dist lockfile in a temporary Docker-install validation directory.
