### PR TITLE
fix: generate agentic workflows bunfig exclusion

### DIFF
--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -20,8 +20,8 @@ interface BunfigToml {
 const minimumReleaseAgeExcludes = [
   // ---------- START: We believe our packages are safe ----------
   '@exercode/problem-utils',
-  '@willbooster/agent-skills',
   '@willbooster-private/agentic-workflows',
+  '@willbooster/agent-skills',
   '@willbooster/babel-configs',
   '@willbooster/monaco-loader',
   '@willbooster/monaco-react',

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -21,7 +21,7 @@ const minimumReleaseAgeExcludes = [
   // ---------- START: We believe our packages are safe ----------
   '@exercode/problem-utils',
   '@willbooster/agent-skills',
-  '@willbooster/agent-workflows',
+  '@willbooster-private/agentic-workflows',
   '@willbooster/babel-configs',
   '@willbooster/monaco-loader',
   '@willbooster/monaco-react',


### PR DESCRIPTION
## Customer Summary

- New projects generated by `wbfy` will exclude the renamed private `agentic-workflows` package from Bun's minimum release age delay.
- This keeps generated Bun configuration aligned with the renamed `WillBooster/agentic-workflows` repository.

## Technical Summary

- Replaced the stale generated exclusion `@willbooster/agent-workflows` with `@willbooster-private/agentic-workflows` in `packages/wbfy/src/generators/bunfig.ts`.
- Kept the `minimumReleaseAgeExcludes` list in ASCII sort order.

## Why

- `agentic-workflows` now publishes under the private-scoped package name, so generated `bunfig.toml` files need to exclude that exact package name.

## Testing

- `yarn verify`
