### PR TITLE
fix: parse each env option as one value

### DIFF
--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -9,6 +9,7 @@ import type { ArgumentsCamelCase, InferredOptionTypes } from 'yargs';
 export const yargsOptionsBuilderForEnv = {
   env: {
     description: '.env files to be loaded.',
+    nargs: 1,
     type: 'array',
   },
   'cascade-env': {

--- a/packages/shared-lib-node/test/spawn.killOnExit.sigterm.test.ts
+++ b/packages/shared-lib-node/test/spawn.killOnExit.sigterm.test.ts
@@ -1,10 +1,10 @@
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { isProcessRunning, wait, waitForProcessStopped } from '../../../test/processUtils.js';
 import { spawnAsync } from '../src/spawn.js';
@@ -12,6 +12,14 @@ import { treeKill } from '../src/treeKill.js';
 
 describe('spawnAsync killOnExit with SIGTERM', () => {
   const pidsToCleanUp = new Set<number>();
+
+  beforeAll(() => {
+    const result = spawnSync('yarn', ['build'], {
+      encoding: 'utf8',
+      stdio: 'inherit',
+    });
+    expect(result.status).toBe(0);
+  });
 
   afterEach(async () => {
     for (const pid of pidsToCleanUp) {


### PR DESCRIPTION
## Summary
- Make `--env` consume exactly one value per flag so positional targets are not swallowed.
- Build `shared-lib-node` dist inside the SIGTERM fixture test before launching the standalone Node harness.

## Verification
- `yarn workspace @willbooster/shared-lib-node test test/spawn.killOnExit.sigterm.test.ts`
- `yarn verify-full`
