### PR TITLE
fix: default wb test server port

### DIFF
--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -130,6 +130,7 @@ export abstract class BaseScripts {
     return this.testE2EProtected(project, argv, dockerScripts.stopAndStart(project), options);
   }
   async testStart(project: Project, argv: ScriptArgv): Promise<string> {
+    project.env.PORT ||= '3000';
     await checkAndKillPortProcess(project.env.PORT, project);
     // Use empty NODE_ENV to avoid "production" mode in some frameworks like Blitz.js.
     return `${buildShellEnvironmentAssignment('NODE_ENV', '')} ${buildShellCommand([
@@ -151,6 +152,7 @@ export abstract class BaseScripts {
     startCommand: string,
     { forwardedPlaywrightArgs = [], playwrightArgs = ['test', 'test/e2e/'] }: TestE2EOptions
   ): Promise<string> {
+    project.env.PORT ||= '3000';
     const port = await checkAndKillPortProcess(project.env.PORT, project);
     const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
     const playwrightCommand = buildPlaywrightCommand(playwrightArgs, argv.targets, argv.bail, forwardedPlaywrightArgs);

--- a/packages/wb/src/scripts/execution/httpServerScripts.ts
+++ b/packages/wb/src/scripts/execution/httpServerScripts.ts
@@ -30,6 +30,7 @@ class HttpServerScripts extends BaseScripts {
       return super.testE2EProtected(project, argv, startCommand, options);
     }
 
+    project.env.PORT ||= '3000';
     const port = await checkAndKillPortProcess(project.env.PORT, project);
     const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
     const targets = argv.targets?.map(String);


### PR DESCRIPTION
## Summary
- Default wb test server PORT to 3000 when it is not provided
- Keep test-on-ci startup/wait logic aligned with apps that use `process.env.PORT || 3000`

## Verification
- yarn verify
