### PR TITLE
fix: run gen-i18n-ts from wb gen-code

### DIFF
--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -38,7 +38,7 @@ export const genCodeCommand: CommandModule = {
   },
 };
 
-function getGenCodeScripts(project: Project): string[] {
+export function getGenCodeScripts(project: Project): string[] {
   const scripts: string[] = [];
   if (project.hasOwnDependency('blitz')) {
     scripts.push('YARN blitz codegen');
@@ -58,7 +58,21 @@ function getGenCodeScripts(project: Project): string[] {
   if (drizzleConfigPath) {
     scripts.push(`YARN drizzle-kit check --config ${drizzleConfigPath} || true`);
   }
+  const genI18nTsScript = getGenI18nTsScript(project);
+  if (genI18nTsScript) {
+    scripts.push(genI18nTsScript);
+  }
   return scripts;
+}
+
+function getGenI18nTsScript(project: Project): string | undefined {
+  if (project.packageJson.scripts?.['gen-i18n-ts']) {
+    return 'YARN run gen-i18n-ts';
+  }
+  if (project.hasOwnDependency('gen-i18n-ts') && fs.existsSync(path.join(project.dirPath, 'i18n'))) {
+    return 'YARN gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP';
+  }
+  return;
 }
 
 function getChakraScript(project: Project): string | undefined {

--- a/packages/wb/test/genCode.test.ts
+++ b/packages/wb/test/genCode.test.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { getGenCodeScripts } from '../src/commands/genCode.js';
+import { Project } from '../src/project.js';
+
+describe('getGenCodeScripts', () => {
+  it('runs the project gen-i18n-ts script when it exists', async () => {
+    const dirPath = await createProject({
+      scripts: {
+        'gen-i18n-ts': 'gen-i18n-ts -i locales -o src/i18n.ts -d en-US',
+      },
+    });
+
+    try {
+      expect(getGenCodeScripts(new Project(dirPath, {}, false))).toContain('YARN run gen-i18n-ts');
+    } finally {
+      await fs.rm(dirPath, { force: true, recursive: true });
+    }
+  });
+
+  it('runs the default gen-i18n-ts command when the package and i18n directory exist', async () => {
+    const dirPath = await createProject({
+      dependencies: {
+        'gen-i18n-ts': '4.0.6',
+      },
+    });
+    await fs.mkdir(path.join(dirPath, 'i18n'));
+
+    try {
+      expect(getGenCodeScripts(new Project(dirPath, {}, false))).toContain(
+        'YARN gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP'
+      );
+    } finally {
+      await fs.rm(dirPath, { force: true, recursive: true });
+    }
+  });
+
+  it('does not run the default gen-i18n-ts command without an i18n directory', async () => {
+    const dirPath = await createProject({
+      dependencies: {
+        'gen-i18n-ts': '4.0.6',
+      },
+    });
+
+    try {
+      expect(getGenCodeScripts(new Project(dirPath, {}, false))).not.toContain(
+        'YARN gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP'
+      );
+    } finally {
+      await fs.rm(dirPath, { force: true, recursive: true });
+    }
+  });
+});
+
+async function createProject(packageJson: Record<string, unknown>): Promise<string> {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-gen-code-'));
+  await fs.writeFile(path.join(dirPath, 'package.json'), JSON.stringify(packageJson));
+  return dirPath;
+}

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -484,7 +484,7 @@ async function normalizePackageMetadata(
   if (genCodeScript?.includes('No code generation needed')) {
     delete jsonObj.scripts['gen-code'];
   } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
-    jsonObj.scripts['gen-code'] = generateWbGenCodeScript(config);
+    jsonObj.scripts['gen-code'] = `${config.isBun ? 'bun --bun ' : ''}wb gen-code`;
   }
   removeGenI18nTsPostinstallScript(jsonObj);
 
@@ -502,14 +502,6 @@ function shouldGenerateWbGenCodeScript(config: PackageConfig, oldGenCodeScript: 
     config.depending.prisma ||
     (config.depending.drizzle && !!oldGenCodeScript?.includes('drizzle-kit check'))
   );
-}
-
-function generateWbGenCodeScript(config: PackageConfig): string {
-  const wbGenCodeScript = `${config.isBun ? 'bun --bun ' : ''}wb gen-code`;
-  if (!config.depending.genI18nTs) return wbGenCodeScript;
-
-  const runScriptCommand = config.isBun ? 'bun run' : 'yarn run';
-  return `${wbGenCodeScript} && ${runScriptCommand} gen-i18n-ts`;
 }
 
 function appendFormatCodeCommand(formatScript: string | undefined, config: PackageConfig): string {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -35,7 +35,7 @@ test('moves gen-i18n-ts execution from postinstall to gen-code', async () => {
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string | undefined>;
     };
-    expect(packageJson.scripts['gen-code']).toBe('wb gen-code && yarn run gen-i18n-ts');
+    expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
     expect(packageJson.scripts.postinstall).toBeUndefined();
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });


### PR DESCRIPTION
## Customer Summary

- Make `wb gen-code` run i18n TypeScript generation automatically when a repository is configured for `gen-i18n-ts`.
- Keep repository `gen-code` scripts simple: wbfy now generates `wb gen-code` instead of appending a separate `gen-i18n-ts` call.

## Technical Summary

- Added i18n generation detection to `wb gen-code`.
- If `package.json` defines a `gen-i18n-ts` script, `wb gen-code` runs `yarn run gen-i18n-ts`.
- If no script exists but the project has a `gen-i18n-ts` dependency and an `i18n/` directory, `wb gen-code` runs `gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP`.
- Updated wbfy package.json generation so `gen-code` remains `wb gen-code`.
- Added regression tests for both script-based and default i18n generation.

## Why

- i18n generation is code generation, so it belongs under the explicit `wb gen-code` workflow.
- Keeping the behavior in `wb` avoids duplicating command chaining in every generated repository script.

## Testing

- `yarn workspace @willbooster/wb test test/genCode.test.ts`
- `yarn workspace @willbooster/wbfy test packageJson.test.ts`
- `yarn verify`
