### PR TITLE
fix: remove redundant gen-i18n-ts scripts

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -486,6 +486,7 @@ async function normalizePackageMetadata(
   } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
     jsonObj.scripts['gen-code'] = `${config.isBun ? 'bun --bun ' : ''}wb gen-code`;
   }
+  removeDefaultGenI18nTsScript(config, jsonObj);
   removeGenI18nTsPostinstallScript(jsonObj);
 
   if (!jsonObj.dependencies.prettier) {
@@ -509,6 +510,21 @@ function appendFormatCodeCommand(formatScript: string | undefined, config: Packa
   // must invoke local package scripts through the repository's package manager.
   const scriptRunner = config.isBun ? 'bun run' : 'yarn';
   return formatScript ? `${formatScript} && ${scriptRunner} format-code` : `${scriptRunner} format-code`;
+}
+
+function removeDefaultGenI18nTsScript(config: PackageConfig, jsonObj: WritablePackageJson): void {
+  if (!config.depending.genI18nTs) return;
+  if (!fs.existsSync(path.join(config.dirPath, 'i18n'))) return;
+
+  const genI18nTsScript = jsonObj.scripts['gen-i18n-ts'];
+  if (typeof genI18nTsScript !== 'string') return;
+  if (!isDefaultGenI18nTsScript(genI18nTsScript)) return;
+
+  delete jsonObj.scripts['gen-i18n-ts'];
+}
+
+function isDefaultGenI18nTsScript(script: string): boolean {
+  return /^gen-i18n-ts\s+-i\s+i18n\s+-o\s+src\/__generated__\/i18n\.ts\s+-d\s+ja-JP$/u.test(script.trim());
 }
 
 function removeGenI18nTsPostinstallScript(jsonObj: WritablePackageJson): void {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -7,9 +7,10 @@ import { expect, test } from 'vitest';
 import { generatePackageJson } from '../src/generators/packageJson.js';
 import { createConfig } from './testConfig.js';
 
-test('moves gen-i18n-ts execution from postinstall to gen-code', async () => {
+test('moves default gen-i18n-ts execution from postinstall to gen-code', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
+  await fs.mkdir(path.join(dirPath, 'i18n'));
 
   await fs.writeFile(
     packageJsonPath,
@@ -36,7 +37,43 @@ test('moves gen-i18n-ts execution from postinstall to gen-code', async () => {
       scripts: Record<string, string | undefined>;
     };
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
+    expect(packageJson.scripts['gen-i18n-ts']).toBeUndefined();
     expect(packageJson.scripts.postinstall).toBeUndefined();
+  } finally {
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('keeps custom gen-i18n-ts scripts', async () => {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
+  const packageJsonPath = path.join(dirPath, 'package.json');
+  await fs.mkdir(path.join(dirPath, 'i18n'));
+
+  await fs.writeFile(
+    packageJsonPath,
+    JSON.stringify({
+      scripts: {
+        'gen-i18n-ts': 'gen-i18n-ts -i locales -o src/i18n.ts -d en-US',
+      },
+      dependencies: {
+        'gen-i18n-ts': '4.0.6',
+      },
+    })
+  );
+
+  try {
+    const config = createConfig({
+      dirPath,
+      isRoot: true,
+      depending: { ...createConfig().depending, genI18nTs: true },
+    });
+    await generatePackageJson(config, config, true);
+
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
+      scripts: Record<string, string | undefined>;
+    };
+    expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
+    expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i locales -o src/i18n.ts -d en-US');
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Customer Summary

- Remove repository-level `gen-i18n-ts` scripts when they only duplicate the default behavior now built into `wb gen-code`.
- Keep custom `gen-i18n-ts` scripts untouched.

## Technical Summary

- Updated wbfy package.json generation to delete `scripts.gen-i18n-ts` only when:
  - the project depends on `gen-i18n-ts`,
  - the project has an `i18n/` directory, and
  - the script is `gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP`.
- Kept `gen-code: wb gen-code` generation unchanged.
- Added regression coverage for default script removal and custom script preservation.

## Why

- `wb gen-code` now runs the same default `gen-i18n-ts` command automatically when `gen-i18n-ts` and `i18n/` are present.
- Keeping the duplicate package script adds noise without changing behavior.

## Testing

- `yarn workspace @willbooster/wbfy test packageJson.test.ts`
- `yarn verify`
