### PR TITLE
fix: improve Docker build cleanup

### DIFF
--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -219,6 +219,7 @@ async function removeProjectCaches(project: Project): Promise<void> {
     '.next/cache',
     '.turbo',
     path.join('.yarn', 'cache'),
+    path.join('.yarn', 'install-state.gz'),
     path.join('node_modules', '.cache'),
     'playwright-report',
     'test-results',

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -33,6 +33,7 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       process.exit(1);
     }
 
+    const optimizedProjects: Project[] = [];
     for (const project of prepareForRunningCommand('optimizeForDockerBuild', projects.descendants)) {
       const packageJson: PackageJson = project.packageJson;
       rewritePrivateGitHubDependencies(project, packageJson);
@@ -50,12 +51,14 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
       if (argv.outside) {
         await writeDockerShellScripts(path.join(distDirPath, 'bash'));
       }
+      optimizedProjects.push(project);
     }
     if (!argv.dryRun && !argv.outside) {
       child_process.spawnSync(packageManager, ['install'], {
         stdio: 'inherit',
       });
       console.info('Installed dependencies.');
+      await cleanupDockerBuildArtifacts(optimizedProjects);
     }
   },
 };
@@ -202,4 +205,46 @@ function optimizeRootProps(packageJson: PackageJson): void {
   delete packageJson.private;
   delete packageJson.publishConfig;
   delete packageJson.prettier;
+}
+
+async function cleanupDockerBuildArtifacts(projects: Project[]): Promise<void> {
+  for (const project of projects) {
+    await removeProjectCaches(project);
+    runDockerCleanupScript(project);
+  }
+}
+
+async function removeProjectCaches(project: Project): Promise<void> {
+  const relativePaths = [
+    '.next/cache',
+    '.turbo',
+    path.join('.yarn', 'cache'),
+    path.join('node_modules', '.cache'),
+    'playwright-report',
+    'test-results',
+  ];
+  const removedPaths: string[] = [];
+  for (const relativePath of relativePaths) {
+    const targetPath = path.join(project.dirPath, relativePath);
+    if (!fs.existsSync(targetPath)) continue;
+
+    await fs.promises.rm(targetPath, { force: true, recursive: true });
+    removedPaths.push(relativePath);
+  }
+  console.info('Removed Docker build caches:', removedPaths.join(', ') || 'none');
+}
+
+function runDockerCleanupScript(project: Project): void {
+  if (project.env.WB_DOCKER !== '1') return;
+
+  const scriptPath = path.join(project.dirPath, 'bash', 'cleanup.sh');
+  if (!fs.existsSync(scriptPath)) return;
+
+  const result = child_process.spawnSync('bash', [scriptPath, '--keep-scripts'], {
+    cwd: project.dirPath,
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    throw new Error(`Failed to run ${path.relative(project.dirPath, scriptPath)}`);
+  }
 }

--- a/packages/wbfy/src/generators/dockerignore.ts
+++ b/packages/wbfy/src/generators/dockerignore.ts
@@ -10,18 +10,44 @@ import { promisePool } from '../utils/promisePool.js';
 // Exercodeではnode_modulesをCOPYする必要があるため、node_modulesを除外してはいけない。
 const commonContent = `
 **/.DS_Store
+**/.cache
+**/.claude
+**/.cursor
+**/.editorconfig
+**/.eslintcache
+**/.gemini
 **/.git
+**/.gitattributes
 **/.github
+**/.gitignore
 **/.idea
+**/.lefthook
+**/.mypy_cache
 **/.next/cache
+**/.npm
+**/.parcel-cache
+**/.pnpm-store
+**/.pytest_cache
+**/.railwayignore
+**/.releaserc.json
+**/.ruff_cache
+**/.tmp
 **/.turbo
+**/.tox
+**/.vscode
 **/.yarn/cache
 **/*.sqlite3*
 **/.yarn/install-state.gz
 **/.venv
+**/__pycache__
+**/*.log
+**/*.pyc
+**/*.tsbuildinfo
 **/coverage
 **/node_modules/.cache
 **/playwright-report
+**/storybook-static
+**/target
 **/test-results
 `;
 

--- a/packages/wbfy/src/generators/dockerignore.ts
+++ b/packages/wbfy/src/generators/dockerignore.ts
@@ -9,10 +9,20 @@ import { promisePool } from '../utils/promisePool.js';
 
 // Exercodeではnode_modulesをCOPYする必要があるため、node_modulesを除外してはいけない。
 const commonContent = `
+**/.DS_Store
+**/.git
+**/.github
 **/.idea
+**/.next/cache
+**/.turbo
+**/.yarn/cache
 **/*.sqlite3*
 **/.yarn/install-state.gz
 **/.venv
+**/coverage
+**/node_modules/.cache
+**/playwright-report
+**/test-results
 `;
 
 export async function generateDockerignore(config: PackageConfig): Promise<void> {


### PR DESCRIPTION
## Summary
- Expand generated `.dockerignore` defaults with safe metadata, cache, report, and language-cache patterns checked against all remote WillBooster and WillBoosterLab repositories with Dockerfiles
- Remove Docker build caches after in-container `wb optimizeForDockerBuild` installs production dependencies
- Run the generated Docker cleanup script from `wb optimizeForDockerBuild` only when `WB_DOCKER=1`

## Verification
- Checked 85 remote repositories via GitHub API; 28 repositories have Dockerfiles
- Verified no explicit Dockerfile `COPY` / `ADD` source is ignored by the generated common patterns
- yarn verify
