### PR TITLE
fix: run codegen from postinstall

### DIFF
--- a/packages/wb/docker/bash/install-litestream.sh
+++ b/packages/wb/docker/bash/install-litestream.sh
@@ -3,6 +3,7 @@
 set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+ARCH=${ARCH:-$(dpkg --print-architecture)}
 
 # Force to use 0.5.10 since the latest litestream is very unstable.
 apt-get -qq install -y --no-install-recommends ca-certificates curl \

--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -40,13 +40,14 @@ export const genCodeCommand: CommandModule = {
 
 export function getGenCodeScripts(project: Project): string[] {
   const scripts: string[] = [];
-  if (project.hasOwnDependency('blitz')) {
+  const prismaGenerateScript = getPrismaGenerateScript(project);
+  if (project.hasOwnDependency('blitz') && project.hasSourceCode) {
     scripts.push('YARN blitz codegen');
-    if (project.hasPrisma) {
-      scripts.push(prismaScripts.generate(project));
+    if (prismaGenerateScript) {
+      scripts.push(prismaGenerateScript);
     }
-  } else if (project.hasPrisma) {
-    scripts.push(prismaScripts.generate(project));
+  } else if (prismaGenerateScript) {
+    scripts.push(prismaGenerateScript);
   }
 
   const chakraTypegenScript = getChakraScript(project);
@@ -67,12 +68,19 @@ export function getGenCodeScripts(project: Project): string[] {
 
 function getGenI18nTsScript(project: Project): string | undefined {
   if (project.packageJson.scripts?.['gen-i18n-ts']) {
+    if (!project.hasSourceCode) return;
     return 'YARN run gen-i18n-ts';
   }
   if (project.hasOwnDependency('gen-i18n-ts') && fs.existsSync(path.join(project.dirPath, 'i18n'))) {
     return 'YARN gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP';
   }
   return;
+}
+
+function getPrismaGenerateScript(project: Project): string | undefined {
+  if (!project.hasPrisma) return;
+  if (!hasPrismaSchema(project)) return;
+  return prismaScripts.generate(project);
 }
 
 function getChakraScript(project: Project): string | undefined {
@@ -105,4 +113,10 @@ function getOwnDependencyMajor(project: Project, packageName: string): number | 
 
 function fileExists(project: Project, filePath: string): boolean {
   return fs.existsSync(path.join(project.dirPath, filePath));
+}
+
+function hasPrismaSchema(project: Project): boolean {
+  return ['prisma/schema.prisma', 'prisma/schema', 'db/schema.prisma'].some((filePath) =>
+    fileExists(project, filePath)
+  );
 }

--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -71,7 +71,11 @@ function getGenI18nTsScript(project: Project): string | undefined {
     if (!project.hasSourceCode) return;
     return 'YARN run gen-i18n-ts';
   }
-  if (project.hasOwnDependency('gen-i18n-ts') && fs.existsSync(path.join(project.dirPath, 'i18n'))) {
+  if (
+    project.hasOwnDependency('gen-i18n-ts') &&
+    project.hasSourceCode &&
+    fs.existsSync(path.join(project.dirPath, 'i18n'))
+  ) {
     return 'YARN gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP';
   }
   return;

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -37,9 +37,11 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
     for (const project of prepareForRunningCommand('optimizeForDockerBuild', projects.descendants)) {
       const packageJson: PackageJson = project.packageJson;
       rewritePrivateGitHubDependencies(project, packageJson);
-      optimizeDevDependencies(argv, packageJson);
+      const removedDevDependencies = optimizeDevDependencies(argv, packageJson);
 
-      optimizeScripts(packageJson);
+      optimizeScripts(packageJson, {
+        removeWbPostinstall: !argv.outside && removedDevDependencies.includes('@willbooster/wb'),
+      });
 
       optimizeRootProps(packageJson);
 
@@ -182,13 +184,14 @@ function removeUnnecessaryDevDependenciesForOutsideDockerBuild(packageJson: Pack
   return removedDeps;
 }
 
-function optimizeScripts(packageJson: PackageJson): void {
+function optimizeScripts(packageJson: PackageJson, options: { removeWbPostinstall: boolean }): void {
   const nameWordsOfUnnecessaryScripts = ['check', 'deploy', 'format', 'lint', 'start', 'test'];
   const contentWordsOfUnnecessaryScripts = ['pinst ', 'husky '];
   const scripts = (packageJson.scripts ?? {}) as Record<string, string>;
   const removedScripts: string[] = [];
   for (const [name, content] of Object.entries(scripts)) {
     if (
+      (options.removeWbPostinstall && name === 'postinstall' && content.trim() === 'wb gen-code') ||
       nameWordsOfUnnecessaryScripts.some((word) => name.startsWith(word)) ||
       // Support "husky" since husky v9 requires `"postinstall": "husky"`
       contentWordsOfUnnecessaryScripts.some((word) => content.includes(word) || content.trim() === word.trim())

--- a/packages/wb/test/genCode.test.ts
+++ b/packages/wb/test/genCode.test.ts
@@ -14,6 +14,7 @@ describe('getGenCodeScripts', () => {
         'gen-i18n-ts': 'gen-i18n-ts -i locales -o src/i18n.ts -d en-US',
       },
     });
+    await fs.mkdir(path.join(dirPath, 'src'));
 
     try {
       expect(getGenCodeScripts(new Project(dirPath, {}, false))).toContain('YARN run gen-i18n-ts');
@@ -50,6 +51,50 @@ describe('getGenCodeScripts', () => {
       expect(getGenCodeScripts(new Project(dirPath, {}, false))).not.toContain(
         'YARN gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP'
       );
+    } finally {
+      await fs.rm(dirPath, { force: true, recursive: true });
+    }
+  });
+
+  it('does not run the project gen-i18n-ts script without source code', async () => {
+    const dirPath = await createProject({
+      scripts: {
+        'gen-i18n-ts': 'gen-i18n-ts -i locales -o src/i18n.ts -d en-US',
+      },
+    });
+
+    try {
+      expect(getGenCodeScripts(new Project(dirPath, {}, false))).not.toContain('YARN run gen-i18n-ts');
+    } finally {
+      await fs.rm(dirPath, { force: true, recursive: true });
+    }
+  });
+
+  it('runs prisma generate when the schema exists', async () => {
+    const dirPath = await createProject({
+      dependencies: {
+        prisma: '6.0.0',
+      },
+    });
+    await fs.mkdir(path.join(dirPath, 'prisma'));
+    await fs.writeFile(path.join(dirPath, 'prisma', 'schema.prisma'), '');
+
+    try {
+      expect(getGenCodeScripts(new Project(dirPath, {}, false))).toContain('PRISMA generate');
+    } finally {
+      await fs.rm(dirPath, { force: true, recursive: true });
+    }
+  });
+
+  it('does not run prisma generate without a schema', async () => {
+    const dirPath = await createProject({
+      dependencies: {
+        prisma: '6.0.0',
+      },
+    });
+
+    try {
+      expect(getGenCodeScripts(new Project(dirPath, {}, false))).not.toContain('PRISMA generate');
     } finally {
       await fs.rm(dirPath, { force: true, recursive: true });
     }

--- a/packages/wb/test/genCode.test.ts
+++ b/packages/wb/test/genCode.test.ts
@@ -30,6 +30,7 @@ describe('getGenCodeScripts', () => {
       },
     });
     await fs.mkdir(path.join(dirPath, 'i18n'));
+    await fs.mkdir(path.join(dirPath, 'src'));
 
     try {
       expect(getGenCodeScripts(new Project(dirPath, {}, false))).toContain(
@@ -46,6 +47,23 @@ describe('getGenCodeScripts', () => {
         'gen-i18n-ts': '4.0.6',
       },
     });
+
+    try {
+      expect(getGenCodeScripts(new Project(dirPath, {}, false))).not.toContain(
+        'YARN gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP'
+      );
+    } finally {
+      await fs.rm(dirPath, { force: true, recursive: true });
+    }
+  });
+
+  it('does not run the default gen-i18n-ts command without source code', async () => {
+    const dirPath = await createProject({
+      dependencies: {
+        'gen-i18n-ts': '4.0.6',
+      },
+    });
+    await fs.mkdir(path.join(dirPath, 'i18n'));
 
     try {
       expect(getGenCodeScripts(new Project(dirPath, {}, false))).not.toContain(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -162,7 +162,6 @@ async function readPackageJson(filePath: string): Promise<WritablePackageJson> {
 
 async function updateScripts(config: PackageConfig, jsonObj: WritablePackageJson): Promise<void> {
   removeLegacyInstallCommands(jsonObj.scripts);
-  removePostinstallScript(jsonObj.scripts);
 
   jsonObj.scripts = { ...jsonObj.scripts, ...generateScripts(config, jsonObj.scripts) };
   delete jsonObj.scripts['start-test-server'];
@@ -187,8 +186,12 @@ function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
   }
 }
 
-function removePostinstallScript(scripts: PackageJson.Scripts): void {
-  delete scripts.postinstall;
+function updatePostinstallScript(scripts: PackageJson.Scripts): void {
+  if (scripts['gen-code']) {
+    scripts.postinstall = 'wb gen-code';
+  } else if (scripts.postinstall?.includes('gen-i18n-ts')) {
+    delete scripts.postinstall;
+  }
 }
 
 function normalizeYarnWorkspaceForeachScripts(scripts: PackageJson.Scripts): void {
@@ -237,7 +240,6 @@ async function applyPackageJsonConventions(
 
   if (config.isRoot) {
     delete jsonObj.devDependencies.husky;
-    delete jsonObj.scripts.postinstall;
     delete jsonObj.scripts.postpublish;
     delete jsonObj.scripts.prepublishOnly;
     delete jsonObj.scripts.prepack;
@@ -492,6 +494,7 @@ async function normalizePackageMetadata(
     jsonObj.scripts['gen-code'] = `${config.isBun ? 'bun --bun ' : ''}wb gen-code`;
   }
   ensureGenI18nTsScripts(config, jsonObj);
+  updatePostinstallScript(jsonObj.scripts);
 
   if (!jsonObj.dependencies.prettier) {
     // Because @types/prettier blocks prettier execution.

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -195,7 +195,7 @@ function removeGenI18nTsPostinstallCommand(scripts: PackageJson.Scripts): void {
     .split(/\s*&&\s*/u)
     .map((command) => command.trim())
     .filter(
-      (command) => command !== '' && !/^(?:bun|yarn)(?:\s+run)?\s+gen-i18n-ts(?:\s+>\s*\/dev\/null)?$/u.test(command)
+      (command) => command !== '' && !/^(?:bun|yarn)(?:\s+run)?\s+gen-i18n-ts(?:\s*>\s*\/dev\/null)?$/u.test(command)
     );
   if (commands.length === 0) {
     delete scripts.postinstall;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -193,7 +193,7 @@ function removeGenI18nTsPostinstallCommand(scripts: PackageJson.Scripts): void {
 
   const commands = postinstall
     .split(/\s*&&\s*/u)
-    .filter((command) => !/^(?:bun|yarn) run gen-i18n-ts > \/dev\/null$/u.test(command));
+    .filter((command) => !/^\s*(?:bun|yarn)(?:\s+run)?\s+gen-i18n-ts(?:\s+>\s*\/dev\/null)?\s*$/u.test(command));
   if (commands.length === 0) {
     delete scripts.postinstall;
   } else {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -162,6 +162,7 @@ async function readPackageJson(filePath: string): Promise<WritablePackageJson> {
 
 async function updateScripts(config: PackageConfig, jsonObj: WritablePackageJson): Promise<void> {
   removeLegacyInstallCommands(jsonObj.scripts);
+  removeGenI18nTsPostinstallCommand(jsonObj.scripts);
 
   jsonObj.scripts = { ...jsonObj.scripts, ...generateScripts(config, jsonObj.scripts) };
   delete jsonObj.scripts['start-test-server'];
@@ -183,6 +184,20 @@ function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
     if (!value.includes('git clone')) {
       scripts[key] = value.replaceAll(/yarn\s*(?:install\s*)?&&\s*/gu, '');
     }
+  }
+}
+
+function removeGenI18nTsPostinstallCommand(scripts: PackageJson.Scripts): void {
+  const postinstall = scripts.postinstall;
+  if (typeof postinstall !== 'string') return;
+
+  const commands = postinstall
+    .split(/\s*&&\s*/u)
+    .filter((command) => !/^(?:bun|yarn) run gen-i18n-ts > \/dev\/null$/u.test(command));
+  if (commands.length === 0) {
+    delete scripts.postinstall;
+  } else {
+    scripts.postinstall = commands.join(' && ');
   }
 }
 
@@ -1040,7 +1055,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
     const hasJsOrTs = doesContainJsOrTs(config);
     const hasJava = doesContainJava(config);
     const oldTest = oldScripts.test;
-    const cleanupPrefix = shouldGenerateWbGenCodeScript(config, oldScripts['gen-code']) ? 'yarn gen-code && ' : '';
+    const cleanupPrefix = shouldRunGenI18nTsBeforeCleanup(config) ? 'yarn gen-i18n-ts && ' : '';
     let scripts: Record<string, string> = {
       cleanup: `${cleanupPrefix}yarn format && yarn lint-fix`,
       format: generateFormatScript(hasJsOrTs, hasJava),
@@ -1097,6 +1112,10 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
     applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
     return scripts;
   }
+}
+
+function shouldRunGenI18nTsBeforeCleanup(config: PackageConfig): boolean {
+  return config.depending.genI18nTs && fs.existsSync(path.join(config.dirPath, 'i18n'));
 }
 
 function applyDatabaseScripts(config: PackageConfig, scripts: Record<string, string>, wbDbCommand: string): void {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -193,7 +193,10 @@ function removeGenI18nTsPostinstallCommand(scripts: PackageJson.Scripts): void {
 
   const commands = postinstall
     .split(/\s*&&\s*/u)
-    .filter((command) => !/^\s*(?:bun|yarn)(?:\s+run)?\s+gen-i18n-ts(?:\s+>\s*\/dev\/null)?\s*$/u.test(command));
+    .map((command) => command.trim())
+    .filter(
+      (command) => command !== '' && !/^(?:bun|yarn)(?:\s+run)?\s+gen-i18n-ts(?:\s+>\s*\/dev\/null)?$/u.test(command)
+    );
   if (commands.length === 0) {
     delete scripts.postinstall;
   } else {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -515,12 +515,8 @@ function ensureGenI18nTsScripts(config: PackageConfig, jsonObj: WritablePackageJ
   if (!config.depending.genI18nTs) return;
   if (!fs.existsSync(path.join(config.dirPath, 'i18n'))) return;
 
+  // Keep i18n generation explicit so Docker dependency layers can install packages before source files are copied.
   jsonObj.scripts['gen-i18n-ts'] ??= 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP';
-
-  const command = `${config.isBun ? 'bun' : 'yarn'} run gen-i18n-ts > /dev/null`;
-  const postinstall = jsonObj.scripts.postinstall;
-  if (postinstall?.split(/\s*&&\s*/u).includes(command)) return;
-  jsonObj.scripts.postinstall = postinstall ? `${postinstall} && ${command}` : command;
 }
 
 async function normalizePublishedConfigPackageMetadata(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1040,8 +1040,9 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
     const hasJsOrTs = doesContainJsOrTs(config);
     const hasJava = doesContainJava(config);
     const oldTest = oldScripts.test;
+    const cleanupPrefix = shouldGenerateWbGenCodeScript(config, oldScripts['gen-code']) ? 'yarn gen-code && ' : '';
     let scripts: Record<string, string> = {
-      cleanup: 'yarn format && yarn lint-fix',
+      cleanup: `${cleanupPrefix}yarn format && yarn lint-fix`,
       format: generateFormatScript(hasJsOrTs, hasJava),
       lint: `oxlint --no-error-on-unmatched-pattern .`,
       'lint-fix': 'yarn lint --fix',

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -527,8 +527,7 @@ function appendFormatCodeCommand(formatScript: string | undefined, config: Packa
 }
 
 function ensureGenI18nTsScripts(config: PackageConfig, jsonObj: WritablePackageJson): void {
-  if (!config.depending.genI18nTs) return;
-  if (!fs.existsSync(path.join(config.dirPath, 'i18n'))) return;
+  if (!shouldManageGenI18nTs(config)) return;
 
   // Keep i18n generation explicit so Docker dependency layers can install packages before source files are copied.
   jsonObj.scripts['gen-i18n-ts'] ??= 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP';
@@ -1055,7 +1054,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
     const hasJsOrTs = doesContainJsOrTs(config);
     const hasJava = doesContainJava(config);
     const oldTest = oldScripts.test;
-    const cleanupPrefix = shouldRunGenI18nTsBeforeCleanup(config) ? 'yarn gen-i18n-ts && ' : '';
+    const cleanupPrefix = shouldManageGenI18nTs(config) ? 'yarn gen-i18n-ts && ' : '';
     let scripts: Record<string, string> = {
       cleanup: `${cleanupPrefix}yarn format && yarn lint-fix`,
       format: generateFormatScript(hasJsOrTs, hasJava),
@@ -1114,7 +1113,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
   }
 }
 
-function shouldRunGenI18nTsBeforeCleanup(config: PackageConfig): boolean {
+function shouldManageGenI18nTs(config: PackageConfig): boolean {
   return config.depending.genI18nTs && fs.existsSync(path.join(config.dirPath, 'i18n'));
 }
 

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -162,7 +162,7 @@ async function readPackageJson(filePath: string): Promise<WritablePackageJson> {
 
 async function updateScripts(config: PackageConfig, jsonObj: WritablePackageJson): Promise<void> {
   removeLegacyInstallCommands(jsonObj.scripts);
-  removeGenI18nTsPostinstallCommand(jsonObj.scripts);
+  removePostinstallScript(jsonObj.scripts);
 
   jsonObj.scripts = { ...jsonObj.scripts, ...generateScripts(config, jsonObj.scripts) };
   delete jsonObj.scripts['start-test-server'];
@@ -187,21 +187,8 @@ function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
   }
 }
 
-function removeGenI18nTsPostinstallCommand(scripts: PackageJson.Scripts): void {
-  const postinstall = scripts.postinstall;
-  if (typeof postinstall !== 'string') return;
-
-  const commands = postinstall
-    .split(/\s*&&\s*/u)
-    .map((command) => command.trim())
-    .filter(
-      (command) => command !== '' && !/^(?:bun|yarn)(?:\s+run)?\s+gen-i18n-ts(?:\s*>\s*\/dev\/null)?$/u.test(command)
-    );
-  if (commands.length === 0) {
-    delete scripts.postinstall;
-  } else {
-    scripts.postinstall = commands.join(' && ');
-  }
+function removePostinstallScript(scripts: PackageJson.Scripts): void {
+  delete scripts.postinstall;
 }
 
 function normalizeYarnWorkspaceForeachScripts(scripts: PackageJson.Scripts): void {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -7,7 +7,7 @@ import { expect, test } from 'vitest';
 import { generatePackageJson } from '../src/generators/packageJson.js';
 import { createConfig } from './testConfig.js';
 
-test('removes gen-i18n-ts postinstall while keeping the script available', async () => {
+test('replaces gen-i18n-ts postinstall with wb gen-code', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
   await fs.mkdir(path.join(dirPath, 'i18n'));
@@ -39,13 +39,13 @@ test('removes gen-i18n-ts postinstall while keeping the script available', async
     expect(packageJson.scripts.cleanup).toBe('yarn gen-i18n-ts && yarn format');
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
     expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP');
-    expect(packageJson.scripts.postinstall).toBeUndefined();
+    expect(packageJson.scripts.postinstall).toBe('wb gen-code');
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }
 });
 
-test('restores missing default gen-i18n-ts script without postinstall', async () => {
+test('restores missing default gen-i18n-ts script with wb gen-code postinstall', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
   await fs.mkdir(path.join(dirPath, 'i18n'));
@@ -74,7 +74,7 @@ test('restores missing default gen-i18n-ts script without postinstall', async ()
     expect(packageJson.scripts.cleanup).toBe('yarn gen-i18n-ts && yarn format');
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
     expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP');
-    expect(packageJson.scripts.postinstall).toBeUndefined();
+    expect(packageJson.scripts.postinstall).toBe('wb gen-code');
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }
@@ -115,7 +115,7 @@ test('keeps custom gen-i18n-ts scripts', async () => {
   }
 });
 
-test('removes unrelated postinstall commands', async () => {
+test('replaces unrelated postinstall commands when code generation is managed', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
   await fs.mkdir(path.join(dirPath, 'i18n'));
@@ -143,13 +143,13 @@ test('removes unrelated postinstall commands', async () => {
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string | undefined>;
     };
-    expect(packageJson.scripts.postinstall).toBeUndefined();
+    expect(packageJson.scripts.postinstall).toBe('wb gen-code');
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }
 });
 
-test('removes empty postinstall command variants', async () => {
+test('replaces empty postinstall command variants when code generation is managed', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
   await fs.mkdir(path.join(dirPath, 'i18n'));
@@ -177,7 +177,7 @@ test('removes empty postinstall command variants', async () => {
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string | undefined>;
     };
-    expect(packageJson.scripts.postinstall).toBeUndefined();
+    expect(packageJson.scripts.postinstall).toBe('wb gen-code');
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -149,6 +149,40 @@ test('removes only stale gen-i18n-ts postinstall commands', async () => {
   }
 });
 
+test('removes stale gen-i18n-ts postinstall command variants', async () => {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
+  const packageJsonPath = path.join(dirPath, 'package.json');
+  await fs.mkdir(path.join(dirPath, 'i18n'));
+
+  await fs.writeFile(
+    packageJsonPath,
+    JSON.stringify({
+      scripts: {
+        postinstall: 'yarn gen-i18n-ts && bun   run   gen-i18n-ts   >   /dev/null',
+      },
+      dependencies: {
+        'gen-i18n-ts': '4.0.6',
+      },
+    })
+  );
+
+  try {
+    const config = createConfig({
+      dirPath,
+      isRoot: false,
+      depending: { ...createConfig().depending, genI18nTs: true },
+    });
+    await generatePackageJson(config, config, true);
+
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
+      scripts: Record<string, string | undefined>;
+    };
+    expect(packageJson.scripts.postinstall).toBeUndefined();
+  } finally {
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+});
+
 test('keeps build-ts as a runtime dependency when prisma seed uses it', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -36,7 +36,7 @@ test('removes gen-i18n-ts postinstall while keeping the script available', async
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string | undefined>;
     };
-    expect(packageJson.scripts.cleanup).toBe('yarn gen-code && yarn format && yarn lint-fix');
+    expect(packageJson.scripts.cleanup).toBe('yarn gen-i18n-ts && yarn format');
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
     expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP');
     expect(packageJson.scripts.postinstall).toBeUndefined();
@@ -71,7 +71,7 @@ test('restores missing default gen-i18n-ts script without postinstall', async ()
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string | undefined>;
     };
-    expect(packageJson.scripts.cleanup).toBe('yarn gen-code && yarn format && yarn lint-fix');
+    expect(packageJson.scripts.cleanup).toBe('yarn gen-i18n-ts && yarn format');
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
     expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP');
     expect(packageJson.scripts.postinstall).toBeUndefined();
@@ -110,6 +110,40 @@ test('keeps custom gen-i18n-ts scripts', async () => {
     };
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
     expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i locales -o src/i18n.ts -d en-US');
+  } finally {
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('removes only stale gen-i18n-ts postinstall commands', async () => {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
+  const packageJsonPath = path.join(dirPath, 'package.json');
+  await fs.mkdir(path.join(dirPath, 'i18n'));
+
+  await fs.writeFile(
+    packageJsonPath,
+    JSON.stringify({
+      scripts: {
+        postinstall: 'echo before && yarn run gen-i18n-ts > /dev/null && echo after',
+      },
+      dependencies: {
+        'gen-i18n-ts': '4.0.6',
+      },
+    })
+  );
+
+  try {
+    const config = createConfig({
+      dirPath,
+      isRoot: false,
+      depending: { ...createConfig().depending, genI18nTs: true },
+    });
+    await generatePackageJson(config, config, true);
+
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
+      scripts: Record<string, string | undefined>;
+    };
+    expect(packageJson.scripts.postinstall).toBe('echo before && echo after');
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -36,6 +36,7 @@ test('removes gen-i18n-ts postinstall while keeping the script available', async
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string | undefined>;
     };
+    expect(packageJson.scripts.cleanup).toBe('yarn gen-code && yarn format && yarn lint-fix');
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
     expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP');
     expect(packageJson.scripts.postinstall).toBeUndefined();
@@ -70,6 +71,7 @@ test('restores missing default gen-i18n-ts script without postinstall', async ()
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string | undefined>;
     };
+    expect(packageJson.scripts.cleanup).toBe('yarn gen-code && yarn format && yarn lint-fix');
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
     expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP');
     expect(packageJson.scripts.postinstall).toBeUndefined();

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -7,7 +7,7 @@ import { expect, test } from 'vitest';
 import { generatePackageJson } from '../src/generators/packageJson.js';
 import { createConfig } from './testConfig.js';
 
-test('keeps default gen-i18n-ts execution available before gen-code', async () => {
+test('removes gen-i18n-ts postinstall while keeping the script available', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
   await fs.mkdir(path.join(dirPath, 'i18n'));
@@ -38,13 +38,13 @@ test('keeps default gen-i18n-ts execution available before gen-code', async () =
     };
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
     expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP');
-    expect(packageJson.scripts.postinstall).toBe('yarn run gen-i18n-ts > /dev/null');
+    expect(packageJson.scripts.postinstall).toBeUndefined();
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }
 });
 
-test('restores missing default gen-i18n-ts execution', async () => {
+test('restores missing default gen-i18n-ts script without postinstall', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
   await fs.mkdir(path.join(dirPath, 'i18n'));
@@ -72,7 +72,7 @@ test('restores missing default gen-i18n-ts execution', async () => {
     };
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
     expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP');
-    expect(packageJson.scripts.postinstall).toBe('yarn run gen-i18n-ts > /dev/null');
+    expect(packageJson.scripts.postinstall).toBeUndefined();
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -158,7 +158,7 @@ test('removes stale gen-i18n-ts postinstall command variants', async () => {
     packageJsonPath,
     JSON.stringify({
       scripts: {
-        postinstall: 'yarn gen-i18n-ts && bun   run   gen-i18n-ts   >   /dev/null',
+        postinstall: ' && yarn gen-i18n-ts && bun   run   gen-i18n-ts   >   /dev/null && ',
       },
       dependencies: {
         'gen-i18n-ts': '4.0.6',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -158,7 +158,7 @@ test('removes stale gen-i18n-ts postinstall command variants', async () => {
     packageJsonPath,
     JSON.stringify({
       scripts: {
-        postinstall: ' && yarn gen-i18n-ts && bun   run   gen-i18n-ts   >   /dev/null && ',
+        postinstall: ' && yarn gen-i18n-ts && bun   run   gen-i18n-ts>/dev/null && ',
       },
       dependencies: {
         'gen-i18n-ts': '4.0.6',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -115,7 +115,7 @@ test('keeps custom gen-i18n-ts scripts', async () => {
   }
 });
 
-test('removes only stale gen-i18n-ts postinstall commands', async () => {
+test('removes unrelated postinstall commands', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
   await fs.mkdir(path.join(dirPath, 'i18n'));
@@ -143,13 +143,13 @@ test('removes only stale gen-i18n-ts postinstall commands', async () => {
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string | undefined>;
     };
-    expect(packageJson.scripts.postinstall).toBe('echo before && echo after');
+    expect(packageJson.scripts.postinstall).toBeUndefined();
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }
 });
 
-test('removes stale gen-i18n-ts postinstall command variants', async () => {
+test('removes empty postinstall command variants', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
   await fs.mkdir(path.join(dirPath, 'i18n'));


### PR DESCRIPTION
## Customer Summary

- Restores automatic code generation after package installation through `postinstall`.
- Keeps Docker dependency installs predictable by making `wb gen-code` skip generation when required inputs are absent.
- Preserves explicit generation during build and cleanup workflows.

## Technical Summary

- Makes `wb gen-code` no-op for Prisma when no Prisma schema exists.
- Makes project `gen-i18n-ts` scripts run only when source code is present.
- Updates `wbfy` to generate `"postinstall": "wb gen-code"` for packages with managed code generation.
- Keeps `gen-i18n-ts` scripts explicit and covered by `wb gen-code`.

## Why

- Fresh clones should get generated files automatically after install.
- Docker dependency layers can install packages before source files are copied, so code generation must be safe when inputs are missing.

## Testing

- `yarn test test/genCode.test.ts` in `packages/wb`
- `yarn test test/packageJson.test.ts` in `packages/wbfy`
- `yarn verify` in `WillBooster/shared`
- Applied updated `wbfy` to `WillBoosterLab/exercode` and `WillBoosterLab/ai-game-builder`
- Verified source-less Docker dependency install simulations with `yarn install --mode=skip-build` for both target repos
- `yarn deploy-build && yarn verify` in both target repos
