### PR TITLE
fix: remove standard gen-i18n script

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -30,6 +30,7 @@ const typescriptDependency = 'typescript';
 const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
 const lefthookDependency = 'lefthook';
+const defaultGenI18nTsScript = 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP';
 const wbfyPackageJson = readWbfyPackageJson();
 const managedDependencyVersions = {
   ...wbfyPackageJson.dependencies,
@@ -493,7 +494,7 @@ async function normalizePackageMetadata(
   } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
     jsonObj.scripts['gen-code'] = `${config.isBun ? 'bun --bun ' : ''}wb gen-code`;
   }
-  ensureGenI18nTsScripts(config, jsonObj);
+  normalizeGenI18nTsScript(config, jsonObj);
   updatePostinstallScript(jsonObj.scripts);
 
   if (!jsonObj.dependencies.prettier) {
@@ -519,11 +520,12 @@ function appendFormatCodeCommand(formatScript: string | undefined, config: Packa
   return formatScript ? `${formatScript} && ${scriptRunner} format-code` : `${scriptRunner} format-code`;
 }
 
-function ensureGenI18nTsScripts(config: PackageConfig, jsonObj: WritablePackageJson): void {
+function normalizeGenI18nTsScript(config: PackageConfig, jsonObj: WritablePackageJson): void {
   if (!shouldManageGenI18nTs(config)) return;
 
-  // Keep i18n generation explicit so Docker dependency layers can install packages before source files are copied.
-  jsonObj.scripts['gen-i18n-ts'] ??= 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP';
+  if (jsonObj.scripts['gen-i18n-ts'] === defaultGenI18nTsScript) {
+    delete jsonObj.scripts['gen-i18n-ts'];
+  }
 }
 
 async function normalizePublishedConfigPackageMetadata(
@@ -1047,9 +1049,8 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
     const hasJsOrTs = doesContainJsOrTs(config);
     const hasJava = doesContainJava(config);
     const oldTest = oldScripts.test;
-    const cleanupPrefix = shouldManageGenI18nTs(config) ? 'yarn gen-i18n-ts && ' : '';
     let scripts: Record<string, string> = {
-      cleanup: `${cleanupPrefix}yarn format && yarn lint-fix`,
+      cleanup: 'yarn format && yarn lint-fix',
       format: generateFormatScript(hasJsOrTs, hasJava),
       lint: `oxlint --no-error-on-unmatched-pattern .`,
       'lint-fix': 'yarn lint --fix',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -36,16 +36,16 @@ test('replaces gen-i18n-ts postinstall with wb gen-code', async () => {
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string | undefined>;
     };
-    expect(packageJson.scripts.cleanup).toBe('yarn gen-i18n-ts && yarn format');
+    expect(packageJson.scripts.cleanup).toBe('yarn format');
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
-    expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP');
+    expect(packageJson.scripts['gen-i18n-ts']).toBeUndefined();
     expect(packageJson.scripts.postinstall).toBe('wb gen-code');
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }
 });
 
-test('restores missing default gen-i18n-ts script with wb gen-code postinstall', async () => {
+test('does not restore missing default gen-i18n-ts script with wb gen-code postinstall', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
   await fs.mkdir(path.join(dirPath, 'i18n'));
@@ -71,9 +71,9 @@ test('restores missing default gen-i18n-ts script with wb gen-code postinstall',
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
       scripts: Record<string, string | undefined>;
     };
-    expect(packageJson.scripts.cleanup).toBe('yarn gen-i18n-ts && yarn format');
+    expect(packageJson.scripts.cleanup).toBe('yarn format');
     expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
-    expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP');
+    expect(packageJson.scripts['gen-i18n-ts']).toBeUndefined();
     expect(packageJson.scripts.postinstall).toBe('wb gen-code');
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });


### PR DESCRIPTION
## Summary

- Removes the standard gen-i18n-ts package script from wbfy-managed package.json files.
- Stops adding yarn gen-i18n-ts to cleanup.
- Keeps custom gen-i18n-ts scripts so wb gen-code can still delegate to project-specific options.

## Testing

- yarn test test/packageJson.test.ts in packages/wbfy
- yarn verify
