### PR TITLE
fix: keep wb runtime dependency for postinstall

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -127,7 +127,6 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
   moveManagedToolDependenciesToDevDependencies(jsonObj);
   const dependencyUpdates = await applyPackageJsonConventions(config, rootConfig, jsonObj);
   await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
-  keepRuntimeManagedToolDependencies(jsonObj, dependencyUpdates);
   addDependencyVersionsToPackageJson(jsonObj, dependencyUpdates);
   await updatePrivatePackages(jsonObj);
   removeEmptyDependencySections(jsonObj);
@@ -296,7 +295,11 @@ async function applyPackageJsonConventions(
   }
 
   if (!isWbPackage(jsonObj)) {
-    devDependencies.push(wbDependency);
+    if (shouldKeepWbAsRuntimeDependency(jsonObj)) {
+      dependencies.push(wbDependency);
+    } else {
+      devDependencies.push(wbDependency);
+    }
   }
   // build-ts owns TypeScript execution and declaration emit. wbfy must always
   // keep existing build-ts users current because older releases can emit .d.ts
@@ -361,38 +364,22 @@ function doesReleaseScriptInstallSemanticRelease(script: unknown): boolean {
 }
 
 function moveManagedToolDependenciesToDevDependencies(jsonObj: WritablePackageJson): void {
-  if (shouldKeepBuildTsAsRuntimeDependency(jsonObj)) {
-    keepRuntimeDependencyVersion(jsonObj, buildTsDependency);
-  }
-  const dependenciesToMove = [
-    ...(shouldKeepWbAsRuntimeDependency(jsonObj) ? [] : [wbDependency]),
-    ...(shouldKeepBuildTsAsRuntimeDependency(jsonObj) ? [] : [buildTsDependency]),
-  ];
-  for (const dependency of dependenciesToMove) {
-    if (!jsonObj.dependencies[dependency]) continue;
-    jsonObj.devDependencies[dependency] ??= jsonObj.dependencies[dependency];
-    delete jsonObj.dependencies[dependency];
-  }
-}
-
-function keepRuntimeManagedToolDependencies(jsonObj: WritablePackageJson, dependencyUpdates: DependencyUpdates): void {
-  if (!shouldKeepWbAsRuntimeDependency(jsonObj)) return;
-
-  dependencyUpdates.devDependencies = dependencyUpdates.devDependencies.filter(
-    (dependency) => dependency !== wbDependency
-  );
-  dependencyUpdates.dependencies.push(wbDependency);
-  keepRuntimeDependencyVersion(jsonObj, wbDependency);
-}
-
-function keepRuntimeDependencyVersion(jsonObj: WritablePackageJson, dependency: string): void {
-  const currentDevDependencyVersion = jsonObj.devDependencies[dependency];
-  if (currentDevDependencyVersion) {
-    const currentDependencyVersion = jsonObj.dependencies[dependency];
-    if (!currentDependencyVersion || isNewerPackageVersion(currentDevDependencyVersion, currentDependencyVersion)) {
-      jsonObj.dependencies[dependency] = currentDevDependencyVersion;
+  for (const [dependency, keepAsRuntime] of [
+    [wbDependency, shouldKeepWbAsRuntimeDependency(jsonObj)],
+    [buildTsDependency, shouldKeepBuildTsAsRuntimeDependency(jsonObj)],
+  ] as const) {
+    if (keepAsRuntime) {
+      const devVersion = jsonObj.devDependencies[dependency];
+      if (!devVersion) continue;
+      const runtimeVersion = jsonObj.dependencies[dependency];
+      if (!runtimeVersion || isNewerPackageVersion(devVersion, runtimeVersion)) {
+        jsonObj.dependencies[dependency] = devVersion;
+      }
+      delete jsonObj.devDependencies[dependency];
+    } else if (jsonObj.dependencies[dependency]) {
+      jsonObj.devDependencies[dependency] ??= jsonObj.dependencies[dependency];
+      delete jsonObj.dependencies[dependency];
     }
-    delete jsonObj.devDependencies[dependency];
   }
 }
 

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -362,15 +362,7 @@ function doesReleaseScriptInstallSemanticRelease(script: unknown): boolean {
 
 function moveManagedToolDependenciesToDevDependencies(jsonObj: WritablePackageJson): void {
   if (shouldKeepBuildTsAsRuntimeDependency(jsonObj)) {
-    const currentDependencyVersion = jsonObj.dependencies[buildTsDependency];
-    const currentDevDependencyVersion = jsonObj.devDependencies[buildTsDependency];
-    if (
-      currentDevDependencyVersion &&
-      (!currentDependencyVersion || isNewerPackageVersion(currentDevDependencyVersion, currentDependencyVersion))
-    ) {
-      jsonObj.dependencies[buildTsDependency] = currentDevDependencyVersion;
-    }
-    delete jsonObj.devDependencies[buildTsDependency];
+    keepRuntimeDependencyVersion(jsonObj, buildTsDependency);
   }
   const dependenciesToMove = [
     ...(shouldKeepWbAsRuntimeDependency(jsonObj) ? [] : [wbDependency]),
@@ -390,13 +382,17 @@ function keepRuntimeManagedToolDependencies(jsonObj: WritablePackageJson, depend
     (dependency) => dependency !== wbDependency
   );
   dependencyUpdates.dependencies.push(wbDependency);
-  const currentDevDependencyVersion = jsonObj.devDependencies[wbDependency];
+  keepRuntimeDependencyVersion(jsonObj, wbDependency);
+}
+
+function keepRuntimeDependencyVersion(jsonObj: WritablePackageJson, dependency: string): void {
+  const currentDevDependencyVersion = jsonObj.devDependencies[dependency];
   if (currentDevDependencyVersion) {
-    const currentDependencyVersion = jsonObj.dependencies[wbDependency];
+    const currentDependencyVersion = jsonObj.dependencies[dependency];
     if (!currentDependencyVersion || isNewerPackageVersion(currentDevDependencyVersion, currentDependencyVersion)) {
-      jsonObj.dependencies[wbDependency] = currentDevDependencyVersion;
+      jsonObj.dependencies[dependency] = currentDevDependencyVersion;
     }
-    delete jsonObj.devDependencies[wbDependency];
+    delete jsonObj.devDependencies[dependency];
   }
 }
 

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -127,6 +127,7 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
   moveManagedToolDependenciesToDevDependencies(jsonObj);
   const dependencyUpdates = await applyPackageJsonConventions(config, rootConfig, jsonObj);
   await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
+  keepRuntimeManagedToolDependencies(jsonObj, dependencyUpdates);
   addDependencyVersionsToPackageJson(jsonObj, dependencyUpdates);
   await updatePrivatePackages(jsonObj);
   removeEmptyDependencySections(jsonObj);
@@ -371,14 +372,37 @@ function moveManagedToolDependenciesToDevDependencies(jsonObj: WritablePackageJs
     }
     delete jsonObj.devDependencies[buildTsDependency];
   }
-  const dependenciesToMove = shouldKeepBuildTsAsRuntimeDependency(jsonObj)
-    ? [wbDependency]
-    : [wbDependency, buildTsDependency];
+  const dependenciesToMove = [
+    ...(shouldKeepWbAsRuntimeDependency(jsonObj) ? [] : [wbDependency]),
+    ...(shouldKeepBuildTsAsRuntimeDependency(jsonObj) ? [] : [buildTsDependency]),
+  ];
   for (const dependency of dependenciesToMove) {
     if (!jsonObj.dependencies[dependency]) continue;
     jsonObj.devDependencies[dependency] ??= jsonObj.dependencies[dependency];
     delete jsonObj.dependencies[dependency];
   }
+}
+
+function keepRuntimeManagedToolDependencies(jsonObj: WritablePackageJson, dependencyUpdates: DependencyUpdates): void {
+  if (!shouldKeepWbAsRuntimeDependency(jsonObj)) return;
+
+  dependencyUpdates.devDependencies = dependencyUpdates.devDependencies.filter(
+    (dependency) => dependency !== wbDependency
+  );
+  dependencyUpdates.dependencies.push(wbDependency);
+  const currentDevDependencyVersion = jsonObj.devDependencies[wbDependency];
+  if (currentDevDependencyVersion) {
+    const currentDependencyVersion = jsonObj.dependencies[wbDependency];
+    if (!currentDependencyVersion || isNewerPackageVersion(currentDevDependencyVersion, currentDependencyVersion)) {
+      jsonObj.dependencies[wbDependency] = currentDevDependencyVersion;
+    }
+    delete jsonObj.devDependencies[wbDependency];
+  }
+}
+
+function shouldKeepWbAsRuntimeDependency(jsonObj: PackageJson): boolean {
+  const postinstallScript = jsonObj.scripts?.postinstall;
+  return typeof postinstallScript === 'string' && /\bwb\b/u.test(postinstallScript);
 }
 
 function shouldKeepBuildTsAsRuntimeDependency(jsonObj: PackageJson): boolean {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -7,14 +7,20 @@ import { expect, test } from 'vitest';
 import { generatePackageJson } from '../src/generators/packageJson.js';
 import { createConfig } from './testConfig.js';
 
-test('replaces gen-i18n-ts postinstall with wb gen-code', async () => {
-  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
-  const packageJsonPath = path.join(dirPath, 'package.json');
-  await fs.mkdir(path.join(dirPath, 'i18n'));
+interface GeneratedPackageJson {
+  dependencies?: Record<string, string | undefined>;
+  devDependencies?: Record<string, string | undefined>;
+  scripts?: Record<string, string | undefined>;
+}
 
-  await fs.writeFile(
-    packageJsonPath,
-    JSON.stringify({
+const genI18nTsDepending = {
+  ...createConfig().depending,
+  genI18nTs: true,
+};
+
+test('replaces default gen-i18n-ts postinstall with managed wb gen-code scripts', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
       scripts: {
         'gen-i18n-ts': 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP',
         postinstall: 'yarn run gen-i18n-ts > /dev/null',
@@ -22,236 +28,134 @@ test('replaces gen-i18n-ts postinstall with wb gen-code', async () => {
       dependencies: {
         'gen-i18n-ts': '4.0.6',
       },
-    })
+    },
+    { depending: genI18nTsDepending, isRoot: true },
+    { createI18nDir: true }
   );
 
-  try {
-    const config = createConfig({
-      dirPath,
-      isRoot: true,
-      depending: { ...createConfig().depending, genI18nTs: true },
-    });
-    await generatePackageJson(config, config, true);
-
-    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
-      scripts: Record<string, string | undefined>;
-    };
-    expect(packageJson.scripts.cleanup).toBe('yarn format');
-    expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
-    expect(packageJson.scripts['gen-i18n-ts']).toBeUndefined();
-    expect(packageJson.scripts.postinstall).toBe('wb gen-code');
-  } finally {
-    await fs.rm(dirPath, { force: true, recursive: true });
-  }
+  expect(packageJson.scripts).toMatchObject({
+    cleanup: 'yarn format',
+    'gen-code': 'wb gen-code',
+    postinstall: 'wb gen-code',
+  });
+  expect(packageJson.scripts?.['gen-i18n-ts']).toBeUndefined();
 });
 
-test('does not restore missing default gen-i18n-ts script with wb gen-code postinstall', async () => {
-  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
-  const packageJsonPath = path.join(dirPath, 'package.json');
-  await fs.mkdir(path.join(dirPath, 'i18n'));
-
-  await fs.writeFile(
-    packageJsonPath,
-    JSON.stringify({
+test('does not restore missing default gen-i18n-ts script with managed wb gen-code postinstall', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
       dependencies: {
         'gen-i18n-ts': '4.0.6',
       },
       scripts: {},
-    })
+    },
+    { depending: genI18nTsDepending, isRoot: true },
+    { createI18nDir: true }
   );
 
-  try {
-    const config = createConfig({
-      dirPath,
-      isRoot: true,
-      depending: { ...createConfig().depending, genI18nTs: true },
-    });
-    await generatePackageJson(config, config, true);
-
-    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
-      scripts: Record<string, string | undefined>;
-    };
-    expect(packageJson.scripts.cleanup).toBe('yarn format');
-    expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
-    expect(packageJson.scripts['gen-i18n-ts']).toBeUndefined();
-    expect(packageJson.scripts.postinstall).toBe('wb gen-code');
-  } finally {
-    await fs.rm(dirPath, { force: true, recursive: true });
-  }
+  expect(packageJson.scripts).toMatchObject({
+    cleanup: 'yarn format',
+    'gen-code': 'wb gen-code',
+    postinstall: 'wb gen-code',
+  });
+  expect(packageJson.scripts?.['gen-i18n-ts']).toBeUndefined();
 });
 
-test('keeps custom gen-i18n-ts scripts', async () => {
-  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
-  const packageJsonPath = path.join(dirPath, 'package.json');
-  await fs.mkdir(path.join(dirPath, 'i18n'));
-
-  await fs.writeFile(
-    packageJsonPath,
-    JSON.stringify({
+test('keeps custom gen-i18n-ts scripts while adding wb gen-code', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
       scripts: {
         'gen-i18n-ts': 'gen-i18n-ts -i locales -o src/i18n.ts -d en-US',
       },
       dependencies: {
         'gen-i18n-ts': '4.0.6',
       },
-    })
+    },
+    { depending: genI18nTsDepending, isRoot: true },
+    { createI18nDir: true }
   );
 
-  try {
-    const config = createConfig({
-      dirPath,
-      isRoot: true,
-      depending: { ...createConfig().depending, genI18nTs: true },
-    });
-    await generatePackageJson(config, config, true);
-
-    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
-      scripts: Record<string, string | undefined>;
-    };
-    expect(packageJson.scripts['gen-code']).toBe('wb gen-code');
-    expect(packageJson.scripts['gen-i18n-ts']).toBe('gen-i18n-ts -i locales -o src/i18n.ts -d en-US');
-  } finally {
-    await fs.rm(dirPath, { force: true, recursive: true });
-  }
+  expect(packageJson.scripts).toMatchObject({
+    'gen-code': 'wb gen-code',
+    'gen-i18n-ts': 'gen-i18n-ts -i locales -o src/i18n.ts -d en-US',
+  });
 });
 
-test('replaces unrelated postinstall commands when code generation is managed', async () => {
-  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
-  const packageJsonPath = path.join(dirPath, 'package.json');
-  await fs.mkdir(path.join(dirPath, 'i18n'));
-
-  await fs.writeFile(
-    packageJsonPath,
-    JSON.stringify({
+test.each([
+  ['mixed commands around gen-i18n-ts', 'echo before && yarn run gen-i18n-ts > /dev/null && echo after'],
+  ['empty command segments around gen-i18n-ts', ' && yarn gen-i18n-ts && bun   run   gen-i18n-ts>/dev/null && '],
+])('replaces %s with managed wb gen-code postinstall', async (_description, postinstall) => {
+  const packageJson = await generatePackageJsonFrom(
+    {
       scripts: {
-        postinstall: 'echo before && yarn run gen-i18n-ts > /dev/null && echo after',
+        postinstall,
       },
       dependencies: {
         'gen-i18n-ts': '4.0.6',
       },
-    })
+    },
+    { depending: genI18nTsDepending },
+    { createI18nDir: true }
   );
 
-  try {
-    const config = createConfig({
-      dirPath,
-      isRoot: false,
-      depending: { ...createConfig().depending, genI18nTs: true },
-    });
-    await generatePackageJson(config, config, true);
-
-    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
-      scripts: Record<string, string | undefined>;
-    };
-    expect(packageJson.scripts.postinstall).toBe('wb gen-code');
-  } finally {
-    await fs.rm(dirPath, { force: true, recursive: true });
-  }
-});
-
-test('replaces empty postinstall command variants when code generation is managed', async () => {
-  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
-  const packageJsonPath = path.join(dirPath, 'package.json');
-  await fs.mkdir(path.join(dirPath, 'i18n'));
-
-  await fs.writeFile(
-    packageJsonPath,
-    JSON.stringify({
-      scripts: {
-        postinstall: ' && yarn gen-i18n-ts && bun   run   gen-i18n-ts>/dev/null && ',
-      },
-      dependencies: {
-        'gen-i18n-ts': '4.0.6',
-      },
-    })
-  );
-
-  try {
-    const config = createConfig({
-      dirPath,
-      isRoot: false,
-      depending: { ...createConfig().depending, genI18nTs: true },
-    });
-    await generatePackageJson(config, config, true);
-
-    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
-      scripts: Record<string, string | undefined>;
-    };
-    expect(packageJson.scripts.postinstall).toBe('wb gen-code');
-  } finally {
-    await fs.rm(dirPath, { force: true, recursive: true });
-  }
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 test('keeps build-ts as a runtime dependency when prisma seed uses it', async () => {
-  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
-  const packageJsonPath = path.join(dirPath, 'package.json');
+  const packageJson = await generatePackageJsonFrom({
+    devDependencies: {
+      'build-ts': '17.1.18',
+    },
+    dependencies: {
+      'build-ts': '17.1.15',
+    },
+    prisma: {
+      seed: 'build-ts run prisma/seed.ts',
+    },
+    scripts: {},
+  });
 
-  await fs.writeFile(
-    packageJsonPath,
-    JSON.stringify({
-      devDependencies: {
-        'build-ts': '17.1.18',
-      },
-      dependencies: {
-        'build-ts': '17.1.15',
-      },
-      prisma: {
-        seed: 'build-ts run prisma/seed.ts',
-      },
-      scripts: {},
-    })
-  );
-
-  try {
-    const config = createConfig({
-      dirPath,
-      isRoot: true,
-    });
-    await generatePackageJson(config, config, true);
-
-    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
-      dependencies: Record<string, string | undefined>;
-      devDependencies: Record<string, string | undefined>;
-    };
-    expect(packageJson.dependencies['build-ts']).toBe('17.1.18');
-    expect(packageJson.devDependencies['build-ts']).toBeUndefined();
-  } finally {
-    await fs.rm(dirPath, { force: true, recursive: true });
-  }
+  expect(packageJson.dependencies?.['build-ts']).toBe('17.1.18');
+  expect(packageJson.devDependencies?.['build-ts']).toBeUndefined();
 });
 
 test('keeps wb as a runtime dependency when postinstall uses it', async () => {
+  const packageJson = await generatePackageJsonFrom({
+    devDependencies: {
+      '@willbooster/wb': '13.22.7',
+    },
+    scripts: {
+      'gen-code': 'wb gen-code',
+      postinstall: 'wb gen-code',
+    },
+  });
+
+  expect(packageJson.dependencies?.['@willbooster/wb']).toBe('13.22.7');
+  expect(packageJson.devDependencies?.['@willbooster/wb']).toBeUndefined();
+});
+
+async function generatePackageJsonFrom(
+  initialPackageJson: Record<string, unknown>,
+  configOverrides: Parameters<typeof createConfig>[0] = {},
+  options: { createI18nDir?: boolean } = {}
+): Promise<GeneratedPackageJson> {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
 
-  await fs.writeFile(
-    packageJsonPath,
-    JSON.stringify({
-      devDependencies: {
-        '@willbooster/wb': '13.22.7',
-      },
-      scripts: {
-        'gen-code': 'wb gen-code',
-        postinstall: 'wb gen-code',
-      },
-    })
-  );
-
   try {
+    if (options.createI18nDir) {
+      await fs.mkdir(path.join(dirPath, 'i18n'));
+    }
+    await fs.writeFile(packageJsonPath, JSON.stringify(initialPackageJson));
+
     const config = createConfig({
+      ...configOverrides,
       dirPath,
-      isRoot: true,
     });
     await generatePackageJson(config, config, true);
 
-    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
-      dependencies: Record<string, string | undefined>;
-      devDependencies: Record<string, string | undefined>;
-    };
-    expect(packageJson.dependencies['@willbooster/wb']).toBe('13.22.7');
-    expect(packageJson.devDependencies['@willbooster/wb']).toBeUndefined();
+    return JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as GeneratedPackageJson;
   } finally {
     await fs.rm(dirPath, { force: true, recursive: true });
   }
-});
+}

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -231,9 +231,6 @@ test('keeps wb as a runtime dependency when postinstall uses it', async () => {
       devDependencies: {
         '@willbooster/wb': '13.22.7',
       },
-      dependencies: {
-        '@willbooster/wb': '13.22.0',
-      },
       scripts: {
         'gen-code': 'wb gen-code',
         postinstall: 'wb gen-code',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -220,3 +220,41 @@ test('keeps build-ts as a runtime dependency when prisma seed uses it', async ()
     await fs.rm(dirPath, { force: true, recursive: true });
   }
 });
+
+test('keeps wb as a runtime dependency when postinstall uses it', async () => {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
+  const packageJsonPath = path.join(dirPath, 'package.json');
+
+  await fs.writeFile(
+    packageJsonPath,
+    JSON.stringify({
+      devDependencies: {
+        '@willbooster/wb': '13.22.7',
+      },
+      dependencies: {
+        '@willbooster/wb': '13.22.0',
+      },
+      scripts: {
+        'gen-code': 'wb gen-code',
+        postinstall: 'wb gen-code',
+      },
+    })
+  );
+
+  try {
+    const config = createConfig({
+      dirPath,
+      isRoot: true,
+    });
+    await generatePackageJson(config, config, true);
+
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as {
+      dependencies: Record<string, string | undefined>;
+      devDependencies: Record<string, string | undefined>;
+    };
+    expect(packageJson.dependencies['@willbooster/wb']).toBe('13.22.7');
+    expect(packageJson.devDependencies['@willbooster/wb']).toBeUndefined();
+  } finally {
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Customer Summary

- Docker and install workflows that run `wb` from `postinstall` keep working when development dependencies are omitted.
- Existing packages that only use `wb` for development-only tasks keep `wb` as a development dependency.

## Technical Summary

- Keeps `@willbooster/wb` in `dependencies` when a package `postinstall` script invokes `wb`.
- Reuses a shared helper for runtime dependency version migration across `wb` and `build-ts`.
- Adds regression coverage for preserving the newer runtime dependency version and removing the duplicate dev dependency.

## Why

- `postinstall: wb gen-code` runs during dependency installation, including Docker installs that omit dev dependencies.
- The dependency placement must follow actual runtime/install usage instead of always treating `wb` as development-only tooling.

## Testing

- `yarn test test/packageJson.test.ts`
- `yarn verify`
