### PR TITLE
fix: clean generated Docker local data

### DIFF
--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -7,13 +7,13 @@ import chalk from 'chalk';
 import type { PackageJson } from 'type-fest';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
-import { findDescendantProjects, type Project } from '../project.js';
+import { findDescendantProjects, getFileDatabaseUrlPath, type Project } from '../project.js';
 import { packageManager } from '../utils/runtime.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
 
 const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
-const sqliteFilePattern = /\.(?:sqlite3?|db)(?:-(?:journal|shm|wal))?$/;
+const sqliteFilePattern = /\.(?:sqlite3?|db)(?:-(?:journal|shm|wal))?$/i;
 
 const builder = {
   outside: {
@@ -256,18 +256,42 @@ async function removePrismaMount(project: Project): Promise<string[]> {
 }
 
 async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
-  const prismaDirPath = path.join(project.dirPath, 'prisma');
-  if (!fs.existsSync(prismaDirPath)) return [];
+  const sqliteDirPaths = getGeneratedSqliteDirPaths(project);
+  const removedPaths = await Promise.all(
+    sqliteDirPaths.map((dirPath) => removeGeneratedSqliteFilesInDir(project, dirPath))
+  );
+  return removedPaths.flat();
+}
 
-  const dirents = await fs.promises.readdir(prismaDirPath, { withFileTypes: true });
+function getGeneratedSqliteDirPaths(project: Project): string[] {
+  const dirPaths = [path.join(project.dirPath, 'prisma')];
+  const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
+  if (dbPath) {
+    for (const baseDirPath of getDatabasePathBaseDirs(project, dbPath)) {
+      dirPaths.push(path.dirname(path.resolve(baseDirPath, dbPath)));
+    }
+  }
+  return [...new Set(dirPaths)].filter((dirPath) => fs.existsSync(dirPath) && isPathInsideProject(project, dirPath));
+}
+
+function getDatabasePathBaseDirs(project: Project, dbPath: string): string[] {
+  if (path.isAbsolute(dbPath)) return [path.parse(dbPath).root];
+  return [project.dirPath, path.join(project.dirPath, 'prisma')];
+}
+
+function isPathInsideProject(project: Project, targetPath: string): boolean {
+  const relativePath = path.relative(project.dirPath, targetPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
+async function removeGeneratedSqliteFilesInDir(project: Project, dirPath: string): Promise<string[]> {
+  const dirents = await fs.promises.readdir(dirPath, { withFileTypes: true });
   const sqliteFileNames = dirents
     .filter((dirent) => dirent.isFile() && sqliteFilePattern.test(dirent.name))
     .map((dirent) => dirent.name);
-  await Promise.all(
-    sqliteFileNames.map((fileName) => fs.promises.rm(path.join(prismaDirPath, fileName), { force: true }))
-  );
+  await Promise.all(sqliteFileNames.map((fileName) => fs.promises.rm(path.join(dirPath, fileName), { force: true })));
 
-  return sqliteFileNames.map((fileName) => path.join('prisma', fileName));
+  return sqliteFileNames.map((fileName) => path.relative(project.dirPath, path.join(dirPath, fileName)));
 }
 
 function runDockerCleanupScript(project: Project): void {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -281,6 +281,7 @@ function getGeneratedSqliteDirPaths(project: Project): string[] {
 
 function isPathInsideProject(project: Project, targetPath: string): boolean {
   const relativePath = path.relative(project.dirPath, targetPath);
+  // `startsWith('..')` would reject project-local names such as `..cache`.
   return relativePath === '' || (relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`));
 }
 

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -267,21 +267,21 @@ function getGeneratedSqliteDirPaths(project: Project): string[] {
   const dirPaths = [path.join(project.dirPath, 'prisma')];
   const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
   if (dbPath) {
-    for (const baseDirPath of getDatabasePathBaseDirs(project, dbPath)) {
-      dirPaths.push(path.dirname(path.resolve(baseDirPath, dbPath)));
+    if (path.isAbsolute(dbPath)) {
+      dirPaths.push(path.dirname(dbPath));
+    } else {
+      dirPaths.push(
+        path.dirname(path.resolve(project.dirPath, dbPath)),
+        path.dirname(path.resolve(project.dirPath, 'prisma', dbPath))
+      );
     }
   }
   return [...new Set(dirPaths)].filter((dirPath) => fs.existsSync(dirPath) && isPathInsideProject(project, dirPath));
 }
 
-function getDatabasePathBaseDirs(project: Project, dbPath: string): string[] {
-  if (path.isAbsolute(dbPath)) return [path.parse(dbPath).root];
-  return [project.dirPath, path.join(project.dirPath, 'prisma')];
-}
-
 function isPathInsideProject(project: Project, targetPath: string): boolean {
   const relativePath = path.relative(project.dirPath, targetPath);
-  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+  return relativePath === '' || (relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`));
 }
 
 async function removeGeneratedSqliteFilesInDir(project: Project, dirPath: string): Promise<string[]> {
@@ -291,7 +291,8 @@ async function removeGeneratedSqliteFilesInDir(project: Project, dirPath: string
     .map((dirent) => dirent.name);
   await Promise.all(sqliteFileNames.map((fileName) => fs.promises.rm(path.join(dirPath, fileName), { force: true })));
 
-  return sqliteFileNames.map((fileName) => path.relative(project.dirPath, path.join(dirPath, fileName)));
+  const relativeDirPath = path.relative(project.dirPath, dirPath);
+  return sqliteFileNames.map((fileName) => path.join(relativeDirPath, fileName));
 }
 
 function runDockerCleanupScript(project: Project): void {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -213,6 +213,7 @@ function optimizeRootProps(packageJson: PackageJson): void {
 async function cleanupDockerBuildArtifacts(projects: Project[]): Promise<void> {
   for (const project of projects) {
     await removeProjectCaches(project);
+    await removeGeneratedLocalData(project);
     runDockerCleanupScript(project);
   }
 }
@@ -236,6 +237,35 @@ async function removeProjectCaches(project: Project): Promise<void> {
     removedPaths.push(relativePath);
   }
   console.info('Removed Docker build caches:', removedPaths.join(', ') || 'none');
+}
+
+async function removeGeneratedLocalData(project: Project): Promise<void> {
+  const removedPaths = [...(await removePrismaMount(project)), ...(await removeGeneratedSqliteFiles(project))];
+  console.info('Removed generated local data:', removedPaths.join(', ') || 'none');
+}
+
+async function removePrismaMount(project: Project): Promise<string[]> {
+  const relativePath = path.join('prisma', 'mount');
+  const targetPath = path.join(project.dirPath, relativePath);
+  if (!fs.existsSync(targetPath)) return [];
+
+  await fs.promises.rm(targetPath, { force: true, recursive: true });
+  return [relativePath];
+}
+
+async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
+  const prismaDirPath = path.join(project.dirPath, 'prisma');
+  if (!fs.existsSync(prismaDirPath)) return [];
+
+  const removedPaths: string[] = [];
+  for (const dirent of await fs.promises.readdir(prismaDirPath, { withFileTypes: true })) {
+    if (!dirent.isFile() || !dirent.name.includes('.sqlite3')) continue;
+
+    const relativePath = path.join('prisma', dirent.name);
+    await fs.promises.rm(path.join(project.dirPath, relativePath), { force: true });
+    removedPaths.push(relativePath);
+  }
+  return removedPaths;
 }
 
 function runDockerCleanupScript(project: Project): void {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -13,6 +13,20 @@ import { packageManager } from '../utils/runtime.js';
 import { prepareForRunningCommand } from './commandUtils.js';
 
 const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
+const sqliteFileSuffixes = [
+  '.sqlite3',
+  '.sqlite',
+  '.db',
+  '.sqlite3-journal',
+  '.sqlite3-shm',
+  '.sqlite3-wal',
+  '.sqlite-journal',
+  '.sqlite-shm',
+  '.sqlite-wal',
+  '.db-journal',
+  '.db-shm',
+  '.db-wal',
+];
 
 const builder = {
   outside: {
@@ -260,7 +274,7 @@ async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
 
   const dirents = await fs.promises.readdir(prismaDirPath, { withFileTypes: true });
   const sqliteFileNames = dirents
-    .filter((dirent) => dirent.isFile() && dirent.name.includes('.sqlite3'))
+    .filter((dirent) => dirent.isFile() && sqliteFileSuffixes.some((suffix) => dirent.name.endsWith(suffix)))
     .map((dirent) => dirent.name);
   await Promise.all(
     sqliteFileNames.map((fileName) => fs.promises.rm(path.join(prismaDirPath, fileName), { force: true }))

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -13,20 +13,7 @@ import { packageManager } from '../utils/runtime.js';
 import { prepareForRunningCommand } from './commandUtils.js';
 
 const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
-const sqliteFileSuffixes = [
-  '.sqlite3',
-  '.sqlite',
-  '.db',
-  '.sqlite3-journal',
-  '.sqlite3-shm',
-  '.sqlite3-wal',
-  '.sqlite-journal',
-  '.sqlite-shm',
-  '.sqlite-wal',
-  '.db-journal',
-  '.db-shm',
-  '.db-wal',
-];
+const sqliteFilePattern = /\.(?:sqlite3?|db)(?:-(?:journal|shm|wal))?$/;
 
 const builder = {
   outside: {
@@ -274,7 +261,7 @@ async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
 
   const dirents = await fs.promises.readdir(prismaDirPath, { withFileTypes: true });
   const sqliteFileNames = dirents
-    .filter((dirent) => dirent.isFile() && sqliteFileSuffixes.some((suffix) => dirent.name.endsWith(suffix)))
+    .filter((dirent) => dirent.isFile() && sqliteFilePattern.test(dirent.name))
     .map((dirent) => dirent.name);
   await Promise.all(
     sqliteFileNames.map((fileName) => fs.promises.rm(path.join(prismaDirPath, fileName), { force: true }))

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -240,7 +240,8 @@ async function removeProjectCaches(project: Project): Promise<void> {
 }
 
 async function removeGeneratedLocalData(project: Project): Promise<void> {
-  const removedPaths = [...(await removePrismaMount(project)), ...(await removeGeneratedSqliteFiles(project))];
+  const removedPathGroups = await Promise.all([removePrismaMount(project), removeGeneratedSqliteFiles(project)]);
+  const removedPaths = removedPathGroups.flat();
   console.info('Removed generated local data:', removedPaths.join(', ') || 'none');
 }
 
@@ -257,15 +258,15 @@ async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
   const prismaDirPath = path.join(project.dirPath, 'prisma');
   if (!fs.existsSync(prismaDirPath)) return [];
 
-  const removedPaths: string[] = [];
-  for (const dirent of await fs.promises.readdir(prismaDirPath, { withFileTypes: true })) {
-    if (!dirent.isFile() || !dirent.name.includes('.sqlite3')) continue;
+  const dirents = await fs.promises.readdir(prismaDirPath, { withFileTypes: true });
+  const sqliteFileNames = dirents
+    .filter((dirent) => dirent.isFile() && dirent.name.includes('.sqlite3'))
+    .map((dirent) => dirent.name);
+  await Promise.all(
+    sqliteFileNames.map((fileName) => fs.promises.rm(path.join(prismaDirPath, fileName), { force: true }))
+  );
 
-    const relativePath = path.join('prisma', dirent.name);
-    await fs.promises.rm(path.join(project.dirPath, relativePath), { force: true });
-    removedPaths.push(relativePath);
-  }
-  return removedPaths;
+  return sqliteFileNames.map((fileName) => path.join('prisma', fileName));
 }
 
 function runDockerCleanupScript(project: Project): void {


### PR DESCRIPTION
## Customer Summary

- Docker build optimization now removes generated local database artifacts automatically.
- Projects no longer need Dockerfile guidance to list those generated files manually.

## Technical Summary

- Added generated Prisma mount cleanup to `wb optimizeForDockerBuild`.
- Added generated SQLite file cleanup to `wb optimizeForDockerBuild`.
- Parallelized independent cleanup operations and SQLite file deletion.

## Why

- Docker images should not carry local generated database state into runtime layers.
- Keeping this behavior in `wb optimizeForDockerBuild` avoids duplicating cleanup details across Dockerfiles and guidelines.

## Testing

- `yarn verify`
