### PR TITLE
fix: clean docker build artifacts more broadly

### DIFF
--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -14,8 +14,8 @@ import { packageManager } from '../utils/runtime.js';
 import { prepareForRunningCommand } from './commandUtils.js';
 
 const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
-const sqliteFilePattern = /(?:\.sqlite3?|\.(?:db)(?:$|[-.]))/i;
-const dockerBuildCachePatterns = [
+const sqliteFilePattern = /\.(?:sqlite3?|db)(?:[-.](?:journal|shm|wal))?$/i;
+const dockerBuildCachePaths = [
   '.cache',
   '.mypy_cache',
   '.next/cache',
@@ -34,10 +34,8 @@ const dockerBuildCachePatterns = [
   'storybook-static',
   'target',
   'test-results',
-  '*.log',
-  '*.pyc',
-  '*.tsbuildinfo',
 ];
+const dockerBuildCachePatterns = ['**/*.log', '**/*.pyc', '**/*.tsbuildinfo', '**/__pycache__'];
 const generatedSqliteDirNames = ['prisma', 'db', 'drizzle'] as const;
 
 const builder = {
@@ -245,21 +243,39 @@ async function cleanupDockerBuildArtifacts(projects: Project[]): Promise<void> {
 }
 
 async function removeProjectCaches(project: Project): Promise<void> {
-  const relativePaths = await globby(dockerBuildCachePatterns, {
-    cwd: project.dirPath,
-    dot: true,
-    followSymbolicLinks: false,
-    onlyFiles: false,
-  });
+  const relativePaths = [
+    ...(await removeDockerBuildCachePaths(project)),
+    ...(await removeDockerBuildCachePatterns(project)),
+  ];
+  console.info('Removed Docker build caches:', relativePaths.join(', ') || 'none');
+}
+
+async function removeDockerBuildCachePaths(project: Project): Promise<string[]> {
   const removedPaths: string[] = [];
-  for (const relativePath of relativePaths) {
+  for (const relativePath of dockerBuildCachePaths) {
     const targetPath = path.join(project.dirPath, relativePath);
     if (!fs.existsSync(targetPath)) continue;
 
     await fs.promises.rm(targetPath, { force: true, recursive: true });
     removedPaths.push(relativePath);
   }
-  console.info('Removed Docker build caches:', removedPaths.join(', ') || 'none');
+  return removedPaths;
+}
+
+async function removeDockerBuildCachePatterns(project: Project): Promise<string[]> {
+  const relativePaths = await globby(dockerBuildCachePatterns, {
+    cwd: project.dirPath,
+    dot: true,
+    followSymbolicLinks: false,
+    ignore: ['node_modules/**', '.yarn/**', '.git/**'],
+    onlyFiles: false,
+  });
+  await Promise.all(
+    relativePaths.map((relativePath) =>
+      fs.promises.rm(path.join(project.dirPath, relativePath), { force: true, recursive: true })
+    )
+  );
+  return relativePaths;
 }
 
 async function removeGeneratedLocalData(project: Project): Promise<void> {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -348,7 +348,10 @@ function getEnvGeneratedSqliteFilePaths(project: Project): string[] {
 
   const filePaths = path.isAbsolute(dbPath)
     ? [dbPath]
-    : [path.resolve(project.dirPath, dbPath), path.resolve(project.dirPath, 'prisma', dbPath)];
+    : [
+        path.resolve(project.dirPath, dbPath),
+        ...generatedSqliteDirNames.map((dirName) => path.resolve(project.dirPath, dirName, dbPath)),
+      ];
   return [...new Set(filePaths)].filter((filePath) => isPathInsideProject(project, filePath));
 }
 

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import chalk from 'chalk';
+import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
@@ -13,7 +14,31 @@ import { packageManager } from '../utils/runtime.js';
 import { prepareForRunningCommand } from './commandUtils.js';
 
 const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
-const sqliteFilePattern = /\.(?:sqlite3?|db)(?:-(?:journal|shm|wal))?$/i;
+const sqliteFilePattern = /(?:\.sqlite3?|\.(?:db)(?:$|[-.]))/i;
+const dockerBuildCachePatterns = [
+  '.cache',
+  '.mypy_cache',
+  '.next/cache',
+  '.parcel-cache',
+  '.pytest_cache',
+  '.ruff_cache',
+  '.tox',
+  '.turbo',
+  '.venv',
+  '.yarn/cache',
+  '.yarn/install-state.gz',
+  '__pycache__',
+  'coverage',
+  'node_modules/.cache',
+  'playwright-report',
+  'storybook-static',
+  'target',
+  'test-results',
+  '*.log',
+  '*.pyc',
+  '*.tsbuildinfo',
+];
+const generatedSqliteDirNames = ['prisma', 'db', 'drizzle'] as const;
 
 const builder = {
   outside: {
@@ -220,15 +245,12 @@ async function cleanupDockerBuildArtifacts(projects: Project[]): Promise<void> {
 }
 
 async function removeProjectCaches(project: Project): Promise<void> {
-  const relativePaths = [
-    '.next/cache',
-    '.turbo',
-    path.join('.yarn', 'cache'),
-    path.join('.yarn', 'install-state.gz'),
-    path.join('node_modules', '.cache'),
-    'playwright-report',
-    'test-results',
-  ];
+  const relativePaths = await globby(dockerBuildCachePatterns, {
+    cwd: project.dirPath,
+    dot: true,
+    followSymbolicLinks: false,
+    onlyFiles: false,
+  });
   const removedPaths: string[] = [];
   for (const relativePath of relativePaths) {
     const targetPath = path.join(project.dirPath, relativePath);
@@ -241,18 +263,34 @@ async function removeProjectCaches(project: Project): Promise<void> {
 }
 
 async function removeGeneratedLocalData(project: Project): Promise<void> {
-  const removedPathGroups = await Promise.all([removePrismaMount(project), removeGeneratedSqliteFiles(project)]);
+  const removedPathGroups = await Promise.all([removeGeneratedMountDirs(project), removeGeneratedSqliteFiles(project)]);
   const removedPaths = removedPathGroups.flat();
   console.info('Removed generated local data:', removedPaths.join(', ') || 'none');
 }
 
-async function removePrismaMount(project: Project): Promise<string[]> {
-  const relativePath = path.join('prisma', 'mount');
-  const targetPath = path.join(project.dirPath, relativePath);
-  if (!fs.existsSync(targetPath)) return [];
+async function removeGeneratedMountDirs(project: Project): Promise<string[]> {
+  const relativePaths = getGeneratedMountDirPaths(project);
+  const removedPaths: string[] = [];
+  for (const relativePath of relativePaths) {
+    const targetPath = path.join(project.dirPath, relativePath);
+    if (!fs.existsSync(targetPath)) continue;
 
-  await fs.promises.rm(targetPath, { force: true, recursive: true });
-  return [relativePath];
+    await fs.promises.rm(targetPath, { force: true, recursive: true });
+    removedPaths.push(relativePath);
+  }
+  return removedPaths;
+}
+
+function getGeneratedMountDirPaths(project: Project): string[] {
+  const defaultPaths = generatedSqliteDirNames.map((dirName) => path.join(dirName, 'mount'));
+  const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
+  if (!dbPath) return defaultPaths;
+
+  const absoluteDirPath = path.dirname(path.isAbsolute(dbPath) ? dbPath : path.resolve(project.dirPath, dbPath));
+  if (path.basename(absoluteDirPath) !== 'mount' || !isPathInsideProject(project, absoluteDirPath)) {
+    return defaultPaths;
+  }
+  return [...new Set([...defaultPaths, path.relative(project.dirPath, absoluteDirPath)])];
 }
 
 async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
@@ -264,7 +302,7 @@ async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
 }
 
 function getGeneratedSqliteDirPaths(project: Project): string[] {
-  const dirPaths = [path.join(project.dirPath, 'prisma')];
+  const dirPaths = generatedSqliteDirNames.map((dirName) => path.join(project.dirPath, dirName));
   const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
   if (dbPath) {
     if (path.isAbsolute(dbPath)) {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -35,7 +35,7 @@ const dockerBuildCachePaths = [
   'target',
   'test-results',
 ];
-const dockerBuildCachePatterns = ['**/*.log', '**/*.pyc', '**/*.tsbuildinfo', '**/__pycache__'];
+const dockerBuildCachePatterns = ['**/*.pyc', '**/*.tsbuildinfo', '**/__pycache__'];
 const generatedSqliteDirNames = ['prisma', 'db', 'drizzle'] as const;
 
 const builder = {
@@ -267,7 +267,7 @@ async function removeDockerBuildCachePatterns(project: Project): Promise<string[
     cwd: project.dirPath,
     dot: true,
     followSymbolicLinks: false,
-    ignore: ['node_modules/**', '.yarn/**', '.git/**'],
+    ignore: ['**/node_modules', '**/node_modules/**', '**/.yarn', '**/.yarn/**', '**/.git', '**/.git/**'],
     onlyFiles: false,
   });
   await Promise.all(

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -306,37 +306,77 @@ function getGeneratedMountDirPaths(project: Project): string[] {
   if (path.basename(absoluteDirPath) !== 'mount' || !isPathInsideProject(project, absoluteDirPath)) {
     return defaultPaths;
   }
-  return [...new Set([...defaultPaths, path.relative(project.dirPath, absoluteDirPath)])];
+  const relativePath = path.relative(project.dirPath, absoluteDirPath);
+  if (!relativePath) return defaultPaths;
+
+  return [...new Set([...defaultPaths, relativePath])];
 }
 
 async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
-  const sqliteDirPaths = getGeneratedSqliteDirPaths(project);
-  const removedPaths = await Promise.all(
-    sqliteDirPaths.map((dirPath) => removeGeneratedSqliteFilesInDir(project, dirPath))
-  );
+  const removedPaths = await Promise.all([
+    removeGeneratedSqliteFilesInDefaultDirs(project),
+    removeEnvGeneratedSqliteFiles(project),
+  ]);
   return removedPaths.flat();
 }
 
-function getGeneratedSqliteDirPaths(project: Project): string[] {
-  const dirPaths = generatedSqliteDirNames.map((dirName) => path.join(project.dirPath, dirName));
-  const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
-  if (dbPath) {
-    if (path.isAbsolute(dbPath)) {
-      dirPaths.push(path.dirname(dbPath));
-    } else {
-      dirPaths.push(
-        path.dirname(path.resolve(project.dirPath, dbPath)),
-        path.dirname(path.resolve(project.dirPath, 'prisma', dbPath))
-      );
+async function removeGeneratedSqliteFilesInDefaultDirs(project: Project): Promise<string[]> {
+  const dirPaths = [path.join(project.dirPath, 'prisma')].filter(
+    (dirPath) => fs.existsSync(dirPath) && isPathInsideProject(project, dirPath)
+  );
+  const removedPaths = await Promise.all(dirPaths.map((dirPath) => removeGeneratedSqliteFilesInDir(project, dirPath)));
+  return removedPaths.flat();
+}
+
+async function removeEnvGeneratedSqliteFiles(project: Project): Promise<string[]> {
+  const dbFilePaths = getEnvGeneratedSqliteFilePaths(project);
+  const removedPaths: string[] = [];
+  for (const dbFilePath of dbFilePaths) {
+    for (const targetPath of getSqliteFileFamilyPaths(dbFilePath)) {
+      if (!(await isFile(targetPath))) continue;
+
+      await fs.promises.rm(targetPath, { force: true });
+      removedPaths.push(path.relative(project.dirPath, targetPath));
     }
   }
-  return [...new Set(dirPaths)].filter((dirPath) => fs.existsSync(dirPath) && isPathInsideProject(project, dirPath));
+  return removedPaths;
+}
+
+function getEnvGeneratedSqliteFilePaths(project: Project): string[] {
+  const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
+  if (!dbPath) return [];
+
+  const filePaths = path.isAbsolute(dbPath)
+    ? [dbPath]
+    : [path.resolve(project.dirPath, dbPath), path.resolve(project.dirPath, 'prisma', dbPath)];
+  return [...new Set(filePaths)].filter((filePath) => isPathInsideProject(project, filePath));
+}
+
+function getSqliteFileFamilyPaths(dbFilePath: string): string[] {
+  return [
+    dbFilePath,
+    `${dbFilePath}-journal`,
+    `${dbFilePath}-shm`,
+    `${dbFilePath}-wal`,
+    `${dbFilePath}.journal`,
+    `${dbFilePath}.shm`,
+    `${dbFilePath}.wal`,
+  ];
 }
 
 function isPathInsideProject(project: Project, targetPath: string): boolean {
   const relativePath = path.relative(project.dirPath, targetPath);
   // `startsWith('..')` would reject project-local names such as `..cache`.
   return relativePath === '' || (relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`));
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.promises.stat(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
 }
 
 async function removeGeneratedSqliteFilesInDir(project: Project, dirPath: string): Promise<string[]> {


### PR DESCRIPTION
## Customer Summary

- `wb optimizeForDockerBuild` now removes common Docker build leftovers without requiring project-specific `rm` commands in Dockerfiles.
- Generated SQLite files and mount directories are cleaned up across Prisma, Blitz-style `db`, Drizzle, and env-configured database paths.
- Cleanup is conservative around source files and dependency directories to avoid deleting unrelated project assets.

## Technical Summary

- Split Docker cleanup into exact cache path removal and limited recursive glob cleanup.
- Added cleanup for generated mount directories under `prisma`, `db`, and `drizzle`, plus safe env-derived mount directories.
- Tightened SQLite cleanup to exact env-derived database file families and the existing default Prisma scan.
- Guarded recursive glob cleanup from nested `node_modules`, `.yarn`, and `.git` directories.

## Why

- Some Dockerfiles had to manually remove `.next/cache`, `.turbo`, Yarn caches, Prisma mount data, and SQLite files after `wb optimizeForDockerBuild`.
- Centralizing the cleanup keeps Dockerfiles simpler and makes the behavior reusable across projects.

## Testing

- `yarn verify`
- `yarn workspace @willbooster/wb typecheck`
- `yarn workspace @willbooster/wb lint`
- `bunx @willbooster-private/agentic-workflows@1.22.0 skills review --agent all`
- `bunx @willbooster-private/agentic-workflows@1.22.0 skills check-pr-ci`
