### PR TITLE
fix: clean generated docker sqlite artifacts

### DIFF
--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -425,7 +425,7 @@ async function removeGeneratedSqliteFilesInDir(project: Project, dirPath: string
 }
 
 function runDockerCleanupScript(project: Project): void {
-  if (project.env.WB_DOCKER !== '1') return;
+  if (!isDockerEnabled(project)) return;
 
   const scriptPath = path.join(project.dirPath, 'bash', 'cleanup.sh');
   if (!fs.existsSync(scriptPath)) return;

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -37,6 +37,7 @@ const dockerBuildCachePaths = [
 ];
 const dockerBuildCachePatterns = ['**/*.pyc', '**/*.tsbuildinfo', '**/__pycache__'];
 const generatedSqliteDirNames = ['prisma', 'db', 'drizzle'] as const;
+const dockerGeneratedDataDirPaths = ['/data'] as const;
 
 const builder = {
   outside: {
@@ -321,9 +322,9 @@ async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
 }
 
 async function removeGeneratedSqliteFilesInDefaultDirs(project: Project): Promise<string[]> {
-  const dirPaths = [path.join(project.dirPath, 'prisma')].filter(
-    (dirPath) => fs.existsSync(dirPath) && isPathInsideProject(project, dirPath)
-  );
+  const dirPaths = generatedSqliteDirNames
+    .map((dirName) => path.join(project.dirPath, dirName))
+    .filter((dirPath) => fs.existsSync(dirPath) && isPathInsideProject(project, dirPath));
   const removedPaths = await Promise.all(dirPaths.map((dirPath) => removeGeneratedSqliteFilesInDir(project, dirPath)));
   return removedPaths.flat();
 }
@@ -352,7 +353,20 @@ function getEnvGeneratedSqliteFilePaths(project: Project): string[] {
         path.resolve(project.dirPath, dbPath),
         ...generatedSqliteDirNames.map((dirName) => path.resolve(project.dirPath, dirName, dbPath)),
       ];
-  return [...new Set(filePaths)].filter((filePath) => isPathInsideProject(project, filePath));
+  return [...new Set(filePaths)].filter((filePath) => isGeneratedSqliteFilePathSafe(project, filePath));
+}
+
+function isGeneratedSqliteFilePathSafe(project: Project, filePath: string): boolean {
+  return isPathInsideProject(project, filePath) || isDockerGeneratedDataFilePath(project, filePath);
+}
+
+function isDockerGeneratedDataFilePath(project: Project, filePath: string): boolean {
+  if (!isDockerEnabled(project)) return false;
+
+  return dockerGeneratedDataDirPaths.some((dirPath) => {
+    const relativePath = path.relative(dirPath, filePath);
+    return relativePath !== '' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
+  });
 }
 
 function getSqliteFileFamilyPaths(dbFilePath: string): string[] {
@@ -371,6 +385,10 @@ function isPathInsideProject(project: Project, targetPath: string): boolean {
   const relativePath = path.relative(project.dirPath, targetPath);
   // `startsWith('..')` would reject project-local names such as `..cache`.
   return relativePath === '' || (relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`));
+}
+
+function isDockerEnabled(project: Project): boolean {
+  return !!project.env.WB_DOCKER && project.env.WB_DOCKER !== '0' && project.env.WB_DOCKER !== 'false';
 }
 
 async function isFile(filePath: string): Promise<boolean> {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -328,14 +328,9 @@ async function removeGeneratedSqliteFilesInDefaultDirs(project: Project): Promis
 }
 
 async function getGeneratedSqliteDirPaths(project: Project): Promise<string[]> {
-  const dirPaths: string[] = [];
-  for (const dirName of generatedSqliteDirNames) {
-    const dirPath = path.join(project.dirPath, dirName);
-    if (await isDirectory(dirPath)) {
-      dirPaths.push(dirPath);
-    }
-  }
-  return dirPaths;
+  const dirPaths = generatedSqliteDirNames.map((dirName) => path.join(project.dirPath, dirName));
+  const results = await Promise.all(dirPaths.map((dirPath) => isDirectory(dirPath)));
+  return dirPaths.filter((_, index) => results[index]);
 }
 
 async function removeEnvGeneratedSqliteFiles(project: Project): Promise<string[]> {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -322,11 +322,20 @@ async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
 }
 
 async function removeGeneratedSqliteFilesInDefaultDirs(project: Project): Promise<string[]> {
-  const dirPaths = generatedSqliteDirNames
-    .map((dirName) => path.join(project.dirPath, dirName))
-    .filter((dirPath) => fs.existsSync(dirPath));
+  const dirPaths = await getGeneratedSqliteDirPaths(project);
   const removedPaths = await Promise.all(dirPaths.map((dirPath) => removeGeneratedSqliteFilesInDir(project, dirPath)));
   return removedPaths.flat();
+}
+
+async function getGeneratedSqliteDirPaths(project: Project): Promise<string[]> {
+  const dirPaths: string[] = [];
+  for (const dirName of generatedSqliteDirNames) {
+    const dirPath = path.join(project.dirPath, dirName);
+    if (await isDirectory(dirPath)) {
+      dirPaths.push(dirPath);
+    }
+  }
+  return dirPaths;
 }
 
 async function removeEnvGeneratedSqliteFiles(project: Project): Promise<string[]> {
@@ -395,6 +404,15 @@ async function isFile(filePath: string): Promise<boolean> {
   try {
     const stat = await fs.promises.stat(filePath);
     return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectory(dirPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.promises.stat(dirPath);
+    return stat.isDirectory();
   } catch {
     return false;
   }

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -365,7 +365,7 @@ function isDockerGeneratedDataFilePath(project: Project, filePath: string): bool
 
   return dockerGeneratedDataDirPaths.some((dirPath) => {
     const relativePath = path.relative(dirPath, filePath);
-    return relativePath !== '' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
+    return relativePath !== '' && relativePath !== '..' && !relativePath.startsWith('../');
   });
 }
 

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -324,7 +324,7 @@ async function removeGeneratedSqliteFiles(project: Project): Promise<string[]> {
 async function removeGeneratedSqliteFilesInDefaultDirs(project: Project): Promise<string[]> {
   const dirPaths = generatedSqliteDirNames
     .map((dirName) => path.join(project.dirPath, dirName))
-    .filter((dirPath) => fs.existsSync(dirPath) && isPathInsideProject(project, dirPath));
+    .filter((dirPath) => fs.existsSync(dirPath));
   const removedPaths = await Promise.all(dirPaths.map((dirPath) => removeGeneratedSqliteFilesInDir(project, dirPath)));
   return removedPaths.flat();
 }


### PR DESCRIPTION
## Customer Summary

- Docker builds no longer need extra `rm` commands for generated SQLite files in common `prisma`, `db`, `drizzle`, and Docker `/data` locations.
- Existing non-Docker runs keep absolute filesystem paths protected from cleanup.
- This prepares downstream Dockerfiles to rely on `wb optimizeForDockerBuild` for build artifact cleanup.

## Technical Summary

- Extended `optimizeForDockerBuild` generated SQLite cleanup to cover `prisma`, `db`, and `drizzle` directories consistently.
- Added Docker-only cleanup support for generated SQLite files under `/data`.
- Added directory checks before scanning generated SQLite artifact directories and aligned Docker cleanup environment checks through `isDockerEnabled`.

## Why

- Several WillBooster and WillBoosterLab Dockerfiles had manual cleanup commands after `wb optimizeForDockerBuild` for artifacts the command should own.
- Centralizing the cleanup reduces repeated Dockerfile logic and keeps artifact handling consistent across projects.

## Testing

- `yarn verify`
- pre-commit and pre-push hooks
- GitHub Actions CI
