### PR TITLE
fix: use latest litestream release

### DIFF
--- a/packages/wb/docker/bash/install-litestream.sh
+++ b/packages/wb/docker/bash/install-litestream.sh
@@ -5,10 +5,8 @@ set -e
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 ARCH=${ARCH:-$(dpkg --print-architecture)}
 
-# Force to use 0.5.10 since the latest litestream is very unstable.
 apt-get -qq install -y --no-install-recommends ca-certificates curl \
   && LITESTREAM_VERSION=$(curl --silent "https://api.github.com/repos/benbjohnson/litestream/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^v//') \
-  && LITESTREAM_VERSION=0.5.10 \
   && DEB_FILE="litestream-${LITESTREAM_VERSION}-linux-${ARCH}.deb" \
   && echo "Installing Litestream: ${DEB_FILE}" \
   && curl -fsSLO https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/${DEB_FILE} \


### PR DESCRIPTION
## Customer Summary

- Updates the Docker Litestream installer to install the latest published Litestream release instead of always forcing version 0.5.10.
- Keeps Litestream installations current for users of the shared Docker setup.
- No manual migration is required.

## Technical Summary

- Removed the hardcoded `LITESTREAM_VERSION=0.5.10` override from `packages/wb/docker/bash/install-litestream.sh`.
- The script now uses the version returned by the existing GitHub releases API lookup.
- No dependency or configuration changes were made.

## Why

- The installer already fetched the latest Litestream release, but the result was immediately overwritten by a fixed version.
- Using the fetched release version makes the script behavior match its release lookup and avoids carrying a stale pin.

## Testing

- `yarn verify`
- `git push -u origin fix/use-latest-litestream-release` (pre-push hook ran package oxlint checks successfully)

## Notes

- The repository PR helper failed locally with: `Cannot find package 'minimatch'` from `@willbooster-private/agentic-workflows@1.22.5`, so this PR was created with `gh pr create` using the same body.
