### PR TITLE
fix: mention workflow settings for Railway repos

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -47,6 +47,10 @@ function generateAgentInstruction(
   extraContent?: string
 ): string {
   const packageManager = getPackageManagerCommand(rootConfig);
+  // WillBooster Railway project identifiers are managed in deploy workflow settings.
+  const railwayInstruction = rootConfig.isRailway
+    ? '- If you need Railway project information, see the workflow settings in `.github/workflows`.'
+    : '';
   const baseContent = `
 ## Project Information
 
@@ -76,7 +80,7 @@ function generateAgentInstruction(
   - Always create new commits. Avoid using \`--amend\`.
 - Always use heredoc syntax when passing multi-line content to any command.
 - Put temporary files in the \`.tmp\` or \`/tmp\` directory.
-${rootConfig.isRailway ? '- If you need Railway project information, see the workflow settings in `.github/workflows`.' : ''}
+${railwayInstruction}
 ${hasPlaywrightTestServer(allConfigs) ? `- Use \`${packageManager} wb start --mode test\` to launch a web server for debugging or testing.` : ''}
 
 ${generateAgentCodingStyle(allConfigs)}

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -49,7 +49,10 @@ function generateAgentInstruction(
   const packageManager = getPackageManagerCommand(rootConfig);
   // WillBooster Railway project identifiers are managed in deploy workflow settings.
   const railwayInstruction = rootConfig.isRailway
-    ? '- If you need Railway project information, see the workflow settings in `.github/workflows`.'
+    ? '\n- If you need Railway project information, see the workflow settings in `.github/workflows`.'
+    : '';
+  const playwrightTestServerInstruction = hasPlaywrightTestServer(allConfigs)
+    ? `\n- Use \`${packageManager} wb start --mode test\` to launch a web server for debugging or testing.`
     : '';
   const baseContent = `
 ## Project Information
@@ -79,9 +82,7 @@ function generateAgentInstruction(
   - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.
   - Always create new commits. Avoid using \`--amend\`.
 - Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the \`.tmp\` or \`/tmp\` directory.
-${railwayInstruction}
-${hasPlaywrightTestServer(allConfigs) ? `- Use \`${packageManager} wb start --mode test\` to launch a web server for debugging or testing.` : ''}
+- Put temporary files in the \`.tmp\` or \`/tmp\` directory.${railwayInstruction}${playwrightTestServerInstruction}
 
 ${generateAgentCodingStyle(allConfigs)}
 `

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
 import { logger } from '../logger.js';
@@ -76,6 +77,7 @@ function generateAgentInstruction(
   - Always create new commits. Avoid using \`--amend\`.
 - Always use heredoc syntax when passing multi-line content to any command.
 - Put temporary files in the \`.tmp\` or \`/tmp\` directory.
+${usesRailway(rootConfig) ? '- If you need Railway project information, see the workflow settings in `.github/workflows`.' : ''}
 ${hasPlaywrightTestServer(allConfigs) ? `- Use \`${packageManager} wb start --mode test\` to launch a web server for debugging or testing.` : ''}
 
 ${generateAgentCodingStyle(allConfigs)}
@@ -142,4 +144,34 @@ ${
 
 function hasPlaywrightTestServer(configs: PackageConfig[]): boolean {
   return configs.some((config) => config.depending.playwrightTest);
+}
+
+function usesRailway(config: PackageConfig): boolean {
+  const scripts = config.packageJson?.scripts;
+  if (scripts && Object.values(scripts).some((script) => typeof script === 'string' && script.includes('railway'))) {
+    return true;
+  }
+
+  if (
+    fs.existsSync(path.resolve(config.dirPath, '.railwayignore')) ||
+    fs.existsSync(path.resolve(config.dirPath, 'railway.json'))
+  ) {
+    return true;
+  }
+
+  return workflowFilesUseRailway(config.dirPath);
+}
+
+function workflowFilesUseRailway(dirPath: string): boolean {
+  const workflowsPath = path.resolve(dirPath, '.github', 'workflows');
+  try {
+    const fileNames = fs.readdirSync(workflowsPath);
+    return fileNames
+      .filter((fileName) => /\.ya?ml$/u.test(fileName))
+      .some((fileName) =>
+        fs.readFileSync(path.join(workflowsPath, fileName), 'utf8').toLowerCase().includes('railway')
+      );
+  } catch {
+    return false;
+  }
 }

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 
 import { logger } from '../logger.js';
@@ -77,7 +76,7 @@ function generateAgentInstruction(
   - Always create new commits. Avoid using \`--amend\`.
 - Always use heredoc syntax when passing multi-line content to any command.
 - Put temporary files in the \`.tmp\` or \`/tmp\` directory.
-${usesRailway(rootConfig) ? '- If you need Railway project information, see the workflow settings in `.github/workflows`.' : ''}
+${rootConfig.isRailway ? '- If you need Railway project information, see the workflow settings in `.github/workflows`.' : ''}
 ${hasPlaywrightTestServer(allConfigs) ? `- Use \`${packageManager} wb start --mode test\` to launch a web server for debugging or testing.` : ''}
 
 ${generateAgentCodingStyle(allConfigs)}
@@ -144,34 +143,4 @@ ${
 
 function hasPlaywrightTestServer(configs: PackageConfig[]): boolean {
   return configs.some((config) => config.depending.playwrightTest);
-}
-
-function usesRailway(config: PackageConfig): boolean {
-  const scripts = config.packageJson?.scripts;
-  if (scripts && Object.values(scripts).some((script) => typeof script === 'string' && script.includes('railway'))) {
-    return true;
-  }
-
-  if (
-    fs.existsSync(path.resolve(config.dirPath, '.railwayignore')) ||
-    fs.existsSync(path.resolve(config.dirPath, 'railway.json'))
-  ) {
-    return true;
-  }
-
-  return workflowFilesUseRailway(config.dirPath);
-}
-
-function workflowFilesUseRailway(dirPath: string): boolean {
-  const workflowsPath = path.resolve(dirPath, '.github', 'workflows');
-  try {
-    const fileNames = fs.readdirSync(workflowsPath);
-    return fileNames
-      .filter((fileName) => /\.ya?ml$/u.test(fileName))
-      .some((fileName) =>
-        fs.readFileSync(path.join(workflowsPath, fileName), 'utf8').toLowerCase().includes('railway')
-      );
-  } catch {
-    return false;
-  }
 }

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -279,7 +279,7 @@ function workflowFilesUseRailway(dirPath: string): boolean {
   try {
     const fileNames = fs.readdirSync(workflowsPath);
     return fileNames
-      .filter((fileName) => /\.ya?ml$/u.test(fileName))
+      .filter((fileName) => /\.ya?ml$/iu.test(fileName))
       .some((fileName) => workflowFileUsesRailway(workflowsPath, fileName));
   } catch {
     return false;

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -288,7 +288,7 @@ function workflowFilesUseRailway(dirPath: string): boolean {
 
 function workflowFileUsesRailway(workflowsPath: string, fileName: string): boolean {
   try {
-    return fs.readFileSync(path.join(workflowsPath, fileName), 'utf8').toLowerCase().includes('railway');
+    return /railway/iu.test(fs.readFileSync(path.join(workflowsPath, fileName), 'utf8'));
   } catch {
     return false;
   }

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -277,10 +277,9 @@ function detectRailway(dirPath: string, packageJson: PackageJson): boolean {
 function workflowFilesUseRailway(dirPath: string): boolean {
   const workflowsPath = path.resolve(dirPath, '.github', 'workflows');
   try {
-    const fileNames = fs.readdirSync(workflowsPath);
-    return fileNames
-      .filter((fileName) => /\.ya?ml$/iu.test(fileName))
-      .some((fileName) => workflowFileUsesRailway(workflowsPath, fileName));
+    return fs
+      .readdirSync(workflowsPath)
+      .some((fileName) => /\.ya?ml$/iu.test(fileName) && workflowFileUsesRailway(workflowsPath, fileName));
   } catch {
     return false;
   }

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -280,9 +280,15 @@ function workflowFilesUseRailway(dirPath: string): boolean {
     const fileNames = fs.readdirSync(workflowsPath);
     return fileNames
       .filter((fileName) => /\.ya?ml$/u.test(fileName))
-      .some((fileName) =>
-        fs.readFileSync(path.join(workflowsPath, fileName), 'utf8').toLowerCase().includes('railway')
-      );
+      .some((fileName) => workflowFileUsesRailway(workflowsPath, fileName));
+  } catch {
+    return false;
+  }
+}
+
+function workflowFileUsesRailway(workflowsPath: string, fileName: string): boolean {
+  try {
+    return fs.readFileSync(path.join(workflowsPath, fileName), 'utf8').toLowerCase().includes('railway');
   } catch {
     return false;
   }

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -21,6 +21,7 @@ export interface PackageConfig {
   repoAuthor?: string;
   repoName?: string;
   isWillBoosterRepo: boolean;
+  isRailway: boolean;
   isBun: boolean;
   isEsmPackage: boolean;
   isWillBoosterConfigs: boolean;
@@ -179,6 +180,7 @@ export async function getPackageConfig(
       isWillBoosterRepo: Boolean(
         repository?.startsWith('github:WillBooster/') || repository?.startsWith('github:WillBoosterLab/')
       ),
+      isRailway: detectRailway(dirPath, packageJson),
       isBun: rootConfig?.isBun || fs.existsSync(path.join(dirPath, 'bun.lock')),
       isEsmPackage: esmPackage,
       isWillBoosterConfigs: packageJsonPath.includes('/willbooster-configs'),
@@ -257,6 +259,33 @@ function hasVersionSettingsFile(dirPath: string): boolean {
     fs.existsSync(path.join(current, '.mise.toml')) ||
     fs.existsSync(path.join(current, '.tool-versions'))
   );
+}
+
+function detectRailway(dirPath: string, packageJson: PackageJson): boolean {
+  const scripts = packageJson.scripts;
+  if (scripts && Object.values(scripts).some((script) => typeof script === 'string' && script.includes('railway'))) {
+    return true;
+  }
+
+  if (fs.existsSync(path.resolve(dirPath, '.railwayignore')) || fs.existsSync(path.resolve(dirPath, 'railway.json'))) {
+    return true;
+  }
+
+  return workflowFilesUseRailway(dirPath);
+}
+
+function workflowFilesUseRailway(dirPath: string): boolean {
+  const workflowsPath = path.resolve(dirPath, '.github', 'workflows');
+  try {
+    const fileNames = fs.readdirSync(workflowsPath);
+    return fileNames
+      .filter((fileName) => /\.ya?ml$/u.test(fileName))
+      .some((fileName) =>
+        fs.readFileSync(path.join(workflowsPath, fileName), 'utf8').toLowerCase().includes('railway')
+      );
+  } catch {
+    return false;
+  }
 }
 
 async function readMiseTasks(dirPath: string): Promise<Record<string, string>> {

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -9,6 +9,7 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
     isReferredByOtherRepo: false,
     repository: 'github:WillBooster/example',
     isWillBoosterRepo: true,
+    isRailway: false,
     isBun: false,
     isEsmPackage: false,
     isWillBoosterConfigs: false,


### PR DESCRIPTION
## Customer Summary

- Adds a Railway-specific generated agent instruction for repositories that use Railway.
- Directs agents to `.github/workflows` when they need Railway project information.
- Keeps the generated instructions tidy when optional guidance is not present.

## Technical Summary

- Adds `isRailway` to `PackageConfig` so Railway detection is centralized.
- Detects Railway usage from package scripts, Railway marker files, and GitHub workflow contents.
- Makes workflow scanning resilient to individual file read errors, case-insensitive for workflow extensions, and simpler by short-circuiting in one pass.
- Updates the agent instruction generator to consume `rootConfig.isRailway`.

## Why

- Railway project details for WillBooster deployment workflows are managed in workflow settings, so agent instructions should point there when a repository uses Railway.
- Centralizing detection on `PackageConfig` avoids duplicating repository detection logic in individual generators.

## Testing

- `yarn verify`
- PR CI passed via `bunx @willbooster-private/agentic-workflows@1.22.8 skills check-pr-ci`
