### PR TITLE
fix: preserve custom database scripts

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1043,7 +1043,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       verify: 'bun --bun wb verify',
       'verify-full': 'bun --bun wb verify --full',
     };
-    applyDatabaseScripts(config, scripts, `bun --bun ${getWbDatabaseCommand(config)}`);
+    applyDatabaseScripts(config, scripts, oldScripts, `bun --bun ${getWbDatabaseCommand(config)}`);
     applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
     if (!hasTypecheck) {
       delete scripts.typecheck;
@@ -1108,7 +1108,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       scripts.verify = 'wb verify';
       scripts['verify-full'] = 'wb verify --full';
     }
-    applyDatabaseScripts(config, scripts, getWbDatabaseCommand(config));
+    applyDatabaseScripts(config, scripts, oldScripts, getWbDatabaseCommand(config));
     applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
     return scripts;
   }
@@ -1118,12 +1118,33 @@ function shouldManageGenI18nTs(config: PackageConfig): boolean {
   return config.depending.genI18nTs && fs.existsSync(path.join(config.dirPath, 'i18n'));
 }
 
-function applyDatabaseScripts(config: PackageConfig, scripts: Record<string, string>, wbDbCommand: string): void {
+function applyDatabaseScripts(
+  config: PackageConfig,
+  scripts: Record<string, string>,
+  oldScripts: PackageJson.Scripts,
+  wbDbCommand: string
+): void {
   if (!config.depending.prisma && !config.depending.drizzle) return;
 
-  scripts['db-create-migration'] = `${wbDbCommand} migrate-dev`;
-  scripts['db-migrate'] = `${wbDbCommand} migrate --check-idempotency`;
-  scripts['db-view'] = `${wbDbCommand} studio`;
+  applyDatabaseScript(scripts, oldScripts, 'db-create-migration', `${wbDbCommand} migrate-dev`);
+  applyDatabaseScript(scripts, oldScripts, 'db-migrate', `${wbDbCommand} migrate --check-idempotency`);
+  applyDatabaseScript(scripts, oldScripts, 'db-view', `${wbDbCommand} studio`);
+}
+
+function applyDatabaseScript(
+  scripts: Record<string, string>,
+  oldScripts: PackageJson.Scripts,
+  name: string,
+  generatedScript: string
+): void {
+  const oldScript = oldScripts[name];
+  // Some repositories wrap migration commands to prepare SQLite directories,
+  // fan out over tenants, or perform cleanup that wb cannot infer generically.
+  scripts[name] = oldScript && !isGeneratedDatabaseScript(oldScript) ? oldScript : generatedScript;
+}
+
+function isGeneratedDatabaseScript(script: string): boolean {
+  return /\bwb\s+(?:db|prisma)\b/u.test(script);
 }
 
 function getWbDatabaseCommand(config: PackageConfig): 'wb db' | 'wb prisma' {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -134,6 +134,23 @@ test('keeps wb as a runtime dependency when postinstall uses it', async () => {
   expect(packageJson.devDependencies?.['@willbooster/wb']).toBeUndefined();
 });
 
+test('keeps custom database scripts for drizzle projects', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      scripts: {
+        'db-migrate': 'bun scripts/runDrizzleMigrationsToAllClients.ts',
+      },
+    },
+    { depending: { ...createConfig().depending, drizzle: true } }
+  );
+
+  expect(packageJson.scripts).toMatchObject({
+    'db-create-migration': 'wb db migrate-dev',
+    'db-migrate': 'bun scripts/runDrizzleMigrationsToAllClients.ts',
+    'db-view': 'wb db studio',
+  });
+});
+
 async function generatePackageJsonFrom(
   initialPackageJson: Record<string, unknown>,
   configOverrides: Parameters<typeof createConfig>[0] = {},


### PR DESCRIPTION
## Customer Summary

- Keeps repository-specific database migration wrappers intact when applying `wbfy`.
- Prevents generated package scripts from dropping setup logic required by SQLite or multi-client database workflows.
- No product behavior changes are introduced.

## Technical Summary

- Updated package script generation to preserve existing database scripts that are not already managed `wb db` or `wb prisma` commands.
- Added a regression test for a Drizzle project with a custom migration wrapper.
- Left standard generated `wb` database scripts in place for projects without custom scripts.

## Why

- Applying `wbfy` to `moti-ai` replaced its custom migration wrapper with a generic `wb db migrate` command.
- The generic command did not create the SQLite database directory before Drizzle opened the file, causing CI setup to fail.

## Testing

- `yarn vitest test/packageJson.test.ts`
- `yarn verify`
- pre-commit cleanup hook
- pre-push oxlint hook
