### PR TITLE
fix: enforce managed playwright use defaults

### DIFF
--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -93,10 +93,11 @@ export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> 
     const parsed = parseObjectLiteralExpression(extractedObjectLiteral.node, extractedObjectLiteral.source);
     if (!parsed) return;
 
-    // Keep filling missing defaults, but don't overwrite local adjustments on every regeneration.
     const shouldUseAppServerDefaults =
       (await doesDefineNextPublicBaseUrl(config.dirPath)) && shouldManageAppServerDefaults(config, parsed);
-    const merged = mergeParsedObjects(createDefaultConfig(config, shouldUseAppServerDefaults), parsed);
+    const defaultConfig = createDefaultConfig(config, shouldUseAppServerDefaults);
+    const merged = mergeParsedObjects(defaultConfig, parsed);
+    applyManagedUseDefaults(merged, defaultConfig);
     setWebServerCommand(merged, config);
 
     const newObjectLiteral = stringifyValue({ kind: 'object', value: merged }, 0);
@@ -131,6 +132,19 @@ function mergeParsedValue(base: ParsedValue | undefined, override: ParsedValue):
     return { kind: 'object', value: mergeParsedObjects(base.value, override.value) };
   }
   return override;
+}
+
+function applyManagedUseDefaults(config: ParsedObject, defaultConfig: ParsedObject): void {
+  const use = config.properties.use;
+  const defaultUse = defaultConfig.properties.use;
+  if (use?.kind !== 'object' || defaultUse?.kind !== 'object') return;
+
+  for (const key of ['trace', 'screenshot', 'video']) {
+    const defaultValue = defaultUse.value.properties[key];
+    if (defaultValue) {
+      use.value.properties[key] = defaultValue;
+    }
+  }
 }
 
 function shouldManageAppServerDefaults(config: PackageConfig, parsed: ParsedObject): boolean {


### PR DESCRIPTION
## Customer Summary

- `wbfy` now updates the managed Playwright `use.trace`, `use.screenshot`, and `use.video` settings even when those fields already exist in `playwright.config.ts`.
- Existing non-managed Playwright settings remain preserved, so local project-specific config is not broadly overwritten.

## Technical Summary

- Split default config creation from merging in `packages/wbfy/src/fixers/playwrightConfig.ts`.
- Added a focused post-merge step that overwrites only the managed `use` artifact settings from the generated defaults.
- Kept the existing merge behavior for other top-level and nested Playwright config fields.

## Why

- The previous recursive merge treated existing `use` values as local overrides, so `wbfy` only backfilled missing artifact settings and did not normalize stale values.
- A targeted post-merge normalization fixes the reported behavior without making `wbfy` overwrite unrelated Playwright customization.

## Testing

- `yarn verify`
- Pre-commit cleanup hook passed.
- Pre-push lint hook passed.

## Notes

- No tests were added because this repository's local instructions say to write tests only when explicitly requested.
