### PR TITLE
fix: generate litestream v0.5 retention config

### DIFF
--- a/packages/wb/docker/bash/install-litestream.sh
+++ b/packages/wb/docker/bash/install-litestream.sh
@@ -4,15 +4,15 @@ set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 ARCH=${ARCH:-$(dpkg --print-architecture)}
+LITESTREAM_VERSION=${LITESTREAM_VERSION:-0.5.12}
 
 apt-get -qq install -y --no-install-recommends ca-certificates curl \
-  && LITESTREAM_VERSION=$(curl --silent "https://api.github.com/repos/benbjohnson/litestream/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^v//') \
   && DEB_FILE="litestream-${LITESTREAM_VERSION}-linux-${ARCH}.deb" \
   && echo "Installing Litestream: ${DEB_FILE}" \
   && curl -fsSLO https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/${DEB_FILE} \
   && dpkg-reconfigure debconf -f noninteractive -p critical \
-  && dpkg -i ${DEB_FILE} \
+  && dpkg -i "${DEB_FILE}" \
   && cp "${SCRIPT_DIR}/run-litestream.sh" /usr/local/bin/run-litestream.sh \
   && chmod +x /usr/local/bin/run-litestream.sh \
   && litestream version \
-  && rm -f ${DEB_FILE}
+  && rm -f "${DEB_FILE}"

--- a/packages/wb/docker/bash/install-litestream.sh
+++ b/packages/wb/docker/bash/install-litestream.sh
@@ -3,15 +3,17 @@
 set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
-ARCH=${ARCH:-$(dpkg --print-architecture)}
-LITESTREAM_ARCH=${ARCH}
-if [[ "${LITESTREAM_ARCH}" == "amd64" ]]; then
-  LITESTREAM_ARCH=x86_64
+if [[ -z "${ARCH:-}" ]]; then
+  case "$(uname -m)" in
+    arm64 | aarch64) ARCH=arm64 ;;
+    x86_64) ARCH=x86_64 ;;
+    *) ARCH=$(uname -m) ;;
+  esac
 fi
 
 apt-get -qq install -y --no-install-recommends ca-certificates curl \
   && LITESTREAM_VERSION=${LITESTREAM_VERSION:-$(curl --silent "https://api.github.com/repos/benbjohnson/litestream/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^v//')} \
-  && DEB_FILE="litestream-${LITESTREAM_VERSION}-linux-${LITESTREAM_ARCH}.deb" \
+  && DEB_FILE="litestream-${LITESTREAM_VERSION}-linux-${ARCH}.deb" \
   && echo "Installing Litestream: ${DEB_FILE}" \
   && curl -fsSLO https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/${DEB_FILE} \
   && dpkg-reconfigure debconf -f noninteractive -p critical \

--- a/packages/wb/docker/bash/install-litestream.sh
+++ b/packages/wb/docker/bash/install-litestream.sh
@@ -4,10 +4,14 @@ set -e
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 ARCH=${ARCH:-$(dpkg --print-architecture)}
-LITESTREAM_VERSION=${LITESTREAM_VERSION:-0.5.12}
+LITESTREAM_ARCH=${ARCH}
+if [[ "${LITESTREAM_ARCH}" == "amd64" ]]; then
+  LITESTREAM_ARCH=x86_64
+fi
 
 apt-get -qq install -y --no-install-recommends ca-certificates curl \
-  && DEB_FILE="litestream-${LITESTREAM_VERSION}-linux-${ARCH}.deb" \
+  && LITESTREAM_VERSION=${LITESTREAM_VERSION:-$(curl --silent "https://api.github.com/repos/benbjohnson/litestream/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^v//')} \
+  && DEB_FILE="litestream-${LITESTREAM_VERSION}-linux-${LITESTREAM_ARCH}.deb" \
   && echo "Installing Litestream: ${DEB_FILE}" \
   && curl -fsSLO https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/${DEB_FILE} \
   && dpkg-reconfigure debconf -f noninteractive -p critical \

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -312,8 +312,10 @@ function createLitestreamConfig(project: Project, orm: DatabaseOrm): void {
     throw new Error(`Missing environment variables for Litestream: ${missingEnvVars.join(', ')}`);
   }
 
-  const retentionCheckInterval = project.env.WB_ENV === 'staging' ? '5m' : '1h';
-  const litestreamConfig = `dbs:
+  const litestreamConfig = `snapshot:
+  interval: 24h  # Create a backup per day
+  retention: 72h # Keep backups for 3 days
+dbs:
   - path: ${dbPath}
     busy-timeout: 5s
     checkpoint-interval: 1m
@@ -323,9 +325,6 @@ function createLitestreamConfig(project: Project, orm: DatabaseOrm): void {
       bucket: ${requiredEnvVars.CLOUDFLARE_R2_LITESTREAM_BUCKET_NAME}
       access-key-id: ${requiredEnvVars.CLOUDFLARE_R2_LITESTREAM_ACCESS_KEY_ID}
       secret-access-key: ${requiredEnvVars.CLOUDFLARE_R2_LITESTREAM_SECRET_ACCESS_KEY}
-      snapshot-interval: 24h  # Create a backup per day
-      retention: 72h          # Keep backups for 3 days
-      retention-check-interval: ${retentionCheckInterval}
       sync-interval: 1m
 `;
 


### PR DESCRIPTION
## Customer Summary

- Restores the intended 3-day Litestream backup retention window for projects using the shared Docker setup.
- Keeps Litestream installation on the latest upstream release by default, while still allowing an explicit `LITESTREAM_VERSION` override when needed.
- Avoids Docker build failures from Debian architecture names that do not match Litestream release asset names.

## Technical Summary

- Moves Litestream backup retention settings from the old replica-level v0.3 keys to the v0.5-compatible top-level `snapshot.interval` and `snapshot.retention` keys.
- Removes obsolete `retention-check-interval` generation because v0.5 enforces snapshot retention during snapshot compaction.
- Derives the default `ARCH` value as the Litestream release asset architecture (`x86_64` or `arm64`) and uses it directly in the `.deb` filename.
- Preserves optional `LITESTREAM_VERSION` and `ARCH` overrides for callers that need them.

## Why

- Production was running Litestream v0.5, but `shared` still generated v0.3-style retention keys, so the intended `72h` retention was not applied.
- Using v0.5-compatible snapshot config makes the generated `/etc/litestream.yml` match the Litestream version currently installed by the Docker image.

## Testing

- `bash -n packages/wb/docker/bash/install-litestream.sh`
- Verified latest Litestream release asset URLs for `linux-arm64` and `linux-x86_64` with `curl -fsSI`.
- Verified a generated v0.5-style `snapshot:` config is accepted by Litestream `0.5.12` via `litestream databases -config`.
- `yarn verify`
- Latest PR CI passed via `bunx @willbooster-private/agentic-workflows@latest skills check-pr-ci`.
