### PR TITLE
fix: keep build-ts for seed scripts

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -392,7 +392,7 @@ function shouldKeepBuildTsAsRuntimeDependency(jsonObj: PackageJson): boolean {
 function doesSeedCommandUseBuildTs(seedCommand: unknown): boolean {
   // Production Docker images run seed scripts after devDependencies are pruned,
   // so TypeScript seed runners must remain available at runtime.
-  return typeof seedCommand === 'string' && /\bbuild-ts\b/u.test(seedCommand);
+  return typeof seedCommand === 'string' && /(?<![\w-])build-ts(?![\w-])/u.test(seedCommand);
 }
 
 async function normalizePackageMetadata(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -386,7 +386,14 @@ function shouldKeepWbAsRuntimeDependency(jsonObj: PackageJson): boolean {
 
 function shouldKeepBuildTsAsRuntimeDependency(jsonObj: PackageJson): boolean {
   const prisma = jsonObj.prisma as { seed?: unknown } | undefined;
-  return typeof prisma?.seed === 'string' && prisma.seed.includes(buildTsDependency);
+  if (doesSeedCommandUseBuildTs(prisma?.seed)) return true;
+  return doesSeedCommandUseBuildTs(jsonObj.scripts?.seed);
+}
+
+function doesSeedCommandUseBuildTs(seedCommand: unknown): boolean {
+  // Production Docker images run seed scripts after devDependencies are pruned,
+  // so TypeScript seed runners must remain available at runtime.
+  return typeof seedCommand === 'string' && seedCommand.includes(buildTsDependency);
 }
 
 async function normalizePackageMetadata(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -392,7 +392,7 @@ function shouldKeepBuildTsAsRuntimeDependency(jsonObj: PackageJson): boolean {
 function doesSeedCommandUseBuildTs(seedCommand: unknown): boolean {
   // Production Docker images run seed scripts after devDependencies are pruned,
   // so TypeScript seed runners must remain available at runtime.
-  return typeof seedCommand === 'string' && seedCommand.includes(buildTsDependency);
+  return typeof seedCommand === 'string' && /\bbuild-ts\b/u.test(seedCommand);
 }
 
 async function normalizePackageMetadata(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -386,8 +386,7 @@ function shouldKeepWbAsRuntimeDependency(jsonObj: PackageJson): boolean {
 
 function shouldKeepBuildTsAsRuntimeDependency(jsonObj: PackageJson): boolean {
   const prisma = jsonObj.prisma as { seed?: unknown } | undefined;
-  if (doesSeedCommandUseBuildTs(prisma?.seed)) return true;
-  return doesSeedCommandUseBuildTs(jsonObj.scripts?.seed);
+  return doesSeedCommandUseBuildTs(prisma?.seed) || doesSeedCommandUseBuildTs(jsonObj.scripts?.seed);
 }
 
 function doesSeedCommandUseBuildTs(seedCommand: unknown): boolean {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -137,6 +137,22 @@ test('keeps build-ts as a runtime dependency when seed script uses it', async ()
   expect(packageJson.devDependencies?.['build-ts']).toBeUndefined();
 });
 
+test('keeps build-ts as a dev dependency when seed script uses a different hyphenated command', async () => {
+  const oldBuildTsVersion = '0.0.1';
+  const packageJson = await generatePackageJsonFrom({
+    devDependencies: {
+      'build-ts': oldBuildTsVersion,
+    },
+    scripts: {
+      seed: 'build-ts-compiler run db/seed.ts && my-build-ts run db/seed.ts',
+    },
+  });
+
+  expect(packageJson.dependencies?.['build-ts']).toBeUndefined();
+  expect(packageJson.devDependencies?.['build-ts']).toMatch(/^\d+\.\d+\.\d+/u);
+  expect(packageJson.devDependencies?.['build-ts']).not.toBe(oldBuildTsVersion);
+});
+
 test('keeps wb as a runtime dependency when postinstall uses it', async () => {
   const oldWbVersion = '0.0.1';
   const packageJson = await generatePackageJsonFrom({

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -121,6 +121,22 @@ test('keeps build-ts as a runtime dependency when prisma seed uses it', async ()
   expect(packageJson.devDependencies?.['build-ts']).toBeUndefined();
 });
 
+test('keeps build-ts as a runtime dependency when seed script uses it', async () => {
+  const oldBuildTsVersion = '0.0.1';
+  const packageJson = await generatePackageJsonFrom({
+    devDependencies: {
+      'build-ts': oldBuildTsVersion,
+    },
+    scripts: {
+      seed: 'build-ts run db/seed.ts',
+    },
+  });
+
+  expect(packageJson.dependencies?.['build-ts']).toMatch(/^\d+\.\d+\.\d+/u);
+  expect(packageJson.dependencies?.['build-ts']).not.toBe(oldBuildTsVersion);
+  expect(packageJson.devDependencies?.['build-ts']).toBeUndefined();
+});
+
 test('keeps wb as a runtime dependency when postinstall uses it', async () => {
   const oldWbVersion = '0.0.1';
   const packageJson = await generatePackageJsonFrom({


### PR DESCRIPTION
## Customer Summary

- Prevents `wbfy` from moving `build-ts` out of runtime dependencies when a project seeds data with a TypeScript seed script.
- Fixes Docker/runtime seed failures for projects that run `yarn run seed` after dev dependencies are pruned.
- Avoids treating similarly named hyphenated commands as `build-ts`.

## Technical Summary

- Extends `shouldKeepBuildTsAsRuntimeDependency` to inspect both Prisma seed hooks and the standard `scripts.seed` command.
- Detects `build-ts` as a standalone command token using lookaround boundaries that exclude word characters and hyphens.
- Adds package-json generator regression coverage for `seed: build-ts run db/seed.ts` and for hyphenated false positives such as `build-ts-compiler` and `my-build-ts`.

## Why

- `optimizeForDockerBuild` removes dev dependencies before production containers run database seed commands. If `build-ts` is only a dev dependency, TypeScript seed scripts fail with `command not found: build-ts`.
- A plain substring or word-boundary match can incorrectly classify unrelated hyphenated command names as `build-ts`.

## Testing

- `yarn vitest test/packageJson.test.ts --testNamePattern 'keeps build-ts|different hyphenated command'`
- `yarn vitest test/packageJson.test.ts`
- `yarn typecheck && yarn lint`
- `bunx @willbooster-private/agentic-workflows@latest skills check-pr-ci`

## Notes

- An earlier `yarn test` attempt failed before relevant tests ran because the existing build setup hit `rollup-plugin-node-externals`: `TypeError: undefined is not a function`.
