### PR TITLE
fix: standardize sqlite env on database url

### DIFF
--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -8,7 +8,12 @@ import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
-import { findDescendantProjects, getFileDatabaseUrlPath, type Project } from '../project.js';
+import {
+  findDescendantProjects,
+  getAbsoluteFileDatabaseUrlPath,
+  getFileDatabaseUrlPath,
+  type Project,
+} from '../project.js';
 import { packageManager } from '../utils/runtime.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
@@ -300,10 +305,10 @@ async function removeGeneratedMountDirs(project: Project): Promise<string[]> {
 
 function getGeneratedMountDirPaths(project: Project): string[] {
   const defaultPaths = generatedSqliteDirNames.map((dirName) => path.join(dirName, 'mount'));
-  const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
+  const dbPath = getAbsoluteFileDatabaseUrlPath(project);
   if (!dbPath) return defaultPaths;
 
-  const absoluteDirPath = path.dirname(path.isAbsolute(dbPath) ? dbPath : path.resolve(project.dirPath, dbPath));
+  const absoluteDirPath = path.dirname(dbPath);
   if (path.basename(absoluteDirPath) !== 'mount' || !isPathInsideProject(project, absoluteDirPath)) {
     return defaultPaths;
   }
@@ -348,15 +353,13 @@ async function removeEnvGeneratedSqliteFiles(project: Project): Promise<string[]
 }
 
 function getEnvGeneratedSqliteFilePaths(project: Project): string[] {
-  const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
-  if (!dbPath) return [];
+  const dbPath = getFileDatabaseUrlPath(project);
+  const absoluteDbPath = getAbsoluteFileDatabaseUrlPath(project);
+  if (!dbPath || !absoluteDbPath) return [];
 
   const filePaths = path.isAbsolute(dbPath)
     ? [dbPath]
-    : [
-        path.resolve(project.dirPath, dbPath),
-        ...generatedSqliteDirNames.map((dirName) => path.resolve(project.dirPath, dirName, dbPath)),
-      ];
+    : [absoluteDbPath, ...generatedSqliteDirNames.map((dirName) => path.resolve(project.dirPath, dirName, dbPath))];
   return [...new Set(filePaths)].filter((filePath) => isGeneratedSqliteFilePathSafe(project, filePath));
 }
 

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
 import type { DatabaseOrm, Project } from '../project.js';
-import { findDescendantProjects, getFileDatabaseUrlPath, isProjectEnvironment } from '../project.js';
+import { findDescendantProjects, getAbsoluteFileDatabaseUrlPath, isProjectEnvironment } from '../project.js';
 import { drizzleScripts } from '../scripts/drizzleScripts.js';
 import { prismaScripts } from '../scripts/prismaScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
@@ -346,9 +346,9 @@ function getLitestreamDbPath(project: Project, orm: DatabaseOrm): string {
     return `${dirName}/mount/prod.sqlite3`;
   }
 
-  const dbPath = project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
+  const dbPath = getAbsoluteFileDatabaseUrlPath(project);
   if (!dbPath) {
-    throw new Error('wb db create-litestream-config for Drizzle requires DATABASE_PATH or file: DATABASE_URL.');
+    throw new Error('wb db create-litestream-config for Drizzle requires file: DATABASE_URL.');
   }
   return dbPath;
 }

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -301,6 +301,13 @@ export function getFileDatabaseUrlPath(project: Pick<Project, 'env'>): string | 
   return normalizedPath || undefined;
 }
 
+export function getAbsoluteFileDatabaseUrlPath(project: Pick<Project, 'env' | 'rootDirPath'>): string | undefined {
+  const dbPath = getFileDatabaseUrlPath(project);
+  if (!dbPath) return;
+
+  return path.isAbsolute(dbPath) ? dbPath : path.resolve(project.rootDirPath, dbPath);
+}
+
 export interface FoundProjects {
   root: Project;
   self: Project;

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { getFileDatabaseUrlPath, isProjectEnvironment, type Project } from '../project.js';
+import { getAbsoluteFileDatabaseUrlPath, isProjectEnvironment, type Project } from '../project.js';
 
 const LITESTREAM_CONFIG_FILE_NAME = 'litestream.yml';
 const DEFAULT_LITESTREAM_CONFIG_PATH = '/etc/litestream.yml';
@@ -16,7 +16,7 @@ class DrizzleScripts {
   reset(project: Project, additionalOptions = ''): string {
     const removeCommand = buildRemoveSqliteDbCommand(project);
     if (!removeCommand) {
-      return "echo 'wb db reset supports Drizzle only when DATABASE_PATH or file: DATABASE_URL is set.' && exit 1";
+      return "echo 'wb db reset supports Drizzle only when file: DATABASE_URL is set.' && exit 1";
     }
 
     return `${removeCommand} && ${this.migrate(project, additionalOptions)}`;
@@ -89,7 +89,7 @@ function buildRemoveSqliteDbFamilyCommand(dbPath: string): string {
 function getSqliteDbPathOrError(project: Project, commandName: string): string {
   const dbPath = getSqliteDbPath(project);
   if (!dbPath) {
-    throw new Error(`wb db ${commandName} supports Drizzle only when DATABASE_PATH or file: DATABASE_URL is set.`);
+    throw new Error(`wb db ${commandName} supports Drizzle only when file: DATABASE_URL is set.`);
   }
   return dbPath;
 }
@@ -100,7 +100,7 @@ function getAbsoluteSqliteDbPath(project: Project, commandName: string): string 
 }
 
 function getSqliteDbPath(project: Project): string | undefined {
-  return project.env.DATABASE_PATH ?? getFileDatabaseUrlPath(project);
+  return getAbsoluteFileDatabaseUrlPath(project);
 }
 
 function getLitestreamConfigOption(project: Project): string {

--- a/packages/wb/test/project.test.ts
+++ b/packages/wb/test/project.test.ts
@@ -4,7 +4,7 @@ import childProcess from 'node:child_process';
 
 import { describe, expect, it } from 'vitest';
 
-import { findDescendantProjects, findSelfProject } from '../src/project.js';
+import { findDescendantProjects, findSelfProject, getAbsoluteFileDatabaseUrlPath } from '../src/project.js';
 
 import { initializeProjectDirectory, tempDir } from './shared.js';
 
@@ -68,6 +68,25 @@ describe('project', () => {
     );
 
     expect(findSelfProject({}, false, path.join(dirPath, 'packages', 'sub1'))?.preferredLinter).toBe('oxlint');
+  });
+
+  it('resolves relative file DATABASE_URL values from the project directory', () => {
+    const project = {
+      dirPath: '/app/packages/server',
+      env: { DATABASE_URL: 'file:../../drizzle/mount/prod.sqlite3' },
+      rootDirPath: '/app',
+    };
+
+    expect(getAbsoluteFileDatabaseUrlPath(project)).toBe('/drizzle/mount/prod.sqlite3');
+  });
+
+  it('resolves root-relative file DATABASE_URL values from the repository root', () => {
+    const project = {
+      env: { DATABASE_URL: 'file:./drizzle/mount/prod.sqlite3' },
+      rootDirPath: '/app',
+    };
+
+    expect(getAbsoluteFileDatabaseUrlPath(project)).toBe('/app/drizzle/mount/prod.sqlite3');
   });
 
   it.runIf(isMiseAvailable())(


### PR DESCRIPTION
## Customer Summary

- Standardizes SQLite configuration on `DATABASE_URL` and removes `DATABASE_PATH` support from `wb` to avoid split configuration.
- Drizzle SQLite paths are resolved from the repository root, so monorepo packages can share one root `.env` value.
- Existing `DATABASE_URL=file:...` users continue to work; `DATABASE_PATH` users must move to `DATABASE_URL`.

## Technical Summary

- Removed `DATABASE_PATH` fallback from Drizzle cleanup, restore, Docker optimization, and Litestream config generation.
- Added `getAbsoluteFileDatabaseUrlPath()` to resolve relative `file:` URLs against `project.rootDirPath`.
- Added unit coverage for repository-root relative path resolution.

## Why

- Keeping both `DATABASE_PATH` and `DATABASE_URL` created ambiguity around which value controlled migrations, app runtime, and Litestream.
- `DATABASE_URL` is already the common SQLite input across the affected repositories.

## Testing

- `yarn verify`
- pre-push lefthook lint checks
