### PR TITLE
fix: support drizzle litestream restore

### DIFF
--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -57,10 +57,22 @@ const cleanUpLitestreamCommand: CommandModule<unknown, InferredOptionTypes<typeo
   },
 };
 
-const createLitestreamConfigCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> = {
+const createLitestreamConfigBuilder = {
+  ...builder,
+  output: {
+    description: 'Output path of the Litestream configuration file.',
+    type: 'string',
+    default: '/etc/litestream.yml',
+  },
+} as const;
+
+const createLitestreamConfigCommand: CommandModule<
+  unknown,
+  InferredOptionTypes<typeof createLitestreamConfigBuilder>
+> = {
   command: 'create-litestream-config',
   describe: 'Create Litestream configuration file',
-  builder,
+  builder: createLitestreamConfigBuilder,
   async handler(argv) {
     const allProjects = await findDatabaseOrmProjects(argv);
     if (allProjects.length > 1) {
@@ -69,7 +81,7 @@ const createLitestreamConfigCommand: CommandModule<unknown, InferredOptionTypes<
       );
     }
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db create-litestream-config', allProjects)) {
-      createLitestreamConfig(project, orm);
+      createLitestreamConfig(project, orm, argv.output);
     }
   },
 };
@@ -117,9 +129,9 @@ const listBackupsCommand: CommandModule<unknown, InferredOptionTypes<typeof buil
   describe: 'List Litestream backups',
   builder,
   async handler(argv) {
-    const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
-    for (const { project } of prepareForRunningDatabaseOrmCommand('prisma list-backups', allProjects)) {
-      await runWithSpawn(prismaScripts.listBackups(project), project, argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db list-backups', allProjects)) {
+      await runWithSpawn(getDatabaseOrmScripts(orm).listBackups(project), project, argv);
     }
   },
 };
@@ -204,7 +216,7 @@ const resetCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> 
 const restoreBuilder = {
   ...builder,
   output: {
-    description: 'Output path of the restored database. Defaults to "<db|prisma>/restored.sqlite3".',
+    description: 'Output path of the restored database. Defaults to "<db|drizzle|prisma>/restored.sqlite3".',
     type: 'string',
   },
 } as const;
@@ -214,11 +226,10 @@ const restoreCommand: CommandModule<unknown, InferredOptionTypes<typeof restoreB
   describe: "Restore DB from Litestream's backup",
   builder: restoreBuilder,
   async handler(argv) {
-    const allProjects = await findDatabaseOrmProjects(argv, 'prisma');
-    for (const { project } of prepareForRunningDatabaseOrmCommand('prisma restore', allProjects)) {
-      const output =
-        argv.output ?? (project.packageJson.dependencies?.blitz ? 'db/restored.sqlite3' : 'prisma/restored.sqlite3');
-      await runWithSpawn(prismaScripts.restore(project, output), project, argv);
+    const allProjects = await findDatabaseOrmProjects(argv);
+    for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db restore', allProjects)) {
+      const output = argv.output ?? getDefaultRestoreOutput(project, orm);
+      await runWithSpawn(getDatabaseOrmScripts(orm).restore(project, output), project, argv);
     }
   },
 };
@@ -297,7 +308,7 @@ const defaultCommand: CommandModule<unknown, InferredOptionTypes<typeof defaultC
   },
 };
 
-function createLitestreamConfig(project: Project, orm: DatabaseOrm): void {
+function createLitestreamConfig(project: Project, orm: DatabaseOrm, configPath: string): void {
   const dbPath = getLitestreamDbPath(project, orm);
   const requiredEnvVars = {
     CLOUDFLARE_R2_LITESTREAM_ACCOUNT_ID: project.env.CLOUDFLARE_R2_LITESTREAM_ACCOUNT_ID,
@@ -328,7 +339,6 @@ dbs:
       sync-interval: 1m
 `;
 
-  const configPath = '/etc/litestream.yml';
   try {
     fs.writeFileSync(configPath, litestreamConfig);
     console.info(`Generated ${configPath}`);
@@ -338,6 +348,12 @@ dbs:
       cause: error,
     });
   }
+}
+
+function getDefaultRestoreOutput(project: Project, orm: DatabaseOrm): string {
+  if (orm === 'prisma')
+    return project.packageJson.dependencies?.blitz ? 'db/restored.sqlite3' : 'prisma/restored.sqlite3';
+  return 'drizzle/restored.sqlite3';
 }
 
 function getLitestreamDbPath(project: Project, orm: DatabaseOrm): string {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -47,6 +47,16 @@ class DrizzleScripts {
       && litestream restore ${litestreamConfigOption} -o "${dbPath}" "${dbPath}" && ls -ahl "${dbPath}" && ALLOW_TO_SKIP_SEED=0 ${this.deploy(project)}`;
   }
 
+  listBackups(project: Project): string {
+    const dbPath = getAbsoluteSqliteDbPath(project, 'list-backups');
+    return `litestream ltx ${getLitestreamConfigOption(project)} "${dbPath}"`;
+  }
+
+  restore(project: Project, outputPath: string): string {
+    const dbPath = getAbsoluteSqliteDbPath(project, 'restore');
+    return `rm -Rf "${outputPath}"*; litestream restore ${getLitestreamConfigOption(project)} -o "${outputPath}" "${dbPath}"`;
+  }
+
   generate(_project: Project, additionalOptions = ''): string {
     return `YARN drizzle-kit generate ${additionalOptions}`;
   }

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { getAbsoluteFileDatabaseUrlPath, isProjectEnvironment, type Project } from '../project.js';
+import { getFileDatabaseUrlPath, isProjectEnvironment, type Project } from '../project.js';
 
 const LITESTREAM_CONFIG_FILE_NAME = 'litestream.yml';
 const DEFAULT_LITESTREAM_CONFIG_PATH = '/etc/litestream.yml';
@@ -110,7 +110,10 @@ function getAbsoluteSqliteDbPath(project: Project, commandName: string): string 
 }
 
 function getSqliteDbPath(project: Project): string | undefined {
-  return getAbsoluteFileDatabaseUrlPath(project);
+  const dbPath = getFileDatabaseUrlPath(project);
+  if (!dbPath) return;
+
+  return path.isAbsolute(dbPath) ? dbPath : path.resolve(project.rootDirPath ?? project.dirPath, dbPath);
 }
 
 function getLitestreamConfigOption(project: Project): string {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -54,7 +54,7 @@ class DrizzleScripts {
 
   restore(project: Project, outputPath: string): string {
     const dbPath = getAbsoluteSqliteDbPath(project, 'restore');
-    return `rm -Rf "${outputPath}"*; litestream restore ${getLitestreamConfigOption(project)} -o "${outputPath}" "${dbPath}"`;
+    return `${buildRemoveSqliteDbCommandForPath(outputPath)}; litestream restore ${getLitestreamConfigOption(project)} -o "${outputPath}" "${dbPath}"`;
   }
 
   generate(_project: Project, additionalOptions = ''): string {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { getFileDatabaseUrlPath, isProjectEnvironment, type Project } from '../project.js';
+import { getAbsoluteFileDatabaseUrlPath, isProjectEnvironment, type Project } from '../project.js';
 
 const LITESTREAM_CONFIG_FILE_NAME = 'litestream.yml';
 const DEFAULT_LITESTREAM_CONFIG_PATH = '/etc/litestream.yml';
@@ -110,10 +110,7 @@ function getAbsoluteSqliteDbPath(project: Project, commandName: string): string 
 }
 
 function getSqliteDbPath(project: Project): string | undefined {
-  const dbPath = getFileDatabaseUrlPath(project);
-  if (!dbPath) return;
-
-  return path.isAbsolute(dbPath) ? dbPath : path.resolve(project.rootDirPath ?? project.dirPath, dbPath);
+  return getAbsoluteFileDatabaseUrlPath(project);
 }
 
 function getLitestreamConfigOption(project: Project): string {

--- a/packages/wb/test/scripts/drizzleScripts.test.ts
+++ b/packages/wb/test/scripts/drizzleScripts.test.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import type { Project } from '../../src/project.js';
+import { drizzleScripts } from '../../src/scripts/drizzleScripts.js';
+
+describe('drizzleScripts Litestream commands', () => {
+  it('lists backups for file DATABASE_URL databases', () => {
+    const project = createDrizzleProject();
+
+    const command = drizzleScripts.listBackups(project);
+
+    expect(command).toBe(
+      `litestream ltx -config ./litestream.yml "${path.join(project.rootDirPath, 'drizzle/mount/prod.sqlite3')}"`
+    );
+  });
+
+  it('restores backups to the requested output path', () => {
+    const project = createDrizzleProject();
+
+    const command = drizzleScripts.restore(project, '/tmp/restored.sqlite3');
+
+    expect(command).toBe(
+      `rm -Rf "/tmp/restored.sqlite3"*; litestream restore -config ./litestream.yml -o "/tmp/restored.sqlite3" "${path.join(project.rootDirPath, 'drizzle/mount/prod.sqlite3')}"`
+    );
+  });
+
+  it('requires a file DATABASE_URL for backup operations', () => {
+    const project = createDrizzleProject({ DATABASE_URL: 'postgresql://localhost:5432/db' });
+
+    expect(() => drizzleScripts.listBackups(project)).toThrow(
+      'wb db list-backups supports Drizzle only when file: DATABASE_URL is set.'
+    );
+    expect(() => drizzleScripts.restore(project, '/tmp/restored.sqlite3')).toThrow(
+      'wb db restore supports Drizzle only when file: DATABASE_URL is set.'
+    );
+  });
+});
+
+function createDrizzleProject(env?: Record<string, string>): Project {
+  return {
+    dirPath: '/repo/packages/server',
+    env: env ?? { DATABASE_URL: 'file:./drizzle/mount/prod.sqlite3' },
+    packageJson: { dependencies: {} },
+    rootDirPath: '/repo',
+  } as unknown as Project;
+}

--- a/packages/wb/test/scripts/drizzleScripts.test.ts
+++ b/packages/wb/test/scripts/drizzleScripts.test.ts
@@ -22,7 +22,7 @@ describe('drizzleScripts Litestream commands', () => {
     const command = drizzleScripts.restore(project, '/tmp/restored.sqlite3');
 
     expect(command).toBe(
-      `rm -Rf "/tmp/restored.sqlite3"*; litestream restore -config ./litestream.yml -o "/tmp/restored.sqlite3" "${path.join(project.rootDirPath, 'drizzle/mount/prod.sqlite3')}"`
+      `rm -f "/tmp/restored.sqlite3" "/tmp/restored.sqlite3-wal" "/tmp/restored.sqlite3-shm"; litestream restore -config ./litestream.yml -o "/tmp/restored.sqlite3" "${path.join(project.rootDirPath, 'drizzle/mount/prod.sqlite3')}"`
     );
   });
 

--- a/packages/wb/test/scripts/execution/baseScripts.test.ts
+++ b/packages/wb/test/scripts/execution/baseScripts.test.ts
@@ -272,6 +272,7 @@ describe('BaseScripts.testE2E', () => {
       hasDrizzle: true,
       hasPrisma: false,
       packageJson: { scripts: {} },
+      rootDirPath: '/tmp/app',
     } as unknown as Project;
 
     const command = await scripts.startTest(drizzleProject, {} as ScriptArgv);


### PR DESCRIPTION
## Customer Summary

- `wb db list-backups` and `wb db restore` now work for Drizzle projects that use SQLite `file:` `DATABASE_URL`.
- `wb db create-litestream-config` can write to a caller-provided path, which makes local backup inspection and restore workflows possible without root access.
- Existing Docker production behavior is unchanged because the default config output remains `/etc/litestream.yml`.

## Technical Summary

- Added `--output` to `wb db create-litestream-config`.
- Extended generic `wb db list-backups` and `wb db restore` to dispatch through the detected ORM instead of restricting them to Prisma.
- Implemented Drizzle Litestream list/restore scripts using the resolved absolute SQLite path from `DATABASE_URL=file:...`.
- Added focused unit coverage for Drizzle Litestream command generation.

## Why

- Drizzle projects such as `smartse-zoom-bot` need to restore Litestream backups locally for read-only data export.
- The previous implementation required `/etc/litestream.yml` and limited restore/list operations to Prisma, blocking that workflow.

## Testing

- `yarn workspace @willbooster/wb exec vitest run test/scripts/drizzleScripts.test.ts test/prisma.test.ts`
- `yarn workspace @willbooster/wb typecheck`
- `yarn verify`
- pre-push hook ran oxlint across packages.
