### PR TITLE
fix: allow explicit litestream config for restore

### DIFF
--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -124,14 +124,22 @@ const generateCommand: CommandModule<unknown, InferredOptionTypes<typeof builder
   },
 };
 
-const listBackupsCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> = {
+const litestreamConfigBuilder = {
+  ...builder,
+  config: {
+    description: 'Path of the Litestream configuration file.',
+    type: 'string',
+  },
+} as const;
+
+const listBackupsCommand: CommandModule<unknown, InferredOptionTypes<typeof litestreamConfigBuilder>> = {
   command: 'list-backups',
   describe: 'List Litestream backups',
-  builder,
+  builder: litestreamConfigBuilder,
   async handler(argv) {
     const allProjects = await findDatabaseOrmProjects(argv);
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db list-backups', allProjects)) {
-      await runWithSpawn(getDatabaseOrmScripts(orm).listBackups(project), project, argv);
+      await runWithSpawn(getDatabaseOrmScripts(orm).listBackups(project, argv.config), project, argv);
     }
   },
 };
@@ -214,7 +222,7 @@ const resetCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> 
 };
 
 const restoreBuilder = {
-  ...builder,
+  ...litestreamConfigBuilder,
   output: {
     description: 'Output path of the restored database. Defaults to "<db|drizzle|prisma>/restored.sqlite3".',
     type: 'string',
@@ -229,7 +237,7 @@ const restoreCommand: CommandModule<unknown, InferredOptionTypes<typeof restoreB
     const allProjects = await findDatabaseOrmProjects(argv);
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db restore', allProjects)) {
       const output = argv.output ?? getDefaultRestoreOutput(project, orm);
-      await runWithSpawn(getDatabaseOrmScripts(orm).restore(project, output), project, argv);
+      await runWithSpawn(getDatabaseOrmScripts(orm).restore(project, output, argv.config), project, argv);
     }
   },
 };

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -47,14 +47,14 @@ class DrizzleScripts {
       && litestream restore ${litestreamConfigOption} -o "${dbPath}" "${dbPath}" && ls -ahl "${dbPath}" && ALLOW_TO_SKIP_SEED=0 ${this.deploy(project)}`;
   }
 
-  listBackups(project: Project): string {
+  listBackups(project: Project, configPath?: string): string {
     const dbPath = getAbsoluteSqliteDbPath(project, 'list-backups');
-    return `litestream ltx ${getLitestreamConfigOption(project)} "${dbPath}"`;
+    return `litestream ltx ${getLitestreamConfigOption(project, configPath)} "${dbPath}"`;
   }
 
-  restore(project: Project, outputPath: string): string {
+  restore(project: Project, outputPath: string, configPath?: string): string {
     const dbPath = getAbsoluteSqliteDbPath(project, 'restore');
-    return `${buildRemoveSqliteDbCommandForPath(outputPath)}; litestream restore ${getLitestreamConfigOption(project)} -o "${outputPath}" "${dbPath}"`;
+    return `${buildRemoveSqliteDbCommandForPath(outputPath)}; litestream restore ${getLitestreamConfigOption(project, configPath)} -o "${outputPath}" "${dbPath}"`;
   }
 
   generate(_project: Project, additionalOptions = ''): string {
@@ -113,7 +113,9 @@ function getSqliteDbPath(project: Project): string | undefined {
   return getAbsoluteFileDatabaseUrlPath(project);
 }
 
-function getLitestreamConfigOption(project: Project): string {
+function getLitestreamConfigOption(project: Project, configPath?: string): string {
+  if (configPath) return `-config "${configPath}"`;
+
   const localConfigPath = path.join(project.dirPath, LITESTREAM_CONFIG_FILE_NAME);
   if (fs.existsSync(localConfigPath)) return `-config ./${LITESTREAM_CONFIG_FILE_NAME}`;
   if (fs.existsSync(DEFAULT_LITESTREAM_CONFIG_PATH)) return `-config ${DEFAULT_LITESTREAM_CONFIG_PATH}`;

--- a/packages/wb/src/scripts/prismaScripts.ts
+++ b/packages/wb/src/scripts/prismaScripts.ts
@@ -45,9 +45,9 @@ class PrismaScripts {
       && litestream restore ${litestreamConfigOption} -o ${dirPath}/prod.sqlite3 ${dirPath}/prod.sqlite3 && ls -ahl ${dirPath}/prod.sqlite3 && ALLOW_TO_SKIP_SEED=0 PRISMA migrate deploy`;
   }
 
-  listBackups(project: Project): string {
+  listBackups(project: Project, configPath?: string): string {
     const dirPath = getDatabaseDirPath(project);
-    return `litestream ltx ${getLitestreamConfigOption(project)} ${dirPath}/prod.sqlite3`;
+    return `litestream ltx ${getLitestreamConfigOption(project, configPath)} ${dirPath}/prod.sqlite3`;
   }
 
   migrate(project: Project, additionalOptions = ''): string {
@@ -72,9 +72,9 @@ class PrismaScripts {
     return steps.filter(Boolean).join(' && ');
   }
 
-  restore(project: Project, outputPath: string): string {
+  restore(project: Project, outputPath: string, configPath?: string): string {
     const dirPath = getDatabaseDirPath(project);
-    return `rm -Rf ${outputPath}*; litestream restore ${getLitestreamConfigOption(project)} -o ${outputPath} ${dirPath}/prod.sqlite3`;
+    return `rm -Rf ${outputPath}*; litestream restore ${getLitestreamConfigOption(project, configPath)} -o ${outputPath} ${dirPath}/prod.sqlite3`;
   }
 
   seed(project: Project, scriptPath?: string): string {
@@ -115,7 +115,9 @@ function getPrismaBaseDir(project: Project): string | undefined {
     ?.dbPath;
 }
 
-function getLitestreamConfigOption(project: Project): string {
+function getLitestreamConfigOption(project: Project, configPath?: string): string {
+  if (configPath) return `-config "${configPath}"`;
+
   const localConfigPath = path.join(project.dirPath, LITESTREAM_CONFIG_FILE_NAME);
   if (fs.existsSync(localConfigPath)) return `-config ./${LITESTREAM_CONFIG_FILE_NAME}`;
   if (fs.existsSync(DEFAULT_LITESTREAM_CONFIG_PATH)) return `-config ${DEFAULT_LITESTREAM_CONFIG_PATH}`;

--- a/packages/wb/test/scripts/drizzleScripts.test.ts
+++ b/packages/wb/test/scripts/drizzleScripts.test.ts
@@ -16,6 +16,16 @@ describe('drizzleScripts Litestream commands', () => {
     );
   });
 
+  it('lists backups with an explicit Litestream config path', () => {
+    const project = createDrizzleProject();
+
+    const command = drizzleScripts.listBackups(project, '/tmp/litestream.yml');
+
+    expect(command).toBe(
+      `litestream ltx -config "/tmp/litestream.yml" "${path.join(project.rootDirPath, 'drizzle/mount/prod.sqlite3')}"`
+    );
+  });
+
   it('restores backups to the requested output path', () => {
     const project = createDrizzleProject();
 
@@ -23,6 +33,16 @@ describe('drizzleScripts Litestream commands', () => {
 
     expect(command).toBe(
       `rm -f "/tmp/restored.sqlite3" "/tmp/restored.sqlite3-wal" "/tmp/restored.sqlite3-shm"; litestream restore -config ./litestream.yml -o "/tmp/restored.sqlite3" "${path.join(project.rootDirPath, 'drizzle/mount/prod.sqlite3')}"`
+    );
+  });
+
+  it('restores backups with an explicit Litestream config path', () => {
+    const project = createDrizzleProject();
+
+    const command = drizzleScripts.restore(project, '/tmp/restored.sqlite3', '/tmp/litestream.yml');
+
+    expect(command).toBe(
+      `rm -f "/tmp/restored.sqlite3" "/tmp/restored.sqlite3-wal" "/tmp/restored.sqlite3-shm"; litestream restore -config "/tmp/litestream.yml" -o "/tmp/restored.sqlite3" "${path.join(project.rootDirPath, 'drizzle/mount/prod.sqlite3')}"`
     );
   });
 


### PR DESCRIPTION
## Customer Summary

- Adds a way to pass a Litestream config file explicitly when listing backups or restoring a database with `wb`.
- This avoids confusion in workspace repositories where the command runs inside a package but the config is generated elsewhere.
- No app behavior changes; this only improves the `wb db` operational workflow.

## Technical Summary

- Adds `--config` to `wb db list-backups` and `wb db restore`.
- Passes the explicit config path through both Prisma and Drizzle Litestream script generation.
- Covers Drizzle command generation with tests for explicit config paths.

## Why

- In workspace repos, `wb db list-backups` and `wb db restore` execute from the database package directory, so a config generated in the root or `/tmp` is not discovered automatically.
- Explicit `--config` lets operators generate sensitive config into `/tmp` and use it without writing secrets into a package directory.

## Testing

- `yarn workspace @willbooster/wb exec vitest run test/scripts/drizzleScripts.test.ts test/prisma.test.ts`
- `yarn workspace @willbooster/wb typecheck`
- `yarn verify`
