### PR TITLE
chore: ignore Playwright MCP artifacts

### DIFF
--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -23,6 +23,7 @@ const commonContent = `
 .idea/copilot.*
 .idea/copilot/chatSessions/
 .playwright-cli/
+.playwright-mcp/
 .serena/
 .tmp/
 .wb/


### PR DESCRIPTION
## Customer Summary

- Generated `.gitignore` files now exclude Playwright MCP local artifacts.
- Developers and agents using Playwright MCP will avoid accidentally surfacing those temporary files in repository status.
- No migration or rollout steps are required.

## Technical Summary

- Added `.playwright-mcp/` to the shared `wbfy` gitignore generator content.
- The change is limited to `packages/wbfy/src/generators/gitignore.ts`.
- No runtime behavior or package dependencies were changed.

## Why

- Playwright MCP can create local working artifacts that should not be committed.
- Keeping the pattern in the generator makes future generated `.gitignore` files consistent across repositories.

## Testing

- `yarn verify`
- Pre-commit hook: `oxfmt` and `oxlint` on the changed file
- Pre-push hook: package `oxlint --quiet` checks
