### PR TITLE
fix: allow oxlint config customizations

### DIFF
--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -104,7 +104,9 @@ function getOxlintBaseConfigModule(config: PackageConfig): string {
 
 function getResolvedConfigContent(baseConfigName: string, isRootConfig: boolean): string {
   if (isRootConfig) {
-    return `const oxlintResolvedConfig = ${baseConfigName};`;
+    return `// Keep a package-local copy so repositories can add settings outside
+// managed blocks without mutating the shared imported config object.
+const oxlintResolvedConfig = { ...${baseConfigName} };`;
   }
 
   return `// Oxlint only supports type-aware options in the root config, while it


### PR DESCRIPTION
## Summary
- make generated root oxlint config use a package-local shallow copy
- document why this keeps repository-specific customizations outside managed blocks safe

## Verification
- yarn verify