### PR TITLE
fix: improve generated oxlint config cloning

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -3,7 +3,7 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Keep a package-local copy so repositories can add settings outside
 // managed blocks without mutating the shared imported config object.
-const oxlintResolvedConfig = { ...oxlintBaseConfig };
+const oxlintResolvedConfig = structuredClone(oxlintBaseConfig);
 // wbfy:end oxlint-base
 
 // wbfy:start oxlint-export

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -2,8 +2,10 @@
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Keep a package-local copy so repositories can add settings outside
-// managed blocks without mutating the shared imported config object.
-const oxlintResolvedConfig = structuredClone(oxlintBaseConfig);
+// managed blocks without mutating the shared imported config object. The plain
+// record assertion prevents TypeScript from exporting oxlint's internal helper
+// types through repository config files.
+const oxlintResolvedConfig = structuredClone(oxlintBaseConfig) as Record<string, unknown>;
 // wbfy:end oxlint-base
 
 // wbfy:start oxlint-export

--- a/packages/shared-lib-blitz-next/oxlint.config.ts
+++ b/packages/shared-lib-blitz-next/oxlint.config.ts
@@ -3,9 +3,9 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a
-// plain object copy so package typechecks do not export oxlint's private helper
+// structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = { ...oxlintBaseConfig };
+const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/shared-lib-blitz-next/oxlint.config.ts
+++ b/packages/shared-lib-blitz-next/oxlint.config.ts
@@ -5,7 +5,7 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 // still auto-discovers package-local config files in monorepos. Keep this as a
 // structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
+const oxlintResolvedConfig = structuredClone(oxlintBaseConfig) as Record<string, unknown>;
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/shared-lib-next/oxlint.config.ts
+++ b/packages/shared-lib-next/oxlint.config.ts
@@ -3,9 +3,9 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a
-// plain object copy so package typechecks do not export oxlint's private helper
+// structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = { ...oxlintBaseConfig };
+const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/shared-lib-next/oxlint.config.ts
+++ b/packages/shared-lib-next/oxlint.config.ts
@@ -5,7 +5,7 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 // still auto-discovers package-local config files in monorepos. Keep this as a
 // structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
+const oxlintResolvedConfig = structuredClone(oxlintBaseConfig) as Record<string, unknown>;
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/shared-lib-node/oxlint.config.ts
+++ b/packages/shared-lib-node/oxlint.config.ts
@@ -3,9 +3,9 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a
-// plain object copy so package typechecks do not export oxlint's private helper
+// structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = { ...oxlintBaseConfig };
+const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/shared-lib-node/oxlint.config.ts
+++ b/packages/shared-lib-node/oxlint.config.ts
@@ -5,7 +5,7 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 // still auto-discovers package-local config files in monorepos. Keep this as a
 // structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
+const oxlintResolvedConfig = structuredClone(oxlintBaseConfig) as Record<string, unknown>;
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/shared-lib-react/oxlint.config.ts
+++ b/packages/shared-lib-react/oxlint.config.ts
@@ -3,9 +3,9 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a
-// plain object copy so package typechecks do not export oxlint's private helper
+// structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = { ...oxlintBaseConfig };
+const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/shared-lib-react/oxlint.config.ts
+++ b/packages/shared-lib-react/oxlint.config.ts
@@ -5,7 +5,7 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 // still auto-discovers package-local config files in monorepos. Keep this as a
 // structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
+const oxlintResolvedConfig = structuredClone(oxlintBaseConfig) as Record<string, unknown>;
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/shared-lib/oxlint.config.ts
+++ b/packages/shared-lib/oxlint.config.ts
@@ -3,9 +3,9 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a
-// plain object copy so package typechecks do not export oxlint's private helper
+// structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = { ...oxlintBaseConfig };
+const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/shared-lib/oxlint.config.ts
+++ b/packages/shared-lib/oxlint.config.ts
@@ -5,7 +5,7 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 // still auto-discovers package-local config files in monorepos. Keep this as a
 // structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
+const oxlintResolvedConfig = structuredClone(oxlintBaseConfig) as Record<string, unknown>;
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/wb/oxlint.config.ts
+++ b/packages/wb/oxlint.config.ts
@@ -3,9 +3,9 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a
-// plain object copy so package typechecks do not export oxlint's private helper
+// structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = { ...oxlintBaseConfig };
+const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/wb/oxlint.config.ts
+++ b/packages/wb/oxlint.config.ts
@@ -5,7 +5,7 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 // still auto-discovers package-local config files in monorepos. Keep this as a
 // structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
+const oxlintResolvedConfig = structuredClone(oxlintBaseConfig) as Record<string, unknown>;
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/wbfy/oxlint.config.ts
+++ b/packages/wbfy/oxlint.config.ts
@@ -3,9 +3,9 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a
-// plain object copy so package typechecks do not export oxlint's private helper
+// structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = { ...oxlintBaseConfig };
+const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/wbfy/oxlint.config.ts
+++ b/packages/wbfy/oxlint.config.ts
@@ -5,7 +5,7 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 // still auto-discovers package-local config files in monorepos. Keep this as a
 // structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = structuredClone(oxlintBaseConfig);
+const oxlintResolvedConfig = structuredClone(oxlintBaseConfig) as Record<string, unknown>;
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base
 

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -108,13 +108,13 @@ function getResolvedConfigContent(baseConfigName: string, isRootConfig: boolean)
 // managed blocks without mutating the shared imported config object. The plain
 // record annotation prevents TypeScript from exporting oxlint's internal helper
 // types through repository config files.
-const oxlintResolvedConfig: Record<string, unknown> = { ...${baseConfigName} };`;
+const oxlintResolvedConfig: Record<string, unknown> = structuredClone(${baseConfigName});`;
   }
 
   return `// Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a
-// plain object copy so package typechecks do not export oxlint's private helper
+// structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = { ...${baseConfigName} };
+const oxlintResolvedConfig: Record<string, unknown> = structuredClone(${baseConfigName});
 delete oxlintResolvedConfig.options;`;
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -106,15 +106,15 @@ function getResolvedConfigContent(baseConfigName: string, isRootConfig: boolean)
   if (isRootConfig) {
     return `// Keep a package-local copy so repositories can add settings outside
 // managed blocks without mutating the shared imported config object. The plain
-// record annotation prevents TypeScript from exporting oxlint's internal helper
+// record assertion prevents TypeScript from exporting oxlint's internal helper
 // types through repository config files.
-const oxlintResolvedConfig: Record<string, unknown> = structuredClone(${baseConfigName});`;
+const oxlintResolvedConfig = structuredClone(${baseConfigName}) as Record<string, unknown>;`;
   }
 
   return `// Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a
 // structured clone so package typechecks do not export oxlint's private helper
 // types through the generated config variable.
-const oxlintResolvedConfig: Record<string, unknown> = structuredClone(${baseConfigName});
+const oxlintResolvedConfig = structuredClone(${baseConfigName}) as Record<string, unknown>;
 delete oxlintResolvedConfig.options;`;
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -105,8 +105,10 @@ function getOxlintBaseConfigModule(config: PackageConfig): string {
 function getResolvedConfigContent(baseConfigName: string, isRootConfig: boolean): string {
   if (isRootConfig) {
     return `// Keep a package-local copy so repositories can add settings outside
-// managed blocks without mutating the shared imported config object.
-const oxlintResolvedConfig = { ...${baseConfigName} };`;
+// managed blocks without mutating the shared imported config object. The plain
+// record annotation prevents TypeScript from exporting oxlint's internal helper
+// types through repository config files.
+const oxlintResolvedConfig: Record<string, unknown> = { ...${baseConfigName} };`;
   }
 
   return `// Oxlint only supports type-aware options in the root config, while it


### PR DESCRIPTION
## Customer Summary

- Fixes generated `oxlint.config.ts` files so repositories can pass TypeScript checks after applying `wbfy`.
- Updates generated config cloning to use `structuredClone(...)` instead of object spread, preventing generated configs from sharing nested imported config state.
- No customer-facing behavior changes are expected.

## Technical Summary

- Emits `structuredClone(baseConfig) as Record<string, unknown>` for generated root and package-local oxlint configs.
- Keeps package-local configs deleting `options` after cloning because oxlint only supports type-aware options in the root config.
- Uses the public `Record<string, unknown>` assertion to avoid exporting inferred oxlint helper types while avoiding TS2322 assignment failures.
- Updates the checked-in generated `oxlint.config.ts` files to match the generator output.

## Why

- Applying `wbfy` to downstream repositories should not leak oxlint private helper types through inferred generated config exports.
- `structuredClone(...)` avoids the shallow-copy aliasing left by `{ ...baseConfig }`.

## Testing

- `yarn typecheck`
- `yarn verify`
- `bunx @willbooster-private/agentic-workflows@latest skills review --agent all`
- `bunx @willbooster-private/agentic-workflows@latest skills check-pr-ci`
- `bunx @willbooster-private/agentic-workflows@latest skills list-pr-review-threads`
- Pre-commit cleanup hook
- Pre-push oxlint check
