### PR TITLE
fix: treat dotenv-owned shutdown signals as clean exits

### DIFF
--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -22,17 +22,25 @@ export function runDotenvCommand(args) {
     env: process.env,
     stdio: 'inherit',
   });
+  const signalHandlers = new Map();
+  let forwardedShutdownSignal;
   child.on('error', (error) => {
     console.error(error);
     process.exit(1);
   });
   for (const signal of shutdownSignals) {
-    process.once(signal, () => {
+    const signalHandler = () => {
+      forwardedShutdownSignal = signal;
       child.kill(signal);
-    });
+    };
+    signalHandlers.set(signal, signalHandler);
+    process.once(signal, signalHandler);
   }
   child.on('exit', (code, signal) => {
-    if (signal && shutdownSignals.has(signal)) {
+    for (const [shutdownSignal, signalHandler] of signalHandlers) {
+      process.off(shutdownSignal, signalHandler);
+    }
+    if (signal && signal === forwardedShutdownSignal) {
       process.exit(0);
     }
     if (signal) {

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -4,6 +4,8 @@ import path from 'node:path';
 import { config } from 'dotenv';
 import { expand } from 'dotenv-expand';
 
+const shutdownSignals = new Set(['SIGINT', 'SIGTERM', 'SIGQUIT']);
+
 export function runDotenvCommand(args) {
   const { command } = parseDotenvArgs(args);
   if (command.length === 0) {
@@ -24,7 +26,15 @@ export function runDotenvCommand(args) {
     console.error(error);
     process.exit(1);
   });
+  for (const signal of shutdownSignals) {
+    process.once(signal, () => {
+      child.kill(signal);
+    });
+  }
   child.on('exit', (code, signal) => {
+    if (signal && shutdownSignals.has(signal)) {
+      process.exit(0);
+    }
     if (signal) {
       process.kill(process.pid, signal);
       return;

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -10,6 +10,8 @@ interface ParsedDotenvArgs {
   command: string[];
 }
 
+const shutdownSignals = new Set<NodeJS.Signals>(['SIGINT', 'SIGTERM', 'SIGQUIT']);
+
 export const dotenvCommand: CommandModule = {
   command: 'dotenv [args..]',
   describe: 'Load .env files and run a command.',
@@ -42,7 +44,15 @@ async function runParsedDotenvCommand({ command }: ParsedDotenvArgs): Promise<vo
     console.error(error);
     process.exit(1);
   });
+  for (const signal of shutdownSignals) {
+    process.once(signal, () => {
+      child.kill(signal);
+    });
+  }
   child.on('exit', (code, signal) => {
+    if (signal && shutdownSignals.has(signal)) {
+      process.exit(0);
+    }
     if (signal) {
       process.kill(process.pid, signal);
       return;

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -40,17 +40,25 @@ async function runParsedDotenvCommand({ command }: ParsedDotenvArgs): Promise<vo
     env: process.env,
     stdio: 'inherit',
   });
+  const signalHandlers = new Map<NodeJS.Signals, () => void>();
+  let forwardedShutdownSignal: NodeJS.Signals | undefined;
   child.on('error', (error) => {
     console.error(error);
     process.exit(1);
   });
   for (const signal of shutdownSignals) {
-    process.once(signal, () => {
+    const signalHandler = (): void => {
+      forwardedShutdownSignal = signal;
       child.kill(signal);
-    });
+    };
+    signalHandlers.set(signal, signalHandler);
+    process.once(signal, signalHandler);
   }
   child.on('exit', (code, signal) => {
-    if (signal && shutdownSignals.has(signal)) {
+    for (const [shutdownSignal, signalHandler] of signalHandlers) {
+      process.off(shutdownSignal, signalHandler);
+    }
+    if (signal && signal === forwardedShutdownSignal) {
       process.exit(0);
     }
     if (signal) {


### PR DESCRIPTION
## Customer Summary

- Railway/serverless sleep and other normal platform shutdowns no longer make `wb dotenv` look like a crashed command.
- Services that run production processes through `wb dotenv` can shut down quietly when the platform sends SIGTERM.
- Unexpected child process terminations still surface as failures, so real crashes remain visible.

## Technical Summary

- `wb dotenv` now forwards `SIGINT`, `SIGTERM`, and `SIGQUIT` to the spawned child process.
- The wrapper exits with code 0 only when the child exits from the same shutdown signal that `wb dotenv` received and forwarded.
- Child-only signal exits keep the previous propagation behavior, and non-zero child exit codes are unchanged.
- Updated both `packages/wb/src/commands/dotenv.ts` and the published bin fast path in `packages/wb/bin/dotenv.js`.

## Why

- Railway serverless/app-sleeping stops containers by sending SIGTERM during normal inactivity shutdown.
- Previously, `wb dotenv` re-signaled itself when the child exited by SIGTERM, causing wrappers such as Bun to report the shutdown as a crash.
- Handling owned shutdown signals in `wb` fixes the behavior across services using `wb dotenv` without adding per-service shell workarounds.

## Testing

- `yarn verify`
- `yarn workspace @willbooster/wb typecheck`
- `yarn workspace @willbooster/wb lint`
- Manual parent SIGTERM check confirmed `wb dotenv` exits with `{ "code": 0, "signal": null }`.
- Manual child-only SIGTERM check confirmed `wb dotenv` exits with `{ "code": null, "signal": "SIGTERM" }`.
- `bunx @willbooster-private/agentic-workflows@1.27.0 skills review --agent all`
- `bunx @willbooster-private/agentic-workflows@1.27.0 skills check-pr-ci`
