### PR TITLE
fix: type generated oxlint and oxfmt configs

### DIFF
--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -40,18 +40,27 @@ function getConfigContent(config: PackageConfig): string {
     return `${managedConfigBlocks.getBlock(
       'base',
       `/// <reference types="node" />
+import type { OxfmtConfig } from 'oxfmt';
+
 // oxlint-disable unicorn/prefer-module -- Oxfmt config files are only auto-discovered as .ts, and CommonJS avoids ESM package loading issues.
 const oxfmtConfig = require('@willbooster/oxfmt-config');
 
-const oxfmtResolvedConfig = oxfmtConfig.default ?? oxfmtConfig;`
+const oxfmtResolvedConfig: OxfmtConfig = oxfmtConfig.default ?? oxfmtConfig;`
     )}
 
 ${managedConfigBlocks.getBlock('export', 'module.exports = oxfmtResolvedConfig;')}
 `;
   }
 
-  return `${managedConfigBlocks.getBlock('base', "import config from '@willbooster/oxfmt-config';")}
+  return `${managedConfigBlocks.getBlock(
+    'base',
+    `import type { OxfmtConfig } from 'oxfmt';
 
-${managedConfigBlocks.getBlock('export', 'export default config;')}
+import config from '@willbooster/oxfmt-config';
+
+const oxfmtResolvedConfig: OxfmtConfig = config;`
+  )}
+
+${managedConfigBlocks.getBlock('export', 'export default oxfmtResolvedConfig;')}
 `;
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -77,6 +77,8 @@ function getConfigContent(config: PackageConfig): string {
     return `${managedConfigBlocks.getBlock(
       'base',
       `/// <reference types="node" />
+import type { OxlintConfig } from 'oxlint';
+
 // oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids ESM package loading issues.
 const oxlintBaseConfig = require('@willbooster/oxlint-config');
 
@@ -89,7 +91,9 @@ ${managedConfigBlocks.getBlock('export', 'module.exports = oxlintResolvedConfig;
 
   return `${managedConfigBlocks.getBlock(
     'base',
-    `import oxlintBaseConfig from '${oxlintBaseConfigModule}';
+    `import type { OxlintConfig } from 'oxlint';
+
+import oxlintBaseConfig from '${oxlintBaseConfigModule}';
 
 ${getResolvedConfigContent('oxlintBaseConfig', isRootConfig)}`
   )}
@@ -105,16 +109,14 @@ function getOxlintBaseConfigModule(config: PackageConfig): string {
 function getResolvedConfigContent(baseConfigName: string, isRootConfig: boolean): string {
   if (isRootConfig) {
     return `// Keep a package-local copy so repositories can add settings outside
-// managed blocks without mutating the shared imported config object. The plain
-// record assertion prevents TypeScript from exporting oxlint's internal helper
-// types through repository config files.
-const oxlintResolvedConfig = structuredClone(${baseConfigName}) as Record<string, unknown>;`;
+// managed blocks without mutating the shared imported config object.
+const oxlintResolvedConfig: OxlintConfig = structuredClone(${baseConfigName});`;
   }
 
   return `// Oxlint only supports type-aware options in the root config, while it
 // still auto-discovers package-local config files in monorepos. Keep this as a
-// structured clone so package typechecks do not export oxlint's private helper
-// types through the generated config variable.
-const oxlintResolvedConfig = structuredClone(${baseConfigName}) as Record<string, unknown>;
+// structured clone so packages can delete root-only settings without mutating
+// the shared imported config object.
+const oxlintResolvedConfig: OxlintConfig = structuredClone(${baseConfigName});
 delete oxlintResolvedConfig.options;`;
 }


### PR DESCRIPTION
## Customer Summary

- Improves generated formatter and linter config files so they use the real tool setting types.
- Keeps repositories able to extend generated oxlint settings without TypeScript errors.
- No repository migration is required beyond rerunning wbfy.

## Technical Summary

- Generates `import type { OxlintConfig } from 'oxlint'` and annotates cloned oxlint config as `OxlintConfig`.
- Generates `import type { OxfmtConfig } from 'oxfmt'` and annotates resolved oxfmt config as `OxfmtConfig`.
- Removes the generic `Record<string, unknown>` assertion from generated oxlint config output.
- Preserves CommonJS-compatible `require(...)` for non-ESM package config files while using type-only imports for settings types.

## Why

- `Record<string, unknown>` is not an accurate type for oxlint or oxfmt settings and makes normal config extension awkward.
- The tool packages already expose `OxlintConfig` and `OxfmtConfig`, so generated config should rely on those public types.

## Testing

- `yarn verify`
- Generated wbfy output against a disposable `exKAZUu/yutsugi` worktree from `origin/main`
- `bun verify` in that disposable `yutsugi` worktree
- Pre-commit cleanup hook on changed generator files
- Pre-push hook: shared package oxlint checks
