### PR TITLE
fix: preserve runtime playwright dependency

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -87,6 +87,8 @@ const obsoleteLintDependencies = [
 const micromatchPackageNames = new Set(['micromatch', '@types/micromatch']);
 const micromatchImportPattern =
   /\bfrom\s+['"]micromatch['"]|\brequire\(\s*['"]micromatch['"]\s*\)|\bimport\(\s*['"]micromatch['"]\s*\)/u;
+const playwrightImportPattern =
+  /\bfrom\s+['"]playwright['"]|\brequire\(\s*['"]playwright['"]\s*\)|\bimport\(\s*['"]playwright['"]\s*\)/u;
 
 const latestDependencyVersionCache = new Map<string, string>();
 const npmPackageTimesCache = new Map<string, Record<string, string>>();
@@ -264,7 +266,13 @@ async function applyPackageJsonConventions(
       if (!hasArtillery && !jsonObj.dependencies['@playwright/test']) {
         devDependencies.push('@playwright/test');
       }
-      delete jsonObj.dependencies.playwright;
+      if (doesContainPlaywrightRuntimeImport(config.dirPath)) {
+        // Runtime source imports need the browser automation package in production builds;
+        // @playwright/test only satisfies test/config imports.
+        if (!jsonObj.dependencies.playwright) dependencies.push('playwright');
+      } else {
+        delete jsonObj.dependencies.playwright;
+      }
       delete jsonObj.devDependencies.playwright;
     }
 
@@ -1009,6 +1017,21 @@ function doesProductCodeImportMicromatch(dirPath: string): boolean {
   return filePaths.some((filePath) => {
     try {
       return micromatchImportPattern.test(fs.readFileSync(path.resolve(dirPath, filePath), 'utf8'));
+    } catch {
+      return false;
+    }
+  });
+}
+
+function doesContainPlaywrightRuntimeImport(dirPath: string): boolean {
+  const filePaths = fg.globSync('{app,src}/**/*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}', {
+    cwd: dirPath,
+    dot: true,
+    ignore: globIgnore,
+  });
+  return filePaths.some((filePath) => {
+    try {
+      return playwrightImportPattern.test(fs.readFileSync(path.resolve(dirPath, filePath), 'utf8'));
     } catch {
       return false;
     }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -268,8 +268,14 @@ async function applyPackageJsonConventions(
       }
       if (doesContainPlaywrightRuntimeImport(config.dirPath)) {
         // Runtime source imports need the browser automation package in production builds;
-        // @playwright/test only satisfies test/config imports.
-        if (!jsonObj.dependencies.playwright) dependencies.push('playwright');
+        // @playwright/test only satisfies test/config imports. Keep the versions aligned
+        // because Playwright rejects mixed test/runtime package copies during test collection.
+        const playwrightVersion = getAlignedPlaywrightVersion(jsonObj);
+        if (playwrightVersion) {
+          jsonObj.dependencies.playwright = playwrightVersion;
+        } else if (!jsonObj.dependencies.playwright) {
+          dependencies.push('playwright');
+        }
       } else {
         delete jsonObj.dependencies.playwright;
       }
@@ -1036,6 +1042,10 @@ function doesContainPlaywrightRuntimeImport(dirPath: string): boolean {
       return false;
     }
   });
+}
+
+function getAlignedPlaywrightVersion(jsonObj: WritablePackageJson): string | undefined {
+  return jsonObj.dependencies['@playwright/test'] ?? jsonObj.devDependencies['@playwright/test'];
 }
 
 function shouldUpdateExistingManagedDependency(


### PR DESCRIPTION
## Customer Summary

- Prevents `wbfy` from removing Playwright when application code imports it at runtime.
- Keeps generated repositories buildable and avoids Playwright test/runtime version conflicts.

## Technical Summary

- Detects `playwright` imports in `app` and `src` source files.
- Preserves or adds `playwright` under runtime `dependencies` when those imports exist.
- Aligns runtime `playwright` with the existing `@playwright/test` version when available.
- Continues removing standalone `playwright` when only Playwright test tooling is present.

## Why

- `@playwright/test` covers test/config usage, but production builds still need the `playwright` package when app source imports it directly.
- Mixed `playwright` and `@playwright/test` versions can create duplicate Playwright copies and break test collection.

## Testing

- `yarn verify`
- pre-push `oxlint` hook
