### PR TITLE
fix: preserve runtime playwright dependency

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -267,6 +267,7 @@ async function applyPackageJsonConventions(
       if (config.depending.playwrightRuntime) {
         // Runtime imports need the standalone package after Docker pruning removes devDependencies.
         jsonObj.dependencies.playwright ??= jsonObj.devDependencies.playwright;
+        dependencies.push('playwright');
         delete jsonObj.devDependencies.playwright;
       } else {
         delete jsonObj.dependencies.playwright;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -264,8 +264,14 @@ async function applyPackageJsonConventions(
       if (!hasArtillery && !jsonObj.dependencies['@playwright/test']) {
         devDependencies.push('@playwright/test');
       }
-      delete jsonObj.dependencies.playwright;
-      delete jsonObj.devDependencies.playwright;
+      if (config.depending.playwrightRuntime) {
+        // Runtime imports need the standalone package after Docker pruning removes devDependencies.
+        jsonObj.dependencies.playwright ??= jsonObj.devDependencies.playwright;
+        delete jsonObj.devDependencies.playwright;
+      } else {
+        delete jsonObj.dependencies.playwright;
+        delete jsonObj.devDependencies.playwright;
+      }
     }
 
     if (config.doesContainSubPackageJsons) {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -266,7 +266,10 @@ async function applyPackageJsonConventions(
       }
       if (config.depending.playwrightRuntime) {
         // Runtime imports need the standalone package after Docker pruning removes devDependencies.
-        jsonObj.dependencies.playwright ??= jsonObj.devDependencies.playwright;
+        jsonObj.dependencies.playwright ??=
+          jsonObj.devDependencies.playwright ??
+          jsonObj.dependencies['@playwright/test'] ??
+          jsonObj.devDependencies['@playwright/test'];
         dependencies.push('playwright');
         delete jsonObj.devDependencies.playwright;
       } else {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -54,6 +54,7 @@ export interface PackageConfig {
     litestream: boolean;
     next: boolean;
     playwrightTest: boolean;
+    playwrightRuntime: boolean;
     prisma: boolean;
     pyright: boolean;
     react: boolean;
@@ -214,6 +215,7 @@ export async function getPackageConfig(
         next: !!dependencies.next,
         playwrightTest:
           !!dependencies['@playwright/test'] || !!devDependencies['@playwright/test'] || !!devDependencies.playwright,
+        playwrightRuntime: doesImportPlaywrightAtRuntime(dirPath),
         prisma: !!dependencies['@prisma/client'] || !!devDependencies.prisma,
         pyright: !!devDependencies.pyright,
         reactNative: !!dependencies['react-native'],
@@ -319,6 +321,20 @@ function readMiseTaskCommand(value: unknown): string {
 
 function containsAny(pattern: string, dirPath: string): boolean {
   return fg.globSync(pattern, { dot: true, cwd: dirPath, ignore: globIgnore }).length > 0;
+}
+
+function doesImportPlaywrightAtRuntime(dirPath: string): boolean {
+  const files = fg.globSync('{app,src}/**/*.{cjs,cts,js,jsx,mjs,mts,ts,tsx}', {
+    dot: true,
+    cwd: dirPath,
+    ignore: [...globIgnore, '**/__tests__/**', '**/*.spec.*', '**/*.test.*', '**/playwright.config.*'],
+  });
+  return files.some((file) => {
+    const content = fs.readFileSync(path.resolve(dirPath, file), 'utf8');
+    return /\bfrom\s+['"]playwright['"]|\bimport\s*\(\s*['"]playwright['"]\s*\)|\brequire\s*\(\s*['"]playwright['"]\s*\)/u.test(
+      content
+    );
+  });
 }
 
 async function fetchRepoInfo(dirPath: string, packageJson: PackageJson): Promise<Record<string, unknown> | undefined> {

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -40,6 +40,7 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
       genI18nTs: false,
       litestream: false,
       next: false,
+      playwrightRuntime: false,
       playwrightTest: false,
       prisma: false,
       pyright: false,


### PR DESCRIPTION
## Customer Summary

- Keeps `wbfy` from removing Playwright when an application uses it at runtime.
- Prevents Docker builds from failing after applying shared package automation to apps with server-side Playwright usage.
- No migration steps are required.

## Technical Summary

- Adds runtime Playwright import detection for non-test `app` and `src` files.
- Preserves `playwright` in `dependencies` when runtime imports exist, while continuing to remove it for Playwright-test-only projects.
- Updates the package config fixture with the new dependency flag.

## Why

- `@playwright/test` does not replace the runtime `playwright` package for server code imports.
- Docker images prune dev dependencies, so runtime imports must remain in `dependencies`.

## Testing

- `yarn verify`
- pre-commit cleanup hook
- pre-push oxlint hook
