### PR TITLE
fix: use bun runner for python setup scripts

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -470,7 +470,8 @@ async function normalizePackageMetadata(
       if (jsonObj.scripts.postinstall === 'poetry install') {
         delete jsonObj.scripts.postinstall;
       }
-      jsonObj.scripts['common/ci-setup'] = `yarn setup-${pythonPackageManager}`;
+      const scriptRunner = config.isBun ? 'bun run' : 'yarn';
+      jsonObj.scripts['common/ci-setup'] = `${scriptRunner} setup-${pythonPackageManager}`;
       delete jsonObj.scripts[`setup-${pythonPackageManager === 'poetry' ? 'uv' : 'poetry'}`];
       delete jsonObj.scripts['setup-poetry-asdf'];
       jsonObj.scripts[`setup-${pythonPackageManager}`] = getPythonSetupCommand(pythonPackageManager);
@@ -495,7 +496,7 @@ async function normalizePackageMetadata(
           jsonObj.scripts.lint = `${pythonRunner} flake8 ${dirNamesStr} && ${jsonObj.scripts.lint}`;
         } else {
           jsonObj.scripts.lint = `${pythonRunner} flake8 ${dirNamesStr}`;
-          jsonObj.scripts['lint-fix'] = 'yarn lint';
+          jsonObj.scripts['lint-fix'] = `${scriptRunner} lint`;
         }
         jsonObj.scripts.format = appendFormatCodeCommand(jsonObj.scripts.format, config);
         dependencyUpdates.pythonDevDependencies.push('black', 'isort', 'flake8');

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -202,9 +202,11 @@ test('uses bun runner for generated Python scripts in bun projects', async () =>
 
   expect(packageJson.scripts).toMatchObject({
     'common/ci-setup': 'bun run setup-uv',
+    'lint-fix': 'bun --bun wb lint --fix',
     'setup-uv': 'uv sync --frozen',
   });
   expect(packageJson.scripts?.['common/ci-setup']).not.toContain('yarn');
+  expect(packageJson.scripts?.['lint-fix']).not.toContain('yarn');
 });
 
 async function generatePackageJsonFrom(

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -193,10 +193,24 @@ test('keeps custom database scripts for drizzle projects', async () => {
   });
 });
 
+test('uses bun runner for generated Python scripts in bun projects', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    { scripts: {} },
+    { doesContainUvLock: true, isBun: true },
+    { files: { 'src/example.py': '', 'test/unit/test_example.py': '' } }
+  );
+
+  expect(packageJson.scripts).toMatchObject({
+    'common/ci-setup': 'bun run setup-uv',
+    'setup-uv': 'uv sync --frozen',
+  });
+  expect(packageJson.scripts?.['common/ci-setup']).not.toContain('yarn');
+});
+
 async function generatePackageJsonFrom(
   initialPackageJson: Record<string, unknown>,
   configOverrides: Parameters<typeof createConfig>[0] = {},
-  options: { createI18nDir?: boolean } = {}
+  options: { createI18nDir?: boolean; files?: Record<string, string> } = {}
 ): Promise<GeneratedPackageJson> {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
   const packageJsonPath = path.join(dirPath, 'package.json');
@@ -204,6 +218,11 @@ async function generatePackageJsonFrom(
   try {
     if (options.createI18nDir) {
       await fs.mkdir(path.join(dirPath, 'i18n'));
+    }
+    for (const [relativePath, content] of Object.entries(options.files ?? {})) {
+      const filePath = path.join(dirPath, relativePath);
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, content);
     }
     await fs.writeFile(packageJsonPath, JSON.stringify(initialPackageJson));
 


### PR DESCRIPTION
## Customer Summary

- Bunを使うPython/uvプロジェクトに`wbfy`を適用したとき、CIセットアップがYarn経由にならないようにしました。
- Bunプロジェクトでは`common/ci-setup`が`bun run setup-uv`として生成されます。

## Technical Summary

- `packages/wbfy/src/generators/packageJson.ts`でPython setup scriptのrunnerを`config.isBun`に応じて切り替えるようにしました。
- 同じPython script生成ブロック内の`lint-fix`も、Yarn固定ではなく同じrunnerを使うようにしました。
- Bun + uv構成のpackage.json生成テストを追加しました。

## Why

- Bunプロジェクトで`common/ci-setup`だけ`yarn setup-uv`になり、生成結果にpackage managerの不整合が出ていたためです。

## Testing

- `yarn workspace @willbooster/wbfy vitest test/packageJson.test.ts`
- `yarn workspace @willbooster/wbfy format-code`
- `yarn workspace @willbooster/wbfy lint`
- `yarn workspace @willbooster/wbfy typecheck`
- `yarn workspace @willbooster/wbfy verify`
