### PR TITLE
fix: run drizzle db seed by default

### DIFF
--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -68,6 +68,10 @@ class DrizzleScripts {
   seed(project: Project, scriptPath?: string): string {
     if (scriptPath) return `BUN build-ts run ${scriptPath}`;
     if (project.packageJson.scripts?.seed) return 'YARN run seed';
+    const defaultSeedPath = path.join('db', 'seed.ts');
+    if (fs.existsSync(path.join(project.dirPath, defaultSeedPath))) {
+      return project.usesBunPackageManager ? `BUN ${defaultSeedPath}` : `BUN build-ts run ${defaultSeedPath}`;
+    }
     return 'true';
   }
 


### PR DESCRIPTION
## Summary

- Makes `wb db seed` run `db/seed.ts` automatically for Drizzle projects when no `scripts.seed` is defined.
- Keeps existing precedence for `--file` and package `scripts.seed`.
- Uses direct Bun execution for Bun projects and the existing `build-ts` path for non-Bun projects.

## Verification

- `yarn verify`
- `yarn workspace @willbooster/wb typecheck`
