### PR TITLE
chore: apply wbfy

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260504.1",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "13.22.18",
+    "@willbooster/wb": "13.22.19",
     "conventional-changelog-conventionalcommits": "9.3.1",
     "lefthook": "2.1.9",
     "oxfmt": "0.57.0",

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -49,7 +49,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260504.1",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "13.22.18",
+    "@willbooster/wb": "13.22.19",
     "blitz": "3.0.2",
     "build-ts": "17.1.30",
     "oxfmt": "0.57.0",

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -49,7 +49,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260504.1",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "13.22.18",
+    "@willbooster/wb": "13.22.19",
     "build-ts": "17.1.30",
     "next": "16.2.6",
     "oxfmt": "0.57.0",

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -54,7 +54,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260504.1",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "13.22.18",
+    "@willbooster/wb": "13.22.19",
     "build-ts": "17.1.30",
     "oxfmt": "0.57.0",
     "oxlint": "1.72.0",

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -58,7 +58,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260504.1",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "13.22.18",
+    "@willbooster/wb": "13.22.19",
     "babel-loader": "10.1.1",
     "build-ts": "17.1.30",
     "oxfmt": "0.57.0",

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -49,7 +49,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260504.1",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "13.22.18",
+    "@willbooster/wb": "13.22.19",
     "build-ts": "17.1.30",
     "oxfmt": "0.57.0",
     "oxlint": "1.72.0",

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -58,7 +58,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260504.1",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "13.22.18",
+    "@willbooster/wb": "13.22.19",
     "@yarnpkg/core": "4.7.0",
     "build-ts": "17.1.30",
     "lefthook": "2.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7345,7 +7345,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260504.1"
     "@willbooster/oxfmt-config": "npm:1.2.2"
     "@willbooster/oxlint-config": "npm:1.4.8"
-    "@willbooster/wb": "npm:13.22.18"
+    "@willbooster/wb": "npm:13.22.19"
     blitz: "npm:3.0.2"
     build-ts: "npm:17.1.30"
     oxfmt: "npm:0.57.0"
@@ -7366,7 +7366,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260504.1"
     "@willbooster/oxfmt-config": "npm:1.2.2"
     "@willbooster/oxlint-config": "npm:1.4.8"
-    "@willbooster/wb": "npm:13.22.18"
+    "@willbooster/wb": "npm:13.22.19"
     build-ts: "npm:17.1.30"
     next: "npm:16.2.6"
     oxfmt: "npm:0.57.0"
@@ -7400,7 +7400,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260504.1"
     "@willbooster/oxfmt-config": "npm:1.2.2"
     "@willbooster/oxlint-config": "npm:1.4.8"
-    "@willbooster/wb": "npm:13.22.18"
+    "@willbooster/wb": "npm:13.22.19"
     build-ts: "npm:17.1.30"
     dotenv: "npm:17.4.2"
     dotenv-expand: "npm:13.0.0"
@@ -7434,7 +7434,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260504.1"
     "@willbooster/oxfmt-config": "npm:1.2.2"
     "@willbooster/oxlint-config": "npm:1.4.8"
-    "@willbooster/wb": "npm:13.22.18"
+    "@willbooster/wb": "npm:13.22.19"
     babel-loader: "npm:10.1.1"
     build-ts: "npm:17.1.30"
     oxfmt: "npm:0.57.0"
@@ -7460,7 +7460,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260504.1"
     "@willbooster/oxfmt-config": "npm:1.2.2"
     "@willbooster/oxlint-config": "npm:1.4.8"
-    "@willbooster/wb": "npm:13.22.18"
+    "@willbooster/wb": "npm:13.22.19"
     build-ts: "npm:17.1.30"
     oxfmt: "npm:0.57.0"
     oxlint: "npm:1.72.0"
@@ -7470,9 +7470,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@willbooster/wb@npm:13.22.18":
-  version: 13.22.18
-  resolution: "@willbooster/wb@npm:13.22.18"
+"@willbooster/wb@npm:13.22.19":
+  version: 13.22.19
+  resolution: "@willbooster/wb@npm:13.22.19"
   dependencies:
     chalk: "npm:5.6.2"
     dotenv: "npm:17.4.2"
@@ -7484,7 +7484,7 @@ __metadata:
     yargs: "npm:18.0.0"
   bin:
     wb: bin/index.js
-  checksum: 10c0/feab9be4efcc6dedd2518cdcb87aa471854b54dab9d6a3a937c5e9e543d9b42e39e2105194f78b04299a5a8ec74b0c5a55f19841549b642d6886608d495ae4bd
+  checksum: 10c0/d70d535237e653fa38fed4a79ac40347a3c4f29fb8c827e157060959ba6bb828917b40d16ade2ad14c6fad353bd24ede4ed8d21bfaa70f0d175d835a6a150202
   languageName: node
   linkType: hard
 
@@ -7541,7 +7541,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260504.1"
     "@willbooster/oxfmt-config": "npm:1.2.2"
     "@willbooster/oxlint-config": "npm:1.4.8"
-    "@willbooster/wb": "npm:13.22.18"
+    "@willbooster/wb": "npm:13.22.19"
     "@yarnpkg/core": "npm:4.7.0"
     build-ts: "npm:17.1.30"
     deepmerge: "npm:4.3.1"
@@ -21420,7 +21420,7 @@ __metadata:
     "@typescript/native-preview": "npm:7.0.0-dev.20260504.1"
     "@willbooster/oxfmt-config": "npm:1.2.2"
     "@willbooster/oxlint-config": "npm:1.4.8"
-    "@willbooster/wb": "npm:13.22.18"
+    "@willbooster/wb": "npm:13.22.19"
     conventional-changelog-conventionalcommits: "npm:9.3.1"
     lefthook: "npm:2.1.9"
     oxfmt: "npm:0.57.0"


### PR DESCRIPTION
## Customer Summary

- No user-visible or behavior changes.

## Technical Summary

- Ran `wbfy` (this repo's own conventional-configuration tool) against itself, bumping `@willbooster/wb` from `13.22.18` to `13.22.19` across `package.json` files in the root and the `shared-lib`, `shared-lib-blitz-next`, `shared-lib-next`, `shared-lib-node`, `shared-lib-react`, and `wbfy` packages, and updating `yarn.lock` accordingly.

## Why

- Keep the repo's own tooling configuration in sync with the latest `wbfy` conventions, following the standard wbfy application workflow.

## Testing

- `yarn verify` (passed)
