### PR TITLE
fix: replace stale Prisma example in wbfy-generated agent docs

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -25,7 +25,7 @@ alwaysApply: true
   - Fix the actual root cause instead of applying workarounds.
 - After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
   - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., Prisma requires `null`).
+  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
 - Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Cursor) <agent@willbooster.com>`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
   - Fix the actual root cause instead of applying workarounds.
 - After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
   - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., Prisma requires `null`).
+  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
 - Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Codex CLI) <agent@willbooster.com>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
   - Fix the actual root cause instead of applying workarounds.
 - After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
   - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., Prisma requires `null`).
+  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
 - Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -19,7 +19,7 @@
   - Fix the actual root cause instead of applying workarounds.
 - After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
   - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., Prisma requires `null`).
+  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
 - Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
   - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
   - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Gemini CLI) <agent@willbooster.com>`.

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -76,7 +76,7 @@ function generateAgentInstruction(
   - Fix the actual root cause instead of applying workarounds.
 - After making code changes, run \`${packageManager} verify-full\` to execute all tests (takes up to 1 hour), or \`${packageManager} verify\` for only type checking and linting (takes up to 10 minutes).
   - If you are confident that your changes will not break any tests, you may use \`verify\`.
-  - Use \`oxlint\` ignore comments with reasons (e.g., \`// oxlint-disable-next-line <rule> -- <reason>\`) if lint errors or warnings cannot be fixed (e.g., Prisma requires \`null\`).
+  - Use \`oxlint\` ignore comments with reasons (e.g., \`// oxlint-disable-next-line <rule> -- <reason>\`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires \`null\`).
 - Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via \`gh\`.
   - Follow the conventional commits; your commit message should start with \`feat:\`, \`fix:\`, etc.
   - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.


### PR DESCRIPTION
## Customer Summary

- No user-visible or behavior changes to any application; this only affects the wording of an example inside the `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`/`.cursor/rules/general.mdc` files that `wbfy` generates for every repository.

## Technical Summary

- `packages/wbfy/src/generators/agents.ts` hardcoded "Prisma requires `null`" as the example reason for an `oxlint` ignore comment. Prisma is no longer used across our repos (many have migrated to Drizzle), so this example was stale and confusing.
- Replaced it with a generic "a third-party API requires `null`" example.
- Re-ran `wbfy` against this repo itself to regenerate `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `.cursor/rules/general.mdc` with the updated wording.

## Why

- Found while cleaning up a stale Prisma reference in `llm-proxy`'s generated docs; traced it back to this hardcoded example in the `wbfy` generator so future `wbfy` runs across all repos produce the corrected wording instead of needing manual fixes downstream.

## Testing

- `yarn verify` (passed)
