### PR TITLE
feat(wb): run cargo fmt for Rust projects in lint --format

### DIFF
--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -129,8 +129,14 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
   const oxfmtFilePathsByProject = new Map<Project, string[]>();
   const pythonFilePathsByProject = new Map<Project, string[]>();
   const dartFilePathsByProject = new Map<Project, string[]>();
-  // `cargo fmt --all` always formats the whole workspace, so only the target
-  // projects are tracked, not individual file paths.
+  // `cargo fmt --all` always formats the whole workspace, so we track target
+  // projects rather than individual file paths. Every project with its own
+  // `Cargo.toml` runs its own `cargo fmt --all`; we intentionally do not dedup
+  // by directory. A nested or sibling crate can be an independent Cargo
+  // workspace that a parent's `cargo fmt --all` never reaches, so skipping it
+  // would leave it unformatted, while any genuinely overlapping runs are
+  // harmless because rustfmt is deterministic and idempotent. Deduping by real
+  // workspace membership would require invoking `cargo locate-project`.
   const cargoFormatProjects = new Set<Project>();
   const prettierFilePaths: string[] = [];
   const packageJsonFilePaths: string[] = [];

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -50,6 +50,7 @@ export type LintCommandArgv = ArgumentsCamelCase<LintCommandOptions> & {
 const oxlintExtensions = new Set(['astro', 'cjs', 'cts', 'js', 'jsx', 'mjs', 'mts', 'svelte', 'ts', 'tsx', 'vue']);
 const pythonExtensions = new Set(['py']);
 const dartExtensions = new Set(['dart']);
+const rustExtensions = new Set(['rs']);
 const oxfmtExtensions = new Set([
   ...oxlintExtensions,
   'css',
@@ -128,6 +129,9 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
   const oxfmtFilePathsByProject = new Map<Project, string[]>();
   const pythonFilePathsByProject = new Map<Project, string[]>();
   const dartFilePathsByProject = new Map<Project, string[]>();
+  // `cargo fmt --all` always formats the whole workspace, so only the target
+  // projects are tracked, not individual file paths.
+  const cargoFormatProjects = new Set<Project>();
   const prettierFilePaths: string[] = [];
   const packageJsonFilePaths: string[] = [];
   let missingLintToolForExplicitFiles = false;
@@ -169,6 +173,10 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
           const dartFilePaths = dartFilePathsByProject.get(project) ?? [];
           dartFilePaths.push(lintPath);
           dartFilePathsByProject.set(project, dartFilePaths);
+          if (fileKind !== 'directory') continue;
+        }
+        if (project.hasCargoToml && (fileKind === 'directory' || rustExtensions.has(extension))) {
+          cargoFormatProjects.add(project);
           if (fileKind !== 'directory') continue;
         }
         if (fileKind === 'directory' || supportsLintingExtension(project, extension)) {
@@ -245,6 +253,9 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
       }
     }
     if (shouldRunFormatters) {
+      for (const project of cargoFormatProjects) {
+        formatterCommands.push({ command: buildCargoFormatCommand(), project });
+      }
       for (const [project, oxfmtFilePaths] of oxfmtFilePathsByProject) {
         formatterCommands.push({ command: buildOxfmtCommand(oxfmtFilePaths), project });
       }
@@ -263,6 +274,7 @@ export async function lint(argv: LintCommandArgv): Promise<number> {
         if (project.hasOxfmt) formatterCommands.push({ command: buildOxfmtCommand(), project });
         if (project.hasPoetryLock) formatterCommands.push({ command: buildPoetryFormatCommand(), project });
         if (project.hasPubspecYaml) formatterCommands.push({ command: buildDartFormatCommand(), project });
+        if (project.hasCargoToml) formatterCommands.push({ command: buildCargoFormatCommand(), project });
       }
     }
   }
@@ -438,6 +450,13 @@ export function buildPoetryFormatCommand(files?: string[]): string {
 export function buildPoetryLintCommand(argv: Partial<Pick<LintCommandOptions, 'quiet'>>, files?: string[]): string {
   const targets = files && files.length > 0 ? files : ['.'];
   return buildShellCommand(['poetry', 'run', 'flake8', ...(argv.quiet ? ['-q'] : []), ...targets]);
+}
+
+export function buildCargoFormatCommand(): string {
+  // Formatting must go through cargo (not rustfmt on individual files) so each
+  // crate's edition and rustfmt configuration are respected; `--all` covers
+  // every workspace member and is a no-op suffix for single-crate projects.
+  return buildShellCommand(['cargo', 'fmt', '--all']);
 }
 
 export function buildDartFormatCommand(files?: string[]): string {

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -183,6 +183,15 @@ export class Project {
   }
 
   @memoizeOne
+  get hasCargoToml(): boolean {
+    // Only the project's own directory is checked because `cargo fmt --all`
+    // covers the whole workspace; matching the root directory too would make
+    // every descendant project run the same workspace-wide command in
+    // parallel.
+    return fs.existsSync(path.join(this.dirPath, 'Cargo.toml'));
+  }
+
+  @memoizeOne
   get preferredLinter(): 'oxlint' | undefined {
     if (this.hasOxlint) return 'oxlint';
     return;


### PR DESCRIPTION
## Customer Summary

- `wb lint --format` (and therefore the cleanup step of `wb verify` / `wb verify --full`) now formats Rust code with `cargo fmt --all` in projects that have a `Cargo.toml`.
- Repositories mixing Rust and JS (e.g. exKAZUu/Fortnexa) no longer fail CI's `cargo fmt --check` on formatting drift that `wb verify` silently ignored.

## Technical Summary

- `Project.hasCargoToml` detects a `Cargo.toml` in the project's own directory only — `cargo fmt --all` covers the whole workspace, so matching the root directory too would make every descendant project run the same workspace-wide command in parallel.
- `lint.ts` adds `buildCargoFormatCommand()` (`cargo fmt --all`) to the formatter commands, both for whole-project runs and when explicit `.rs` files or directories are passed (formatting goes through cargo so each crate's edition and rustfmt config are respected).
- Each project with its own `Cargo.toml` runs its own `cargo fmt --all`; runs are intentionally not deduped by directory. A nested or sibling crate can be an independent Cargo workspace that a parent's `cargo fmt --all` never reaches, so skipping it would leave it unformatted, while any genuinely overlapping runs are harmless because rustfmt is deterministic and idempotent. A comment above `cargoFormatProjects` documents this.

## Why

- Rust projects previously received no formatting from `wb lint --format`, so `wb verify` reported success while CI's `cargo fmt --all -- --check` step failed (observed on Fortnexa PR exKAZUu/Fortnexa#22).
- Mirrors the existing Poetry (Python) and Dart integrations.

## Testing

- `yarn typecheck` and `CI=1 yarn vitest run test/lint.test.ts test/project.test.ts` in `packages/wb` — pass.
- End-to-end: appended a deliberately misformatted function to a Rust file in Fortnexa, ran the locally built `wb lint --fix --format` there, and confirmed `cargo fmt --all` ran and normalized the code; non-Rust behavior (oxfmt, sort-package-json) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
