### PR TITLE
fix: make generated oxlint config tolerate stale exports

### DIFF
--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -93,7 +93,11 @@ ${managedConfigBlocks.getBlock('export', 'module.exports = oxlintResolvedConfig;
     'base',
     `import type { OxlintConfig } from 'oxlint';
 
-import oxlintBaseConfig from '${oxlintBaseConfigModule}';
+// Import the module namespace so stale installs with older package export
+// metadata still expose the typed config through the actual default export.
+import * as oxlintBaseConfigModule from '${oxlintBaseConfigModule}';
+
+const oxlintBaseConfig = (oxlintBaseConfigModule as { default: OxlintConfig }).default;
 
 ${getResolvedConfigContent('oxlintBaseConfig', isRootConfig)}`
   )}


### PR DESCRIPTION
## Customer Summary

- Fixes wbfy-generated Oxlint config so Bun projects can lint even when local installs still contain older `@willbooster/oxlint-config` export metadata.
- No migration steps are needed; future wbfy runs will generate the safer import shape automatically.

## Technical Summary

- Updated `packages/wbfy/src/generators/oxlintConfig.ts` to generate an ESM namespace import for `@willbooster/oxlint-config`.
- The generated config now extracts the typed `default` export through a local `{ default: OxlintConfig }` shape before cloning it.
- CommonJS package generation is unchanged.

## Why

- `bun lint` in `moti-ai` failed because `oxlint.config.ts` cloned the imported module value as `OxlintConfig`, but a stale local `node_modules` had `@willbooster/oxlint-config@1.4.4` while the lockfile required `1.4.8`.
- With that stale package export metadata, TypeScript interpreted the import as the module object rather than the config object, producing TS2559.
- A fresh `bun install` fixed the immediate local state, but wbfy should generate config that is robust to that stale export metadata.

## Testing

- `bun lint` in `/Users/exkazuu/ghq/github.com/WillBooster/moti-ai` reproduced the TS2559 failure before `bun install`.
- `bun install` then `bun lint` in `/Users/exkazuu/ghq/github.com/WillBooster/moti-ai` passed, confirming the stale install root cause.
- Temporary Bun repro with `@willbooster/oxlint-config@1.4.4` passed `bunx oxlint --no-error-on-unmatched-pattern .` using the new generated import shape.
- `yarn workspace @willbooster/wbfy lint`
- `yarn workspace @willbooster/wbfy typecheck`
- `yarn verify`
- Pre-push hook: workspace oxlint check passed.
