### PR TITLE
chore(wbfy): gitignore local Claude Code state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 !.keep
 .antigravitycli/
 .aider*
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 .env.production
 */mount/*.hash
 .devcontainer/

--- a/packages/shared-lib-blitz-next/.gitignore
+++ b/packages/shared-lib-blitz-next/.gitignore
@@ -6,6 +6,8 @@
 !.keep
 .antigravitycli/
 .aider*
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 .env.production
 */mount/*.hash
 .devcontainer/

--- a/packages/shared-lib-next/.gitignore
+++ b/packages/shared-lib-next/.gitignore
@@ -6,6 +6,8 @@
 !.keep
 .antigravitycli/
 .aider*
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 .env.production
 */mount/*.hash
 .devcontainer/

--- a/packages/shared-lib-node/.gitignore
+++ b/packages/shared-lib-node/.gitignore
@@ -6,6 +6,8 @@
 !.keep
 .antigravitycli/
 .aider*
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 .env.production
 */mount/*.hash
 .devcontainer/

--- a/packages/shared-lib-react/.gitignore
+++ b/packages/shared-lib-react/.gitignore
@@ -6,6 +6,8 @@
 !.keep
 .antigravitycli/
 .aider*
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 .env.production
 */mount/*.hash
 .devcontainer/

--- a/packages/shared-lib/.gitignore
+++ b/packages/shared-lib/.gitignore
@@ -6,6 +6,8 @@
 !.keep
 .antigravitycli/
 .aider*
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 .env.production
 */mount/*.hash
 .devcontainer/

--- a/packages/wb/.gitignore
+++ b/packages/wb/.gitignore
@@ -6,6 +6,8 @@
 !.keep
 .antigravitycli/
 .aider*
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 .env.production
 */mount/*.hash
 .devcontainer/

--- a/packages/wbfy/.gitignore
+++ b/packages/wbfy/.gitignore
@@ -7,6 +7,8 @@ test-fixtures/
 !.keep
 .antigravitycli/
 .aider*
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 .env.production
 */mount/*.hash
 .devcontainer/

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -16,6 +16,8 @@ const commonContent = `
 !.keep
 .antigravitycli/
 .aider*
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 .env.production
 */mount/*.hash
 .devcontainer/


### PR DESCRIPTION
## Customer Summary

- Local, machine-specific Claude Code state files (`.claude/scheduled_tasks.lock`, `.claude/settings.local.json`) are no longer tracked by git in projects generated or maintained by wbfy.
- No change to any deployed product behavior; this only affects repository hygiene for developers using Claude Code.

## Technical Summary

- Added `.claude/scheduled_tasks.lock` and `.claude/settings.local.json` to the common `.gitignore` content generated by `packages/wbfy/src/generators/gitignore.ts`.
- Ran `yarn start` in `packages/wbfy` against this repo to regenerate all `.gitignore` files (root and each workspace package), propagating the new ignore rules.

## Why

- These files hold per-developer, per-machine Claude Code state (task locks, local settings overrides) and should never be committed.

## Testing

- `yarn start /Users/exkazuu/ghq/github.com/WillBooster/shared` in `packages/wbfy` (regenerated config, including all `.gitignore` files)
- `yarn verify`
