### PR TITLE
fix(wbfy): stop generating autofix workflow for private repos

### DIFF
--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -92,22 +92,6 @@ const publicRepoAutofixWorkflow: Workflow = {
   },
 };
 
-const privateRepoAutofixWorkflow: Workflow = {
-  name: 'Fix code automatically',
-  on: {
-    pull_request: null,
-  },
-  concurrency: {
-    group: '${{ github.workflow }}-${{ github.ref }}',
-    'cancel-in-progress': true,
-  },
-  jobs: {
-    autofix: {
-      uses: 'WillBooster/reusable-workflows/.github/workflows/autofix.yml@main',
-    },
-  },
-};
-
 const workflows = {
   test: {
     name: 'Test',
@@ -230,6 +214,12 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
     ]);
     if (rootConfig.depending.semanticRelease) {
       fileNameSet.add('release.yml');
+    }
+    if (!rootConfig.isPublicRepo) {
+      // The reusable test workflow already fixes and pushes code on private repos,
+      // so a separate autofix workflow only duplicates the same process.
+      fileNameSet.delete('autofix.yml');
+      await promisePool.run(() => fs.promises.rm(path.join(workflowsPath, 'autofix.yml'), { force: true }));
     }
 
     for (const fileName of fileNameSet) {
@@ -426,10 +416,6 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
 }
 
 function generateAutofixWorkflow(config: PackageConfig): Workflow {
-  if (!config.isPublicRepo) {
-    return structuredClone(privateRepoAutofixWorkflow);
-  }
-
   const packageManager = config.isBun ? 'bun' : 'yarn';
   const steps: Step[] = [
     { uses: 'actions/checkout@v6' },


### PR DESCRIPTION
## Customer Summary

- Private repositories no longer get a separate "Fix code automatically" (autofix) GitHub Actions workflow; automatic code fixes keep working through the existing Test workflow.
- Pull requests in private repositories use fewer CI runner resources and no longer risk two workflows pushing the same fix commit at the same time.
- Public repositories are unaffected.

## Technical Summary

- `wbfy` no longer generates `.github/workflows/autofix.yml` for private repos and deletes an existing one so already-wbfy'd repos (e.g. llm-proxy) converge on the next wbfy run.
- Removed the now-unused `privateRepoAutofixWorkflow` template from `packages/wbfy/src/generators/workflow.ts`.
- Public repos keep their autofix workflow, which delegates to the autofix.ci app; the reusable `test.yml` continues to fail on unfixed diffs there.

## Why

- On private repos, every PR push launched two jobs duplicating the same process: the reusable `test.yml` "Fix code" step (gen-code → cleanup/lint-fix → build, then commit & push) and the separate `autofix.yml` workflow doing a full checkout + setup + install + the same fix sequence — even when nothing needed fixing.
- Both workflows could push the same `fix: apply changes of autofix workflow` commit concurrently, racing each other with non-fast-forward failures and retrigger churn.
- Since `test.yml` must run lint/gen-code/build anyway before typecheck/test, fixing there is effectively free, making the separate autofix workflow pure overhead on private repos.

## Testing

- `yarn typecheck` and `yarn lint` in `packages/wbfy` pass.
- CI on this PR passed (`check-pr-ci`: all workflows succeeded).
- Reviewed by antigravity and claude review agents: no concerns.
