### PR TITLE
feat: absorb remaining Cloudflare Workers dev patterns into wb

### DIFF
--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -56,7 +56,15 @@ export type EnvReaderOptions = Partial<ArgumentsCamelCase<InferredOptionTypes<ty
  * */
 export function readEnvironmentVariables(
   argv: EnvReaderOptions,
-  cwd: string
+  cwd: string,
+  options?: {
+    /**
+     * Load variables even if they already exist in process.env.
+     * Useful when a parent process has already injected the .env values into the environment
+     * and the file-defined variables themselves are needed (e.g. `wb gen-dev-vars`).
+     */
+    ignoreProcessEnv?: boolean;
+  }
 ): [Record<string, string>, [string, string[]][]] {
   let envPaths = (argv.env ?? []).map((envPath) => path.resolve(cwd, envPath.toString()));
   const cascade =
@@ -94,7 +102,7 @@ export function readEnvironmentVariables(
   for (const envPath of envPaths) {
     const keys: string[] = [];
     for (const [key, value] of Object.entries(readEnvFile(path.join(cwd, envPath)))) {
-      if (!(key in envVars) && !(key in process.env)) {
+      if (!(key in envVars) && (options?.ignoreProcessEnv || !(key in process.env))) {
         envVars[key] = value;
         keys.push(key);
       }

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -112,7 +112,7 @@ export function readEnvironmentVariables(
       console.info(`Read ${keys.length} environment variables from ${envPath}`);
     }
   }
-  const [miseEnvVars, miseEnvVarNames] = readMiseEnvironmentVariables(cwd, cascade, envVars);
+  const [miseEnvVars, miseEnvVarNames] = readMiseEnvironmentVariables(cwd, cascade, envVars, options);
   Object.assign(envVars, miseEnvVars);
   if (miseEnvVarNames.length > 0) {
     envPathAndLoadedEnvVarNames.push([miseEnvironmentSourceName(cascade), miseEnvVarNames]);
@@ -139,7 +139,8 @@ export function readEnvironmentVariables(
 function readMiseEnvironmentVariables(
   cwd: string,
   cascade: string | undefined,
-  currentEnvVars: Record<string, string>
+  currentEnvVars: Record<string, string>,
+  options?: { ignoreProcessEnv?: boolean }
 ): [Record<string, string>, string[]] {
   if (!hasProjectMiseConfig(cwd)) return [{}, []];
 
@@ -164,8 +165,14 @@ function readMiseEnvironmentVariables(
   const envVars: Record<string, string> = {};
   const keys: string[] = [];
   for (const [key, value] of Object.entries(parsed)) {
-    if (typeof value !== 'string') continue;
-    if (key in currentEnvVars || process.env[key] === value) continue;
+    if (typeof value !== 'string' || key in currentEnvVars) continue;
+    if (options?.ignoreProcessEnv) {
+      // `mise env` always emits PATH due to tool shims; consumers of file-defined variables
+      // (e.g. `wb gen-dev-vars`) must not propagate it.
+      if (key === 'PATH') continue;
+    } else if (process.env[key] === value) {
+      continue;
+    }
     envVars[key] = value;
     keys.push(key);
   }

--- a/packages/wb/src/commands/genDevVars.ts
+++ b/packages/wb/src/commands/genDevVars.ts
@@ -58,8 +58,7 @@ export const genDevVarsCommand: CommandModule<unknown, GenDevVarsCommandOptions>
 };
 
 function escapeDotenvValue(value: string): string {
-  return value
-    .replaceAll('\\', String.raw`\\`)
-    .replaceAll('"', String.raw`\"`)
-    .replaceAll('\n', String.raw`\n`);
+  // Dotenv's double-quoted syntax only unescapes \n and \r; escaping backslashes or quotes
+  // would inject literal backslashes into the parsed value (verified with dotenv 17).
+  return value.replaceAll('\n', String.raw`\n`);
 }

--- a/packages/wb/src/commands/genDevVars.ts
+++ b/packages/wb/src/commands/genDevVars.ts
@@ -41,10 +41,14 @@ export const genDevVarsCommand: CommandModule<unknown, GenDevVarsCommandOptions>
       envVars[key] ||= project.env[key] || '';
     }
 
+    // Emit values single-quoted: dotenv (which wrangler uses for .dev.vars) preserves
+    // single-quoted values literally, round-tripping newlines, quotes, backslashes, and
+    // literal \n sequences (verified against wrangler's bundled dotenv 16); double-quoted
+    // emission would corrupt values containing literal \n (e.g. PEM keys).
     const lines = Object.entries(envVars)
       .filter(([, value]) => value !== '')
       .toSorted(([a], [b]) => a.localeCompare(b))
-      .map(([key, value]) => `${key}="${escapeDotenvValue(value)}"`);
+      .map(([key, value]) => `${key}='${value}'`);
     const outputPath = path.resolve(project.dirPath, argv.path ?? '.dev.vars');
     if (argv.dryRun) {
       console.info(chalk.cyan(`Would generate ${outputPath} with ${lines.length} environment variables.`));
@@ -56,9 +60,3 @@ export const genDevVarsCommand: CommandModule<unknown, GenDevVarsCommandOptions>
     console.info(chalk.green(`Generated ${outputPath} with ${lines.length} environment variables.`));
   },
 };
-
-function escapeDotenvValue(value: string): string {
-  // Dotenv's double-quoted syntax only unescapes \n and \r; escaping backslashes or quotes
-  // would inject literal backslashes into the parsed value (verified with dotenv 17).
-  return value.replaceAll('\n', String.raw`\n`);
-}

--- a/packages/wb/src/commands/genDevVars.ts
+++ b/packages/wb/src/commands/genDevVars.ts
@@ -41,14 +41,10 @@ export const genDevVarsCommand: CommandModule<unknown, GenDevVarsCommandOptions>
       envVars[key] ||= project.env[key] || '';
     }
 
-    // Emit values single-quoted: dotenv (which wrangler uses for .dev.vars) preserves
-    // single-quoted values literally, round-tripping newlines, quotes, backslashes, and
-    // literal \n sequences (verified against wrangler's bundled dotenv 16); double-quoted
-    // emission would corrupt values containing literal \n (e.g. PEM keys).
     const lines = Object.entries(envVars)
       .filter(([, value]) => value !== '')
       .toSorted(([a], [b]) => a.localeCompare(b))
-      .map(([key, value]) => `${key}='${value}'`);
+      .map(([key, value]) => `${key}=${quoteDotenvValue(value)}`);
     const outputPath = path.resolve(project.dirPath, argv.path ?? '.dev.vars');
     if (argv.dryRun) {
       console.info(chalk.cyan(`Would generate ${outputPath} with ${lines.length} environment variables.`));
@@ -60,3 +56,18 @@ export const genDevVarsCommand: CommandModule<unknown, GenDevVarsCommandOptions>
     console.info(chalk.green(`Generated ${outputPath} with ${lines.length} environment variables.`));
   },
 };
+
+/**
+ * Quote a value for dotenv (which wrangler uses for .dev.vars). Single-quoted values are
+ * preserved literally — round-tripping newlines, quotes, backslashes, and literal \n sequences
+ * (verified against wrangler's bundled dotenv 16) — except that a single quote right before a
+ * newline closes the quoted span early; such values use double quotes with escaped newlines,
+ * which dotenv unescapes (only corrupting the vanishingly rare value that also contains a
+ * literal \n sequence).
+ */
+function quoteDotenvValue(value: string): string {
+  if (value.includes("'") && value.includes('\n')) {
+    return `"${value.replaceAll('\n', String.raw`\n`)}"`;
+  }
+  return `'${value}'`;
+}

--- a/packages/wb/src/commands/genDevVars.ts
+++ b/packages/wb/src/commands/genDevVars.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { readEnvironmentVariables } from '@willbooster/shared-lib-node/src';
+import chalk from 'chalk';
+import type { ArgumentsCamelCase, Argv, CommandModule, InferredOptionTypes } from 'yargs';
+
+import { findSelfProject } from '../project.js';
+import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+
+// Cloudflare Workers don't see the process environment; wrangler dev reads vars from a .dev.vars
+// file next to its config file instead. This command bridges wb-managed .env files to that file.
+const builder = {} as const;
+
+type GenDevVarsCommandOptions = InferredOptionTypes<typeof builder & typeof sharedOptionsBuilder>;
+type GenDevVarsCommandArgv = ArgumentsCamelCase<GenDevVarsCommandOptions & { path?: string }>;
+
+export const genDevVarsCommand: CommandModule<unknown, GenDevVarsCommandOptions> = {
+  command: 'gen-dev-vars [path]',
+  describe:
+    'Generate a .dev.vars file for `wrangler dev` from the environment variables loaded from .env files (plus WB_ENV and NEXT_PUBLIC_WB_ENV).',
+  builder: (yargs) =>
+    yargs.positional('path', {
+      description: 'Output path of the generated .dev.vars file.',
+      type: 'string',
+      default: '.dev.vars',
+    }) as unknown as Argv<GenDevVarsCommandOptions>,
+  async handler(argv: GenDevVarsCommandArgv) {
+    const project = findSelfProject(argv);
+    if (!project) {
+      console.error(chalk.red('No project found.'));
+      process.exit(1);
+    }
+
+    // Restrict to the variables loaded from .env files (wb's environment contract) so that
+    // unrelated process environment variables never leak into the generated file. Ignore
+    // process.env because the parent wb process injects the .env values into it, which would
+    // otherwise suppress loading them here.
+    const [envVars] = readEnvironmentVariables(argv, project.dirPath, { ignoreProcessEnv: true });
+    for (const key of ['WB_ENV', 'NEXT_PUBLIC_WB_ENV']) {
+      envVars[key] ||= project.env[key] || '';
+    }
+
+    const lines = Object.entries(envVars)
+      .filter(([, value]) => value !== '')
+      .toSorted(([a], [b]) => a.localeCompare(b))
+      .map(([key, value]) => `${key}="${escapeDotenvValue(value)}"`);
+    const outputPath = path.resolve(project.dirPath, argv.path ?? '.dev.vars');
+    if (argv.dryRun) {
+      console.info(chalk.cyan(`Would generate ${outputPath} with ${lines.length} environment variables.`));
+      return;
+    }
+
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, lines.join('\n') + '\n');
+    console.info(chalk.green(`Generated ${outputPath} with ${lines.length} environment variables.`));
+  },
+};
+
+function escapeDotenvValue(value: string): string {
+  return value
+    .replaceAll('\\', String.raw`\\`)
+    .replaceAll('"', String.raw`\"`)
+    .replaceAll('\n', String.raw`\n`);
+}

--- a/packages/wb/src/commands/start.ts
+++ b/packages/wb/src/commands/start.ts
@@ -11,7 +11,9 @@ import { plainAppScripts } from '../scripts/execution/plainAppScripts.js';
 import { remixScripts } from '../scripts/execution/remixScripts.js';
 import { vinextScripts } from '../scripts/execution/vinextScripts.js';
 import { viteScripts } from '../scripts/execution/viteScripts.js';
+import { workersScripts } from '../scripts/execution/workersScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
+import { findWranglerConfigPath } from '../utils/wrangler.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
 import { httpServerPackages } from './httpServerPackages.js';
@@ -57,6 +59,9 @@ export const startCommand: CommandModule<unknown, InferredOptionTypes<typeof bui
         scripts = remixScripts;
       } else if (devDeps.vite) {
         scripts = viteScripts;
+      } else if (findWranglerConfigPath(project)) {
+        // Plain Cloudflare Workers app; vinext apps are detected above.
+        scripts = workersScripts;
       } else if (
         (httpServerPackages.some((p) => deps[p]) && !deps['firebase-functions']) ||
         (project.hasDockerfile && /EXPOSE\s+8080/.test(project.dockerfile))

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -19,8 +19,10 @@ import { plainAppScripts } from '../scripts/execution/plainAppScripts.js';
 import { remixScripts } from '../scripts/execution/remixScripts.js';
 import { vinextScripts } from '../scripts/execution/vinextScripts.js';
 import { viteScripts } from '../scripts/execution/viteScripts.js';
+import { workersScripts } from '../scripts/execution/workersScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { findWranglerConfigPath } from '../utils/wrangler.js';
 
 import { httpServerPackages } from './httpServerPackages.js';
 
@@ -123,6 +125,9 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
       scripts = remixScripts;
     } else if (devDeps.vite) {
       scripts = viteScripts;
+    } else if (findWranglerConfigPath(project)) {
+      // Plain Cloudflare Workers app; vinext apps are detected above.
+      scripts = workersScripts;
     } else if (httpServerPackages.some((p) => deps[p]) && !deps['firebase-functions']) {
       scripts = httpServerScripts;
     } else {

--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -15,8 +15,10 @@ import { plainAppScripts } from '../scripts/execution/plainAppScripts.js';
 import { remixScripts } from '../scripts/execution/remixScripts.js';
 import { vinextScripts } from '../scripts/execution/vinextScripts.js';
 import { viteScripts } from '../scripts/execution/viteScripts.js';
+import { workersScripts } from '../scripts/execution/workersScripts.js';
 import { runWithSpawn, runWithSpawnInParallel } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { findWranglerConfigPath } from '../utils/wrangler.js';
 import { promisePool } from '../utils/promisePool.js';
 
 import { httpServerPackages } from './httpServerPackages.js';
@@ -66,6 +68,9 @@ export async function testOnCi(
       scripts = remixScripts;
     } else if (devDeps.vite) {
       scripts = viteScripts;
+    } else if (findWranglerConfigPath(project)) {
+      // Plain Cloudflare Workers app; vinext apps are detected above.
+      scripts = workersScripts;
     } else if (httpServerPackages.some((p) => deps[p]) && !deps['firebase-functions']) {
       scripts = httpServerScripts;
     } else {

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -9,6 +9,7 @@ import { buildIfNeededCommand } from './commands/buildIfNeeded.js';
 import { concurrentlyCommand } from './commands/concurrently.js';
 import { dotenvCommand } from './commands/dotenv.js';
 import { genCodeCommand } from './commands/genCode.js';
+import { genDevVarsCommand } from './commands/genDevVars.js';
 import { killPortIfNonCiCommand } from './commands/killPortIfNonCi.js';
 import { lintCommand } from './commands/lint.js';
 import { maintenanceCommand } from './commands/maintenance.js';
@@ -42,6 +43,7 @@ await yargs(hideBin(process.argv))
   .command(concurrentlyCommand)
   .command(dotenvCommand)
   .command(genCodeCommand)
+  .command(genDevVarsCommand)
   .command(killPortIfNonCiCommand)
   .command(lintCommand)
   .command(maintenanceCommand)

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -4,11 +4,7 @@ import { isProjectEnvironment } from '../../project.js';
 import { buildEnvReaderOptionArgs } from '../../sharedOptionsBuilder.js';
 import { checkAndKillPortProcess } from '../../utils/port.js';
 import { buildShellCommand, buildShellEnvironmentAssignment } from '../../utils/shell.js';
-import {
-  findWranglerConfigPath,
-  getLocalWranglerStateDir,
-  wrapWithLocalD1DatabaseUrl,
-} from '../../utils/wrangler.js';
+import { findWranglerConfigPath, getLocalWranglerStateDir, wrapWithLocalD1DatabaseUrl } from '../../utils/wrangler.js';
 import type { ScriptArgv } from '../builder.js';
 import { toDevNull } from '../builder.js';
 import { dockerScripts } from '../dockerScripts.js';

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -1,9 +1,14 @@
 import type { TestArgv } from '../../commands/test.js';
 import type { Project } from '../../project.js';
+import { isProjectEnvironment } from '../../project.js';
 import { buildEnvReaderOptionArgs } from '../../sharedOptionsBuilder.js';
 import { checkAndKillPortProcess } from '../../utils/port.js';
 import { buildShellCommand, buildShellEnvironmentAssignment } from '../../utils/shell.js';
-import { wrapWithLocalD1DatabaseUrl } from '../../utils/wrangler.js';
+import {
+  findWranglerConfigPath,
+  getLocalWranglerStateDir,
+  wrapWithLocalD1DatabaseUrl,
+} from '../../utils/wrangler.js';
 import type { ScriptArgv } from '../builder.js';
 import { toDevNull } from '../builder.js';
 import { dockerScripts } from '../dockerScripts.js';
@@ -109,7 +114,14 @@ export abstract class BaseScripts {
   }
 
   protected buildProductionCommand(project: Project, argv: ScriptArgv, commands: string[]): string {
+    // Test-environment wrangler state is disposable; wipe it entirely (not just D1) before
+    // migrating, since stale KV cache entries or Durable Object storage can break e2e tests.
+    const wranglerStateWipeCommands =
+      isProjectEnvironment(project, 'test') && findWranglerConfigPath(project)
+        ? [`rm -Rf "${getLocalWranglerStateDir(project)}"`]
+        : [];
     const migrationCommands = [
+      ...wranglerStateWipeCommands,
       ...(project.hasPrisma ? [prismaScripts.migrate(project)] : []),
       ...(project.hasDrizzle ? [wrapWithLocalD1DatabaseUrl(project, drizzleScripts.migrateForStart(project))] : []),
     ];

--- a/packages/wb/src/scripts/execution/vinextScripts.ts
+++ b/packages/wb/src/scripts/execution/vinextScripts.ts
@@ -1,5 +1,5 @@
 import type { Project } from '../../project.js';
-import { getLocalWranglerStateDir } from '../../utils/wrangler.js';
+import { buildGenDevVarsCommand, buildWranglerDevCommand, getLocalWranglerStateDir } from '../../utils/wrangler.js';
 import type { ScriptArgv } from '../builder.js';
 
 import { BaseScripts } from './baseScripts.js';
@@ -22,12 +22,17 @@ class VinextScripts extends BaseScripts {
   protected override buildDefaultProductionStartCommands(project: Project, argv: ScriptArgv): string[] {
     project.env.PORT ||= '3000';
     const port = project.env.PORT;
-    // `vinext build` emits a worker bundle and its wrangler config under dist/server.
+    // `vinext build` emits a worker bundle and its wrangler config under dist/server, so the
+    // .dev.vars file exposing wb-managed environment variables must be generated after building.
     // `--local-upstream` keeps request URLs on the local host; otherwise, wrangler dev simulates
     // the production custom domain declared in the wrangler config routes.
     return [
       project.buildCommand,
-      `YARN wrangler dev --config dist/server/wrangler.json --ip 127.0.0.1 --port ${port} --persist-to "${getLocalWranglerStateDir(project)}" --local-upstream localhost:${port} ${argv.normalizedArgsText ?? ''}`.trim(),
+      buildGenDevVarsCommand(argv, 'dist/server/.dev.vars'),
+      buildWranglerDevCommand(
+        project,
+        `dev --config dist/server/wrangler.json --ip 127.0.0.1 --port ${port} --persist-to "${getLocalWranglerStateDir(project)}" --local-upstream localhost:${port} ${argv.normalizedArgsText ?? ''}`.trim()
+      ),
     ];
   }
 }

--- a/packages/wb/src/scripts/execution/workersScripts.ts
+++ b/packages/wb/src/scripts/execution/workersScripts.ts
@@ -1,0 +1,52 @@
+import type { Project } from '../../project.js';
+import {
+  buildGenDevVarsCommand,
+  buildWranglerDevCommand,
+  findD1MigrationsDirPath,
+  getD1DatabaseName,
+  getLocalWranglerStateDir,
+} from '../../utils/wrangler.js';
+import type { ScriptArgv } from '../builder.js';
+
+import { BaseScripts } from './baseScripts.js';
+
+/**
+ * A collection of scripts for executing plain Cloudflare Workers apps (detected via a wrangler
+ * config file when no other framework matches; vinext apps have their own scripts).
+ * Note that `YARN zzz` is replaced with `yarn zzz` or `node_modules/.bin/zzz`.
+ */
+class WorkersScripts extends BaseScripts {
+  constructor() {
+    super(false);
+  }
+
+  protected override startDevProtected(project: Project, argv: ScriptArgv): string {
+    return this.buildWranglerDevCommands(project, argv).join(' && ');
+  }
+
+  protected override buildDefaultProductionStartCommands(project: Project, argv: ScriptArgv): string[] {
+    // wrangler dev bundles the worker itself, so no separate build step is needed.
+    return this.buildWranglerDevCommands(project, argv);
+  }
+
+  private buildWranglerDevCommands(project: Project, argv: ScriptArgv): string[] {
+    project.env.PORT ||= '8787';
+    const stateDir = getLocalWranglerStateDir(project);
+
+    const commands = [buildGenDevVarsCommand(argv, '.dev.vars')];
+    // Apply wrangler-native D1 migrations (if any) so the local database matches the deployed one.
+    const d1DatabaseName = getD1DatabaseName(project);
+    if (d1DatabaseName && findD1MigrationsDirPath(project)) {
+      commands.push(`YARN wrangler d1 migrations apply ${d1DatabaseName} --local --persist-to "${stateDir}"`);
+    }
+    commands.push(
+      buildWranglerDevCommand(
+        project,
+        `dev --ip 127.0.0.1 --port ${project.env.PORT} --persist-to "${stateDir}" ${argv.normalizedArgsText ?? ''}`.trim()
+      )
+    );
+    return commands;
+  }
+}
+
+export const workersScripts = new WorkersScripts();

--- a/packages/wb/src/scripts/execution/workersScripts.ts
+++ b/packages/wb/src/scripts/execution/workersScripts.ts
@@ -33,11 +33,14 @@ class WorkersScripts extends BaseScripts {
     project.env.PORT ||= '8787';
     const stateDir = getLocalWranglerStateDir(project);
 
+    // These helpers read the default-named wrangler config; that is safe because workersScripts
+    // itself is only selected when such a config file exists in the project directory.
     const commands = [buildGenDevVarsCommand(argv, '.dev.vars')];
     // Apply wrangler-native D1 migrations (if any) so the local database matches the deployed one.
+    // CI=true suppresses wrangler's interactive confirmation prompt.
     const d1DatabaseName = getD1DatabaseName(project);
     if (d1DatabaseName && findD1MigrationsDirPath(project)) {
-      commands.push(`YARN wrangler d1 migrations apply ${d1DatabaseName} --local --persist-to "${stateDir}"`);
+      commands.push(`CI=true YARN wrangler d1 migrations apply ${d1DatabaseName} --local --persist-to "${stateDir}"`);
     }
     commands.push(
       buildWranglerDevCommand(

--- a/packages/wb/src/utils/wrangler.ts
+++ b/packages/wb/src/utils/wrangler.ts
@@ -145,8 +145,11 @@ export function buildMaterializeLocalD1Command(project: Pick<Project, 'env'>, da
  * without destroying development state.
  */
 export function getLocalWranglerStateDir(project: Pick<Project, 'env'>): string {
-  // Mirror isProjectEnvironment, which also accepts MISE_ENV, so that e.g. MISE_ENV=test
-  // resolves to the test state directory instead of wiping the development one.
-  const wbEnv = project.env.WB_ENV || project.env.MISE_ENV;
+  // Destructive test resets are gated on isProjectEnvironment(project, 'test'), which accepts
+  // either WB_ENV or MISE_ENV; resolve to the test directory whenever either says 'test' so
+  // that such resets can never target the development state.
+  const wbEnv = [project.env.WB_ENV, project.env.MISE_ENV].includes('test')
+    ? 'test'
+    : project.env.WB_ENV || project.env.MISE_ENV;
   return !wbEnv || wbEnv === 'development' ? '.wrangler/state' : `.wrangler/state-${wbEnv}`;
 }

--- a/packages/wb/src/utils/wrangler.ts
+++ b/packages/wb/src/utils/wrangler.ts
@@ -2,8 +2,44 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type { Project } from '../project.js';
+import { buildEnvReaderOptionArgs } from '../sharedOptionsBuilder.js';
+import type { ScriptArgv } from '../scripts/builder.js';
+import { buildShellCommand } from './shell.js';
 
 const wranglerConfigFileNames = ['wrangler.jsonc', 'wrangler.json', 'wrangler.toml'];
+
+/**
+ * Build a command generating a .dev.vars file (via `wb gen-dev-vars`) so that
+ * `wrangler dev` can see the wb-managed environment variables.
+ */
+export function buildGenDevVarsCommand(argv: ScriptArgv, outputPath: string): string {
+  return buildShellCommand(['YARN', 'wb', 'gen-dev-vars', ...buildEnvReaderOptionArgs(argv), outputPath]);
+}
+
+/**
+ * Build a `wrangler dev`-style command. `env -u CLOUDFLARE_ENV` makes wrangler serve the top-level
+ * (non-deploy) config. On Bun projects, wrangler must run with the real Node.js runtime:
+ * wrangler dev does not support Bun, and `bun --bun` shims `node` in PATH to Bun,
+ * so a non-Bun node binary is resolved explicitly.
+ */
+export function buildWranglerDevCommand(project: Project, args: string): string {
+  const wranglerJsPath = project.usesBunPackageManager ? findWranglerJsPath(project) : undefined;
+  if (!wranglerJsPath) return `env -u CLOUDFLARE_ENV YARN wrangler ${args}`.trim();
+
+  return `env -u CLOUDFLARE_ENV "$(which -a node | grep -vi bun | head -1)" "${wranglerJsPath}" ${args}`.trim();
+}
+
+function findWranglerJsPath(project: Pick<Project, 'dirPath'>): string | undefined {
+  let currentPath = project.dirPath;
+  for (;;) {
+    const wranglerJsPath = path.join(currentPath, 'node_modules', 'wrangler', 'bin', 'wrangler.js');
+    if (fs.existsSync(wranglerJsPath)) return wranglerJsPath;
+
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) return;
+    currentPath = parentPath;
+  }
+}
 
 /**
  * Prefix the given script with commands exporting DATABASE_URL pointing to the local miniflare D1 SQLite file,
@@ -44,11 +80,36 @@ export function getD1DatabaseName(project: Pick<Project, 'dirPath'>): string | u
 }
 
 export function findWranglerConfigPath(project: Pick<Project, 'dirPath'>): string | undefined {
+  // Tests may pass partial Project objects without dirPath.
+  if (!project.dirPath) return;
+
   for (const fileName of wranglerConfigFileNames) {
     const filePath = path.join(project.dirPath, fileName);
     if (fs.existsSync(filePath)) return filePath;
   }
   return;
+}
+
+/**
+ * Get the path of the wrangler-native D1 migrations directory (`migrations_dir` in the wrangler
+ * config, defaulting to `migrations`) if it exists on disk.
+ */
+export function findD1MigrationsDirPath(project: Pick<Project, 'dirPath'>): string | undefined {
+  const configPath = findWranglerConfigPath(project);
+  if (!configPath) return;
+
+  let migrationsDir = 'migrations';
+  for (const line of fs.readFileSync(configPath, 'utf8').split('\n')) {
+    if (/^\s*(?:#|\/\/)/u.test(line)) continue;
+
+    const match = /(?:^|[,{])\s*["']?migrations_dir["']?\s*[:=]\s*["']([^"']+)["']/u.exec(line);
+    if (match) {
+      migrationsDir = match[1] as string;
+      break;
+    }
+  }
+  const migrationsDirPath = path.join(project.dirPath, migrationsDir);
+  return fs.existsSync(migrationsDirPath) ? migrationsDirPath : undefined;
 }
 
 /**

--- a/packages/wb/src/utils/wrangler.ts
+++ b/packages/wb/src/utils/wrangler.ts
@@ -26,7 +26,7 @@ export function buildWranglerDevCommand(project: Project, args: string): string 
   const wranglerJsPath = project.usesBunPackageManager ? findWranglerJsPath(project) : undefined;
   if (!wranglerJsPath) return `env -u CLOUDFLARE_ENV YARN wrangler ${args}`.trim();
 
-  return `env -u CLOUDFLARE_ENV "$(which -a node | grep -vi bun | head -1)" "${wranglerJsPath}" ${args}`.trim();
+  return `env -u CLOUDFLARE_ENV "${findRealNodePath()}" "${wranglerJsPath}" ${args}`.trim();
 }
 
 function findWranglerJsPath(project: Pick<Project, 'dirPath'>): string | undefined {
@@ -39,6 +39,22 @@ function findWranglerJsPath(project: Pick<Project, 'dirPath'>): string | undefin
     if (parentPath === currentPath) return;
     currentPath = parentPath;
   }
+}
+
+function findRealNodePath(): string {
+  for (const dirPath of (process.env.PATH ?? '').split(path.delimiter)) {
+    if (!dirPath) continue;
+
+    try {
+      // `bun --bun` shims `node` in PATH via a symlink to the Bun binary; follow symlinks to skip it.
+      const realPath = fs.realpathSync(path.join(dirPath, 'node'));
+      if (path.basename(realPath).includes('bun')) continue;
+      return realPath;
+    } catch {
+      // No node binary in this directory.
+    }
+  }
+  return 'node';
 }
 
 /**

--- a/packages/wb/src/utils/wrangler.ts
+++ b/packages/wb/src/utils/wrangler.ts
@@ -145,6 +145,8 @@ export function buildMaterializeLocalD1Command(project: Pick<Project, 'env'>, da
  * without destroying development state.
  */
 export function getLocalWranglerStateDir(project: Pick<Project, 'env'>): string {
-  const wbEnv = project.env.WB_ENV;
+  // Mirror isProjectEnvironment, which also accepts MISE_ENV, so that e.g. MISE_ENV=test
+  // resolves to the test state directory instead of wiping the development one.
+  const wbEnv = project.env.WB_ENV || project.env.MISE_ENV;
   return !wbEnv || wbEnv === 'development' ? '.wrangler/state' : `.wrangler/state-${wbEnv}`;
 }


### PR DESCRIPTION
## Customer Summary

- Cloudflare Workers projects — vinext apps and plain workers alike — can now be developed, tested, and served locally with the standard `wb start` / `wb test` commands, with no hand-written shell scripts.
- Environment variables managed by wb's `.env` files now reach the locally running worker automatically, including multi-line secrets such as PEM keys.
- Test runs always work on isolated, disposable state; a test run can never destroy development data, even with contradictory environment configuration.

## Technical Summary

- **`wb gen-dev-vars [path]`** (new command): writes the variables loaded from the `.env` cascade into a `.dev.vars` file, since Workers don't see the process environment. `readEnvironmentVariables` (shared-lib-node) gains `ignoreProcessEnv` (parent wb processes inject loaded values into child environments, which suppressed re-loading); the option propagates to mise env loading, which excludes mise's always-emitted `PATH`. Values are emitted single-quoted — verified to round-trip newlines, literal `\n`, quotes, backslashes, and JSON against wrangler's bundled dotenv 16 — with a double-quoted fallback for values containing both a quote and a newline.
- **`vinextScripts`**: production/test serving generates `dist/server/.dev.vars` after `vinext build` and runs `wrangler dev` with `CLOUDFLARE_ENV` unset; fully replaces ai-game-builder's `startTestServer.sh`.
- **`workersScripts`** (new execution class): plain Workers apps (default-named wrangler config, no other framework match) get `gen-dev-vars` → `CI=true wrangler d1 migrations apply --local` (when a D1 database and migrations dir exist) → `wrangler dev`. On Bun projects, wrangler dev runs under a real Node binary resolved by following PATH symlinks (Bun's node shim links to the Bun binary); replaces llm-proxy's `start-production.sh`.
- **`baseScripts`**: the test environment wipes the whole local wrangler state before migrations (stale KV cache / Durable Object storage breaks e2e tests). `getLocalWranglerStateDir` resolves to the test directory whenever either `WB_ENV` or `MISE_ENV` is `test`, matching `isProjectEnvironment`'s gating semantics, so the wipe can never target development state.

## Why

- Follow-up to #911: ai-game-builder and llm-proxy still needed hand-written scripts for `.dev.vars` bridging, plain-worker serving, and test-state resets. Absorbing them makes future Cloudflare/vinext/D1 repos work with wb out of the box.

## Testing

- `yarn typecheck`, `yarn lint`; wb (106), wbfy (25), and shared-lib-node (31) vitest suites pass.
- End-to-end with source-built wb overlaid into each repo's node_modules: llm-proxy `bun --bun wb start` → HTTP 200 `{"status":"ok"}` (gen-dev-vars + D1 migrations + node-run wrangler dev); ai-game-builder `wb start --mode test` → HTTP 200 with correct test `.dev.vars` (`AUTH_SECRET`, `WB_ENV=test`, test base URL).
- Dotenv round-trip matrix (PEM with real newlines, literal `\n`, embedded/trailing quotes, JSON, backslashes, quote-before-newline) verified with a real `wb gen-dev-vars` run parsed by wrangler's bundled dotenv 16.3.1.
- Reviewed via the antigravity and claude review workflows until both returned "There is no concern"; all gemini inline threads addressed and resolved.

## Notes

- Values containing a single quote, a real newline, and a literal `\n` sequence simultaneously remain unsupported (documented in code; vanishingly rare).
- When ai-game-builder adopts this, its `.env.test` should set `NEXT_PUBLIC_WB_ENV=test` (the old script forced this value).
