### PR TITLE
feat: migrate wbfy from tsgo preview to stable TypeScript 7

### DIFF
--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -51,8 +51,6 @@ export const bunMinimumReleaseAgeExcludes = [
   '@typescript/typescript-linux-arm',
   '@typescript/typescript-linux-arm64',
   '@typescript/typescript-linux-x64',
-  '@typescript/typescript-win32-arm64',
-  '@typescript/typescript-win32-x64',
   // Bun itself releases its first-party type packages in lockstep with the
   // runtime, so generated Bun repos must be able to install them immediately.
   '@types/bun',

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -45,14 +45,14 @@ export const bunMinimumReleaseAgeExcludes = [
 
   // wbfy pins these tooling packages and may apply them immediately after a
   // release, before the global minimum-release-age window has elapsed.
-  '@typescript/native-preview',
-  '@typescript/native-preview-darwin-arm64',
-  '@typescript/native-preview-darwin-x64',
-  '@typescript/native-preview-linux-arm',
-  '@typescript/native-preview-linux-arm64',
-  '@typescript/native-preview-linux-x64',
-  '@typescript/native-preview-win32-arm64',
-  '@typescript/native-preview-win32-x64',
+  'typescript',
+  '@typescript/typescript-darwin-arm64',
+  '@typescript/typescript-darwin-x64',
+  '@typescript/typescript-linux-arm',
+  '@typescript/typescript-linux-arm64',
+  '@typescript/typescript-linux-x64',
+  '@typescript/typescript-win32-arm64',
+  '@typescript/typescript-win32-x64',
   // Bun itself releases its first-party type packages in lockstep with the
   // runtime, so generated Bun repos must be able to install them immediately.
   '@types/bun',

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -26,8 +26,10 @@ import { bunMinimumReleaseAgeExcludes, bunMinimumReleaseAgeSeconds } from './bun
 import { yarnNpmMinimalAgeGate, yarnNpmPreapprovedPackages } from './yarnrc.js';
 
 const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', 'oxfmt', 'oxlint', 'oxlint-tsgolint'];
-const typescriptGoDependency = '@typescript/native-preview';
 const typescriptDependency = 'typescript';
+// TypeScript 7 ships the native compiler as the `typescript` package, replacing
+// the `@typescript/native-preview` (tsgo) preview wbfy relied on before the release.
+const deprecatedTypescriptGoDependency = '@typescript/native-preview';
 const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
 const lefthookDependency = 'lefthook';
@@ -36,6 +38,7 @@ const managedDependencyNames = new Set([
   wbDependency,
   buildTsDependency,
   lefthookDependency,
+  typescriptDependency,
   'sort-package-json',
   ...oxlintDeps,
 ]);
@@ -330,12 +333,9 @@ async function applyPackageJsonConventions(
   devDependencies.push(...tsconfigBaseDependencies);
 
   if (config.doesContainTypeScript || config.doesContainTypeScriptInPackages) {
-    devDependencies.push(typescriptGoDependency);
-    if (config.depending.next) {
-      // Next.js still uses the `typescript` package during dev/build startup for
-      // TypeScript apps even when repositories delegate explicit typechecking to tsgo.
-      devDependencies.push(typescriptDependency);
-    }
+    // TypeScript 7 ships the native compiler as the `typescript` package, so it is
+    // now the managed compiler for every TypeScript repo (typechecking runs `tsc`).
+    devDependencies.push(typescriptDependency);
     if (config.isBun) {
       devDependencies.push('@types/bun');
     } else if (!config.depending.reactNative) {
@@ -731,9 +731,12 @@ async function removeDeprecatedStuff(
   delete jsonObj.dependencies.tslib;
   delete jsonObj.devDependencies['@willbooster/renovate-config'];
   delete jsonObj.devDependencies['@willbooster/tsconfig'];
-  // Next.js still requires the `typescript` package at build/dev time for
-  // TypeScript projects even when repos use tsgo for explicit typechecking.
-  if (!config.depending.next) {
+  // TypeScript 7 replaced the `@typescript/native-preview` (tsgo) preview with the
+  // native `typescript` package, so drop the deprecated preview from existing repos.
+  delete jsonObj.dependencies[deprecatedTypescriptGoDependency];
+  delete jsonObj.devDependencies[deprecatedTypescriptGoDependency];
+  // Non-TypeScript repos should not keep a stray `typescript` package.
+  if (!config.doesContainTypeScript && !config.doesContainTypeScriptInPackages) {
     delete jsonObj.devDependencies[typescriptDependency];
   }
   delete jsonObj.devDependencies.lerna;
@@ -883,8 +886,8 @@ function getLatestDependencyVersion(config: PackageConfig, dependency: string): 
 }
 
 function getDependencyVersionFromNpm(config: PackageConfig, dependency: string): string {
-  // npm's latest dist-tag still tracks TS7 dev snapshots; wbfy should follow
-  // the public beta channel until the stable TS7 package layout is finalized.
+  // wbfy-managed tooling (preapproved packages) adopts the latest release immediately,
+  // bypassing the minimum-release-age gate applied to unreviewed dependencies.
   if (!shouldApplyPackageAgeGate(config, dependency)) {
     return getRawDependencyVersionFromNpm(dependency);
   }
@@ -917,7 +920,7 @@ function isPublishedBeforeAgeGate(publishedAt: string | undefined, packageAgeGat
 }
 
 function getNpmPackageTimes(dependency: string): Record<string, string> {
-  const packageName = getDependencySpecifier(dependency).replace(/@[^@/]+$/u, '');
+  const packageName = dependency.replace(/@[^@/]+$/u, '');
   const cachedTimes = npmPackageTimesCache.get(packageName);
   if (cachedTimes) return cachedTimes;
 
@@ -958,22 +961,12 @@ function doesPackagePatternMatch(pattern: string, dependency: string): boolean {
 }
 
 function getRawDependencyVersionFromNpm(dependency: string): string {
-  return (
-    spawnSyncAndReturnStdout(
-      'npm',
-      ['show', getDependencySpecifier(dependency), 'version', '--workspaces=false'],
-      process.cwd()
-    ) || '*'
-  );
+  return spawnSyncAndReturnStdout('npm', ['show', dependency, 'version', '--workspaces=false'], process.cwd()) || '*';
 }
 
 function getInstallDependencySpecifier(config: PackageConfig, dependency: string): string {
   if (dependency === wbDependency) return `${dependency}@${getLatestDependencyVersion(config, dependency)}`;
-  return getDependencySpecifier(dependency);
-}
-
-function getDependencySpecifier(dependency: string): string {
-  return dependency === typescriptGoDependency ? `${dependency}@beta` : dependency;
+  return dependency;
 }
 
 function removeObsoleteLintDependencies(
@@ -1034,7 +1027,6 @@ function shouldUpdateExistingManagedDependency(
   if (!currentVersion) return true;
   if (currentVersion === '*') return true;
   if (isWorkspaceProtocolRange(currentVersion)) return true;
-  if (dependency === typescriptGoDependency) return isNewerManagedDependencyVersion(config, dependency, currentVersion);
   // wbfy owns these tool dependencies, but applying wbfy should not downgrade a
   // repository that already pins a newer reviewed release.
   return managedDependencyNames.has(dependency) && isNewerManagedDependencyVersion(config, dependency, currentVersion);
@@ -1142,7 +1134,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       lint: `oxlint --no-error-on-unmatched-pattern .`,
       'lint-fix': 'yarn lint --fix',
       'format-code': `oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'`,
-      typecheck: 'tsgo --noEmit',
+      typecheck: 'tsc --noEmit',
     };
     if (hasJava) {
       scripts.prettify = `prettier --cache --no-error-on-unmatched-pattern --write "**/{.*/,}*.{${extensions.prettierOnly.join(',')}}" "!**/test{-,/}fixtures/**"`;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -737,6 +737,7 @@ async function removeDeprecatedStuff(
   delete jsonObj.devDependencies[deprecatedTypescriptGoDependency];
   // Non-TypeScript repos should not keep a stray `typescript` package.
   if (!config.doesContainTypeScript && !config.doesContainTypeScriptInPackages) {
+    delete jsonObj.dependencies[typescriptDependency];
     delete jsonObj.devDependencies[typescriptDependency];
   }
   delete jsonObj.devDependencies.lerna;

--- a/packages/wbfy/src/generators/yarnrc.ts
+++ b/packages/wbfy/src/generators/yarnrc.ts
@@ -44,6 +44,8 @@ export const yarnNpmPreapprovedPackages = [
   'next',
   '@next/*',
   '@types/*',
+  // TypeScript 7 ships the native compiler as `typescript`; `@typescript/*` covers its platform binaries.
+  'typescript',
   '@typescript/*',
   '@oxfmt/*',
   '@oxlint/*',


### PR DESCRIPTION
## Why

TypeScript 7 has shipped **stable as the `typescript` package** (`7.0.2`), which now provides the native `tsc`. wbfy previously generated repos that used the **preview** `@typescript/native-preview` package and its `tsgo` binary. This migrates wbfy to the stable release.

Yarn `4.17.1` needs no code change — `generateYarnrcYml` already resolves the latest `@yarnpkg/cli` dynamically and runs `yarn set version`, so generated repos already adopt `4.17.1`.

## What changed (wbfy generation logic only)

- **`typescript` is now a managed devDependency** for every TypeScript repo, added to `managedDependencyNames`. Dropped the Next.js-only special case — it is the compiler everywhere now.
- **Removes the deprecated `@typescript/native-preview`** from existing repos on the next wbfy run.
- **Typecheck script** now generates `tsc --noEmit` instead of `tsgo --noEmit`.
- **Version resolution** uses the stable `latest` dist-tag (removed the `@beta` preview-channel workaround); handled through the shared managed-dependency path, so the `native-preview` special cases in `shouldUpdateExistingManagedDependency` / `getDependencySpecifier` are gone.
- **Age-gate excludes**: swapped the `@typescript/native-preview-*` platform packages for the `@typescript/typescript-*` binaries in `bunfig.ts`, and preapproved `typescript` in `yarnrc.ts` (the existing `@typescript/*` glob already covers its platform binaries).

`wb typecheck` already selects `tsc` when a repo depends on `typescript`, so no change was needed there.

## Verification

- `yarn typecheck` (wbfy) — passes
- `yarn lint` (wbfy) — passes
- `yarn test` (wbfy) — 24/25 pass. The one failure (`uses stable age-gated versions…`) is a **pre-existing** network-latency timeout that also fails on `main`/baseline (real npm calls, 5s timeout), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)