### PR TITLE
fix: run Workers e2e tests via the unit-test runner without Playwright

### DIFF
--- a/packages/wb/src/scripts/execution/httpServerScripts.ts
+++ b/packages/wb/src/scripts/execution/httpServerScripts.ts
@@ -11,7 +11,7 @@ import { BaseScripts, type TestE2EOptions } from './baseScripts.js';
  * A collection of scripts for executing an app that utilizes an HTTP server like express.
  * Note that `YARN zzz` is replaced with `yarn zzz` or `node_modules/.bin/zzz`.
  */
-class HttpServerScripts extends BaseScripts {
+export class HttpServerScripts extends BaseScripts {
   constructor() {
     super(false);
   }

--- a/packages/wb/src/scripts/execution/workersScripts.ts
+++ b/packages/wb/src/scripts/execution/workersScripts.ts
@@ -8,18 +8,16 @@ import {
 } from '../../utils/wrangler.js';
 import type { ScriptArgv } from '../builder.js';
 
-import { BaseScripts } from './baseScripts.js';
+import { HttpServerScripts } from './httpServerScripts.js';
 
 /**
  * A collection of scripts for executing plain Cloudflare Workers apps (detected via a wrangler
  * config file when no other framework matches; vinext apps have their own scripts).
+ * Extends HttpServerScripts so that e2e tests run via the unit-test runner against the running
+ * worker when the project has no Playwright config.
  * Note that `YARN zzz` is replaced with `yarn zzz` or `node_modules/.bin/zzz`.
  */
-class WorkersScripts extends BaseScripts {
-  constructor() {
-    super(false);
-  }
-
+class WorkersScripts extends HttpServerScripts {
   protected override startDevProtected(project: Project, argv: ScriptArgv): string {
     return this.buildWranglerDevCommands(project, argv).join(' && ');
   }


### PR DESCRIPTION
## Overview

Follow-up bugfix to #913, caught by llm-proxy's PR CI: `workersScripts` inherited `BaseScripts`' Playwright-based e2e flow, so `wb test` on a Workers app without Playwright failed with `Script not found "playwright"`.

## Changes

- `HttpServerScripts` is exported, and `WorkersScripts` extends it instead of `BaseScripts`, inheriting its `testE2EProtected`: when the project has a Playwright config, the standard flow runs; otherwise e2e targets run via the unit-test runner (e.g. `bun test test/e2e/`) against the running worker — matching how bun-test-based API workers like llm-proxy structure their e2e suites.

## Testing

- `yarn typecheck`, `yarn lint`, wb vitest suite (106) pass.
- `wb test --dry-run` against llm-proxy's server package now emits `bun test test/e2e` (previously `playwright test`), with the full workers start chain (gen-dev-vars → D1 migrations → wrangler dev) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)