### PR TITLE
feat(wbfy): apply standard Next.js settings to next.config.ts

### DIFF
--- a/packages/wbfy/src/fixers/nextConfig.ts
+++ b/packages/wbfy/src/fixers/nextConfig.ts
@@ -52,15 +52,6 @@ export async function fixNextConfigJson(config: PackageConfig): Promise<void> {
   });
 }
 
-// Unwrap `{ ... } as NextConfig` / `{ ... } satisfies NextConfig` down to the object literal.
-function unwrapObjectLiteral(node: ast.Expression): ast.ObjectLiteralExpression | undefined {
-  let current: ast.Node = node;
-  while (ast.isAsExpression(current) || ast.isSatisfiesExpression(current)) {
-    current = current.expression;
-  }
-  return ast.isObjectLiteralExpression(current) ? current : undefined;
-}
-
 function getNextConfigObjectLiteral(
   filePath: string
 ): { source: ast.SourceFile; objectLiteral: ast.ObjectLiteralExpression } | undefined {
@@ -95,10 +86,11 @@ function getNextConfigObjectLiteral(
       const objectLiteral = unwrapObjectLiteral(node.initializer);
       if (objectLiteral && ast.isIdentifier(node.name)) {
         variableObjectLiterals.set(node.name.getText(source), objectLiteral);
-        // A `: NextConfig` annotation (or `satisfies NextConfig`) marks the canonical config object.
+        // A `: NextConfig` annotation (or `satisfies`/`as NextConfig`) marks the canonical config object.
         const isTypedAsNextConfig =
           node.type?.getText(source) === 'NextConfig' ||
-          (ast.isSatisfiesExpression(node.initializer) && node.initializer.type.getText(source) === 'NextConfig');
+          ((ast.isSatisfiesExpression(node.initializer) || ast.isAsExpression(node.initializer)) &&
+            node.initializer.type.getText(source) === 'NextConfig');
         if (isTypedAsNextConfig) typedConfigObjectLiterals.push(objectLiteral);
       }
     }
@@ -112,4 +104,13 @@ function getNextConfigObjectLiteral(
     (exportedIdentifier ? variableObjectLiterals.get(exportedIdentifier) : undefined) ??
     variableObjectLiterals.get('nextConfig');
   return objectLiteral ? { source, objectLiteral } : undefined;
+}
+
+// Unwrap `{ ... } as NextConfig` / `{ ... } satisfies NextConfig` down to the object literal.
+function unwrapObjectLiteral(node: ast.Expression): ast.ObjectLiteralExpression | undefined {
+  let current: ast.Node = node;
+  while (ast.isAsExpression(current) || ast.isSatisfiesExpression(current)) {
+    current = current.expression;
+  }
+  return ast.isObjectLiteralExpression(current) ? current : undefined;
 }

--- a/packages/wbfy/src/fixers/nextConfig.ts
+++ b/packages/wbfy/src/fixers/nextConfig.ts
@@ -31,7 +31,9 @@ export async function fixNextConfigJson(config: PackageConfig): Promise<void> {
 
     // `properties` includes spread assignments (`...rest`) that carry no name, so guard before reading it.
     const existingProperties = new Set(
-      objectLiteral.properties.map((property) => ('name' in property ? property.name?.getText(source) : undefined))
+      objectLiteral.properties.map((property) =>
+        'name' in property && property.name ? getPropertyKey(property.name, source) : undefined
+      )
     );
     const propertyTexts = managedProperties
       .filter((property) => !existingProperties.has(property.name))
@@ -40,9 +42,14 @@ export async function fixNextConfigJson(config: PackageConfig): Promise<void> {
 
     const oldContent = source.text;
     const insertionPoint = objectLiteral.getEnd() - 1;
-    // Read the trailing comma from the AST rather than scanning the source text, which would be
-    // fooled by a comma inside a trailing comment (e.g. `foo: 1 // a, b`) and drop the separator.
-    const prefix = objectLiteral.properties.length > 0 && !objectLiteral.properties.hasTrailingComma ? ', ' : '';
+    // The native TS AST does not reliably expose `properties.hasTrailingComma`, so scan the source
+    // between the last property and the closing brace. Strip comments first so a comma inside a
+    // trailing comment (e.g. `foo: 1 // a, b`) is not mistaken for a real trailing comma.
+    const lastProperty = objectLiteral.properties.at(-1);
+    const hasTrailingComma = lastProperty
+      ? stripComments(oldContent.slice(lastProperty.getEnd(), insertionPoint)).includes(',')
+      : false;
+    const prefix = objectLiteral.properties.length > 0 && !hasTrailingComma ? ', ' : '';
     const newContent = `${oldContent.slice(0, insertionPoint)}${prefix}${propertyTexts.join(', ')}${oldContent.slice(
       insertionPoint
     )}`;
@@ -139,4 +146,15 @@ function unwrapParentheses(node: ast.Expression): ast.Expression {
 // Match both the bare `NextConfig` and qualified forms like `import('next').NextConfig`.
 function isNextConfigType(typeText: string): boolean {
   return typeText === 'NextConfig' || typeText.endsWith('.NextConfig');
+}
+
+// Return a property key without surrounding quotes, so `'reactCompiler'` matches `reactCompiler`.
+// Identifier, string-literal and numeric-literal names all expose the unquoted value via `.text`.
+function getPropertyKey(name: ast.PropertyName, source: ast.SourceFile): string {
+  return 'text' in name && typeof name.text === 'string' ? name.text : name.getText(source);
+}
+
+// Remove line and block comments from a source snippet.
+function stripComments(text: string): string {
+  return text.replaceAll(/\/\/[^\n]*|\/\*[\s\S]*?\*\//g, '');
 }

--- a/packages/wbfy/src/fixers/nextConfig.ts
+++ b/packages/wbfy/src/fixers/nextConfig.ts
@@ -9,9 +9,18 @@ import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 import { parseSourceFile } from '../utils/typescriptApi.js';
 
+// Settings every WillBooster Next.js project should carry. `name` is the top-level
+// property key used to detect whether the setting already exists; `text` is inserted
+// verbatim (a whole `key: value` pair) when the key is missing.
+const managedProperties: readonly { name: string; text: string }[] = [
+  { name: 'reactCompiler', text: 'reactCompiler: true' },
+  { name: 'reactStrictMode', text: 'reactStrictMode: true' },
+  { name: 'typescript', text: 'typescript: { ignoreBuildErrors: true }' },
+];
+
 export async function fixNextConfigJson(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('fixNextConfigJson', async () => {
-    const filePath = ['js', 'mjs', 'cjs']
+    const filePath = ['ts', 'mts', 'cts', 'js', 'mjs', 'cjs']
       .map((ext) => path.resolve(config.dirPath, `next.config.${ext}`))
       .find((p) => fs.existsSync(p));
     if (!filePath) return;
@@ -24,10 +33,9 @@ export async function fixNextConfigJson(config: PackageConfig): Promise<void> {
     const existingProperties = new Set(
       objectLiteral.properties.map((property) => ('name' in property ? property.name?.getText(source) : undefined))
     );
-    const propertyTexts: string[] = [];
-    if (!existingProperties.has('typescript')) {
-      propertyTexts.push('typescript: { ignoreBuildErrors: true }');
-    }
+    const propertyTexts = managedProperties
+      .filter((property) => !existingProperties.has(property.name))
+      .map((property) => property.text);
     if (propertyTexts.length === 0) return;
 
     const oldContent = source.text;
@@ -44,30 +52,64 @@ export async function fixNextConfigJson(config: PackageConfig): Promise<void> {
   });
 }
 
+// Unwrap `{ ... } as NextConfig` / `{ ... } satisfies NextConfig` down to the object literal.
+function unwrapObjectLiteral(node: ast.Expression): ast.ObjectLiteralExpression | undefined {
+  let current: ast.Node = node;
+  while (ast.isAsExpression(current) || ast.isSatisfiesExpression(current)) {
+    current = current.expression;
+  }
+  return ast.isObjectLiteralExpression(current) ? current : undefined;
+}
+
 function getNextConfigObjectLiteral(
   filePath: string
 ): { source: ast.SourceFile; objectLiteral: ast.ObjectLiteralExpression } | undefined {
   const source = parseSourceFile(filePath);
   if (!source) return undefined;
 
-  let objectLiteral: ast.ObjectLiteralExpression | undefined;
+  // The WillBooster standard declares the config as `const nextConfig: NextConfig = { ... }` and
+  // exports it (possibly wrapped, e.g. `withSentryConfig(...)`), so the object literal is rarely
+  // the direct operand of `export default`/`module.exports`. Collect every candidate and pick the
+  // most authoritative one below.
+  let directObjectLiteral: ast.ObjectLiteralExpression | undefined;
+  let exportedIdentifier: string | undefined;
+  const variableObjectLiterals = new Map<string, ast.ObjectLiteralExpression>();
+  const typedConfigObjectLiterals: ast.ObjectLiteralExpression[] = [];
+
   const visit = (node: ast.Node): void => {
-    if (objectLiteral) return;
-    if (ast.isExportAssignment(node) && ast.isObjectLiteralExpression(node.expression)) {
-      objectLiteral = node.expression;
-      return;
-    }
-    if (
+    if (ast.isExportAssignment(node)) {
+      const objectLiteral = unwrapObjectLiteral(node.expression);
+      if (objectLiteral) {
+        directObjectLiteral ??= objectLiteral;
+      } else if (ast.isIdentifier(node.expression)) {
+        exportedIdentifier ??= node.expression.getText(source);
+      }
+    } else if (
       ast.isBinaryExpression(node) &&
       node.operatorToken.kind === ast.SyntaxKind.EqualsToken &&
-      node.left.getText(source) === 'module.exports' &&
-      ast.isObjectLiteralExpression(node.right)
+      node.left.getText(source) === 'module.exports'
     ) {
-      objectLiteral = node.right;
-      return;
+      const objectLiteral = unwrapObjectLiteral(node.right);
+      if (objectLiteral) directObjectLiteral ??= objectLiteral;
+    } else if (ast.isVariableDeclaration(node) && node.initializer) {
+      const objectLiteral = unwrapObjectLiteral(node.initializer);
+      if (objectLiteral && ast.isIdentifier(node.name)) {
+        variableObjectLiterals.set(node.name.getText(source), objectLiteral);
+        // A `: NextConfig` annotation (or `satisfies NextConfig`) marks the canonical config object.
+        const isTypedAsNextConfig =
+          node.type?.getText(source) === 'NextConfig' ||
+          (ast.isSatisfiesExpression(node.initializer) && node.initializer.type.getText(source) === 'NextConfig');
+        if (isTypedAsNextConfig) typedConfigObjectLiterals.push(objectLiteral);
+      }
     }
     node.forEachChild(visit);
   };
   source.forEachChild(visit);
+
+  const objectLiteral =
+    typedConfigObjectLiterals[0] ??
+    directObjectLiteral ??
+    (exportedIdentifier ? variableObjectLiterals.get(exportedIdentifier) : undefined) ??
+    variableObjectLiterals.get('nextConfig');
   return objectLiteral ? { source, objectLiteral } : undefined;
 }

--- a/packages/wbfy/src/fixers/nextConfig.ts
+++ b/packages/wbfy/src/fixers/nextConfig.ts
@@ -40,11 +40,9 @@ export async function fixNextConfigJson(config: PackageConfig): Promise<void> {
 
     const oldContent = source.text;
     const insertionPoint = objectLiteral.getEnd() - 1;
-    const lastProperty = objectLiteral.properties.at(-1);
-    const hasTrailingComma = lastProperty
-      ? oldContent.slice(lastProperty.getEnd(), insertionPoint).includes(',')
-      : false;
-    const prefix = objectLiteral.properties.length > 0 && !hasTrailingComma ? ', ' : '';
+    // Read the trailing comma from the AST rather than scanning the source text, which would be
+    // fooled by a comma inside a trailing comment (e.g. `foo: 1 // a, b`) and drop the separator.
+    const prefix = objectLiteral.properties.length > 0 && !objectLiteral.properties.hasTrailingComma ? ', ' : '';
     const newContent = `${oldContent.slice(0, insertionPoint)}${prefix}${propertyTexts.join(', ')}${oldContent.slice(
       insertionPoint
     )}`;
@@ -86,11 +84,13 @@ function getNextConfigObjectLiteral(
       const objectLiteral = unwrapObjectLiteral(node.initializer);
       if (objectLiteral && ast.isIdentifier(node.name)) {
         variableObjectLiterals.set(node.name.getText(source), objectLiteral);
-        // A `: NextConfig` annotation (or `satisfies`/`as NextConfig`) marks the canonical config object.
+        // A `: NextConfig` annotation or a `satisfies`/`as NextConfig` assertion marks the canonical
+        // config object (accepting qualified names such as `import('next').NextConfig`).
+        const annotationType = node.type?.getText(source);
+        const assertedType = getAssertedType(node.initializer)?.getText(source);
         const isTypedAsNextConfig =
-          node.type?.getText(source) === 'NextConfig' ||
-          ((ast.isSatisfiesExpression(node.initializer) || ast.isAsExpression(node.initializer)) &&
-            node.initializer.type.getText(source) === 'NextConfig');
+          (annotationType !== undefined && isNextConfigType(annotationType)) ||
+          (assertedType !== undefined && isNextConfigType(assertedType));
         if (isTypedAsNextConfig) typedConfigObjectLiterals.push(objectLiteral);
       }
     }
@@ -106,11 +106,37 @@ function getNextConfigObjectLiteral(
   return objectLiteral ? { source, objectLiteral } : undefined;
 }
 
-// Unwrap `{ ... } as NextConfig` / `{ ... } satisfies NextConfig` down to the object literal.
+// Unwrap `({ ... })` / `{ ... } as NextConfig` / `{ ... } satisfies NextConfig` to the object literal.
 function unwrapObjectLiteral(node: ast.Expression): ast.ObjectLiteralExpression | undefined {
-  let current: ast.Node = node;
+  const current = unwrapExpression(node);
+  return ast.isObjectLiteralExpression(current) ? current : undefined;
+}
+
+// Return the asserted type of a `satisfies`/`as` expression, if any (ignoring wrapping parentheses).
+function getAssertedType(node: ast.Expression): ast.TypeNode | undefined {
+  const current = unwrapParentheses(node);
+  return ast.isAsExpression(current) || ast.isSatisfiesExpression(current) ? current.type : undefined;
+}
+
+// Peel parentheses and `as`/`satisfies` assertions off an expression.
+function unwrapExpression(node: ast.Expression): ast.Node {
+  let current: ast.Node = unwrapParentheses(node);
   while (ast.isAsExpression(current) || ast.isSatisfiesExpression(current)) {
+    current = unwrapParentheses(current.expression);
+  }
+  return current;
+}
+
+// Peel wrapping parentheses off an expression.
+function unwrapParentheses(node: ast.Expression): ast.Expression {
+  let current = node;
+  while (ast.isParenthesizedExpression(current)) {
     current = current.expression;
   }
-  return ast.isObjectLiteralExpression(current) ? current : undefined;
+  return current;
+}
+
+// Match both the bare `NextConfig` and qualified forms like `import('next').NextConfig`.
+function isNextConfigType(typeText: string): boolean {
+  return typeText === 'NextConfig' || typeText.endsWith('.NextConfig');
 }

--- a/packages/wbfy/src/fixers/nextConfig.ts
+++ b/packages/wbfy/src/fixers/nextConfig.ts
@@ -86,7 +86,11 @@ function getNextConfigObjectLiteral(
       node.left.getText(source) === 'module.exports'
     ) {
       const objectLiteral = unwrapObjectLiteral(node.right);
-      if (objectLiteral) directObjectLiteral ??= objectLiteral;
+      if (objectLiteral) {
+        directObjectLiteral ??= objectLiteral;
+      } else if (ast.isIdentifier(node.right)) {
+        exportedIdentifier ??= node.right.getText(source);
+      }
     } else if (ast.isVariableDeclaration(node) && node.initializer) {
       const objectLiteral = unwrapObjectLiteral(node.initializer);
       if (objectLiteral && ast.isIdentifier(node.name)) {


### PR DESCRIPTION
## Customer Summary

- `wbfy` now automatically brings a project's Next.js config in line with the WillBooster standard. Previously it silently did nothing on the config files we actually use.
- Running `wbfy` ensures `reactCompiler`, `reactStrictMode`, and `typescript: { ignoreBuildErrors: true }` are set in `next.config.*`, adding only the missing ones. Configs that are already compliant are left untouched.

## Technical Summary

- Recognize `next.config.ts`/`.mts`/`.cts` in addition to `.js`/`.mjs`/`.cjs` (the prior fixer only matched the JS variants, so it never ran on our `.ts` configs).
- Resolve the config object literal robustly: a `NextConfig`-typed variable, a `satisfies`/`as NextConfig` assertion (including qualified names like `import('next').NextConfig`), an `export default <identifier>` / `module.exports = <identifier>` reference, or a `nextConfig` variable — unwrapping parentheses and `as`/`satisfies` chains.
- Ensure `reactCompiler: true`, `reactStrictMode: true`, and `typescript: { ignoreBuildErrors: true }` are present, inserting only the missing ones (idempotent).
- Detect the trailing comma by scanning the source with comments stripped (the native TS 7 AST does not reliably expose `properties.hasTrailingComma`; relying on it produced a double-comma syntax error). Compare existing keys by their unquoted `.text` so quoted keys are not duplicated.

## Why

- The old fixer matched neither the `.ts` extension nor the `const nextConfig: NextConfig = {...}` + wrapped-export pattern used across our repos (`WillBoosterLab/exercode`, `WillBoosterLab/ai-game-builder`), and only ensured `typescript.ignoreBuildErrors`. `WillBooster/pkg-preflight` was left non-compliant.

## Testing

- `yarn workspace @willbooster/wbfy verify` passes (typecheck + lint).
- Isolated fixer runs against copies of `exercode`/`ai-game-builder` (already compliant) are no-ops; `pkg-preflight`, empty-object, `module.exports` (direct and identifier), parenthesized `satisfies`, qualified-type, quoted-key, trailing-comma, and comma-in-comment fixtures each produce valid, correctly-formatted output with only the missing settings added.
- End-to-end: ran the built wbfy on `WillBooster/pkg-preflight`; its `next.config.ts` gained `reactCompiler`, `reactStrictMode`, and `typescript: { ignoreBuildErrors: true }`.
- Antigravity and Claude reviews both return "There is no concern."; CI is green.
