### PR TITLE
fix(wbfy): add babel-plugin-react-compiler for Next.js projects

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -304,6 +304,13 @@ async function applyPackageJsonConventions(
     }
   }
 
+  // fixers/nextConfig.ts enables `reactCompiler: true` for every Next.js project, and Next.js
+  // resolves `babel-plugin-react-compiler` at build time when React Compiler is on. Add it here so
+  // the managed next.config never breaks `next build` with an unresolved-package error.
+  if (config.depending.next) {
+    devDependencies.push('babel-plugin-react-compiler');
+  }
+
   if (!isWbPackage(jsonObj)) {
     if (shouldKeepWbAsRuntimeDependency(jsonObj)) {
       dependencies.push(wbDependency);


### PR DESCRIPTION
## Why

wbfy's `fixers/nextConfig.ts` enables `reactCompiler: true` in `next.config.*` for **every** Next.js project. When React Compiler is enabled, Next.js resolves `babel-plugin-react-compiler` at build time. If the package is missing, `next build` fails:

```
Failed to resolve package babel-plugin-react-compiler while attempting to resolve React Compiler
React compiler is enabled in next.config.ts. ... Is babel-plugin-react-compiler installed in your node_modules directory?
```

This currently breaks the build (and CI) for Next.js projects that wbfy touches (e.g. WillBooster/pkg-preflight).

## What

Add `babel-plugin-react-compiler` as a managed devDependency whenever a project depends on Next.js (`config.depending.next`), so the wbfy-managed `next.config` never breaks `next build`.