### PR TITLE
fix(wbfy): preserve MISE_ENV prefix and drop --bun from Playwright verify-full

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1277,7 +1277,11 @@ function applyMiseTaskScripts(
  */
 function extractMiseBridgeEnvPrefix(script: unknown, name: string): string | undefined {
   if (typeof script !== 'string') return undefined;
-  const match = new RegExp(String.raw`^((?:\w+=\S+\s+)*)mise run ${escapeRegExp(name)}$`, 'u').exec(script.trim());
+  // Each assignment value may be double-quoted, single-quoted, or an unquoted run of non-whitespace,
+  // so prefixes like `MISE_ENV="a b"` (whose value contains spaces) are matched instead of dropped.
+  const match = new RegExp(String.raw`^((?:\w+=(?:"[^"]*"|'[^']*'|\S+)\s+)*)mise run ${escapeRegExp(name)}$`, 'u').exec(
+    script.trim()
+  );
   return match?.[1];
 }
 

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1132,7 +1132,11 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
       test: 'bun wb test',
       typecheck: 'bun --bun wb typecheck',
       verify: 'bun --bun wb verify',
-      'verify-full': 'bun --bun wb verify --full',
+      // `verify --full` runs Playwright, and Bun's `--bun` flag installs a node->bun PATH shim that
+      // propagates into Playwright's child processes, crashing test loading with an opaque
+      // "ResolveMessage {}". Omit `--bun` for Playwright projects so `wb verify --full` (and thus
+      // Playwright) runs under Node.js; wb still uses Bun for its own inner commands.
+      'verify-full': config.depending.playwrightTest ? 'bun wb verify --full' : 'bun --bun wb verify --full',
     };
     applyDatabaseScripts(config, scripts, oldScripts, `bun --bun ${getWbDatabaseCommand(config)}`);
     applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
@@ -1256,9 +1260,25 @@ function applyMiseTaskScripts(
   for (const name of names) {
     if (!hasMiseTask(config, name)) continue;
     if (doesMiseTaskCallPackageScript(config, name)) continue;
-    if (oldScripts[name] && !isWbfyManagedMiseBridge(oldScripts[name], name) && !(name in scripts)) continue;
-    scripts[name] = `mise run ${name}`;
+    // Preserve a leading `KEY=VALUE ` env prefix (e.g. `MISE_ENV=test`) on an existing mise bridge.
+    // Such a prefix is required for mise config environments (mise.<MISE_ENV>.toml), which are
+    // selected from MISE_ENV *before* mise starts and cannot be switched from inside a task; dropping
+    // it would silently run the task in the default environment.
+    const envPrefix = extractMiseBridgeEnvPrefix(oldScripts[name], name);
+    if (envPrefix === undefined && oldScripts[name] && !(name in scripts)) continue;
+    scripts[name] = `${envPrefix ?? ''}mise run ${name}`;
   }
+}
+
+/**
+ * Returns the leading `KEY=VALUE ` env-var prefix of an existing `mise run <name>` bridge script
+ * (possibly an empty string when the bridge has no prefix), or `undefined` when the script is not a
+ * mise bridge for the given task.
+ */
+function extractMiseBridgeEnvPrefix(script: unknown, name: string): string | undefined {
+  if (typeof script !== 'string') return undefined;
+  const match = new RegExp(String.raw`^((?:\w+=\S+\s+)*)mise run ${escapeRegExp(name)}$`, 'u').exec(script.trim());
+  return match?.[1];
 }
 
 function hasMiseTask(config: PackageConfig, name: string): boolean {
@@ -1272,10 +1292,6 @@ function doesMiseTaskCallPackageScript(config: PackageConfig, name: string): boo
   return packageManagers.some((packageManager) =>
     new RegExp(String.raw`\b${packageManager}\s+(?:run\s+)?${escapeRegExp(name)}(?![a-zA-Z0-9_\-:.])`, 'u').test(task)
   );
-}
-
-function isWbfyManagedMiseBridge(script: unknown, name: string): boolean {
-  return script === `mise run ${name}`;
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -209,6 +209,43 @@ test('uses bun runner for generated Python scripts in bun projects', async () =>
   expect(packageJson.scripts?.['lint-fix']).not.toContain('yarn');
 });
 
+test('preserves a leading MISE_ENV prefix on a mise bridge script', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      scripts: {
+        test: 'MISE_ENV=test mise run test',
+      },
+    },
+    { isBun: true, miseTasks: { test: 'bun run playwright test' } }
+  );
+
+  expect(packageJson.scripts?.test).toBe('MISE_ENV=test mise run test');
+});
+
+test('regenerates a plain mise bridge script without inventing an env prefix', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      scripts: {
+        test: 'mise run test',
+      },
+    },
+    { isBun: true, miseTasks: { test: 'bun run playwright test' } }
+  );
+
+  expect(packageJson.scripts?.test).toBe('mise run test');
+});
+
+test('drops --bun from verify-full for Playwright projects but keeps it otherwise', async () => {
+  const withPlaywright = await generatePackageJsonFrom(
+    { scripts: {} },
+    { isBun: true, depending: { ...createConfig().depending, playwrightTest: true } }
+  );
+  const withoutPlaywright = await generatePackageJsonFrom({ scripts: {} }, { isBun: true });
+
+  expect(withPlaywright.scripts?.['verify-full']).toBe('bun wb verify --full');
+  expect(withoutPlaywright.scripts?.['verify-full']).toBe('bun --bun wb verify --full');
+});
+
 async function generatePackageJsonFrom(
   initialPackageJson: Record<string, unknown>,
   configOverrides: Parameters<typeof createConfig>[0] = {},

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -222,6 +222,19 @@ test('preserves a leading MISE_ENV prefix on a mise bridge script', async () => 
   expect(packageJson.scripts?.test).toBe('MISE_ENV=test mise run test');
 });
 
+test('preserves a quoted MISE_ENV value containing spaces on a mise bridge script', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      scripts: {
+        test: 'MISE_ENV="test development" mise run test',
+      },
+    },
+    { isBun: true, miseTasks: { test: 'bun run playwright test' } }
+  );
+
+  expect(packageJson.scripts?.test).toBe('MISE_ENV="test development" mise run test');
+});
+
 test('regenerates a plain mise bridge script without inventing an env prefix', async () => {
   const packageJson = await generatePackageJsonFrom(
     {


### PR DESCRIPTION
## Why

While running `wbfy` on a Cloudflare + D1 project (vinext on Cloudflare Workers), two generated `package.json` scripts had to be hand-fixed after every run:

### 1. mise config-environment prefix was stripped

The mise-bridge generator rewrote `MISE_ENV=test mise run test` → bare `mise run test`, dropping the env prefix. That prefix is required for [mise config environments](https://mise.jdx.dev/configuration/environments.html) (`mise.<MISE_ENV>.toml`), which are selected from `MISE_ENV` **before** mise starts and cannot be switched from inside a task. For Cloudflare projects it also isolates the miniflare D1/KV/R2 test state (`persistState` keyed on `MISE_ENV` in `vite.config.ts`), so losing it makes E2E tests run against dev data / the wrong port.

Now `applyMiseTaskScripts` preserves any leading `KEY=VALUE ` prefix on an existing mise bridge, and only regenerates a bare bridge when none was present.

### 2. `--bun` broke Playwright in `verify-full`

`verify-full` was always generated as `bun --bun wb verify --full`. Bun's `--bun` flag installs a node→bun PATH shim that propagates into Playwright's child processes and crashes test loading with an opaque `ResolveMessage {}`. For Playwright projects (`config.depending.playwrightTest`), `verify-full` now omits `--bun` so Playwright runs under Node.js; wb still uses Bun for its own inner commands. Non-Playwright projects are unchanged.

## Tests

Added three cases to `packageJson.test.ts`:
- preserves a leading `MISE_ENV` prefix on a mise bridge script
- regenerates a plain mise bridge without inventing an env prefix
- drops `--bun` from `verify-full` for Playwright projects but keeps it otherwise