### PR TITLE
feat(wb): warn when Playwright specs are undiscoverable

### DIFF
--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -288,13 +288,14 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
 export function warnIfPlaywrightSpecsAreUndiscoverable(
   project: Pick<Project, 'dirPath' | 'name' | 'packageJson'>
 ): void {
-  // Only a project's OWN Playwright config counts here. `hasPlaywrightConfig` walks up to the
+  // Callers invoke this only after establishing that test/e2e is missing, so it is not re-checked
+  // here. Only a project's OWN Playwright config counts: `hasPlaywrightConfig` walks up to the
   // monorepo root, so reusing it would false-positive on library packages and the root itself,
   // which legitimately share a root-level playwright.config.ts but keep e2e specs in a single app
   // package. A workspace root delegates e2e to its packages, so it never warns either.
   const hasLocalPlaywrightConfig = fs.existsSync(path.join(project.dirPath, 'playwright.config.ts'));
   const isWorkspaceRoot = !!project.packageJson.workspaces;
-  if (!hasLocalPlaywrightConfig || isWorkspaceRoot || fs.existsSync(path.join(project.dirPath, 'test', 'e2e'))) return;
+  if (!hasLocalPlaywrightConfig || isWorkspaceRoot) return;
 
   console.warn(
     chalk.yellow(

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -289,13 +289,13 @@ export function warnIfPlaywrightSpecsAreUndiscoverable(
   project: Pick<Project, 'dirPath' | 'name' | 'packageJson'>
 ): void {
   // Callers invoke this only after establishing that test/e2e is missing, so it is not re-checked
-  // here. Only a project's OWN Playwright config counts: `hasPlaywrightConfig` walks up to the
-  // monorepo root, so reusing it would false-positive on library packages and the root itself,
-  // which legitimately share a root-level playwright.config.ts but keep e2e specs in a single app
-  // package. A workspace root delegates e2e to its packages, so it never warns either.
-  const hasLocalPlaywrightConfig = fs.existsSync(path.join(project.dirPath, 'playwright.config.ts'));
-  const isWorkspaceRoot = !!project.packageJson.workspaces;
-  if (!hasLocalPlaywrightConfig || isWorkspaceRoot) return;
+  // here. A workspace root delegates e2e to its packages, so it never warns (checked first to skip
+  // the filesystem lookup below). Only a project's OWN Playwright config counts: `hasPlaywrightConfig`
+  // walks up to the monorepo root, so reusing it would false-positive on library packages and the
+  // root itself, which legitimately share a root-level playwright.config.ts but keep e2e specs in a
+  // single app package.
+  if (project.packageJson.workspaces) return;
+  if (!fs.existsSync(path.join(project.dirPath, 'playwright.config.ts'))) return;
 
   console.warn(
     chalk.yellow(

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -286,9 +286,15 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
  * without running any tests.
  */
 export function warnIfPlaywrightSpecsAreUndiscoverable(
-  project: Pick<Project, 'dirPath' | 'hasPlaywrightConfig' | 'name'>
+  project: Pick<Project, 'dirPath' | 'name' | 'packageJson'>
 ): void {
-  if (!project.hasPlaywrightConfig || fs.existsSync(path.join(project.dirPath, 'test', 'e2e'))) return;
+  // Only a project's OWN Playwright config counts here. `hasPlaywrightConfig` walks up to the
+  // monorepo root, so reusing it would false-positive on library packages and the root itself,
+  // which legitimately share a root-level playwright.config.ts but keep e2e specs in a single app
+  // package. A workspace root delegates e2e to its packages, so it never warns either.
+  const hasLocalPlaywrightConfig = fs.existsSync(path.join(project.dirPath, 'playwright.config.ts'));
+  const isWorkspaceRoot = !!project.packageJson.workspaces;
+  if (!hasLocalPlaywrightConfig || isWorkspaceRoot || fs.existsSync(path.join(project.dirPath, 'test', 'e2e'))) return;
 
   console.warn(
     chalk.yellow(

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -153,6 +153,7 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
     }
     // Skip e2e tests if not needed or no e2e directory exists
     if (!shouldRunE2e || !fs.existsSync(path.join(project.dirPath, 'test', 'e2e'))) {
+      if (shouldRunE2e) warnIfPlaywrightSpecsAreUndiscoverable(project);
       continue;
     }
 
@@ -276,6 +277,25 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
     }
   }
   return 0;
+}
+
+/**
+ * Warn when a project has a Playwright config but no test/e2e directory.
+ * wb discovers e2e tests only under test/e2e/, so such projects would otherwise have their
+ * Playwright specs silently skipped and `wb test` / `wb verify --full` would report success
+ * without running any tests.
+ */
+export function warnIfPlaywrightSpecsAreUndiscoverable(
+  project: Pick<Project, 'dirPath' | 'hasPlaywrightConfig' | 'name'>
+): void {
+  if (!project.hasPlaywrightConfig || fs.existsSync(path.join(project.dirPath, 'test', 'e2e'))) return;
+
+  console.warn(
+    chalk.yellow(
+      `Skipping e2e tests for ${project.name}: a Playwright config exists but the test/e2e directory is missing. ` +
+        'wb only discovers Playwright specs under test/e2e/, so move them there to run e2e tests.'
+    )
+  );
 }
 
 export function withDefaultTestCascadeEnv(argv: TestCommandArgv): TestCommandArgv {

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -298,8 +298,7 @@ export function warnIfPlaywrightSpecsAreUndiscoverable(
 
   console.warn(
     chalk.yellow(
-      `Skipping e2e tests for ${project.name}: a Playwright config exists but the test/e2e directory is missing. ` +
-        'wb only discovers Playwright specs under test/e2e/, so move them there to run e2e tests.'
+      `Skipping e2e tests for ${project.name}: a Playwright config exists but the test/e2e directory is missing. wb only discovers Playwright specs under test/e2e/, so move them there to run e2e tests.`
     )
   );
 }

--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -22,6 +22,7 @@ import { findWranglerConfigPath } from '../utils/wrangler.js';
 import { promisePool } from '../utils/promisePool.js';
 
 import { httpServerPackages } from './httpServerPackages.js';
+import { warnIfPlaywrightSpecsAreUndiscoverable } from './test.js';
 
 const testOnCiBuilder = {
   silent: {
@@ -110,6 +111,8 @@ export async function testOnCi(
       if (hasDockerfile) {
         await runWithSpawn(dockerScripts.stop(project), project, argv);
       }
+    } else {
+      warnIfPlaywrightSpecsAreUndiscoverable(project);
     }
   }
 }


### PR DESCRIPTION
## Customer Summary

- No behavior change for correctly laid-out projects. A project whose Playwright specs live outside `test/e2e/` now gets a clear warning instead of a silent success without any tests.
- Monorepos are unaffected: library packages and workspace roots that share a root-level Playwright config are no longer warned by mistake.

## Technical Summary

- `wb test` and `wb test-on-ci` gate e2e execution on the existence of `test/e2e/`. A new `warnIfPlaywrightSpecsAreUndiscoverable` helper (exported from `commands/test.ts`, reused in `commands/testOnCi.ts`) prints a yellow warning when a project has a Playwright config but no `test/e2e/` directory.
- The warning predicate uses the project's OWN local `playwright.config.ts` and skips workspace roots. It deliberately does not use `Project.hasPlaywrightConfig`, which walks up to the monorepo root and would false-positive on library packages and roots that share a root-level config. The workspace-root check runs first to avoid an unnecessary filesystem lookup.
- Callers already establish that `test/e2e/` is missing before invoking the helper, so that check is not repeated inside it.

## Why

- While verifying the Cloudflare Workers + D1 support on exKAZUu/yutsugi (exKAZUu/yutsugi#141), `wb verify --full` reported success in 2 seconds without running a single test: the repo's specs lived in `test/` with `testDir: './test'`, invisible to wb's `test/e2e/` convention. A silent skip makes full verification look green while providing no coverage; this warning surfaces the misconfiguration.
- Gating on the local config (instead of the walk-up `hasPlaywrightConfig`) keeps the yutsugi-style single-package case warning while avoiding noise on monorepos with a shared root-level Playwright config and package-level `test/e2e/`.

## Testing

- `yarn verify` — passed.
- CI (GitHub Actions) — all workflows passed.
- Manual check: ran `yarn start test -w <fixture>` against a minimal project containing `playwright.config.ts` but no `test/e2e/`; the warning is printed and e2e is skipped. yutsugi (which now has `test/e2e/`) runs its 20 tests normally.
