### PR TITLE
fix(wbfy): detect Bun projects via bunfig.toml in addition to bun.lock

### DIFF
--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -187,6 +187,7 @@ export async function getPackageConfig(
       isRailway: detectRailway(dirPath, packageJson),
       isBun:
         rootConfig?.isBun ||
+        fs.existsSync(path.join(dirPath, 'bun.lockb')) ||
         fs.existsSync(path.join(dirPath, 'bun.lock')) ||
         // Some repos gitignore bun.lock, so it may be missing on fresh clones.
         // bunfig.toml is committed and generated only for Bun projects, making it a reliable signal.

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -185,7 +185,12 @@ export async function getPackageConfig(
       ),
       isCloudflare: detectCloudflare(dirPath, packageJson),
       isRailway: detectRailway(dirPath, packageJson),
-      isBun: rootConfig?.isBun || fs.existsSync(path.join(dirPath, 'bun.lock')),
+      isBun:
+        rootConfig?.isBun ||
+        fs.existsSync(path.join(dirPath, 'bun.lock')) ||
+        // Some repos gitignore bun.lock, so it may be missing on fresh clones.
+        // bunfig.toml is committed and generated only for Bun projects, making it a reliable signal.
+        fs.existsSync(path.join(dirPath, 'bunfig.toml')),
       isEsmPackage: esmPackage,
       isWillBoosterConfigs: packageJsonPath.includes('/willbooster-configs'),
       doesContainSubPackageJsons: containsAny('packages/**/package.json', dirPath),


### PR DESCRIPTION
## Summary

`isBun` detection relied solely on the presence of `bun.lock` on disk. Some repos (e.g. `draft-booster`) gitignore `bun.lock`, so on a fresh clone the lockfile is absent and wbfy misdetects the project as Yarn — rewriting scripts, adding `packageManager: yarn@…`, and generating `yarn.lock`/`.yarnrc.yml` in a Bun project.

This adds `bunfig.toml` as a fallback signal: it is committed to the repo and generated by wbfy only for Bun projects, so it reliably marks a Bun project even when the lockfile is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)