### PR TITLE
fix(wb,wbfy): improve generated agent instructions and make verify type-check everything

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -7,48 +7,37 @@ alwaysApply: true
 ## Project Information
 
 - Name: `willbooster-shared`
-- Description: undefined
 - Package Manager: yarn
 
 ## General Instructions
 
-- Create a new branch if the current branch is `main`.
-- Run any `git` commands sequentially.
-- Write tests ONLY if explicitly requested. If requested, follow these rules:
+- If on `main`, create a new branch; otherwise work on the current branch.
+- Run `git` commands one at a time to avoid `index.lock` conflicts.
+- Write tests when explicitly requested, or when you judge the change worth testing; without a request, cover only the essential behavior.
+- When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
-  - Always investigate the root cause of a test failure before fixing it.
-  - Avoid adding wait functions in E2E tests unless strictly necessary.
-- When fixing issues, follow these rules:
-  - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
-  - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
-  - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
-- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
-  - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
-  - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Cursor) <agent@willbooster.com>`.
-  - Always create new commits. Avoid using `--amend`.
-- Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the `.tmp` or `/tmp` directory.
+  - Avoid fixed waits in E2E tests; wait for conditions instead.
+- When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
+- After making changes, run `yarn verify` (type checking and linting; takes up to 10 minutes), or `yarn verify-full` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
+- Once verified, commit and push to the current (non-main) branch, and create a PR via `gh` if none exists for the branch.
+  - Follow the Conventional Commits format (e.g., `feat:`, `fix:`).
+  - End your commit message with a blank line followed by `Co-authored-by: WillBooster (Cursor) <agent@willbooster.com>`.
+  - Always create new commits; avoid `--amend`.
+- Use heredoc for multi-line command input (e.g., `git commit -F -`, `gh pr create --body-file -`).
+- Put temporary files in `.tmp`; use `/tmp` only for files that must live outside the repo.
 
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., `function caller() { callee(); } function callee() { ... }`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of `join()` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use `assert` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`).
+- Prefer `undefined` over `null` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of `join()` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, `assert` at startup to fail fast.
 - Use `project.env` instead of `process.env` on `wb` package.
 - Always drop any Windows support.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -2,20 +2,14 @@ Review in English based on the following coding standards.
 
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., `function caller() { callee(); } function callee() { ... }`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of `join()` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use `assert` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`).
+- Prefer `undefined` over `null` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of `join()` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, `assert` at startup to fail fast.
 - Use `project.env` instead of `process.env` on `wb` package.
 - Always drop any Windows support.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,48 +1,37 @@
 ## Project Information
 
 - Name: `willbooster-shared`
-- Description: undefined
 - Package Manager: yarn
 
 ## General Instructions
 
-- Create a new branch if the current branch is `main`.
-- Run any `git` commands sequentially.
-- Write tests ONLY if explicitly requested. If requested, follow these rules:
+- If on `main`, create a new branch; otherwise work on the current branch.
+- Run `git` commands one at a time to avoid `index.lock` conflicts.
+- Write tests when explicitly requested, or when you judge the change worth testing; without a request, cover only the essential behavior.
+- When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
-  - Always investigate the root cause of a test failure before fixing it.
-  - Avoid adding wait functions in E2E tests unless strictly necessary.
-- When fixing issues, follow these rules:
-  - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
-  - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
-  - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
-- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
-  - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
-  - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Codex CLI) <agent@willbooster.com>`.
-  - Always create new commits. Avoid using `--amend`.
-- Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the `.tmp` or `/tmp` directory.
+  - Avoid fixed waits in E2E tests; wait for conditions instead.
+- When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
+- After making changes, run `yarn verify` (type checking and linting; takes up to 10 minutes), or `yarn verify-full` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
+- Once verified, commit and push to the current (non-main) branch, and create a PR via `gh` if none exists for the branch.
+  - Follow the Conventional Commits format (e.g., `feat:`, `fix:`).
+  - End your commit message with a blank line followed by `Co-authored-by: WillBooster (Codex CLI) <agent@willbooster.com>`.
+  - Always create new commits; avoid `--amend`.
+- Use heredoc for multi-line command input (e.g., `git commit -F -`, `gh pr create --body-file -`).
+- Put temporary files in `.tmp`; use `/tmp` only for files that must live outside the repo.
 
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., `function caller() { callee(); } function callee() { ... }`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of `join()` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use `assert` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`).
+- Prefer `undefined` over `null` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of `join()` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, `assert` at startup to fail fast.
 - Use `project.env` instead of `process.env` on `wb` package.
 - Always drop any Windows support.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,48 +1,37 @@
 ## Project Information
 
 - Name: `willbooster-shared`
-- Description: undefined
 - Package Manager: yarn
 
 ## General Instructions
 
-- Create a new branch if the current branch is `main`.
-- Run any `git` commands sequentially.
-- Write tests ONLY if explicitly requested. If requested, follow these rules:
+- If on `main`, create a new branch; otherwise work on the current branch.
+- Run `git` commands one at a time to avoid `index.lock` conflicts.
+- Write tests when explicitly requested, or when you judge the change worth testing; without a request, cover only the essential behavior.
+- When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
-  - Always investigate the root cause of a test failure before fixing it.
-  - Avoid adding wait functions in E2E tests unless strictly necessary.
-- When fixing issues, follow these rules:
-  - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
-  - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
-  - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
-- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
-  - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
-  - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>`.
-  - Always create new commits. Avoid using `--amend`.
-- Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the `.tmp` or `/tmp` directory.
+  - Avoid fixed waits in E2E tests; wait for conditions instead.
+- When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
+- After making changes, run `yarn verify` (type checking and linting; takes up to 10 minutes), or `yarn verify-full` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
+- Once verified, commit and push to the current (non-main) branch, and create a PR via `gh` if none exists for the branch.
+  - Follow the Conventional Commits format (e.g., `feat:`, `fix:`).
+  - End your commit message with a blank line followed by `Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>`.
+  - Always create new commits; avoid `--amend`.
+- Use heredoc for multi-line command input (e.g., `git commit -F -`, `gh pr create --body-file -`).
+- Put temporary files in `.tmp`; use `/tmp` only for files that must live outside the repo.
 
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., `function caller() { callee(); } function callee() { ... }`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of `join()` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use `assert` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`).
+- Prefer `undefined` over `null` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of `join()` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, `assert` at startup to fail fast.
 - Use `project.env` instead of `process.env` on `wb` package.
 - Always drop any Windows support.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,48 +1,37 @@
 ## Project Information
 
 - Name: `willbooster-shared`
-- Description: undefined
 - Package Manager: yarn
 
 ## General Instructions
 
-- Create a new branch if the current branch is `main`.
-- Run any `git` commands sequentially.
-- Write tests ONLY if explicitly requested. If requested, follow these rules:
+- If on `main`, create a new branch; otherwise work on the current branch.
+- Run `git` commands one at a time to avoid `index.lock` conflicts.
+- Write tests when explicitly requested, or when you judge the change worth testing; without a request, cover only the essential behavior.
+- When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
-  - Always investigate the root cause of a test failure before fixing it.
-  - Avoid adding wait functions in E2E tests unless strictly necessary.
-- When fixing issues, follow these rules:
-  - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
-  - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run `yarn verify-full` to execute all tests (takes up to 1 hour), or `yarn verify` for only type checking and linting (takes up to 10 minutes).
-  - If you are confident that your changes will not break any tests, you may use `verify`.
-  - Use `oxlint` ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires `null`).
-- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via `gh`.
-  - Follow the conventional commits; your commit message should start with `feat:`, `fix:`, etc.
-  - If not specified, make sure to add a new line at the end of your commit message with: `Co-authored-by: WillBooster (Gemini CLI) <agent@willbooster.com>`.
-  - Always create new commits. Avoid using `--amend`.
-- Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the `.tmp` or `/tmp` directory.
+  - Avoid fixed waits in E2E tests; wait for conditions instead.
+- When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
+- After making changes, run `yarn verify` (type checking and linting; takes up to 10 minutes), or `yarn verify-full` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
+- Once verified, commit and push to the current (non-main) branch, and create a PR via `gh` if none exists for the branch.
+  - Follow the Conventional Commits format (e.g., `feat:`, `fix:`).
+  - End your commit message with a blank line followed by `Co-authored-by: WillBooster (Gemini CLI) <agent@willbooster.com>`.
+  - Always create new commits; avoid `--amend`.
+- Use heredoc for multi-line command input (e.g., `git commit -F -`, `gh pr create --body-file -`).
+- Put temporary files in `.tmp`; use `/tmp` only for files that must live outside the repo.
 
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., `function caller() { callee(); } function callee() { ... }`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of `join()` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use `assert` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., `// oxlint-disable-next-line <rule> -- <reason>`).
+- Prefer `undefined` over `null` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of `join()` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, `assert` at startup to fail fast.
 - Use `project.env` instead of `process.env` on `wb` package.
 - Always drop any Windows support.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -6,6 +6,9 @@ import oxlintBaseConfig from '@willbooster/oxlint-config';
 // Keep a package-local copy so repositories can add settings outside
 // managed blocks without mutating the shared imported config object.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
+// The type-aware options make lint perform type checking. Always force them on here,
+// inside the managed block, so no customization can silently disable type checking.
+oxlintResolvedConfig.options = { ...oxlintResolvedConfig.options, typeAware: true, typeCheck: true };
 // wbfy:end oxlint-base
 
 // wbfy:start oxlint-export

--- a/packages/shared-lib-blitz-next/oxlint.config.ts
+++ b/packages/shared-lib-blitz-next/oxlint.config.ts
@@ -3,10 +3,9 @@ import type { OxlintConfig } from 'oxlint';
 
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
-// Oxlint only supports type-aware options in the root config, while it
-// still auto-discovers package-local config files in monorepos. Keep this as a
-// structured clone so packages can delete root-only settings without mutating
-// the shared imported config object.
+// Oxlint rejects the root-only type-aware options outside the root config, so delete them
+// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base

--- a/packages/shared-lib-blitz-next/oxlint.config.ts
+++ b/packages/shared-lib-blitz-next/oxlint.config.ts
@@ -4,7 +4,7 @@ import type { OxlintConfig } from 'oxlint';
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint rejects the root-only type-aware options outside the root config, so delete them
-// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// here. This does NOT disable type checking: the lint commands pass the --type-aware and
 // --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -35,7 +35,7 @@
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
     "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
-    "lint": "oxlint --no-error-on-unmatched-pattern .",
+    "lint": "oxlint --type-aware --type-check --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "vitest",
     "typecheck": "wb typecheck",

--- a/packages/shared-lib-next/oxlint.config.ts
+++ b/packages/shared-lib-next/oxlint.config.ts
@@ -3,10 +3,9 @@ import type { OxlintConfig } from 'oxlint';
 
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
-// Oxlint only supports type-aware options in the root config, while it
-// still auto-discovers package-local config files in monorepos. Keep this as a
-// structured clone so packages can delete root-only settings without mutating
-// the shared imported config object.
+// Oxlint rejects the root-only type-aware options outside the root config, so delete them
+// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base

--- a/packages/shared-lib-next/oxlint.config.ts
+++ b/packages/shared-lib-next/oxlint.config.ts
@@ -4,7 +4,7 @@ import type { OxlintConfig } from 'oxlint';
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint rejects the root-only type-aware options outside the root config, so delete them
-// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// here. This does NOT disable type checking: the lint commands pass the --type-aware and
 // --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -35,7 +35,7 @@
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
     "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
-    "lint": "oxlint --no-error-on-unmatched-pattern .",
+    "lint": "oxlint --type-aware --type-check --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "vitest",
     "typecheck": "wb typecheck",

--- a/packages/shared-lib-node/oxlint.config.ts
+++ b/packages/shared-lib-node/oxlint.config.ts
@@ -3,10 +3,9 @@ import type { OxlintConfig } from 'oxlint';
 
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
-// Oxlint only supports type-aware options in the root config, while it
-// still auto-discovers package-local config files in monorepos. Keep this as a
-// structured clone so packages can delete root-only settings without mutating
-// the shared imported config object.
+// Oxlint rejects the root-only type-aware options outside the root config, so delete them
+// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base

--- a/packages/shared-lib-node/oxlint.config.ts
+++ b/packages/shared-lib-node/oxlint.config.ts
@@ -4,7 +4,7 @@ import type { OxlintConfig } from 'oxlint';
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint rejects the root-only type-aware options outside the root config, so delete them
-// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// here. This does NOT disable type checking: the lint commands pass the --type-aware and
 // --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -35,7 +35,7 @@
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
     "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
-    "lint": "oxlint --no-error-on-unmatched-pattern .",
+    "lint": "oxlint --type-aware --type-check --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "vitest test/",
     "typecheck": "wb typecheck",

--- a/packages/shared-lib-react/oxlint.config.ts
+++ b/packages/shared-lib-react/oxlint.config.ts
@@ -3,10 +3,9 @@ import type { OxlintConfig } from 'oxlint';
 
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
-// Oxlint only supports type-aware options in the root config, while it
-// still auto-discovers package-local config files in monorepos. Keep this as a
-// structured clone so packages can delete root-only settings without mutating
-// the shared imported config object.
+// Oxlint rejects the root-only type-aware options outside the root config, so delete them
+// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base

--- a/packages/shared-lib-react/oxlint.config.ts
+++ b/packages/shared-lib-react/oxlint.config.ts
@@ -4,7 +4,7 @@ import type { OxlintConfig } from 'oxlint';
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint rejects the root-only type-aware options outside the root config, so delete them
-// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// here. This does NOT disable type checking: the lint commands pass the --type-aware and
 // --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -31,7 +31,7 @@
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
     "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
-    "lint": "oxlint --no-error-on-unmatched-pattern .",
+    "lint": "oxlint --type-aware --type-check --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "storybook": "start-storybook -p 6006",
     "test/ci": "yarn build-storybook",

--- a/packages/shared-lib/oxlint.config.ts
+++ b/packages/shared-lib/oxlint.config.ts
@@ -3,10 +3,9 @@ import type { OxlintConfig } from 'oxlint';
 
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
-// Oxlint only supports type-aware options in the root config, while it
-// still auto-discovers package-local config files in monorepos. Keep this as a
-// structured clone so packages can delete root-only settings without mutating
-// the shared imported config object.
+// Oxlint rejects the root-only type-aware options outside the root config, so delete them
+// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base

--- a/packages/shared-lib/oxlint.config.ts
+++ b/packages/shared-lib/oxlint.config.ts
@@ -4,7 +4,7 @@ import type { OxlintConfig } from 'oxlint';
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint rejects the root-only type-aware options outside the root config, so delete them
-// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// here. This does NOT disable type checking: the lint commands pass the --type-aware and
 // --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -35,7 +35,7 @@
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
     "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
-    "lint": "oxlint --no-error-on-unmatched-pattern .",
+    "lint": "oxlint --type-aware --type-check --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "test": "vitest",
     "typecheck": "wb typecheck",

--- a/packages/wb/oxlint.config.ts
+++ b/packages/wb/oxlint.config.ts
@@ -3,10 +3,9 @@ import type { OxlintConfig } from 'oxlint';
 
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
-// Oxlint only supports type-aware options in the root config, while it
-// still auto-discovers package-local config files in monorepos. Keep this as a
-// structured clone so packages can delete root-only settings without mutating
-// the shared imported config object.
+// Oxlint rejects the root-only type-aware options outside the root config, so delete them
+// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base

--- a/packages/wb/oxlint.config.ts
+++ b/packages/wb/oxlint.config.ts
@@ -4,7 +4,7 @@ import type { OxlintConfig } from 'oxlint';
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint rejects the root-only type-aware options outside the root config, so delete them
-// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// here. This does NOT disable type checking: the lint commands pass the --type-aware and
 // --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -21,7 +21,7 @@
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
     "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
-    "lint": "oxlint --no-error-on-unmatched-pattern .",
+    "lint": "oxlint --type-aware --type-check --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "start": "build-ts run src/index.ts --",
     "start-prod": "yarn build && yarn wb",

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -422,8 +422,9 @@ export function buildLintCommand(
   files?: string[]
 ): string | undefined {
   if (project.preferredLinter === 'oxlint') {
-    // This also performs TypeScript type checking: @willbooster/oxlint-config enables
-    // oxlint's type-aware mode (oxlint-tsgolint), which reports type-check diagnostics.
+    // With the root config, this also reports type-check diagnostics (@willbooster/oxlint-config
+    // enables oxlint's type-aware mode via oxlint-tsgolint). Package-local configs delete those
+    // root-only options, so per-package runs in monorepos do not type-check.
     return buildShellCommand([
       'YARN',
       'oxlint',

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -417,18 +417,19 @@ function shouldSuppressSuccessfulVerifyOutput(command: string): boolean {
 }
 
 export function buildLintCommand(
-  project: Pick<Project, 'preferredLinter'>,
+  project: Pick<Project, 'preferredLinter' | 'hasTypeAwareOxlint'>,
   argv: Pick<LintCommandOptions, 'fix' | 'format'> & Partial<Pick<LintCommandOptions, 'quiet'>>,
   files?: string[]
 ): string | undefined {
   if (project.preferredLinter === 'oxlint') {
-    // With the root config, this also reports type-check diagnostics (@willbooster/oxlint-config
-    // enables oxlint's type-aware mode via oxlint-tsgolint). Package-local configs delete those
-    // root-only options, so per-package runs in monorepos do not type-check.
     return buildShellCommand([
       'YARN',
       'oxlint',
       '--no-error-on-unmatched-pattern',
+      // Type-aware mode makes oxlint report type-check diagnostics. Pass the flags explicitly
+      // because oxlint rejects the equivalent options in non-root configs, so per-package runs
+      // in monorepos would otherwise miss type errors.
+      ...(project.hasTypeAwareOxlint ? ['--type-aware', '--type-check'] : []),
       ...(argv.quiet ? ['--quiet'] : []),
       ...(argv.fix ? ['--fix'] : []),
       ...(files ?? ['.']),

--- a/packages/wb/src/commands/lint.ts
+++ b/packages/wb/src/commands/lint.ts
@@ -422,6 +422,8 @@ export function buildLintCommand(
   files?: string[]
 ): string | undefined {
   if (project.preferredLinter === 'oxlint') {
+    // This also performs TypeScript type checking: @willbooster/oxlint-config enables
+    // oxlint's type-aware mode (oxlint-tsgolint), which reports type-check diagnostics.
     return buildShellCommand([
       'YARN',
       'oxlint',

--- a/packages/wb/src/commands/typecheck.ts
+++ b/packages/wb/src/commands/typecheck.ts
@@ -23,7 +23,10 @@ export const typeCheckCommand: CommandModule<unknown, TypeCheckCommandOptions> =
   },
 };
 
-export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
+export async function typeCheck(
+  argv: TypeCheckCommandArgv,
+  options: { skipTypeScript?: boolean } = {}
+): Promise<number> {
   const projects = await findDescendantProjects(argv, false);
   if (!projects) {
     console.error(chalk.red('No project found.'));
@@ -33,7 +36,7 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
   let removedNextDir = false as boolean;
   const promises = projects.descendants.map(async (project) => {
     const commands: string[] = [];
-    if (!project.packageJson.workspaces || project.hasSourceCode) {
+    if (!options.skipTypeScript && (!project.packageJson.workspaces || project.hasSourceCode)) {
       commands.push(...buildTypeScriptTypeCheckCommands(project));
     }
     if (!project.packageJson.workspaces && project.hasOwnDependency('pyright')) {

--- a/packages/wb/src/commands/typecheck.ts
+++ b/packages/wb/src/commands/typecheck.ts
@@ -23,10 +23,7 @@ export const typeCheckCommand: CommandModule<unknown, TypeCheckCommandOptions> =
   },
 };
 
-export async function typeCheck(
-  argv: TypeCheckCommandArgv,
-  options: { skipTypeScript?: boolean } = {}
-): Promise<number> {
+export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
   const projects = await findDescendantProjects(argv, false);
   if (!projects) {
     console.error(chalk.red('No project found.'));
@@ -36,7 +33,7 @@ export async function typeCheck(
   let removedNextDir = false as boolean;
   const promises = projects.descendants.map(async (project) => {
     const commands: string[] = [];
-    if (!options.skipTypeScript && (!project.packageJson.workspaces || project.hasSourceCode)) {
+    if (!project.packageJson.workspaces || project.hasSourceCode) {
       commands.push(...buildTypeScriptTypeCheckCommands(project));
     }
     if (!project.packageJson.workspaces && project.hasOwnDependency('pyright')) {

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -13,6 +13,7 @@ import { packageManager } from '../utils/runtime.js';
 
 import { lint, type LintCommandArgv } from './lint.js';
 import { test, type TestCommandArgv, withDefaultTestCascadeEnv } from './test.js';
+import { typeCheck, type TypeCheckCommandArgv } from './typecheck.js';
 
 const builder = {
   full: {
@@ -72,6 +73,13 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
       } as unknown as LintCommandArgv),
     { silent: true }
   );
+  // Lint type-checks via oxlint's type-aware flags; fall back to the typecheck command when that
+  // is unavailable (e.g., the project lacks oxlint or oxlint-tsgolint).
+  if (!project.hasTypeAwareOxlint) {
+    await runInProcessCommand('typecheck', () =>
+      typeCheck({ ...argv, _: ['typecheck'] } as unknown as TypeCheckCommandArgv)
+    );
+  }
 }
 
 async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Promise<void> {

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -76,6 +76,8 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
   // Type-aware lint reports TypeScript diagnostics only for the files oxlint actually lints, and
   // the shared config ignores directories tsc still compiles (e.g. `__generated__`, `@types`,
   // `dist`). Keep the typecheck command so `verify` stays equivalent to "the repository compiles".
+  // The overlap with lint is deliberate: `--type-aware` also powers type-aware lint rules, and
+  // dropping only `--type-check` from lint saves ~0.1s, far less than the coverage it would cost.
   await runInProcessCommand(
     'typecheck',
     () => typeCheck({ ...argv, _: ['typecheck'] } as unknown as TypeCheckCommandArgv),

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
 
 import type { Project } from '../project.js';
-import { findDescendantProjects, findRootAndSelfProjects, findSelfProject } from '../project.js';
+import { findRootAndSelfProjects, findSelfProject } from '../project.js';
 import { configureEnv } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { packageManager } from '../utils/runtime.js';
@@ -73,21 +73,11 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
       } as unknown as LintCommandArgv),
     { silent: true }
   );
-  // Lint already covers TypeScript diagnostics via oxlint's type-aware flags, so run the
-  // typecheck command only for what lint cannot check: TypeScript when type-aware oxlint is
-  // unavailable, and Pyright for Python projects.
-  const skipTypeScript = project.hasTypeAwareOxlint;
-  if (!skipTypeScript || (await hasPyrightProject(argv))) {
-    await runInProcessCommand('typecheck', () =>
-      typeCheck({ ...argv, _: ['typecheck'] } as unknown as TypeCheckCommandArgv, { skipTypeScript })
-    );
-  }
-}
-
-async function hasPyrightProject(argv: VerifyCodeCommandArgv): Promise<boolean> {
-  const projects = await findDescendantProjects(argv, false);
-  return !!projects?.descendants.some(
-    (project) => !project.packageJson.workspaces && project.hasOwnDependency('pyright')
+  // Type-aware lint reports TypeScript diagnostics only for the files oxlint actually lints, and
+  // the shared config ignores directories tsc still compiles (e.g. `__generated__`, `@types`,
+  // `dist`). Keep the typecheck command so `verify` stays equivalent to "the repository compiles".
+  await runInProcessCommand('typecheck', () =>
+    typeCheck({ ...argv, _: ['typecheck'] } as unknown as TypeCheckCommandArgv)
   );
 }
 

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -76,8 +76,10 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
   // Type-aware lint reports TypeScript diagnostics only for the files oxlint actually lints, and
   // the shared config ignores directories tsc still compiles (e.g. `__generated__`, `@types`,
   // `dist`). Keep the typecheck command so `verify` stays equivalent to "the repository compiles".
-  await runInProcessCommand('typecheck', () =>
-    typeCheck({ ...argv, _: ['typecheck'] } as unknown as TypeCheckCommandArgv)
+  await runInProcessCommand(
+    'typecheck',
+    () => typeCheck({ ...argv, _: ['typecheck'] } as unknown as TypeCheckCommandArgv),
+    { silent: true }
   );
 }
 

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
 
 import type { Project } from '../project.js';
-import { findRootAndSelfProjects, findSelfProject } from '../project.js';
+import { findDescendantProjects, findRootAndSelfProjects, findSelfProject } from '../project.js';
 import { configureEnv } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { packageManager } from '../utils/runtime.js';
@@ -73,13 +73,22 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv): Promis
       } as unknown as LintCommandArgv),
     { silent: true }
   );
-  // Lint type-checks via oxlint's type-aware flags; fall back to the typecheck command when that
-  // is unavailable (e.g., the project lacks oxlint or oxlint-tsgolint).
-  if (!project.hasTypeAwareOxlint) {
+  // Lint already covers TypeScript diagnostics via oxlint's type-aware flags, so run the
+  // typecheck command only for what lint cannot check: TypeScript when type-aware oxlint is
+  // unavailable, and Pyright for Python projects.
+  const skipTypeScript = project.hasTypeAwareOxlint;
+  if (!skipTypeScript || (await hasPyrightProject(argv))) {
     await runInProcessCommand('typecheck', () =>
-      typeCheck({ ...argv, _: ['typecheck'] } as unknown as TypeCheckCommandArgv)
+      typeCheck({ ...argv, _: ['typecheck'] } as unknown as TypeCheckCommandArgv, { skipTypeScript })
     );
   }
+}
+
+async function hasPyrightProject(argv: VerifyCodeCommandArgv): Promise<boolean> {
+  const projects = await findDescendantProjects(argv, false);
+  return !!projects?.descendants.some(
+    (project) => !project.packageJson.workspaces && project.hasOwnDependency('pyright')
+  );
 }
 
 async function runProjectTest(project: Project, argv: VerifyCodeCommandArgv): Promise<void> {

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -158,6 +158,12 @@ export class Project {
   }
 
   @memoizeOne
+  get hasTypeAwareOxlint(): boolean {
+    // Oxlint's type-aware mode requires the oxlint-tsgolint binary.
+    return this.hasOxlint && this.hasDependency('oxlint-tsgolint');
+  }
+
+  @memoizeOne
   get hasOxfmt(): boolean {
     return this.hasDependency('oxfmt');
   }

--- a/packages/wb/test/lint.test.ts
+++ b/packages/wb/test/lint.test.ts
@@ -22,15 +22,23 @@ import {
 
 describe('lint', () => {
   it('builds an oxlint command for oxlint projects', () => {
-    expect(buildLintCommand({ preferredLinter: 'oxlint' }, { fix: true, format: false }, ['/tmp/example.ts'])).toBe(
-      'YARN oxlint --no-error-on-unmatched-pattern --fix /tmp/example.ts'
-    );
+    expect(
+      buildLintCommand({ preferredLinter: 'oxlint', hasTypeAwareOxlint: false }, { fix: true, format: false }, [
+        '/tmp/example.ts',
+      ])
+    ).toBe('YARN oxlint --no-error-on-unmatched-pattern --fix /tmp/example.ts');
   });
 
   it('uses the current directory when oxlint runs without explicit files', () => {
-    expect(buildLintCommand({ preferredLinter: 'oxlint' }, { fix: false, format: false })).toBe(
-      'YARN oxlint --no-error-on-unmatched-pattern .'
-    );
+    expect(
+      buildLintCommand({ preferredLinter: 'oxlint', hasTypeAwareOxlint: false }, { fix: false, format: false })
+    ).toBe('YARN oxlint --no-error-on-unmatched-pattern .');
+  });
+
+  it('passes type-aware flags when oxlint-tsgolint is available', () => {
+    expect(
+      buildLintCommand({ preferredLinter: 'oxlint', hasTypeAwareOxlint: true }, { fix: false, format: false })
+    ).toBe('YARN oxlint --no-error-on-unmatched-pattern --type-aware --type-check .');
   });
 
   it('builds poetry commands for explicit python files', () => {
@@ -52,9 +60,11 @@ describe('lint', () => {
   });
 
   it('escapes shell-sensitive file paths', () => {
-    expect(buildLintCommand({ preferredLinter: 'oxlint' }, { fix: false, format: false }, ['/tmp/evil"file.ts'])).toBe(
-      `YARN oxlint --no-error-on-unmatched-pattern '/tmp/evil"file.ts'`
-    );
+    expect(
+      buildLintCommand({ preferredLinter: 'oxlint', hasTypeAwareOxlint: false }, { fix: false, format: false }, [
+        '/tmp/evil"file.ts',
+      ])
+    ).toBe(`YARN oxlint --no-error-on-unmatched-pattern '/tmp/evil"file.ts'`);
   });
 
   it('keeps prettier args to prettier-only formats for oxlint projects', () => {

--- a/packages/wbfy/oxlint.config.ts
+++ b/packages/wbfy/oxlint.config.ts
@@ -3,10 +3,9 @@ import type { OxlintConfig } from 'oxlint';
 
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
-// Oxlint only supports type-aware options in the root config, while it
-// still auto-discovers package-local config files in monorepos. Keep this as a
-// structured clone so packages can delete root-only settings without mutating
-// the shared imported config object.
+// Oxlint rejects the root-only type-aware options outside the root config, so delete them
+// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;
 // wbfy:end oxlint-base

--- a/packages/wbfy/oxlint.config.ts
+++ b/packages/wbfy/oxlint.config.ts
@@ -4,7 +4,7 @@ import type { OxlintConfig } from 'oxlint';
 import oxlintBaseConfig from '@willbooster/oxlint-config';
 
 // Oxlint rejects the root-only type-aware options outside the root config, so delete them
-// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// here. This does NOT disable type checking: the lint commands pass the --type-aware and
 // --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(oxlintBaseConfig);
 delete oxlintResolvedConfig.options;

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -20,7 +20,7 @@
     "cleanup": "yarn format && yarn lint-fix",
     "format": "sort-package-json && yarn format-code",
     "format-code": "oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'",
-    "lint": "oxlint --no-error-on-unmatched-pattern .",
+    "lint": "oxlint --type-aware --type-check --no-error-on-unmatched-pattern .",
     "lint-fix": "yarn lint --fix",
     "start": "build-ts run src/index.ts --env .env --",
     "start-prod": "yarn build && yarn wbfy",

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -75,7 +75,7 @@ function generateAgentInstruction(
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
   - Avoid fixed waits in E2E tests; wait for conditions instead.
 - When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
-- After making changes, run \`${packageManager} verify\` (type checking and linting; takes up to 10 minutes), or \`${packageManager} verify-full\` (all tests; takes up to 1 hour) if you changed runtime behavior (not only types, docs, or config). Fix errors and re-run until it passes.
+- After making changes, run \`${packageManager} verify\` (type checking and linting; takes up to 10 minutes), or \`${packageManager} verify-full\` (all tests; takes up to 1 hour) if you changed runtime behavior or tests (not only types, docs, or config). Fix errors and re-run until it passes.
 - Once verified, commit and push to the current (non-main) branch, and create a PR via \`gh\` if none exists for the branch.
   - Follow the Conventional Commits format (e.g., \`feat:\`, \`fix:\`).${coAuthorInstruction}
   - Always create new commits; avoid \`--amend\`.

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -48,8 +48,10 @@ function generateAgentInstruction(
 ): string {
   const packageManager = getPackageManagerCommand(rootConfig);
   const description = rootConfig.packageJson?.description;
-  // "type checking and linting" is accurate for `verify`: @willbooster/oxlint-config enables
-  // oxlint's type-aware mode (oxlint-tsgolint), which reports type-check diagnostics during lint.
+  // `verify` lints per package cwd, where package oxlint configs drop the root-only type-aware
+  // options, so type errors in workspace packages are caught only by the `typecheck` script.
+  const hasTypecheck = allConfigs.some((c) => c.doesContainTypeScript || c.doesContainTypeScriptInPackages);
+  const typecheckInstruction = hasTypecheck ? `\`${packageManager} typecheck\` and ` : '';
   // WillBooster Railway project identifiers are managed in deploy workflow settings.
   const railwayInstruction = rootConfig.isRailway
     ? '\n- Railway project information is in the deploy workflows under `.github/workflows`.'
@@ -77,7 +79,7 @@ function generateAgentInstruction(
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
   - Avoid fixed waits in E2E tests; wait for conditions instead.
 - When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
-- After making changes, run \`${packageManager} verify\` (type checking and linting; takes up to 10 minutes), or \`${packageManager} verify-full\` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
+- After making changes, run ${typecheckInstruction}\`${packageManager} verify\` (linting; takes up to 10 minutes), or \`${packageManager} verify-full\` (all tests; takes up to 1 hour) instead of \`verify\` if you changed runtime behavior or tests. Fix errors and re-run until they pass.
 - Once verified, commit and push to the current (non-main) branch, and create a PR via \`gh\` if none exists for the branch.
   - Follow the Conventional Commits format (e.g., \`feat:\`, \`fix:\`).${coAuthorInstruction}
   - Always create new commits; avoid \`--amend\`.

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -56,7 +56,7 @@ function generateAgentInstruction(
     ? `\n- Use \`${packageManager} wb start --mode test\` to launch a web server for debugging or testing.`
     : '';
   const coAuthorInstruction = rootConfig.isWillBoosterRepo
-    ? `\n  - End your commit message with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`.`
+    ? `\n  - End your commit message with a blank line followed by \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`.`
     : '';
   const baseContent = `
 ## Project Information
@@ -79,7 +79,7 @@ function generateAgentInstruction(
 - Once verified, commit and push to the current (non-main) branch, and create a PR via \`gh\` if none exists for the branch.
   - Follow the Conventional Commits format (e.g., \`feat:\`, \`fix:\`).${coAuthorInstruction}
   - Always create new commits; avoid \`--amend\`.
-- Use heredoc for multi-line command arguments (e.g., \`git commit -m\`, \`gh pr create --body\`).
+- Use heredoc for multi-line command input (e.g., \`git commit -F -\`, \`gh pr create --body-file -\`).
 - Put temporary files in \`.tmp\`; use \`/tmp\` only for files that must live outside the repo.${railwayInstruction}${playwrightTestServerInstruction}
 
 ${generateAgentCodingStyle(allConfigs)}

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -68,7 +68,7 @@ function generateAgentInstruction(
 
 - If on \`main\`, create a new branch; otherwise work on the current branch.
 - Run \`git\` commands one at a time to avoid \`index.lock\` conflicts.
-- Write tests when explicitly requested, or when the change has behavior worth verifying; without a request, cover only the essential behavior.
+- Write tests when explicitly requested, or when you judge the change worth testing; without a request, cover only the essential behavior.
 - When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -48,6 +48,8 @@ function generateAgentInstruction(
 ): string {
   const packageManager = getPackageManagerCommand(rootConfig);
   const description = rootConfig.packageJson?.description;
+  // "type checking and linting" is accurate for `verify`: @willbooster/oxlint-config enables
+  // oxlint's type-aware mode (oxlint-tsgolint), which reports type-check diagnostics during lint.
   // WillBooster Railway project identifiers are managed in deploy workflow settings.
   const railwayInstruction = rootConfig.isRailway
     ? '\n- Railway project information is in the deploy workflows under `.github/workflows`.'
@@ -75,7 +77,7 @@ function generateAgentInstruction(
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
   - Avoid fixed waits in E2E tests; wait for conditions instead.
 - When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
-- After making changes, run \`${packageManager} verify\` (type checking and linting; takes up to 10 minutes), or \`${packageManager} verify-full\` (all tests; takes up to 1 hour) if you changed runtime behavior or tests (not only types, docs, or config). Fix errors and re-run until it passes.
+- After making changes, run \`${packageManager} verify\` (type checking and linting; takes up to 10 minutes), or \`${packageManager} verify-full\` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
 - Once verified, commit and push to the current (non-main) branch, and create a PR via \`gh\` if none exists for the branch.
   - Follow the Conventional Commits format (e.g., \`feat:\`, \`fix:\`).${coAuthorInstruction}
   - Always create new commits; avoid \`--amend\`.

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -48,10 +48,6 @@ function generateAgentInstruction(
 ): string {
   const packageManager = getPackageManagerCommand(rootConfig);
   const description = rootConfig.packageJson?.description;
-  // `verify` lints per package cwd, where package oxlint configs drop the root-only type-aware
-  // options, so type errors in workspace packages are caught only by the `typecheck` script.
-  const hasTypecheck = allConfigs.some((c) => c.doesContainTypeScript || c.doesContainTypeScriptInPackages);
-  const typecheckInstruction = hasTypecheck ? `\`${packageManager} typecheck\` and ` : '';
   // WillBooster Railway project identifiers are managed in deploy workflow settings.
   const railwayInstruction = rootConfig.isRailway
     ? '\n- Railway project information is in the deploy workflows under `.github/workflows`.'
@@ -79,7 +75,7 @@ function generateAgentInstruction(
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
   - Avoid fixed waits in E2E tests; wait for conditions instead.
 - When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
-- After making changes, run ${typecheckInstruction}\`${packageManager} verify\` (linting; takes up to 10 minutes), or \`${packageManager} verify-full\` (all tests; takes up to 1 hour) instead of \`verify\` if you changed runtime behavior or tests. Fix errors and re-run until they pass.
+- After making changes, run \`${packageManager} verify\` (type checking and linting; takes up to 10 minutes), or \`${packageManager} verify-full\` (all tests; takes up to 1 hour) if you changed runtime behavior or tests. Fix errors and re-run until it passes.
 - Once verified, commit and push to the current (non-main) branch, and create a PR via \`gh\` if none exists for the branch.
   - Follow the Conventional Commits format (e.g., \`feat:\`, \`fix:\`).${coAuthorInstruction}
   - Always create new commits; avoid \`--amend\`.

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -47,42 +47,40 @@ function generateAgentInstruction(
   extraContent?: string
 ): string {
   const packageManager = getPackageManagerCommand(rootConfig);
+  const description = rootConfig.packageJson?.description;
   // WillBooster Railway project identifiers are managed in deploy workflow settings.
   const railwayInstruction = rootConfig.isRailway
-    ? '\n- If you need Railway project information, see the workflow settings in `.github/workflows`.'
+    ? '\n- Railway project information is in the deploy workflows under `.github/workflows`.'
     : '';
   const playwrightTestServerInstruction = hasPlaywrightTestServer(allConfigs)
     ? `\n- Use \`${packageManager} wb start --mode test\` to launch a web server for debugging or testing.`
     : '';
+  const coAuthorInstruction = rootConfig.isWillBoosterRepo
+    ? `\n  - End your commit message with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`.`
+    : '';
   const baseContent = `
 ## Project Information
 
-- Name: \`${rootConfig.packageJson?.name || 'unknown'}\`
-- Description: ${rootConfig.packageJson?.description}
+- Name: \`${rootConfig.packageJson?.name || 'unknown'}\`${description ? `\n- Description: ${description}` : ''}
 - Package Manager: ${packageManager}
 
 ## General Instructions
 
-- Create a new branch if the current branch is \`main\`.
-- Run any \`git\` commands sequentially.
-- Write tests ONLY if explicitly requested. If requested, follow these rules:
+- If on \`main\`, create a new branch; otherwise work on the current branch.
+- Run \`git\` commands one at a time to avoid \`index.lock\` conflicts.
+- Write tests when explicitly requested, or when the change has behavior worth verifying; without a request, cover only the essential behavior.
+- When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.
   - Prefer actual API calls over mocks, unless actual calls are impractical, have unintended side effects, or mocks are explicitly requested.
-  - Always investigate the root cause of a test failure before fixing it.
-  - Avoid adding wait functions in E2E tests unless strictly necessary.
-- When fixing issues, follow these rules:
-  - Investigate the root cause first (e.g., by gathering debug logs, taking screenshots, etc.).
-  - Fix the actual root cause instead of applying workarounds.
-- After making code changes, run \`${packageManager} verify-full\` to execute all tests (takes up to 1 hour), or \`${packageManager} verify\` for only type checking and linting (takes up to 10 minutes).
-  - If you are confident that your changes will not break any tests, you may use \`verify\`.
-  - Use \`oxlint\` ignore comments with reasons (e.g., \`// oxlint-disable-next-line <rule> -- <reason>\`) if lint errors or warnings cannot be fixed (e.g., a third-party API requires \`null\`).
-- Once you have verified your changes, commit and push them to the current (non-main) branch, then create a PR via \`gh\`.
-  - Follow the conventional commits; your commit message should start with \`feat:\`, \`fix:\`, etc.
-  - If not specified, make sure to add a new line at the end of your commit message${rootConfig.isWillBoosterRepo ? ` with: \`Co-authored-by: WillBooster (${toolName}) <agent@willbooster.com>\`` : ''}.
-  - Always create new commits. Avoid using \`--amend\`.
-- Always use heredoc syntax when passing multi-line content to any command.
-- Put temporary files in the \`.tmp\` or \`/tmp\` directory.${railwayInstruction}${playwrightTestServerInstruction}
+  - Avoid fixed waits in E2E tests; wait for conditions instead.
+- When fixing issues (including test failures), investigate the root cause first (e.g., via debug logs or screenshots) and fix it instead of applying workarounds.
+- After making changes, run \`${packageManager} verify\` (type checking and linting; takes up to 10 minutes), or \`${packageManager} verify-full\` (all tests; takes up to 1 hour) if you changed runtime behavior (not only types, docs, or config). Fix errors and re-run until it passes.
+- Once verified, commit and push to the current (non-main) branch, and create a PR via \`gh\` if none exists for the branch.
+  - Follow the Conventional Commits format (e.g., \`feat:\`, \`fix:\`).${coAuthorInstruction}
+  - Always create new commits; avoid \`--amend\`.
+- Use heredoc for multi-line command arguments (e.g., \`git commit -m\`, \`gh pr create --body\`).
+- Put temporary files in \`.tmp\`; use \`/tmp\` only for files that must live outside the repo.${railwayInstruction}${playwrightTestServerInstruction}
 
 ${generateAgentCodingStyle(allConfigs)}
 `
@@ -104,39 +102,33 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
   return `
 ## Coding Style
 
-- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Use camelCase file names for JavaScript/TypeScript (PascalCase for React components).
 - Simplify code as much as possible to eliminate redundancy.
-- Design each module with high cohesion, grouping related functionality together.
-  - Refactor existing large modules into smaller, focused modules when necessary.
-  - Create well-organized directory structures with low coupling and high cohesion.
-- Place calling functions above the functions they call to maintain a clear top-down order.
-  - e.g., \`function caller() { callee(); } function callee() { ... }\`
-  - Unlike functions, place variable and type declarations ABOVE their usage.
-- Write comments and JSDoc for complex or hard-to-understand code.
-  - Explain "why" in comments and "what" in JSDoc.
-  - Avoid stating what can be easily understood from the code itself.
-- Prefer \`undefined\` over \`null\` unless explicitly required by APIs or libraries.
-- Prefer using a single template literal for prompts instead of \`join()\` with a pre-computable array literal of strings.
-- Assume that all environment variables are properly defined.
-  - If validation is required, use \`assert\` to fail fast (e.g., during startup).
+- Design modules and directories with high cohesion and low coupling; split large modules when needed.
+- Place calling functions above the functions they call (top-down order); place variable and type declarations above their usage.
+- Write comments and JSDoc only for hard-to-understand code: explain "why" in comments and "what" in JSDoc.
+- If lint errors or warnings cannot be fixed, use ignore comments with reasons (e.g., \`// oxlint-disable-next-line <rule> -- <reason>\`).
+- Prefer \`undefined\` over \`null\` unless required by APIs or libraries.
+- Build prompts as a single template literal instead of \`join()\` on a pre-computable array of strings.
+- Assume all environment variables are defined; if validation is needed, \`assert\` at startup to fail fast.
 ${
   allConfigs.some((c) => c.depending.genI18nTs)
-    ? `- When introducing new string literals in React components, update the language resource files in the \`i18n\` directory (e.g., \`i18n/ja-JP.json\`). Reference these strings using the \`i18n\` utility. For example, use \`i18n.pages.home.title()\` for \`{ "pages": { "home": { "title": "My App" } } }\`.`
+    ? `- When adding string literals in React components, register them in the \`i18n\` resource files (e.g., \`i18n/ja-JP.json\`) and reference them via the \`i18n\` utility (e.g., \`i18n.pages.home.title()\` for \`{ "pages": { "home": { "title": "My App" } } }\`).`
     : ''
 }
 
 ${
   allConfigs.some((c) => c.depending.react || c.depending.next)
     ? `- Prefer lambda over \`function\` for React components, e.g., \`const Button: React.FC = () => {\`.
-- Prefer \`useImmer\` for storing an array or an object to \`useState\`.
-- Allow \`autoFocus\` to minimize user effort.`
+- Prefer \`useImmer\` over \`useState\` for arrays and objects.
+- Use \`autoFocus\` where it reduces user effort.`
     : ''
 }
 ${
   allConfigs.some((c) => c.depending.next)
     ? `
-- Since this project uses the React Compiler, you do not need to use \`useCallback\` or \`useMemo\` for performance optimization.
-- Assume there is only a single server instance.
+- This project uses the React Compiler, so \`useCallback\` and \`useMemo\` are unnecessary for performance.
+- Assume a single server instance.
 `
     : ''
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -110,13 +110,15 @@ function getResolvedConfigContent(baseConfigName: string, isRootConfig: boolean)
   if (isRootConfig) {
     return `// Keep a package-local copy so repositories can add settings outside
 // managed blocks without mutating the shared imported config object.
-const oxlintResolvedConfig: OxlintConfig = structuredClone(${baseConfigName});`;
+const oxlintResolvedConfig: OxlintConfig = structuredClone(${baseConfigName});
+// The type-aware options make lint perform type checking. Always force them on here,
+// inside the managed block, so no customization can silently disable type checking.
+oxlintResolvedConfig.options = { ...oxlintResolvedConfig.options, typeAware: true, typeCheck: true };`;
   }
 
-  return `// Oxlint only supports type-aware options in the root config, while it
-// still auto-discovers package-local config files in monorepos. Keep this as a
-// structured clone so packages can delete root-only settings without mutating
-// the shared imported config object.
+  return `// Oxlint rejects the root-only type-aware options outside the root config, so delete them
+// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(${baseConfigName});
 delete oxlintResolvedConfig.options;`;
 }

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -117,7 +117,7 @@ oxlintResolvedConfig.options = { ...oxlintResolvedConfig.options, typeAware: tru
   }
 
   return `// Oxlint rejects the root-only type-aware options outside the root config, so delete them
-// here. This does NOT disable type checking: wb lint always passes the --type-aware and
+// here. This does NOT disable type checking: the lint commands pass the --type-aware and
 // --type-check flags explicitly.
 const oxlintResolvedConfig: OxlintConfig = structuredClone(${baseConfigName});
 delete oxlintResolvedConfig.options;`;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1154,7 +1154,9 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
     let scripts: Record<string, string> = {
       cleanup: 'yarn format && yarn lint-fix',
       format: generateFormatScript(hasJsOrTs, hasJava),
-      lint: `oxlint --no-error-on-unmatched-pattern .`,
+      // Package-local configs must delete the root-only type-aware options, so pass the flags
+      // explicitly. Otherwise this script would silently skip type checking in workspace packages.
+      lint: `oxlint${hasTypecheck ? ' --type-aware --type-check' : ''} --no-error-on-unmatched-pattern .`,
       'lint-fix': 'yarn lint --fix',
       'format-code': `oxfmt --write --no-error-on-unmatched-pattern . '!**/package.json'`,
       typecheck: 'tsc --noEmit',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -259,6 +259,14 @@ test('drops --bun from verify-full for Playwright projects but keeps it otherwis
   expect(withoutPlaywright.scripts?.['verify-full']).toBe('bun --bun wb verify --full');
 });
 
+test('type-checks in the lint script of TypeScript projects', { timeout: 60 * 1000 }, async () => {
+  const withTypeScript = await generatePackageJsonFrom({ scripts: {} }, { doesContainTypeScript: true });
+  const withoutTypeScript = await generatePackageJsonFrom({ scripts: {} }, { doesContainJavaScript: true });
+
+  expect(withTypeScript.scripts?.lint).toBe('oxlint --type-aware --type-check --no-error-on-unmatched-pattern .');
+  expect(withoutTypeScript.scripts?.lint).toBe('oxlint --no-error-on-unmatched-pattern .');
+});
+
 async function generatePackageJsonFrom(
   initialPackageJson: Record<string, unknown>,
   configOverrides: Parameters<typeof createConfig>[0] = {},


### PR DESCRIPTION
## Customer Summary

- The instructions wbfy generates for coding agents (`AGENTS.md` / `CLAUDE.md` / `GEMINI.md` / `.cursor/rules/general.mdc`) are clearer, shorter, and fix several process gaps: when to run `verify` vs `verify-full`, when tests are expected, branching, PR creation, and working heredoc examples. No `Description: undefined` line when `package.json` has no description.
- `wb verify` now genuinely means "the repository type-checks". Previously it could report success while a type error was present, so a green verify no longer implies a broken build slips through.
- `yarn lint` / `yarn cleanup` in workspace packages now report type errors too, instead of silently skipping them.
- No migration needed. Repositories may newly surface type errors that were previously hidden; those are pre-existing errors, not new ones.

## Technical Summary

- **wbfy — agent instructions** (`generators/agents.ts`): rewrote the generated instruction templates; merged duplicated root-cause/cohesion guidance, fixed the dangling co-author sentence for non-WillBooster repos, required a blank line before the `Co-authored-by` trailer, and pointed heredoc examples at stdin-reading flags (`git commit -F -`, `gh pr create --body-file -`).
- **wb — lint** (`commands/lint.ts`, `project.ts`): `buildLintCommand` passes `--type-aware --type-check` whenever `oxlint-tsgolint` is available (new `Project.hasTypeAwareOxlint`). Oxlint rejects the equivalent options outside the root config, so package-local configs must delete them; passing the flags explicitly keeps per-package runs type-aware.
- **wb — verify** (`commands/verifyCode.ts`): `verify` runs the `typecheck` stage (silently, like `cleanup`). Type-aware lint is *not* a substitute for `tsc`: oxlint emits TypeScript diagnostics only for files it lints, and the shared config ignores directories `tsc` still compiles (`__generated__`, `@types`, `dist`, `no-format`, `3rd-party`).
- **wbfy — generated configs/scripts** (`generators/oxlintConfig.ts`, `generators/packageJson.ts`): the root oxlint config forces the type-aware options on inside the managed block, and the generated per-package `lint` script passes `--type-aware --type-check` for TypeScript projects — without it, `yarn lint` and `yarn cleanup` skipped type checking entirely.

## Why

- The agent instructions had accumulated ambiguous and contradictory rules, and two examples were simply wrong (`git commit -m` / `gh pr create --body` cannot read a heredoc).
- Reviewing that change surfaced a bigger problem: `wb verify` did not type-check workspace packages at all, so agents told to "run verify" could ship code that does not compile. Making lint type-aware fixed most of it, but lint alone still misses every file oxlint ignores, so `verify` must keep running `tsc`.

## Testing

- `wb verify --full` (lint + typecheck + all tests) passes on this branch.
- Gap reproduced and confirmed closed: with `export const b: number = "bad";` in `packages/wb/src/__generated__/gen.ts` (a directory the shared oxlint config ignores), type-aware `oxlint` reports nothing, while `wb verify` now exits 1 with `error TS2322` and `Failed (exit code 1): typecheck`. Removing the file makes verify pass.
- Package-lint gap confirmed: inside `packages/wb`, `oxlint --no-error-on-unmatched-pattern .` reported no type error, while the same command with `--type-aware --type-check` reported `TS2322`.
- New unit tests: type-aware flags in `buildLintCommand` (`packages/wb/test/lint.test.ts`) and in the generated `lint` script (`packages/wbfy/test/packageJson.test.ts`).
- Non-TypeScript projects verified unaffected: `wb typecheck` on a pure-JavaScript project prints `No type errors found.` and exits 0, since the typecheck command no-ops without a `typescript` dependency.

## Notes

- `verify` now type-checks twice (type-aware lint + `tsc`). This is deliberate: `--type-aware` powers type-aware lint rules that `tsc` does not replace, and measured on this repo `--type-check` adds only ~0.1s on top of `--type-aware` (0.6-0.7s either way), because tsgolint already builds the TypeScript program.
- Consolidating on the root oxlint config (removing package-local configs) was evaluated and rejected: the shared config's override `files` patterns are config-relative and stop matching workspace paths (reproduced as 10 `no-unused-vars` false positives on `_`-prefixed parameters).
