### PR TITLE
refactor(wb): remove deprecated @typescript/native-preview (tsgo) typecheck fallback

### DIFF
--- a/packages/wb/src/commands/typecheck.ts
+++ b/packages/wb/src/commands/typecheck.ts
@@ -82,9 +82,9 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
 }
 
 function buildTypeScriptTypeCheckCommands(project: Project): string[] {
-  if (project.hasOwnDependency('@typescript/native-preview')) {
-    return ['BUN tsgo --noEmit'];
-  }
+  // TypeScript 7 ships the native compiler as `typescript` (`tsc`); wbfy removes the
+  // deprecated `@typescript/native-preview` (tsgo) preview from all repos, so repos
+  // still on the preview should run wbfy instead of relying on a tsgo fallback here.
   if (project.hasOwnDependency('typescript')) {
     return ['BUN tsc --noEmit'];
   }


### PR DESCRIPTION
## Customer Summary

- No user-visible changes for repositories managed by wbfy. Repositories still depending on the deprecated `@typescript/native-preview` preview should run wbfy (which migrates them to TypeScript 7) instead of relying on `wb typecheck`'s tsgo fallback.

## Technical Summary

- Removed the `@typescript/native-preview` → `tsgo --noEmit` branch from `buildTypeScriptTypeCheckCommands` in `packages/wb/src/commands/typecheck.ts`; type checking now always uses `tsc` from the `typescript` package.

## Why

- TypeScript 7 ships the native compiler as the `typescript` package, and wbfy strips `@typescript/native-preview` from every repository it manages (see WillBooster/build-ts#649 for the related build-ts fix). The tsgo fallback is dead code in the managed fleet.

## Testing

- `yarn verify` (type checking and linting) — passed with no errors.
