### PR TITLE
feat(wbfy): support Tauri projects

### DIFF
--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -112,6 +112,11 @@ android/app/src/main/assets/
     if (config.depending.storybook) {
       names.push('storybookjs');
     }
+    if (config.depending.tauri) {
+      names.push('rust');
+      headUserContent += `src-tauri/gen/schemas/
+`;
+    }
     if (config.depending.litestream) {
       headUserContent += `gcp-sa-key.json
 `;
@@ -163,6 +168,11 @@ android/app/src/main/assets/
       }
     }
     generated = generated.replaceAll(/^.idea\/?$/gm, '# .idea');
+    if (config.depending.tauri) {
+      // The rust template ignores Cargo.lock, but Tauri projects are applications,
+      // so their Cargo.lock must be committed for reproducible builds.
+      generated = generated.replaceAll(/^Cargo\.lock$/gm, '# Cargo.lock');
+    }
     if (rootConfig.depending.reactNative || config.depending.reactNative || config.doesContainPubspecYaml) {
       generated = generated.replaceAll(/^(.idea\/.+)$/gm, '$1\nandroid/$1');
     }

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -114,6 +114,8 @@ android/app/src/main/assets/
     }
     if (config.depending.tauri) {
       names.push('rust');
+    }
+    if (config.doesContainTauriConfig) {
       headUserContent += `src-tauri/gen/schemas/
 `;
     }
@@ -172,12 +174,16 @@ android/app/src/main/assets/
     }
     generated = generated.replaceAll(/^.idea\/?$/gm, '# .idea');
     if (config.depending.tauri) {
-      // The rust template ignores Cargo.lock, but Tauri projects are applications,
-      // so their Cargo.lock must be committed for reproducible builds.
-      generated = generated.replaceAll(/^Cargo\.lock$/gm, '# Cargo.lock');
       // The rust template's unanchored debug/ would also hide frontend source
       // directories such as src/debug/; cargo output is already covered by target/.
       generated = generated.replaceAll(/^debug\/$/gm, '# debug/');
+    }
+    if (config.doesContainTauriConfig) {
+      // The rust template ignores Cargo.lock, but a src-tauri configuration marks an
+      // application, whose Cargo.lock must be committed for reproducible builds.
+      // Tauri plugin libraries (detected only via @tauri-apps/* dependencies) keep
+      // the template's library policy of ignoring Cargo.lock.
+      generated = generated.replaceAll(/^Cargo\.lock$/gm, '# Cargo.lock');
     }
     if (rootConfig.depending.reactNative || config.depending.reactNative || config.doesContainPubspecYaml) {
       generated = generated.replaceAll(/^(.idea\/.+)$/gm, '$1\nandroid/$1');

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -175,6 +175,9 @@ android/app/src/main/assets/
       // The rust template ignores Cargo.lock, but Tauri projects are applications,
       // so their Cargo.lock must be committed for reproducible builds.
       generated = generated.replaceAll(/^Cargo\.lock$/gm, '# Cargo.lock');
+      // The rust template's unanchored debug/ would also hide frontend source
+      // directories such as src/debug/; cargo output is already covered by target/.
+      generated = generated.replaceAll(/^debug\/$/gm, '# debug/');
     }
     if (rootConfig.depending.reactNative || config.depending.reactNative || config.doesContainPubspecYaml) {
       generated = generated.replaceAll(/^(.idea\/.+)$/gm, '$1\nandroid/$1');

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -116,7 +116,10 @@ android/app/src/main/assets/
       names.push('rust');
     }
     if (config.doesContainTauriConfig) {
-      headUserContent += `src-tauri/gen/schemas/
+      // !Cargo.lock overrides any pre-existing unanchored Cargo.lock rule from a
+      // parent .gitignore, so the application lockfile stays committable.
+      headUserContent += `!Cargo.lock
+src-tauri/gen/schemas/
 `;
     }
     if (config.depending.litestream) {
@@ -178,11 +181,13 @@ android/app/src/main/assets/
       // directories such as src/debug/; cargo output is already covered by target/.
       generated = generated.replaceAll(/^debug\/$/gm, '# debug/');
     }
-    if (config.doesContainTauriConfig) {
+    if (config.doesContainTauriConfig || config.doesContainTauriConfigInPackages) {
       // The rust template ignores Cargo.lock, but a src-tauri configuration marks an
-      // application, whose Cargo.lock must be committed for reproducible builds.
-      // Tauri plugin libraries (detected only via @tauri-apps/* dependencies) keep
-      // the template's library policy of ignoring Cargo.lock.
+      // application, whose Cargo.lock must be committed for reproducible builds. The
+      // rule is also disabled when a sub package contains a Tauri application, because
+      // an unanchored Cargo.lock rule in a parent .gitignore would hide the nested
+      // application's lockfile. Tauri plugin libraries (detected only via
+      // @tauri-apps/* dependencies) keep the template's policy of ignoring Cargo.lock.
       generated = generated.replaceAll(/^Cargo\.lock$/gm, '# Cargo.lock');
     }
     if (rootConfig.depending.reactNative || config.depending.reactNative || config.doesContainPubspecYaml) {

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -122,7 +122,10 @@ android/app/src/main/assets/
 `;
     }
     if (config.isCloudflare || rootConfig.isCloudflare) {
-      headUserContent += `.wrangler/
+      // .dev.vars* hold local secrets for wrangler dev and must never be committed,
+      // unlike the committed .env/.env.staging files of the WillBooster convention.
+      headUserContent += `.dev.vars*
+.wrangler/
 `;
     }
     if (rootConfig.depending.vinext || config.depending.vinext) {

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -273,11 +273,26 @@ function deleteLegacyModuleSettings(
   ) {
     delete compilerOptions.moduleResolution;
   }
-  if (config.isBun || config.depending.reactNative || compilerOptions.module !== 'ESNext') return;
+  if (config.isBun || config.depending.reactNative) return;
 
-  // Node base configs now pair their resolver with a matching module kind. Keeping
-  // older ESNext overrides creates invalid generated configs for TS 6.
-  delete compilerOptions.module;
+  if (compilerOptions.module === 'ESNext') {
+    // Node base configs now pair their resolver with a matching module kind. Keeping
+    // older ESNext overrides creates invalid generated configs for TS 6.
+    delete compilerOptions.module;
+  }
+
+  const moduleKind = typeof compilerOptions.module === 'string' ? compilerOptions.module.toLowerCase() : undefined;
+  if (
+    typeof compilerOptions.moduleResolution === 'string' &&
+    compilerOptions.moduleResolution.toLowerCase() === 'bundler' &&
+    (moduleKind === undefined || moduleKind === 'node16' || moduleKind === 'nodenext')
+  ) {
+    // The node base configs pair module=NodeNext with moduleResolution=NodeNext, and
+    // TypeScript rejects a bundler resolver with node module kinds. Such a resolver is
+    // usually left over from pre-wbfy bundler-oriented configs (e.g. Vite/Tauri
+    // frontends), so drop it and let the base configs choose a consistent pair.
+    delete compilerOptions.moduleResolution;
+  }
 }
 
 function normalizeCommonJsTsconfigSettings(

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -161,12 +161,10 @@ function addScriptsIncludeForFrameworkProject(settings: TsConfigJson): void {
 
 function normalizeNextTsconfigModuleSettings(compilerOptions: TsConfigJson.CompilerOptions | undefined): void {
   if (!compilerOptions) return;
-  if (
-    compilerOptions.moduleResolution === 'node' ||
-    compilerOptions.moduleResolution === 'Node' ||
-    compilerOptions.moduleResolution === 'node10' ||
-    compilerOptions.moduleResolution === undefined
-  ) {
+  // TypeScript treats option values case-insensitively, so normalize before comparison.
+  const moduleResolution =
+    typeof compilerOptions.moduleResolution === 'string' ? compilerOptions.moduleResolution.toLowerCase() : undefined;
+  if (moduleResolution === 'node' || moduleResolution === 'node10' || moduleResolution === undefined) {
     // Next.js writes "node" during build when this option is missing, but
     // tsgolint treats that spelling as the removed node10 resolver.
     compilerOptions.moduleResolution = 'bundler';
@@ -264,35 +262,44 @@ function deleteLegacyModuleSettings(
 ): void {
   if (!compilerOptions) return;
 
+  // TypeScript treats option values case-insensitively, so normalize before comparison.
+  const moduleResolution = lowerCaseSetting(compilerOptions.moduleResolution);
   // TypeScript 6 removed the old node10 resolver spelling, so inherited base configs
   // should choose the resolver unless a project already opted into a modern one.
-  if (
-    compilerOptions.moduleResolution === 'node' ||
-    compilerOptions.moduleResolution === 'Node' ||
-    compilerOptions.moduleResolution === 'node10'
-  ) {
+  if (moduleResolution === 'node' || moduleResolution === 'node10') {
     delete compilerOptions.moduleResolution;
   }
   if (config.isBun || config.depending.reactNative) return;
 
-  if (compilerOptions.module === 'ESNext') {
+  if (moduleResolution === 'bundler' && (config.depending.vite || config.depending.tauri)) {
+    // Vite owns bundling for these packages and their sources rely on bundler-mode
+    // resolution (e.g. extensionless imports), so keep an explicitly valid pair that
+    // overrides the node base configs instead of falling back to NodeNext.
+    compilerOptions.module = 'ESNext';
+    return;
+  }
+
+  if (lowerCaseSetting(compilerOptions.module) === 'esnext') {
     // Node base configs now pair their resolver with a matching module kind. Keeping
     // older ESNext overrides creates invalid generated configs for TS 6.
     delete compilerOptions.module;
   }
 
-  const moduleKind = typeof compilerOptions.module === 'string' ? compilerOptions.module.toLowerCase() : undefined;
+  const moduleKind = lowerCaseSetting(compilerOptions.module);
   if (
-    typeof compilerOptions.moduleResolution === 'string' &&
-    compilerOptions.moduleResolution.toLowerCase() === 'bundler' &&
-    (moduleKind === undefined || moduleKind === 'node16' || moduleKind === 'nodenext')
+    moduleResolution === 'bundler' &&
+    (compilerOptions.module === undefined || moduleKind === 'node16' || moduleKind === 'nodenext')
   ) {
     // The node base configs pair module=NodeNext with moduleResolution=NodeNext, and
     // TypeScript rejects a bundler resolver with node module kinds. Such a resolver is
-    // usually left over from pre-wbfy bundler-oriented configs (e.g. Vite/Tauri
-    // frontends), so drop it and let the base configs choose a consistent pair.
+    // usually left over from pre-wbfy bundler-oriented configs, so drop it and let the
+    // base configs choose a consistent pair.
     delete compilerOptions.moduleResolution;
   }
+}
+
+function lowerCaseSetting(value: unknown): string | undefined {
+  return typeof value === 'string' ? value.toLowerCase() : undefined;
 }
 
 function normalizeCommonJsTsconfigSettings(

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -139,7 +139,7 @@ async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promi
   const filePath = path.resolve(config.dirPath, 'tsconfig.json');
   try {
     const settings = JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as TsConfigJson;
-    normalizeNextTsconfigModuleSettings(settings.compilerOptions);
+    normalizeNextTsconfigModuleSettings(settings);
     normalizeNextTsconfigPathAliases(settings.compilerOptions);
     addScriptsIncludeForFrameworkProject(settings);
     await promisePool.run(() => fsUtil.generateFile(filePath, JSON.stringify(settings, undefined, 2)));
@@ -159,15 +159,20 @@ function addScriptsIncludeForFrameworkProject(settings: TsConfigJson): void {
   settings.include.sort();
 }
 
-function normalizeNextTsconfigModuleSettings(compilerOptions: TsConfigJson.CompilerOptions | undefined): void {
+function normalizeNextTsconfigModuleSettings(settings: TsConfigJson): void {
+  const compilerOptions = settings.compilerOptions;
   if (!compilerOptions) return;
-  // TypeScript treats option values case-insensitively, so normalize before comparison.
-  const moduleResolution =
-    typeof compilerOptions.moduleResolution === 'string' ? compilerOptions.moduleResolution.toLowerCase() : undefined;
+  const moduleResolution = lowerCaseSetting(compilerOptions.moduleResolution);
   if (moduleResolution === 'node' || moduleResolution === 'node10' || moduleResolution === undefined) {
-    // Next.js writes "node" during build when this option is missing, but
-    // tsgolint treats that spelling as the removed node10 resolver.
-    compilerOptions.moduleResolution = 'bundler';
+    if (settings.extends) {
+      // An extended config may already supply a valid module/resolver pair, so only
+      // remove the removed-in-TS6 node10 spellings instead of forcing bundler on it.
+      delete compilerOptions.moduleResolution;
+    } else {
+      // Next.js writes "node" during build when this option is missing, but
+      // tsgolint treats that spelling as the removed node10 resolver.
+      compilerOptions.moduleResolution = 'bundler';
+    }
   }
 }
 
@@ -271,10 +276,14 @@ function deleteLegacyModuleSettings(
   }
   if (config.isBun || config.depending.reactNative) return;
 
-  if (moduleResolution === 'bundler' && (config.depending.vite || config.depending.tauri)) {
-    // Vite owns bundling for these packages and their sources rely on bundler-mode
-    // resolution (e.g. extensionless imports), so keep an explicitly valid pair that
-    // overrides the node base configs instead of falling back to NodeNext.
+  if (config.depending.vite || config.depending.tauri) {
+    // Vite owns module semantics for these packages and their sources rely on
+    // bundler-mode resolution (e.g. extensionless imports), so pin the bundler pair
+    // even when a legacy config used the node resolver, instead of falling back to
+    // the node base configs' NodeNext.
+    if (moduleResolution !== 'bundler') {
+      compilerOptions.moduleResolution = 'bundler';
+    }
     const moduleKind = lowerCaseSetting(compilerOptions.module);
     // TypeScript pairs the bundler resolver with Preserve or ES-module kinds. Keep an
     // existing valid kind (e.g. Preserve, which handles import and require syntax
@@ -291,9 +300,10 @@ function deleteLegacyModuleSettings(
     delete compilerOptions.moduleResolution;
   }
 
-  if (lowerCaseSetting(compilerOptions.module) === 'esnext') {
-    // Node base configs now pair their resolver with a matching module kind. Keeping
-    // older ESNext overrides creates invalid generated configs for TS 6.
+  const moduleKind = lowerCaseSetting(compilerOptions.module);
+  if (moduleKind === 'preserve' || moduleKind?.startsWith('es')) {
+    // Node base configs pair their resolver with a matching module kind; leftover
+    // ES/Preserve overrides are invalid with every pair they may choose.
     delete compilerOptions.module;
   }
 }

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -275,26 +275,26 @@ function deleteLegacyModuleSettings(
     // Vite owns bundling for these packages and their sources rely on bundler-mode
     // resolution (e.g. extensionless imports), so keep an explicitly valid pair that
     // overrides the node base configs instead of falling back to NodeNext.
-    compilerOptions.module = 'ESNext';
+    const moduleKind = lowerCaseSetting(compilerOptions.module);
+    // TypeScript pairs the bundler resolver with Preserve or ES-module kinds. Keep an
+    // existing valid kind (e.g. Preserve, which handles import and require syntax
+    // separately) and fill in ESNext only when the pair would otherwise be invalid.
+    if (moduleKind === undefined || (moduleKind !== 'preserve' && !moduleKind.startsWith('es'))) {
+      compilerOptions.module = 'ESNext';
+    }
     return;
+  }
+
+  if (moduleResolution === 'bundler') {
+    // The node base configs provide a consistent module/resolver pair, and every
+    // module kind they may choose is invalid with a leftover bundler resolver.
+    delete compilerOptions.moduleResolution;
   }
 
   if (lowerCaseSetting(compilerOptions.module) === 'esnext') {
     // Node base configs now pair their resolver with a matching module kind. Keeping
     // older ESNext overrides creates invalid generated configs for TS 6.
     delete compilerOptions.module;
-  }
-
-  const moduleKind = lowerCaseSetting(compilerOptions.module);
-  if (
-    moduleResolution === 'bundler' &&
-    (compilerOptions.module === undefined || moduleKind === 'node16' || moduleKind === 'nodenext')
-  ) {
-    // The node base configs pair module=NodeNext with moduleResolution=NodeNext, and
-    // TypeScript rejects a bundler resolver with node module kinds. Such a resolver is
-    // usually left over from pre-wbfy bundler-oriented configs, so drop it and let the
-    // base configs choose a consistent pair.
-    delete compilerOptions.moduleResolution;
   }
 }
 

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -37,6 +37,7 @@ export interface PackageConfig {
   doesContainPomXml: boolean;
   doesContainPubspecYaml: boolean;
   doesContainTauriConfig: boolean;
+  doesContainTauriConfigInPackages: boolean;
   doesContainTemplateYaml: boolean;
   doesContainVscodeSettingsJson: boolean;
   // source code files
@@ -211,6 +212,10 @@ export async function getPackageConfig(
       doesContainPomXml: fs.existsSync(path.resolve(dirPath, 'pom.xml')),
       doesContainPubspecYaml: fs.existsSync(path.resolve(dirPath, 'pubspec.yaml')),
       doesContainTauriConfig,
+      doesContainTauriConfigInPackages: containsAny(
+        'packages/**/src-tauri/{tauri.conf.json,tauri.conf.json5,Tauri.toml}',
+        dirPath
+      ),
       doesContainTemplateYaml: fs.existsSync(path.resolve(dirPath, 'template.yaml')),
       doesContainVscodeSettingsJson: fs.existsSync(path.resolve(dirPath, '.vscode', 'settings.json')),
       doesContainJavaScript: containsAny('{app,src,test,scripts}/**/*.{cjs,mjs,js,jsx}', dirPath),

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -62,6 +62,7 @@ export interface PackageConfig {
     reactNative: boolean;
     semanticRelease: boolean;
     storybook: boolean;
+    tauri: boolean;
     vinext: boolean;
     wb: boolean;
     chakra: boolean;
@@ -234,6 +235,10 @@ export async function getPackageConfig(
           releasePlugins.length > 0
         ),
         storybook: !!devDependencies['@storybook/react'],
+        tauri:
+          !!dependencies['@tauri-apps/api'] ||
+          !!devDependencies['@tauri-apps/cli'] ||
+          fs.existsSync(path.resolve(dirPath, 'src-tauri', 'tauri.conf.json')),
         vinext: !!dependencies.vinext || !!devDependencies.vinext,
         wb: !!dependencies['@willbooster/wb'] || !!devDependencies['@willbooster/wb'],
       },

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -64,6 +64,7 @@ export interface PackageConfig {
     storybook: boolean;
     tauri: boolean;
     vinext: boolean;
+    vite: boolean;
     wb: boolean;
     chakra: boolean;
     drizzle: boolean;
@@ -237,9 +238,15 @@ export async function getPackageConfig(
         storybook: !!devDependencies['@storybook/react'],
         tauri:
           !!dependencies['@tauri-apps/api'] ||
+          !!devDependencies['@tauri-apps/api'] ||
+          !!dependencies['@tauri-apps/cli'] ||
           !!devDependencies['@tauri-apps/cli'] ||
-          fs.existsSync(path.resolve(dirPath, 'src-tauri', 'tauri.conf.json')),
+          // Tauri officially supports JSON, JSON5, and TOML configuration formats.
+          ['tauri.conf.json', 'tauri.conf.json5', 'Tauri.toml'].some((fileName) =>
+            fs.existsSync(path.resolve(dirPath, 'src-tauri', fileName))
+          ),
         vinext: !!dependencies.vinext || !!devDependencies.vinext,
+        vite: !!dependencies.vite || !!devDependencies.vite,
         wb: !!dependencies['@willbooster/wb'] || !!devDependencies['@willbooster/wb'],
       },
       release: {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -36,6 +36,7 @@ export interface PackageConfig {
   doesContainUvLock: boolean;
   doesContainPomXml: boolean;
   doesContainPubspecYaml: boolean;
+  doesContainTauriConfig: boolean;
   doesContainTemplateYaml: boolean;
   doesContainVscodeSettingsJson: boolean;
   // source code files
@@ -173,6 +174,10 @@ export async function getPackageConfig(
       }
     }
     const repository = repoFullName ? `github:${repoFullName}` : undefined;
+    // Tauri officially supports JSON, JSON5, and TOML configuration formats.
+    const doesContainTauriConfig = ['tauri.conf.json', 'tauri.conf.json5', 'Tauri.toml'].some((fileName) =>
+      fs.existsSync(path.resolve(dirPath, 'src-tauri', fileName))
+    );
     const config: PackageConfig = {
       dirPath,
       dockerfile,
@@ -205,6 +210,7 @@ export async function getPackageConfig(
       doesContainUvLock: fs.existsSync(path.resolve(dirPath, 'uv.lock')),
       doesContainPomXml: fs.existsSync(path.resolve(dirPath, 'pom.xml')),
       doesContainPubspecYaml: fs.existsSync(path.resolve(dirPath, 'pubspec.yaml')),
+      doesContainTauriConfig,
       doesContainTemplateYaml: fs.existsSync(path.resolve(dirPath, 'template.yaml')),
       doesContainVscodeSettingsJson: fs.existsSync(path.resolve(dirPath, '.vscode', 'settings.json')),
       doesContainJavaScript: containsAny('{app,src,test,scripts}/**/*.{cjs,mjs,js,jsx}', dirPath),
@@ -241,10 +247,7 @@ export async function getPackageConfig(
           !!devDependencies['@tauri-apps/api'] ||
           !!dependencies['@tauri-apps/cli'] ||
           !!devDependencies['@tauri-apps/cli'] ||
-          // Tauri officially supports JSON, JSON5, and TOML configuration formats.
-          ['tauri.conf.json', 'tauri.conf.json5', 'Tauri.toml'].some((fileName) =>
-            fs.existsSync(path.resolve(dirPath, 'src-tauri', fileName))
-          ),
+          doesContainTauriConfig,
         vinext: !!dependencies.vinext || !!devDependencies.vinext,
         vite: !!dependencies.vite || !!devDependencies.vite,
         wb: !!dependencies['@willbooster/wb'] || !!devDependencies['@willbooster/wb'],
@@ -267,6 +270,7 @@ export async function getPackageConfig(
       config.doesContainUvLock ||
       config.doesContainPomXml ||
       config.doesContainPubspecYaml ||
+      config.doesContainTauriConfig ||
       config.doesContainTemplateYaml
     ) {
       return config;

--- a/packages/wbfy/test/packageConfig.test.ts
+++ b/packages/wbfy/test/packageConfig.test.ts
@@ -33,6 +33,23 @@ test('accepts Cargo-only Tauri projects without a package.json', async () => {
   }
 });
 
+test('detects a nested Tauri application from a parent package', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-package-config-'));
+  try {
+    const srcTauriDirPath = path.join(tempDirPath, 'packages', 'root', 'packages', 'app', 'src-tauri');
+    fs.mkdirSync(srcTauriDirPath, { recursive: true });
+    // The packages/root layout keeps getPackageConfig from looking up a GitHub repository.
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), '{}');
+    fs.writeFileSync(path.join(tempDirPath, 'packages', 'root', 'package.json'), '{}');
+    fs.writeFileSync(path.join(srcTauriDirPath, 'tauri.conf.json'), '{}');
+    const config = await getPackageConfig(path.join(tempDirPath, 'packages', 'root'));
+    expect(config?.doesContainTauriConfig).toBe(false);
+    expect(config?.doesContainTauriConfigInPackages).toBe(true);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 async function detectTauri(setup: { packageJson?: object; srcTauriFileName?: string }): Promise<boolean> {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-package-config-'));
   try {

--- a/packages/wbfy/test/packageConfig.test.ts
+++ b/packages/wbfy/test/packageConfig.test.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { getPackageConfig } from '../src/packageConfig.js';
+
+test('detects Tauri packages from every supported signal', async () => {
+  expect(await detectTauri({ packageJson: { dependencies: { '@tauri-apps/api': '2.0.0' } } })).toBe(true);
+  expect(await detectTauri({ packageJson: { devDependencies: { '@tauri-apps/api': '2.0.0' } } })).toBe(true);
+  expect(await detectTauri({ packageJson: { dependencies: { '@tauri-apps/cli': '2.0.0' } } })).toBe(true);
+  expect(await detectTauri({ packageJson: { devDependencies: { '@tauri-apps/cli': '2.0.0' } } })).toBe(true);
+  expect(await detectTauri({ srcTauriFileName: 'tauri.conf.json' })).toBe(true);
+  expect(await detectTauri({ srcTauriFileName: 'tauri.conf.json5' })).toBe(true);
+  expect(await detectTauri({ srcTauriFileName: 'Tauri.toml' })).toBe(true);
+  expect(await detectTauri({})).toBe(false);
+});
+
+async function detectTauri(setup: { packageJson?: object; srcTauriFileName?: string }): Promise<boolean> {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-package-config-'));
+  try {
+    // Place the package under packages/ so getPackageConfig treats it as a sub package
+    // and skips the GitHub repository lookup.
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), '{}');
+    const packageDirPath = path.join(tempDirPath, 'packages', 'app');
+    fs.mkdirSync(packageDirPath, { recursive: true });
+    fs.writeFileSync(path.join(packageDirPath, 'package.json'), JSON.stringify(setup.packageJson ?? {}));
+    if (setup.srcTauriFileName) {
+      const srcTauriDirPath = path.join(packageDirPath, 'src-tauri');
+      fs.mkdirSync(srcTauriDirPath);
+      fs.writeFileSync(path.join(srcTauriDirPath, setup.srcTauriFileName), '');
+    }
+    const config = await getPackageConfig(packageDirPath);
+    return config?.depending.tauri ?? false;
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+}

--- a/packages/wbfy/test/packageConfig.test.ts
+++ b/packages/wbfy/test/packageConfig.test.ts
@@ -17,6 +17,22 @@ test('detects Tauri packages from every supported signal', async () => {
   expect(await detectTauri({})).toBe(false);
 });
 
+test('accepts Cargo-only Tauri projects without a package.json', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-package-config-'));
+  try {
+    const srcTauriDirPath = path.join(tempDirPath, 'packages', 'app', 'src-tauri');
+    fs.mkdirSync(srcTauriDirPath, { recursive: true });
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), '{}');
+    fs.writeFileSync(path.join(srcTauriDirPath, 'tauri.conf.json'), '{}');
+    const config = await getPackageConfig(path.join(tempDirPath, 'packages', 'app'));
+    expect(config).toBeDefined();
+    expect(config?.doesContainTauriConfig).toBe(true);
+    expect(config?.depending.tauri).toBe(true);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 async function detectTauri(setup: { packageJson?: object; srcTauriFileName?: string }): Promise<boolean> {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-package-config-'));
   try {

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -24,6 +24,7 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
     doesContainPomXml: false,
     doesContainPubspecYaml: false,
     doesContainTauriConfig: false,
+    doesContainTauriConfigInPackages: false,
     doesContainTemplateYaml: false,
     doesContainVscodeSettingsJson: false,
     doesContainJavaScript: false,

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -49,6 +49,7 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
       reactNative: false,
       semanticRelease: false,
       storybook: false,
+      tauri: false,
       vinext: false,
       wb: false,
     },

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -51,6 +51,7 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
       storybook: false,
       tauri: false,
       vinext: false,
+      vite: false,
       wb: false,
     },
     release: {

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -23,6 +23,7 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
     doesContainUvLock: false,
     doesContainPomXml: false,
     doesContainPubspecYaml: false,
+    doesContainTauriConfig: false,
     doesContainTemplateYaml: false,
     doesContainVscodeSettingsJson: false,
     doesContainJavaScript: false,

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -52,6 +52,40 @@ test('drops a leftover bundler resolution paired with CommonJS in non-bundler pa
   expect(compilerOptions.moduleResolution).toBeUndefined();
 });
 
+test('migrates a legacy node resolver to the bundler pair for Vite-dependent packages', async () => {
+  const compilerOptions = await generateCompilerOptionsFrom(
+    { compilerOptions: { module: 'ESNext', moduleResolution: 'node' } },
+    { vite: true }
+  );
+  expect(compilerOptions.moduleResolution).toBe('bundler');
+  expect(compilerOptions.module).toBe('ESNext');
+});
+
+test('drops leftover ES-module and Preserve kinds when falling back to the node bases', async () => {
+  const es2022Options = await generateCompilerOptionsFrom({
+    compilerOptions: { module: 'ES2022', moduleResolution: 'bundler' },
+  });
+  expect(es2022Options.module).toBeUndefined();
+  expect(es2022Options.moduleResolution).toBeUndefined();
+
+  const preserveOptions = await generateCompilerOptionsFrom({
+    compilerOptions: { module: 'Preserve', moduleResolution: 'bundler' },
+  });
+  expect(preserveOptions.module).toBeUndefined();
+  expect(preserveOptions.moduleResolution).toBeUndefined();
+});
+
+test('does not force a bundler resolver on Next configs that extend a base config', async () => {
+  const extendedOptions = await generateCompilerOptionsFrom(
+    { extends: '@tsconfig/node-lts/tsconfig.json', compilerOptions: {} },
+    { next: true }
+  );
+  expect(extendedOptions.moduleResolution).toBeUndefined();
+
+  const standaloneOptions = await generateCompilerOptionsFrom({ compilerOptions: {} }, { next: true });
+  expect(standaloneOptions.moduleResolution).toBe('bundler');
+});
+
 test('drops removed node10 resolver spellings regardless of casing', async () => {
   const compilerOptions = await generateCompilerOptionsFrom({ compilerOptions: { moduleResolution: 'Node10' } });
   expect(compilerOptions.moduleResolution).toBeUndefined();

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { generateTsconfig } from '../src/generators/tsconfig.js';
+import type { PackageConfig } from '../src/packageConfig.js';
+import { promisePool } from '../src/utils/promisePool.js';
+
+import { createConfig } from './testConfig.js';
+
+test('keeps the bundler pair for Vite-dependent packages', async () => {
+  const compilerOptions = await generateCompilerOptionsFrom(
+    { compilerOptions: { module: 'ESNext', moduleResolution: 'bundler' } },
+    { vite: true }
+  );
+  expect(compilerOptions.moduleResolution).toBe('bundler');
+  expect(compilerOptions.module).toBe('ESNext');
+});
+
+test('keeps the bundler pair for Tauri-dependent packages', async () => {
+  const compilerOptions = await generateCompilerOptionsFrom(
+    { compilerOptions: { moduleResolution: 'Bundler' } },
+    { tauri: true }
+  );
+  expect(compilerOptions.moduleResolution).toBe('Bundler');
+  expect(compilerOptions.module).toBe('ESNext');
+});
+
+test('drops a leftover bundler resolution and esnext module regardless of casing', async () => {
+  const compilerOptions = await generateCompilerOptionsFrom({
+    compilerOptions: { module: 'esnext', moduleResolution: 'Bundler' },
+  });
+  expect(compilerOptions.module).toBeUndefined();
+  expect(compilerOptions.moduleResolution).toBeUndefined();
+});
+
+test('drops removed node10 resolver spellings regardless of casing', async () => {
+  const compilerOptions = await generateCompilerOptionsFrom({ compilerOptions: { moduleResolution: 'Node10' } });
+  expect(compilerOptions.moduleResolution).toBeUndefined();
+});
+
+async function generateCompilerOptionsFrom(
+  existingTsconfig: object,
+  dependingOverrides: Partial<PackageConfig['depending']> = {}
+): Promise<Record<string, unknown>> {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-tsconfig-'));
+  try {
+    fs.writeFileSync(path.join(tempDirPath, 'tsconfig.json'), JSON.stringify(existingTsconfig));
+    const config = createConfig({ dirPath: tempDirPath, isRoot: true, doesContainTypeScript: true });
+    Object.assign(config.depending, dependingOverrides);
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    const generated = JSON.parse(fs.readFileSync(path.join(tempDirPath, 'tsconfig.json'), 'utf8')) as {
+      compilerOptions?: Record<string, unknown>;
+    };
+    return generated.compilerOptions ?? {};
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+}

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -36,6 +36,22 @@ test('drops a leftover bundler resolution and esnext module regardless of casing
   expect(compilerOptions.moduleResolution).toBeUndefined();
 });
 
+test('keeps an existing Preserve module kind for Vite-dependent packages', async () => {
+  const compilerOptions = await generateCompilerOptionsFrom(
+    { compilerOptions: { module: 'Preserve', moduleResolution: 'bundler' } },
+    { vite: true }
+  );
+  expect(compilerOptions.module).toBe('Preserve');
+  expect(compilerOptions.moduleResolution).toBe('bundler');
+});
+
+test('drops a leftover bundler resolution paired with CommonJS in non-bundler packages', async () => {
+  const compilerOptions = await generateCompilerOptionsFrom({
+    compilerOptions: { module: 'CommonJS', moduleResolution: 'bundler' },
+  });
+  expect(compilerOptions.moduleResolution).toBeUndefined();
+});
+
 test('drops removed node10 resolver spellings regardless of casing', async () => {
   const compilerOptions = await generateCompilerOptionsFrom({ compilerOptions: { moduleResolution: 'Node10' } });
   expect(compilerOptions.moduleResolution).toBeUndefined();


### PR DESCRIPTION
## Customer Summary

- `wbfy` can now be applied to Tauri desktop-app repositories (e.g. WillBooster/cheerlings) without manual fixes: generated .gitignore, tsconfig, and other conventions come out valid for Tauri + Vite projects.
- Existing non-Tauri repositories also benefit from safer tsconfig migration (fewer invalid generated configs).

## Technical Summary

- Detection: `depending.tauri` matches `@tauri-apps/api` / `@tauri-apps/cli` in either dependency section or a `src-tauri` config (`tauri.conf.json` / `tauri.conf.json5` / `Tauri.toml`); `doesContainTauriConfig` marks an application and `doesContainTauriConfigInPackages` marks a parent of a nested application. Cargo-only Tauri projects (no package.json) are now accepted.
- .gitignore: Tauri packages get the `rust` template with the unanchored `debug/` commented out (it would hide `src/debug/` frontend sources). Applications keep `Cargo.lock` committed (`# Cargo.lock` + `!Cargo.lock` override, disabled for parents of nested apps too), while Tauri plugin libraries keep the template's library policy. Cloudflare packages now ignore `.dev.vars*`.
- tsconfig: Vite/Tauri packages are pinned to the bundler pair (preserving an existing Preserve/ES-module kind, filling in ESNext otherwise), including migration from the removed `node` resolver. For node-base packages, leftover `bundler` resolvers and ES/Preserve module kinds are dropped; comparisons are case-insensitive; Next configs with `extends` no longer get a forced bundler resolver.
- Tests: new `test/tsconfig.test.ts` (9 cases) and `test/packageConfig.test.ts` (3 cases).

## Why

- WillBooster/cheerlings is the first Tauri project under company conventions; applying the previous `wbfy` produced invalid tsconfigs and left Rust artifacts untracked/mis-ignored.
- Fixes were driven by an adversarial multi-agent review loop (Codex / Claude / Antigravity, 6 rounds until no concerns), each finding validated against TypeScript/Tauri/git primary behavior before fixing.

## Testing

- `yarn verify` in `packages/wbfy` passes; `yarn test` passes (one npm-registry-dependent test is flaky under parallel load and passes in isolation).
- Applied this wbfy build to WillBooster/cheerlings (Tauri + Vite + Cloudflare Workers monorepo) three times during the loop: generated configs are valid and lint/typecheck/tests/CI pass there.

## Notes (if needed)

- Generated `.gitignore` files in existing Tauri-less repositories are unaffected; Cloudflare repositories will gain a `.dev.vars*` ignore line on their next wbfy run.
