### PR TITLE
feat(wbfy): generate test-rust workflow and require its status check for Rust repos

### DIFF
--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -118,6 +118,24 @@ const workflows = {
       },
     },
   },
+  'test-rust': {
+    name: 'Test Rust',
+    on: {
+      pull_request: null,
+      push: {
+        branches: ['main', 'wbfy'],
+      },
+    },
+    concurrency: {
+      group: '${{ github.workflow }}-${{ github.ref }}',
+      'cancel-in-progress': true,
+    },
+    jobs: {
+      'test-rust': {
+        uses: 'WillBooster/reusable-workflows/.github/workflows/test-rust.yml@main',
+      },
+    },
+  },
   release: {
     name: 'Release',
     on: {
@@ -215,6 +233,9 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
     if (rootConfig.depending.semanticRelease) {
       fileNameSet.add('release.yml');
     }
+    if (rootConfig.cargoTomlDirPaths.length > 0) {
+      fileNameSet.add('test-rust.yml');
+    }
     if (!rootConfig.isPublicRepo) {
       // The reusable test workflow already fixes and pushes code on private repos,
       // so a separate autofix workflow only duplicates the same process.
@@ -247,6 +268,9 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
     return;
   }
 
+  // A test-rust.yml in a repo without Rust code is a custom workflow that merely shares the name; leave it alone.
+  if (kind === 'test-rust' && config.cargoTomlDirPaths.length === 0) return;
+
   let newSettings = structuredClone(kind in workflows ? workflows[kind as keyof typeof workflows] : {}) as Workflow;
 
   try {
@@ -259,6 +283,16 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
 
   // Skip a broken workflow
   if (!('jobs' in newSettings)) return;
+
+  if (kind === 'test-rust') {
+    // Migrate hand-written Rust workflows (e.g. an inline cargo-check job) to the reusable workflow.
+    for (const [jobName, job] of Object.entries(newSettings.jobs)) {
+      if (!job.uses?.includes('/reusable-workflows/')) {
+        delete newSettings.jobs[jobName];
+      }
+    }
+    moveToBottom(newSettings, 'jobs');
+  }
 
   if (kind.startsWith('deploy')) {
     newSettings = {
@@ -313,7 +347,8 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
       }
       break;
     }
-    case 'test': {
+    case 'test':
+    case 'test-rust': {
       // Don't use `paths-ignore` for test because GitHub's Branch Protection and Rulesets require job running.
       // The reusable test workflow no longer needs Actions write access.
       delete newSettings.permissions?.actions;
@@ -373,6 +408,15 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
     }
   }
 
+  if (kind === 'test-rust') {
+    const [rustDirPath] = config.cargoTomlDirPaths;
+    if (rustDirPath && rustDirPath !== '.') {
+      job.with.working_directory = rustDirPath;
+    } else {
+      delete job.with.working_directory;
+    }
+  }
+
   if (config.repository?.startsWith('github:WillBooster/')) {
     job.uses = job.uses?.replace('WillBoosterLab/', 'WillBooster/');
   } else if (config.repository?.startsWith('github:WillBoosterLab/')) {
@@ -392,7 +436,7 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
     job.with.ci_label = 'large';
   }
   // Because github.event.repository.private is always true if job is scheduled
-  if (kind === 'release' || kind === 'test' || kind.startsWith('deploy')) {
+  if (kind === 'release' || kind.startsWith('test') || kind.startsWith('deploy')) {
     if (config.isPublicRepo) {
       job.with.github_hosted_runner = true;
     }

--- a/packages/wbfy/src/github/ruleset.ts
+++ b/packages/wbfy/src/github/ruleset.ts
@@ -60,6 +60,8 @@ const GITHUB_API_VERSION_HEADER = {
   'X-GitHub-Api-Version': '2022-11-28',
 } as const;
 
+const GITHUB_ACTIONS_INTEGRATION_ID = 15_368;
+
 const PROTECT_MAIN_RULESET: RepositoryRulesetPayload = {
   name: 'Protect main',
   target: 'branch',
@@ -82,11 +84,11 @@ const PROTECT_MAIN_RULESET: RepositoryRulesetPayload = {
         required_status_checks: [
           {
             context: 'test / test',
-            integration_id: 15_368,
+            integration_id: GITHUB_ACTIONS_INTEGRATION_ID,
           },
           {
             context: 'semantic-pr / semantic-pr',
-            integration_id: 15_368,
+            integration_id: GITHUB_ACTIONS_INTEGRATION_ID,
           },
         ],
       },
@@ -126,7 +128,7 @@ export async function setupRepositoryRulesets(config: PackageConfig): Promise<vo
     const octokit = getOctokit(owner);
 
     try {
-      await upsertProtectMainRuleset(octokit, owner, repo);
+      await upsertProtectMainRuleset(octokit, owner, repo, buildProtectMainRuleset(config));
     } catch (error) {
       if (!isGitHubPermissionOrVisibilityError(error)) throw error;
 
@@ -137,8 +139,28 @@ export async function setupRepositoryRulesets(config: PackageConfig): Promise<vo
   });
 }
 
-async function upsertProtectMainRuleset(octokit: Octokit, owner: string, repo: string): Promise<void> {
-  const existingRuleset = await findRepositoryRuleset(octokit, owner, repo, PROTECT_MAIN_RULESET.name);
+function buildProtectMainRuleset(config: PackageConfig): RepositoryRulesetPayload {
+  const ruleset = structuredClone(PROTECT_MAIN_RULESET);
+  if (config.cargoTomlDirPaths.length > 0) {
+    for (const rule of ruleset.rules) {
+      if (rule.type !== 'required_status_checks') continue;
+      // The context is `<caller job id> / <reusable job id>` of the wbfy-generated test-rust.yml.
+      rule.parameters.required_status_checks.push({
+        context: 'test-rust / test-rust',
+        integration_id: GITHUB_ACTIONS_INTEGRATION_ID,
+      });
+    }
+  }
+  return ruleset;
+}
+
+async function upsertProtectMainRuleset(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ruleset: RepositoryRulesetPayload
+): Promise<void> {
+  const existingRuleset = await findRepositoryRuleset(octokit, owner, repo, ruleset.name);
   const existingRulesetId = existingRuleset?.id;
 
   await withRetry(
@@ -148,7 +170,7 @@ async function upsertProtectMainRuleset(octokit: Octokit, owner: string, repo: s
           owner,
           repo,
           ruleset_id: existingRulesetId,
-          ...PROTECT_MAIN_RULESET,
+          ...ruleset,
           headers: GITHUB_API_VERSION_HEADER,
         });
         return;
@@ -157,7 +179,7 @@ async function upsertProtectMainRuleset(octokit: Octokit, owner: string, repo: s
       await octokit.request('POST /repos/{owner}/{repo}/rulesets', {
         owner,
         repo,
-        ...PROTECT_MAIN_RULESET,
+        ...ruleset,
         headers: GITHUB_API_VERSION_HEADER,
       });
     },

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -27,6 +27,8 @@ export interface PackageConfig {
   isEsmPackage: boolean;
   isWillBoosterConfigs: boolean;
   // dependency information
+  /** Directories containing Cargo.toml (relative to dirPath, root-most first). Empty if the repo has no Rust code. */
+  cargoTomlDirPaths: string[];
   doesContainSubPackageJsons: boolean;
   doesContainDockerfile: boolean;
   doesContainGemfile: boolean;
@@ -202,6 +204,7 @@ export async function getPackageConfig(
         fs.existsSync(path.join(dirPath, 'bunfig.toml')),
       isEsmPackage: esmPackage,
       isWillBoosterConfigs: packageJsonPath.includes('/willbooster-configs'),
+      cargoTomlDirPaths: findCargoTomlDirPaths(dirPath),
       doesContainSubPackageJsons: containsAny('packages/**/package.json', dirPath),
       doesContainDockerfile: !!dockerfile || fs.existsSync(path.resolve(dirPath, 'docker-compose.yml')),
       doesContainGemfile: fs.existsSync(path.resolve(dirPath, 'Gemfile')),
@@ -369,6 +372,13 @@ function readMiseTaskCommand(value: unknown): string {
 
 function containsAny(pattern: string, dirPath: string): boolean {
   return fg.globSync(pattern, { dot: true, cwd: dirPath, ignore: globIgnore }).length > 0;
+}
+
+function findCargoTomlDirPaths(dirPath: string): string[] {
+  return fg
+    .globSync('**/Cargo.toml', { dot: true, cwd: dirPath, ignore: globIgnore })
+    .map((filePath) => path.dirname(filePath))
+    .toSorted((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b));
 }
 
 function doesImportPlaywrightAtRuntime(dirPath: string): boolean {

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -14,6 +14,7 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
     isBun: false,
     isEsmPackage: false,
     isWillBoosterConfigs: false,
+    cargoTomlDirPaths: [],
     doesContainSubPackageJsons: false,
     doesContainDockerfile: false,
     doesContainGemfile: false,


### PR DESCRIPTION
## Customer Summary

- No end-user impact; this improves internal repository automation.
- Repositories containing Rust code (e.g., Tauri desktop apps) now get their Rust CI workflow generated automatically by `wbfy`, running on self-hosted runners for private repos per our runner policy, and a broken Rust build now blocks merging.

## Technical Summary

- `packageConfig.ts`: add `cargoTomlDirPaths` (directories containing `Cargo.toml`, root-most first; `node_modules`/`target` etc. excluded via `globIgnore`).
- `generators/workflow.ts`: when Rust code exists, generate `.github/workflows/test-rust.yml` as a thin caller of `WillBooster/reusable-workflows/.github/workflows/test-rust.yml@main` (merged in WillBooster/reusable-workflows#422) with `working_directory` set to the root-most Cargo.toml directory. Hand-written inline Rust jobs (e.g. a `cargo-check` job) are dropped during generation so existing repos migrate automatically. `paths-ignore` is stripped like the `test` workflow because the job backs a required status check. A `test-rust.yml` in a repo without Rust code is left untouched.
- `github/ruleset.ts`: build the "Protect main" ruleset payload per repo; when the repo contains Rust code, add `test-rust / test-rust` to the required status checks. Extracted the GitHub Actions integration id into a constant.

## Why

- cheerlings (private) had a hand-written Rust workflow hard-coded to `macos-latest`, violating the policy that private repositories run CI on self-hosted runners, and its Rust check was not a required status check, so broken Rust builds could merge. Centralizing generation in `wbfy` prevents both mistakes across all repositories.

## Testing

- `yarn tsc --noEmit` passed; `yarn vitest run` has the same 6 pre-existing environment-dependent failures as `main` (mise spawn), no new failures.
- Trial-ran this branch's `wbfy` against WillBooster/cheerlings: generated the expected thin caller (legacy `cargo-check` job removed, `working_directory: packages/desktop/src-tauri`) and the repo ruleset now requires `test-rust / test-rust`. The cheerlings PR applying this will verify the workflow end-to-end.
