### PR TITLE
fix: preserve bunfig [test] sections when wbfy regenerates bunfig.toml

### DIFF
--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -162,7 +162,7 @@ const newContent = (existingContent: string | undefined): string => {
   return `env = false
 telemetry = false
 
-[install]
+${extractRawTestSections(existingContent)}[install]
 exact = ${bunfigToml?.install?.exact === false ? 'false' : 'true'}
 linker = "hoisted"
 minimumReleaseAge = ${bunMinimumReleaseAgeSeconds} # 5 days
@@ -171,6 +171,27 @@ ${bunMinimumReleaseAgeExcludes.map((packageName) => `    "${packageName}",`).joi
 ]
 `;
 };
+
+/**
+ * Preserve the project's `[test]` sections (e.g. preload scripts swapping a Cloudflare D1 client
+ * for a local SQLite one) verbatim, comments included; wbfy manages only the other sections.
+ */
+export function extractRawTestSections(content: string | undefined): string {
+  if (!content) return '';
+
+  const preservedLines: string[] = [];
+  let inTestSection = false;
+  for (const line of content.split('\n')) {
+    const sectionMatch = /^\s*\[([^\]]+)\]/.exec(line);
+    if (sectionMatch) {
+      inTestSection = sectionMatch[1] === 'test' || (sectionMatch[1] as string).startsWith('test.');
+    }
+    if (inTestSection && line.trim()) {
+      preservedLines.push(line);
+    }
+  }
+  return preservedLines.length > 0 ? `${preservedLines.join('\n')}\n\n` : '';
+}
 
 function parseBunfigToml(content: string | undefined): BunfigToml | undefined {
   if (!content) {

--- a/packages/wbfy/test/bunfig.test.ts
+++ b/packages/wbfy/test/bunfig.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest';
+
+import { extractRawTestSections } from '../src/generators/bunfig.js';
+
+test('preserves [test] sections with their comments and drops other sections', () => {
+  const existingContent = `env = false
+telemetry = false
+
+[run]
+bun = true
+
+[test]
+# The production db client targets Cloudflare D1; unit tests swap it for a
+# local SQLite client before any test module loads.
+preload = ["./test/unit/preloadDbClient.ts"]
+
+[install]
+exact = true
+`;
+
+  expect(extractRawTestSections(existingContent)).toBe(`[test]
+# The production db client targets Cloudflare D1; unit tests swap it for a
+# local SQLite client before any test module loads.
+preload = ["./test/unit/preloadDbClient.ts"]
+
+`);
+});
+
+test('returns an empty string when there is no [test] section', () => {
+  expect(extractRawTestSections(undefined)).toBe('');
+  expect(extractRawTestSections('env = false\n\n[install]\nexact = true\n')).toBe('');
+});


### PR DESCRIPTION
## Summary

`generateBunfigToml` emitted only the managed `env`/`telemetry`/`[install]` settings, silently deleting any other section from an existing `bunfig.toml`. This wiped agentic-workflows-dashboard's `[test]` section (a `preload` swapping the Cloudflare D1 client for bun:sqlite), so every unit test failed on CI with `Cannot find package 'cloudflare:workers'`.

`[test]` / `[test.*]` sections are now preserved verbatim (comments included) between the managed header and `[install]`; `[run]` remains intentionally dropped (no-`--bun` policy).

## Testing

- New unit tests for `extractRawTestSections` (preserve with comments; empty when absent).
- `yarn verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
