### PR TITLE
fix(wbfy): keep @typescript/native-preview for Next.js repos alongside typescript v7

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -28,9 +28,13 @@ import { yarnNpmMinimalAgeGate, yarnNpmPreapprovedPackages } from './yarnrc.js';
 
 const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', 'oxfmt', 'oxlint', 'oxlint-tsgolint'];
 const typescriptDependency = 'typescript';
-// TypeScript 7 ships the native compiler as the `typescript` package, replacing
-// the `@typescript/native-preview` (tsgo) preview wbfy relied on before the release.
-const deprecatedTypescriptGoDependency = '@typescript/native-preview';
+// TypeScript 7's `typescript` package is the tsgo native compiler and exposes no
+// programmatic API. Next.js's build-time `verifyTypeScriptSetup` needs that API, so
+// `next build` fails ("trying to use TypeScript but do not have the required package(s)")
+// with only `typescript` v7 installed. Next.js resolves the tsgo binary through the
+// separate `@typescript/native-preview` package, so Next.js-family repos must install
+// both; other repos only need `typescript` for `tsc` typechecks.
+const typescriptGoDependency = '@typescript/native-preview';
 const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
 const lefthookDependency = 'lefthook';
@@ -40,6 +44,7 @@ const managedDependencyNames = new Set([
   buildTsDependency,
   lefthookDependency,
   typescriptDependency,
+  typescriptGoDependency,
   'sort-package-json',
   ...oxlintDeps,
 ]);
@@ -344,6 +349,12 @@ async function applyPackageJsonConventions(
     // TypeScript 7 ships the native compiler as the `typescript` package, so it is
     // now the managed compiler for every TypeScript repo (typechecking runs `tsc`).
     devDependencies.push(typescriptDependency);
+    // Next.js's `next build` inspects `@typescript/native-preview` (tsgo) to run its type
+    // check; the `typescript` v7 package alone lacks the API next needs, so keep both
+    // installed for Next.js-family repos. See the typescriptGoDependency comment above.
+    if (config.depending.next || config.depending.blitz || config.depending.vinext) {
+      devDependencies.push(typescriptGoDependency);
+    }
     if (config.isBun) {
       devDependencies.push('@types/bun');
     } else if (!config.depending.reactNative) {
@@ -739,10 +750,11 @@ async function removeDeprecatedStuff(
   delete jsonObj.dependencies.tslib;
   delete jsonObj.devDependencies['@willbooster/renovate-config'];
   delete jsonObj.devDependencies['@willbooster/tsconfig'];
-  // TypeScript 7 replaced the `@typescript/native-preview` (tsgo) preview with the
-  // native `typescript` package, so drop the deprecated preview from existing repos.
-  delete jsonObj.dependencies[deprecatedTypescriptGoDependency];
-  delete jsonObj.devDependencies[deprecatedTypescriptGoDependency];
+  // Drop `@typescript/native-preview` (tsgo) here so non-Next.js repos never carry it;
+  // this runs before applyPackageJsonConventions, which re-adds it for Next.js-family
+  // repos that need it alongside the `typescript` v7 package for `next build`.
+  delete jsonObj.dependencies[typescriptGoDependency];
+  delete jsonObj.devDependencies[typescriptGoDependency];
   // Non-TypeScript repos should not keep a stray `typescript` package.
   if (!config.doesContainTypeScript && !config.doesContainTypeScriptInPackages) {
     delete jsonObj.dependencies[typescriptDependency];

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -272,6 +272,32 @@ test('type-checks in the lint script of TypeScript projects', { timeout: 60 * 10
   expect(withoutTypeScript.scripts?.lint).toBe('oxlint --no-error-on-unmatched-pattern .');
 });
 
+test('installs @typescript/native-preview alongside typescript for Next.js repos', { timeout: 60 * 1000 }, async () => {
+  const nextRepo = await generatePackageJsonFrom(
+    { scripts: {} },
+    { doesContainTypeScript: true, depending: { ...createConfig().depending, next: true } }
+  );
+  const nonNextRepo = await generatePackageJsonFrom({ scripts: {} }, { doesContainTypeScript: true });
+
+  expect(nextRepo.devDependencies?.typescript).toBeDefined();
+  // Next.js's `next build` needs the tsgo binary via `@typescript/native-preview`.
+  expect(nextRepo.devDependencies?.['@typescript/native-preview']).toBeDefined();
+  expect(nonNextRepo.devDependencies?.typescript).toBeDefined();
+  expect(nonNextRepo.devDependencies?.['@typescript/native-preview']).toBeUndefined();
+});
+
+test('drops @typescript/native-preview from non-Next.js TypeScript repos', { timeout: 60 * 1000 }, async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      scripts: {},
+      devDependencies: { '@typescript/native-preview': '7.0.0-dev.20260101.1' },
+    },
+    { doesContainTypeScript: true }
+  );
+
+  expect(packageJson.devDependencies?.['@typescript/native-preview']).toBeUndefined();
+});
+
 async function generatePackageJsonFrom(
   initialPackageJson: Record<string, unknown>,
   configOverrides: Parameters<typeof createConfig>[0] = {},


### PR DESCRIPTION
## Problem

TypeScript 7's `typescript` package is the tsgo native compiler and exposes **no programmatic JS API**. Next.js's build-time `verifyTypeScriptSetup` needs that API, so `next build` fails with:

```
It looks like you're trying to use TypeScript but do not have the required package(s) installed.
Usage Error: Package "typescript" is already listed as a regular dependency
```

when only `typescript` v7 is installed. Next.js instead resolves the tsgo binary through the separate `@typescript/native-preview` package, so Next.js repos need **both**.

This surfaced when applying wbfy to `exercode`: `build-ts` moved from `@typescript/native-preview` to `typescript@7.0.2`, so the native-preview package disappeared from the tree and `next build` broke. (Confirmed: restoring `@typescript/native-preview` makes the build pass again.)

## Change

wbfy previously dropped `@typescript/native-preview` unconditionally as "deprecated". Now:

- The deprecation cleanup still deletes it first (so non-Next.js repos never carry it), and
- `applyPackageJsonConventions` **re-adds it for Next.js-family repos** (`next` / `blitz` / `vinext`) alongside `typescript`.
- It is registered in `managedDependencyNames` so wbfy keeps it current.

Non-Next.js TypeScript repos (e.g. `code-analyzer`) are unchanged — they only need `typescript` for `tsc` typechecks.

## Tests

Added two unit tests in `packageJson.test.ts`:
- Next.js repos get both `typescript` and `@typescript/native-preview`; non-Next.js repos get only `typescript`.
- `@typescript/native-preview` is dropped from non-Next.js TypeScript repos.

## Verification

- `yarn verify` (typecheck + lint) passes.
- New tests pass.
- Re-ran wbfy on `exercode`: it now adds `@typescript/native-preview`, and `next build` (`yarn run build/core`) succeeds.
