### PR TITLE
refactor(wbfy): drop redundant native-preview tests and sharpen test-writing guidance

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -13,7 +13,7 @@ alwaysApply: true
 
 - If on `main`, create a new branch; otherwise work on the current branch.
 - Run `git` commands one at a time to avoid `index.lock` conflicts.
-- Write tests when explicitly requested, or when you judge the change worth testing; without a request, cover only the essential behavior.
+- Write a test only when explicitly requested, or when a behavior is both likely to regress AND has no other automatic safeguard (type checking, linting, or an existing test/CI check would not catch the breakage). Skip the test when an existing signal already catches the regression, or when you are only confirming an external fact (a library's behavior, whether a version fixes an issue)—verify those once manually instead of adding a permanent test.
 - When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 - If on `main`, create a new branch; otherwise work on the current branch.
 - Run `git` commands one at a time to avoid `index.lock` conflicts.
-- Write tests when explicitly requested, or when you judge the change worth testing; without a request, cover only the essential behavior.
+- Write a test only when explicitly requested, or when a behavior is both likely to regress AND has no other automatic safeguard (type checking, linting, or an existing test/CI check would not catch the breakage). Skip the test when an existing signal already catches the regression, or when you are only confirming an external fact (a library's behavior, whether a version fixes an issue)—verify those once manually instead of adding a permanent test.
 - When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 - If on `main`, create a new branch; otherwise work on the current branch.
 - Run `git` commands one at a time to avoid `index.lock` conflicts.
-- Write tests when explicitly requested, or when you judge the change worth testing; without a request, cover only the essential behavior.
+- Write a test only when explicitly requested, or when a behavior is both likely to regress AND has no other automatic safeguard (type checking, linting, or an existing test/CI check would not catch the breakage). Skip the test when an existing signal already catches the regression, or when you are only confirming an external fact (a library's behavior, whether a version fixes an issue)—verify those once manually instead of adding a permanent test.
 - When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,7 +7,7 @@
 
 - If on `main`, create a new branch; otherwise work on the current branch.
 - Run `git` commands one at a time to avoid `index.lock` conflicts.
-- Write tests when explicitly requested, or when you judge the change worth testing; without a request, cover only the essential behavior.
+- Write a test only when explicitly requested, or when a behavior is both likely to regress AND has no other automatic safeguard (type checking, linting, or an existing test/CI check would not catch the breakage). Skip the test when an existing signal already catches the regression, or when you are only confirming an external fact (a library's behavior, whether a version fixes an issue)—verify those once manually instead of adding a permanent test.
 - When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.

--- a/packages/wb/src/commands/typecheck.ts
+++ b/packages/wb/src/commands/typecheck.ts
@@ -83,8 +83,9 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
 
 function buildTypeScriptTypeCheckCommands(project: Project): string[] {
   // TypeScript 7 ships the native compiler as `typescript` (`tsc`); wbfy removes the
-  // deprecated `@typescript/native-preview` (tsgo) preview from all repos, so repos
-  // still on the preview should run wbfy instead of relying on a tsgo fallback here.
+  // `@typescript/native-preview` (tsgo) preview from non-Next.js repos (Next.js-family
+  // repos keep it for `next build`), so repos still on the preview should run wbfy
+  // instead of relying on a tsgo fallback here.
   if (project.hasOwnDependency('typescript')) {
     return ['BUN tsc --noEmit'];
   }

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -68,7 +68,7 @@ function generateAgentInstruction(
 
 - If on \`main\`, create a new branch; otherwise work on the current branch.
 - Run \`git\` commands one at a time to avoid \`index.lock\` conflicts.
-- Write tests when explicitly requested, or when you judge the change worth testing; without a request, cover only the essential behavior.
+- Write a test only when explicitly requested, or when a behavior is both likely to regress AND has no other automatic safeguard (type checking, linting, or an existing test/CI check would not catch the breakage). Skip the test when an existing signal already catches the regression, or when you are only confirming an external fact (a library's behavior, whether a version fixes an issue)—verify those once manually instead of adding a permanent test.
 - When writing tests, follow these rules:
   - Continue modifying tests and/or code until all tests pass.
   - Ensure tests are idempotent and independent (e.g., reset persistent data) so they can run repeatedly or in parallel.

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -272,32 +272,6 @@ test('type-checks in the lint script of TypeScript projects', { timeout: 60 * 10
   expect(withoutTypeScript.scripts?.lint).toBe('oxlint --no-error-on-unmatched-pattern .');
 });
 
-test('installs @typescript/native-preview alongside typescript for Next.js repos', { timeout: 60 * 1000 }, async () => {
-  const nextRepo = await generatePackageJsonFrom(
-    { scripts: {} },
-    { doesContainTypeScript: true, depending: { ...createConfig().depending, next: true } }
-  );
-  const nonNextRepo = await generatePackageJsonFrom({ scripts: {} }, { doesContainTypeScript: true });
-
-  expect(nextRepo.devDependencies?.typescript).toBeDefined();
-  // Next.js's `next build` needs the tsgo binary via `@typescript/native-preview`.
-  expect(nextRepo.devDependencies?.['@typescript/native-preview']).toBeDefined();
-  expect(nonNextRepo.devDependencies?.typescript).toBeDefined();
-  expect(nonNextRepo.devDependencies?.['@typescript/native-preview']).toBeUndefined();
-});
-
-test('drops @typescript/native-preview from non-Next.js TypeScript repos', { timeout: 60 * 1000 }, async () => {
-  const packageJson = await generatePackageJsonFrom(
-    {
-      scripts: {},
-      devDependencies: { '@typescript/native-preview': '7.0.0-dev.20260101.1' },
-    },
-    { doesContainTypeScript: true }
-  );
-
-  expect(packageJson.devDependencies?.['@typescript/native-preview']).toBeUndefined();
-});
-
 async function generatePackageJsonFrom(
   initialPackageJson: Record<string, unknown>,
   configOverrides: Parameters<typeof createConfig>[0] = {},


### PR DESCRIPTION
## Motivation

Follow-up to #935.

### 1. Remove the two `@typescript/native-preview` unit tests

They guard a simple conditional (which repos get `@typescript/native-preview`) that:

- **Is already covered by an existing signal**: if the branch regresses, applying wbfy to any Next.js repo makes `next build` fail in that repo's CI.
- **Was not cheap/deterministic**: it resolved dependency versions from the npm registry.

Per the principle "don't add a test that only re-checks what an existing, reliable automated signal already catches," these are removed. (The pre-merge-vs-downstream-CI tradeoff was weighed deliberately; a regression surfaces on the next wbfy application with bounded blast radius.)

### 2. Sharpen the generated test-writing guidance

The `AGENTS.md` / `CLAUDE.md` prompt line now instructs agents to write a test **only when a behavior is both likely to regress AND has no other automatic safeguard** (type checking, linting, or an existing test/CI check), and to verify external facts once manually instead of adding a permanent test.

### 3. Review fixes

- Synced the regenerated guidance line into the repo's own `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `.cursor/rules/general.mdc` (they were out of sync with the updated `agents.ts` template).
- Corrected a stale comment in `wb` typecheck: wbfy removes `@typescript/native-preview` only from non-Next.js repos (Next.js-family repos keep it for `next build`), not from all repos.

## Verification

- `yarn verify` (typecheck + lint) passes for `wbfy` and `wb`.
- `test/packageJson.test.ts` passes (17 tests).
- Multi-agent review (codex, antigravity) converged to "no concern".
