### PR TITLE
fix(wbfy): skip Protect main ruleset for reusable-workflows repo

### DIFF
--- a/packages/wbfy/src/github/ruleset.ts
+++ b/packages/wbfy/src/github/ruleset.ts
@@ -1,6 +1,7 @@
 import type { Octokit } from '@octokit/core';
 import { withRetry } from '@willbooster/shared-lib/src';
 
+import { isReusableWorkflowsRepo } from '../generators/workflow.js';
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { getOctokit, gitHubUtil, hasGitHubToken } from '../utils/githubUtil.js';
@@ -123,6 +124,9 @@ export async function setupRepositoryRulesets(config: PackageConfig): Promise<vo
     const [owner, repo] = gitHubUtil.getOrgAndName(config.repository ?? '');
     if (!owner || !repo) return;
     if (owner !== 'WillBooster') return;
+    // The reusable-workflows repo hosts workflow_call definitions, so the
+    // Protect main ruleset would require test/semantic-pr checks that never run there.
+    if (isReusableWorkflowsRepo(config.repository)) return;
     if (!hasGitHubToken(owner)) return;
 
     const octokit = getOctokit(owner);


### PR DESCRIPTION
## Why

Running `wbfy` on `WillBooster/reusable-workflows` applied a **Protect main** repository ruleset that requires the status checks `test / test` and `semantic-pr / semantic-pr`. Those checks never run in that repo:

- `test.yml` / `semantic-pr.yml` there are `on: workflow_call` **reusable definitions**, not callers, so the repo's own PRs/pushes produce **zero** check runs (confirmed: `commits/main/check-runs` → `total: 0`).
- The `test / test` context is `<caller job> / <reusable job>`; reusable-workflows has no caller.

Consequently the ruleset never gates on real, repo-local test results: merges relied entirely on the team `bypass_actors` entry, and with `strict_required_status_checks_policy: false` a once-reported status for that generic context can be reused across commits (a "borrowed pass"). So the protection was illusory.

`wbfy` already skips **workflow generation** for this repo via `isReusableWorkflowsRepo`, but `setupRepositoryRulesets` ran unconditionally.

## What

- Guard `setupRepositoryRulesets` with `isReusableWorkflowsRepo`, mirroring `generateWorkflows`, so no ruleset is created for the reusable-workflows repo.

The already-created broken ruleset on the live repo (id `18702867`) was deleted out-of-band as part of resolving the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
