### PR TITLE
fix: append `wrangler types` to gen-code and postinstall for Cloudflare projects

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -192,12 +192,22 @@ function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
   }
 }
 
-function updatePostinstallScript(scripts: PackageJson.Scripts): void {
+function updatePostinstallScript(scripts: PackageJson.Scripts, config: PackageConfig): void {
   if (scripts['gen-code']) {
-    scripts.postinstall = 'wb gen-code';
+    scripts.postinstall = appendWranglerTypes('wb gen-code', config);
   } else if (scripts.postinstall?.includes('gen-i18n-ts')) {
     delete scripts.postinstall;
   }
+}
+
+/**
+ * Cloudflare Workers projects rely on `wrangler types` to (re)generate the gitignored
+ * worker-configuration.d.ts. Because `wb gen-code` does not produce it, append the command to
+ * code-generation scripts; otherwise a fresh checkout (e.g. CI) would fail type checking.
+ */
+function appendWranglerTypes(script: string, config: PackageConfig): string {
+  if (!config.isCloudflare) return script;
+  return `${script} && ${config.isBun ? 'bunx ' : ''}wrangler types`;
 }
 
 function normalizeYarnWorkspaceForeachScripts(scripts: PackageJson.Scripts): void {
@@ -531,10 +541,10 @@ async function normalizePackageMetadata(
   if (genCodeScript?.includes('No code generation needed')) {
     delete jsonObj.scripts['gen-code'];
   } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
-    jsonObj.scripts['gen-code'] = `${config.isBun ? 'bun ' : ''}wb gen-code`;
+    jsonObj.scripts['gen-code'] = appendWranglerTypes(`${config.isBun ? 'bun ' : ''}wb gen-code`, config);
   }
   normalizeGenI18nTsScript(config, jsonObj);
-  updatePostinstallScript(jsonObj.scripts);
+  updatePostinstallScript(jsonObj.scripts, config);
 
   if (!jsonObj.dependencies.prettier) {
     // Because @types/prettier blocks prettier execution.

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -176,6 +176,19 @@ test('uses stable age-gated versions for generated dependencies when skipping in
   expect(packageJson.devDependencies?.prettier).toMatch(/^\d+\.\d+\.\d+$/u);
 });
 
+test('appends wrangler types to gen-code and postinstall for Cloudflare projects', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    { scripts: {} },
+    { depending: genI18nTsDepending, isBun: true, isCloudflare: true },
+    { createI18nDir: true }
+  );
+
+  expect(packageJson.scripts).toMatchObject({
+    'gen-code': 'bun wb gen-code && bunx wrangler types',
+    postinstall: 'wb gen-code && bunx wrangler types',
+  });
+});
+
 test('keeps custom database scripts for drizzle projects', async () => {
   const packageJson = await generatePackageJsonFrom(
     {


### PR DESCRIPTION
## Why

The managed `gen-code`/`postinstall` scripts run only `wb gen-code`, which does not generate the gitignored `worker-configuration.d.ts`. Cloudflare Workers projects require `wrangler types` to produce it.

Previously wbfy stripped a project's `&& wrangler types` suffix from these scripts, so a fresh checkout (e.g. CI) failed type checking because the Cloudflare env types were missing.

## What

- Append `wrangler types` (`bunx wrangler types` for Bun projects) to the generated `gen-code` and `postinstall` scripts when `config.isCloudflare` is true.
- Add a test covering the Cloudflare case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
