### PR TITLE
fix(wb): keep project binaries resolvable in wb dotenv child processes

### DIFF
--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -16,12 +16,17 @@ export function runDotenvCommand(args) {
 
   const cwd = path.resolve(process.cwd());
   readAndApplyEnvironmentVariables(cwd);
+  const berryBinFolderPath = process.env.BERRY_BIN_FOLDER;
   removeNpmAndYarnEnvironmentVariables(process.env);
   // Stripping yarn's environment also removes its temporary bin folder — the ONLY place
   // yarn Berry exposes dependency executables — so restore the project's own
   // node_modules/.bin directories (nearest first) to keep bare binary names resolvable.
-  // Mirrors src/utils/binPath.ts for this startup fast path.
-  prependNodeModulesBinToPath(cwd, process.env);
+  // Plug'n'Play installs create no node_modules at all; the temporary bin folder is then the
+  // sole source of dependency executables, so restore it instead. Mirrors
+  // src/commands/dotenv.ts + src/utils/binPath.ts for this startup fast path.
+  if (!prependNodeModulesBinToPath(cwd, process.env) && berryBinFolderPath) {
+    process.env.PATH = process.env.PATH ? `${berryBinFolderPath}:${process.env.PATH}` : berryBinFolderPath;
+  }
 
   const child = childProcess.spawn(command[0], command.slice(1), {
     cwd,

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -24,6 +24,11 @@ export function runDotenvCommand(args) {
   // Plug'n'Play installs create no node_modules at all; the temporary bin folder is then the
   // sole source of dependency executables, so restore it instead. Mirrors
   // src/commands/dotenv.ts + src/utils/binPath.ts for this startup fast path.
+  // The temporary folder is deliberately NOT restored when .bin directories exist: it also
+  // contains node/yarn shims, and a leaked node shim would violate wb's real-Node guarantee
+  // for tools like wrangler/vinext. Child `yarn` invocations stay resolvable through the
+  // launcher on the base PATH (mise/corepack), which every supported environment has —
+  // nothing could have started `yarn run`/`wb dotenv` without it.
   if (!prependNodeModulesBinToPath(cwd, process.env) && berryBinFolderPath) {
     process.env.PATH = process.env.PATH ? `${berryBinFolderPath}:${process.env.PATH}` : berryBinFolderPath;
   }

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -1,4 +1,5 @@
 import childProcess from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 
 import { config } from 'dotenv';
@@ -16,6 +17,11 @@ export function runDotenvCommand(args) {
   const cwd = path.resolve(process.cwd());
   readAndApplyEnvironmentVariables(cwd);
   removeNpmAndYarnEnvironmentVariables(process.env);
+  // Stripping yarn's environment also removes its temporary bin folder — the ONLY place
+  // yarn Berry exposes dependency executables — so restore the project's own
+  // node_modules/.bin directories (nearest first) to keep bare binary names resolvable.
+  // Mirrors src/utils/binPath.ts for this startup fast path.
+  prependNodeModulesBinToPath(cwd, process.env);
 
   const child = childProcess.spawn(command[0], command.slice(1), {
     cwd,
@@ -87,6 +93,29 @@ function removeNpmAndYarnEnvironmentVariables(envVars) {
       delete envVars[key];
     }
   }
+}
+
+function prependNodeModulesBinToPath(dirPath, env) {
+  const binPaths = [];
+  let currentPath = path.resolve(dirPath);
+  for (;;) {
+    const binPath = path.join(currentPath, 'node_modules', '.bin');
+    if (fs.existsSync(binPath)) {
+      binPaths.push(binPath);
+    }
+
+    if (fs.existsSync(path.join(currentPath, '.git'))) {
+      break;
+    }
+    const parentPath = path.dirname(currentPath);
+    if (currentPath === parentPath) {
+      break;
+    }
+    currentPath = parentPath;
+  }
+  if (binPaths.length === 0) return false;
+  env.PATH = env.PATH ? `${binPaths.join(':')}:${env.PATH}` : binPaths.join(':');
+  return true;
 }
 
 function parseDotenvArgs(args) {

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -2,6 +2,8 @@ import { spawn } from 'node:child_process';
 import path from 'node:path';
 
 import { removeNpmAndYarnEnvironmentVariables } from '@willbooster/shared-lib-node/src';
+
+import { prependNodeModulesBinToPath } from '../utils/binPath.js';
 import { config } from 'dotenv';
 import { expand } from 'dotenv-expand';
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
@@ -34,6 +36,10 @@ async function runParsedDotenvCommand({ command }: ParsedDotenvArgs): Promise<vo
   const cwd = path.resolve(process.cwd());
   readAndApplyEnvironmentVariables(cwd);
   removeNpmAndYarnEnvironmentVariables(process.env);
+  // Stripping yarn's environment also removes its temporary bin folder — the ONLY place
+  // yarn Berry exposes dependency executables — so restore the project's own
+  // node_modules/.bin directories to keep bare binary names resolvable.
+  prependNodeModulesBinToPath(cwd, process.env);
 
   const child = spawn(command[0]!, command.slice(1), {
     cwd,

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -42,6 +42,11 @@ async function runParsedDotenvCommand({ command }: ParsedDotenvArgs): Promise<vo
   // node_modules/.bin directories to keep bare binary names resolvable. Plug'n'Play installs
   // create no node_modules at all; the temporary bin folder is then the sole source of
   // dependency executables, so restore it instead.
+  // The temporary folder is deliberately NOT restored when .bin directories exist: it also
+  // contains node/yarn shims, and a leaked node shim would violate wb's real-Node guarantee
+  // for tools like wrangler/vinext. Child `yarn` invocations stay resolvable through the
+  // launcher on the base PATH (mise/corepack), which every supported environment has —
+  // nothing could have started `yarn run`/`wb dotenv` without it.
   if (!prependNodeModulesBinToPath(cwd, process.env) && berryBinFolderPath) {
     process.env.PATH = process.env.PATH ? `${berryBinFolderPath}:${process.env.PATH}` : berryBinFolderPath;
   }

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -35,11 +35,16 @@ async function runParsedDotenvCommand({ command }: ParsedDotenvArgs): Promise<vo
 
   const cwd = path.resolve(process.cwd());
   readAndApplyEnvironmentVariables(cwd);
+  const berryBinFolderPath = process.env.BERRY_BIN_FOLDER;
   removeNpmAndYarnEnvironmentVariables(process.env);
   // Stripping yarn's environment also removes its temporary bin folder — the ONLY place
   // yarn Berry exposes dependency executables — so restore the project's own
-  // node_modules/.bin directories to keep bare binary names resolvable.
-  prependNodeModulesBinToPath(cwd, process.env);
+  // node_modules/.bin directories to keep bare binary names resolvable. Plug'n'Play installs
+  // create no node_modules at all; the temporary bin folder is then the sole source of
+  // dependency executables, so restore it instead.
+  if (!prependNodeModulesBinToPath(cwd, process.env) && berryBinFolderPath) {
+    process.env.PATH = process.env.PATH ? `${berryBinFolderPath}:${process.env.PATH}` : berryBinFolderPath;
+  }
 
   const child = spawn(command[0]!, command.slice(1), {
     cwd,

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -7,6 +7,7 @@ import { memoizeOne } from 'at-decorators';
 import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
 
+import { prependNodeModulesBinToPath } from './utils/binPath.js';
 import { isCI } from './utils/ci.js';
 
 export type DatabaseOrm = 'prisma' | 'drizzle';
@@ -238,25 +239,7 @@ export class Project {
 
   @memoizeOne
   get binExists(): boolean {
-    let binFound = false;
-    let currentPath = this.dirPath;
-    for (;;) {
-      const binPath = path.join(currentPath, 'node_modules', '.bin');
-      if (fs.existsSync(binPath)) {
-        this.env.PATH = `${binPath}:${this.env.PATH}`;
-        binFound = true;
-      }
-
-      if (fs.existsSync(path.join(currentPath, '.git'))) {
-        break;
-      }
-      const parentPath = path.dirname(currentPath);
-      if (currentPath === parentPath) {
-        break;
-      }
-      currentPath = parentPath;
-    }
-    return binFound;
+    return prependNodeModulesBinToPath(this.dirPath, this.env);
   }
 
   findFile(fileName: string): string {

--- a/packages/wb/src/utils/binPath.ts
+++ b/packages/wb/src/utils/binPath.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Prepend every existing `node_modules/.bin` directory from the given directory up to the
+ * repository root (or filesystem root) to the environment's PATH. Needed wherever wb strips
+ * yarn's temporary bin folder from PATH (yarn Berry exposes dependency executables only
+ * through that folder, never through `node_modules/.bin` on PATH), so that bare binary names
+ * in wrapped commands keep resolving.
+ */
+export function prependNodeModulesBinToPath(dirPath: string, env: Record<string, string | undefined>): boolean {
+  let binFound = false;
+  let currentPath = path.resolve(dirPath);
+  for (;;) {
+    const binPath = path.join(currentPath, 'node_modules', '.bin');
+    if (fs.existsSync(binPath)) {
+      env.PATH = `${binPath}:${env.PATH}`;
+      binFound = true;
+    }
+
+    if (fs.existsSync(path.join(currentPath, '.git'))) {
+      break;
+    }
+    const parentPath = path.dirname(currentPath);
+    if (currentPath === parentPath) {
+      break;
+    }
+    currentPath = parentPath;
+  }
+  return binFound;
+}

--- a/packages/wb/src/utils/binPath.ts
+++ b/packages/wb/src/utils/binPath.ts
@@ -3,19 +3,19 @@ import path from 'node:path';
 
 /**
  * Prepend every existing `node_modules/.bin` directory from the given directory up to the
- * repository root (or filesystem root) to the environment's PATH. Needed wherever wb strips
+ * repository root (or filesystem root) to the environment's PATH, nearest directory first so
+ * a workspace-local dependency wins over a repository-root one. Needed wherever wb strips
  * yarn's temporary bin folder from PATH (yarn Berry exposes dependency executables only
  * through that folder, never through `node_modules/.bin` on PATH), so that bare binary names
  * in wrapped commands keep resolving.
  */
 export function prependNodeModulesBinToPath(dirPath: string, env: Record<string, string | undefined>): boolean {
-  let binFound = false;
+  const binPaths: string[] = [];
   let currentPath = path.resolve(dirPath);
   for (;;) {
     const binPath = path.join(currentPath, 'node_modules', '.bin');
     if (fs.existsSync(binPath)) {
-      env.PATH = env.PATH ? `${binPath}:${env.PATH}` : binPath;
-      binFound = true;
+      binPaths.push(binPath);
     }
 
     if (fs.existsSync(path.join(currentPath, '.git'))) {
@@ -27,5 +27,7 @@ export function prependNodeModulesBinToPath(dirPath: string, env: Record<string,
     }
     currentPath = parentPath;
   }
-  return binFound;
+  if (binPaths.length === 0) return false;
+  env.PATH = env.PATH ? `${binPaths.join(':')}:${env.PATH}` : binPaths.join(':');
+  return true;
 }

--- a/packages/wb/src/utils/binPath.ts
+++ b/packages/wb/src/utils/binPath.ts
@@ -14,7 +14,7 @@ export function prependNodeModulesBinToPath(dirPath: string, env: Record<string,
   for (;;) {
     const binPath = path.join(currentPath, 'node_modules', '.bin');
     if (fs.existsSync(binPath)) {
-      env.PATH = `${binPath}:${env.PATH}`;
+      env.PATH = env.PATH ? `${binPath}:${env.PATH}` : binPath;
       binFound = true;
     }
 

--- a/packages/wb/test/binDotenv.test.ts
+++ b/packages/wb/test/binDotenv.test.ts
@@ -1,0 +1,43 @@
+import childProcess from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const binIndexPath = fileURLToPath(new URL('../bin/index.js', import.meta.url));
+
+describe('bin/index.js dotenv fast path', () => {
+  let projectDirPath: string;
+
+  beforeEach(async () => {
+    projectDirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-bin-dotenv-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectDirPath, { force: true, recursive: true });
+  });
+
+  it('resolves bare binary names from node_modules/.bin after stripping the yarn environment', async () => {
+    // The released `wb dotenv` routes through bin/dotenv.js (not dist), so this must be
+    // exercised through bin/index.js: helper unit tests cannot catch drift between the
+    // TypeScript implementation and this startup fast path.
+    await fs.mkdir(path.join(projectDirPath, '.git'), { recursive: true });
+    const binDirPath = path.join(projectDirPath, 'node_modules', '.bin');
+    await fs.mkdir(binDirPath, { recursive: true });
+    const probePath = path.join(binDirPath, 'review-probe');
+    await fs.writeFile(probePath, '#!/bin/sh\necho probe-ok\n', { mode: 0o755 });
+
+    const result = childProcess.spawnSync(process.execPath, [binIndexPath, 'dotenv', '--', 'review-probe'], {
+      cwd: projectDirPath,
+      encoding: 'utf8',
+      // A yarn-like environment: the temporary bin folder is the only PATH entry yarn adds,
+      // and wb dotenv strips it before spawning.
+      env: { PATH: '/usr/bin:/bin', BERRY_BIN_FOLDER: '/tmp/xfs-fake' },
+    });
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('probe-ok\n');
+    expect(result.status).toBe(0);
+  });
+});

--- a/packages/wb/test/binDotenv.test.ts
+++ b/packages/wb/test/binDotenv.test.ts
@@ -40,4 +40,22 @@ describe('bin/index.js dotenv fast path', () => {
     expect(result.stdout).toBe('probe-ok\n');
     expect(result.status).toBe(0);
   });
+
+  it("restores yarn's temporary bin folder for Plug'n'Play projects without node_modules", async () => {
+    // PnP installs create no node_modules/.bin, so the (otherwise stripped) BERRY_BIN_FOLDER
+    // is the only source of dependency executables and must be restored.
+    await fs.mkdir(path.join(projectDirPath, '.git'), { recursive: true });
+    const berryBinDirPath = path.join(projectDirPath, 'berry-bin');
+    await fs.mkdir(berryBinDirPath, { recursive: true });
+    await fs.writeFile(path.join(berryBinDirPath, 'review-probe'), '#!/bin/sh\necho pnp-ok\n', { mode: 0o755 });
+
+    const result = childProcess.spawnSync(process.execPath, [binIndexPath, 'dotenv', '--', 'review-probe'], {
+      cwd: projectDirPath,
+      encoding: 'utf8',
+      env: { PATH: `${berryBinDirPath}:/usr/bin:/bin`, BERRY_BIN_FOLDER: berryBinDirPath },
+    });
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('pnp-ok\n');
+    expect(result.status).toBe(0);
+  });
 });

--- a/packages/wb/test/binPath.test.ts
+++ b/packages/wb/test/binPath.test.ts
@@ -26,8 +26,9 @@ describe('prependNodeModulesBinToPath', () => {
 
     const env: Record<string, string | undefined> = { PATH: '/usr/bin' };
     expect(prependNodeModulesBinToPath(appDirPath, env)).toBe(true);
+    // Nearest first: a workspace-local dependency must win over a repository-root one.
     expect(env.PATH).toBe(
-      [path.join(rootDirPath, 'node_modules', '.bin'), path.join(appDirPath, 'node_modules', '.bin'), '/usr/bin'].join(
+      [path.join(appDirPath, 'node_modules', '.bin'), path.join(rootDirPath, 'node_modules', '.bin'), '/usr/bin'].join(
         ':'
       )
     );

--- a/packages/wb/test/binPath.test.ts
+++ b/packages/wb/test/binPath.test.ts
@@ -44,4 +44,17 @@ describe('prependNodeModulesBinToPath', () => {
     expect(prependNodeModulesBinToPath(rootDirPath, env)).toBe(false);
     expect(env.PATH).toBe('/usr/bin');
   });
+
+  it('handles undefined or missing PATH in env correctly', async () => {
+    await fs.mkdir(path.join(rootDirPath, '.git'), { recursive: true });
+    await fs.mkdir(path.join(rootDirPath, 'node_modules', '.bin'), { recursive: true });
+
+    const env: Record<string, string | undefined> = { PATH: undefined };
+    expect(prependNodeModulesBinToPath(rootDirPath, env)).toBe(true);
+    expect(env.PATH).toBe(path.join(rootDirPath, 'node_modules', '.bin'));
+
+    const env2: Record<string, string | undefined> = {};
+    expect(prependNodeModulesBinToPath(rootDirPath, env2)).toBe(true);
+    expect(env2.PATH).toBe(path.join(rootDirPath, 'node_modules', '.bin'));
+  });
 });

--- a/packages/wb/test/binPath.test.ts
+++ b/packages/wb/test/binPath.test.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { prependNodeModulesBinToPath } from '../src/utils/binPath.js';
+
+describe('prependNodeModulesBinToPath', () => {
+  let rootDirPath: string;
+
+  beforeEach(async () => {
+    rootDirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-bin-path-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(rootDirPath, { force: true, recursive: true });
+  });
+
+  it('prepends every node_modules/.bin up to the repository root', async () => {
+    // <root>/.git, <root>/node_modules/.bin, <root>/packages/app/node_modules/.bin
+    await fs.mkdir(path.join(rootDirPath, '.git'), { recursive: true });
+    await fs.mkdir(path.join(rootDirPath, 'node_modules', '.bin'), { recursive: true });
+    const appDirPath = path.join(rootDirPath, 'packages', 'app');
+    await fs.mkdir(path.join(appDirPath, 'node_modules', '.bin'), { recursive: true });
+
+    const env: Record<string, string | undefined> = { PATH: '/usr/bin' };
+    expect(prependNodeModulesBinToPath(appDirPath, env)).toBe(true);
+    expect(env.PATH).toBe(
+      [path.join(rootDirPath, 'node_modules', '.bin'), path.join(appDirPath, 'node_modules', '.bin'), '/usr/bin'].join(
+        ':'
+      )
+    );
+
+    // The walk stops at the repository root (.git), so a .bin above it is not added.
+    const env2: Record<string, string | undefined> = { PATH: '/usr/bin' };
+    expect(prependNodeModulesBinToPath(path.join(rootDirPath, 'packages'), env2)).toBe(true);
+    expect(env2.PATH).toBe(`${path.join(rootDirPath, 'node_modules', '.bin')}:/usr/bin`);
+  });
+
+  it('returns false and keeps PATH unchanged when no .bin directory exists', async () => {
+    await fs.mkdir(path.join(rootDirPath, '.git'), { recursive: true });
+    const env: Record<string, string | undefined> = { PATH: '/usr/bin' };
+    expect(prependNodeModulesBinToPath(rootDirPath, env)).toBe(false);
+    expect(env.PATH).toBe('/usr/bin');
+  });
+});


### PR DESCRIPTION
## Summary

Root-cause fix for the `spawn build-ts ENOENT` failure hit by `WillBoosterLab/ai-game-builder`'s first `run-script.yml` job (`wb dotenv -- build-ts run ...`):

- Yarn Berry exposes dependency executables ONLY through its temporary bin folder (`$TMPDIR/xfs-*`); it never puts `node_modules/.bin` on PATH.
- `wb dotenv` deliberately strips yarn's environment (including temp-dir PATH segments) before spawning — removing that sole source of project binaries.
- wb already solves this for its own commands via `Project#binExists`, but `wb dotenv` never did — and the released `wb` additionally routes `dotenv` through the plain-JS startup fast path (`bin/index.js` → `bin/dotenv.js`), which needed the same fix.

Changes:
- Extract the `.bin` walk into `prependNodeModulesBinToPath` (reused by `Project#binExists`), prepending **nearest-first** so a workspace-local dependency wins over a repository-root one, and handling an undefined `PATH`.
- Apply it in both `wb dotenv` implementations after the stripping; for **Plug'n'Play** projects (no `node_modules` at all) the captured `BERRY_BIN_FOLDER` is restored instead. The Berry folder is deliberately NOT restored when `.bin` directories exist — it also contains node/yarn shims, and a leaked node shim would violate wb's real-Node guarantee (child `yarn` calls resolve via the base-PATH launcher every supported environment has).
- Integration tests exercise the shipped `bin/index.js` path (node-modules and PnP-like cases), catching drift between the TypeScript and fast-path implementations; unit tests cover ordering, the `.git` boundary, no-op, and undefined-PATH cases.

## Review

`/review-fix agy,claude,codex` ran to roster exhaustion: round-1 findings (released-entry bypass — Claude+Codex; nearest-first ordering — Claude; undefined PATH — Antigravity, committed by the agent itself) all fixed; round-2 (PnP support — Codex) fixed; round-3 (restore the Berry folder even when `.bin` exists — Codex) rejected as unreachable through supported callers (a base-PATH yarn launcher is a precondition for anything that invokes `wb dotenv`) and risky (node-shim leakage), documented in code comments.

## Test plan

- Reproduced the original failure with the released wb and verified the fix end-to-end (`wb dotenv -- build-ts --version` → `17.1.34` from ai-game-builder).
- All 129 wb tests pass; `yarn verify` clean.
- After release: WillBoosterLab/ai-game-builder#681 drops its `node_modules/.bin/` workaround and bumps wb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
