### PR TITLE
fix(wb): pass deploy secrets through a mode-0600 temporary file instead of /dev/stdin

### DIFF
--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -392,47 +392,58 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       delete deployEnv.CLOUDFLARE_ENV;
       // 0o700 directory + 0o600 file: readable only by the deploying user, like the dotenv
       // files the CI workflow already writes next to it. wrangler runs through an async spawn
-      // with forwarded shutdown signals (spawnSync would block the event loop, so a Ctrl-C
-      // would kill the process before any cleanup) and the directory is removed in a finally,
-      // so an interrupted deploy cannot leave the plaintext secrets behind.
+      // (spawnSync would block the event loop, so a shutdown signal would kill the process
+      // before any cleanup) and the directory is removed in a finally, so an interrupted
+      // deploy cannot leave the plaintext secrets behind. The shutdown handlers — including
+      // SIGHUP, on which Node also terminates by default — are installed BEFORE the file is
+      // written: a signal arriving before wrangler exists removes the directory and re-raises;
+      // afterwards it is forwarded to wrangler, whose exit resolves the await so the finally
+      // runs before the signal is re-raised below.
       const secretsDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wb-deploy-'));
+      const shutdownSignals = ['SIGHUP', 'SIGINT', 'SIGTERM', 'SIGQUIT'] as const;
+      const signalHandlers = new Map<NodeJS.Signals, () => void>();
+      let wranglerProcess: ReturnType<typeof spawn> | undefined;
+      for (const signal of shutdownSignals) {
+        const signalHandler = (): void => {
+          if (wranglerProcess) {
+            wranglerProcess.kill(signal);
+          } else {
+            fs.rmSync(secretsDirPath, { force: true, recursive: true });
+            // The once-handler is already removed, so re-raising triggers the default behavior.
+            process.kill(process.pid, signal);
+          }
+        };
+        signalHandlers.set(signal, signalHandler);
+        process.once(signal, signalHandler);
+      }
       let deployStatus: number | null;
       let deploySignal: NodeJS.Signals | undefined;
       try {
         const secretsFilePath = path.join(secretsDirPath, 'secrets.json');
         fs.writeFileSync(secretsFilePath, JSON.stringify(secrets), { mode: 0o600 });
         deployStatus = await new Promise<number | null>((resolve) => {
-          const child = spawn('wrangler', [...deployArgs, secretsFilePath], {
+          wranglerProcess = spawn('wrangler', [...deployArgs, secretsFilePath], {
             cwd: project.dirPath,
             env: deployEnv as NodeJS.ProcessEnv,
             stdio: ['ignore', 'inherit', 'inherit'],
           });
-          const shutdownSignals = ['SIGINT', 'SIGTERM', 'SIGQUIT'] as const;
-          const signalHandlers = new Map<NodeJS.Signals, () => void>();
-          for (const signal of shutdownSignals) {
-            const signalHandler = (): void => {
-              child.kill(signal);
-            };
-            signalHandlers.set(signal, signalHandler);
-            process.once(signal, signalHandler);
-          }
           const finish = (status: number | null, signal: NodeJS.Signals | null | undefined): void => {
-            for (const [shutdownSignal, signalHandler] of signalHandlers) {
-              process.off(shutdownSignal, signalHandler);
-            }
             deploySignal = signal ?? undefined;
             resolve(status);
           };
-          child.on('error', (error) => {
+          wranglerProcess.on('error', (error) => {
             console.error(error);
             finish(1, undefined);
           });
-          child.on('exit', (code, signal) => {
+          wranglerProcess.on('exit', (code, signal) => {
             finish(code, signal);
           });
         });
       } finally {
         // process.exit skips finally blocks, so the exit-on-failure below stays outside.
+        for (const [shutdownSignal, signalHandler] of signalHandlers) {
+          process.off(shutdownSignal, signalHandler);
+        }
         fs.rmSync(secretsDirPath, { force: true, recursive: true });
       }
       if (deploySignal) {

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -391,20 +391,54 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       const deployEnv = { ...project.env };
       delete deployEnv.CLOUDFLARE_ENV;
       // 0o700 directory + 0o600 file: readable only by the deploying user, like the dotenv
-      // files the CI workflow already writes next to it.
+      // files the CI workflow already writes next to it. wrangler runs through an async spawn
+      // with forwarded shutdown signals (spawnSync would block the event loop, so a Ctrl-C
+      // would kill the process before any cleanup) and the directory is removed in a finally,
+      // so an interrupted deploy cannot leave the plaintext secrets behind.
       const secretsDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wb-deploy-'));
       let deployStatus: number | null;
+      let deploySignal: NodeJS.Signals | undefined;
       try {
         const secretsFilePath = path.join(secretsDirPath, 'secrets.json');
         fs.writeFileSync(secretsFilePath, JSON.stringify(secrets), { mode: 0o600 });
-        deployStatus = spawnSync('wrangler', [...deployArgs, secretsFilePath], {
-          cwd: project.dirPath,
-          env: deployEnv as NodeJS.ProcessEnv,
-          stdio: ['ignore', 'inherit', 'inherit'],
-        }).status;
+        deployStatus = await new Promise<number | null>((resolve) => {
+          const child = spawn('wrangler', [...deployArgs, secretsFilePath], {
+            cwd: project.dirPath,
+            env: deployEnv as NodeJS.ProcessEnv,
+            stdio: ['ignore', 'inherit', 'inherit'],
+          });
+          const shutdownSignals = ['SIGINT', 'SIGTERM', 'SIGQUIT'] as const;
+          const signalHandlers = new Map<NodeJS.Signals, () => void>();
+          for (const signal of shutdownSignals) {
+            const signalHandler = (): void => {
+              child.kill(signal);
+            };
+            signalHandlers.set(signal, signalHandler);
+            process.once(signal, signalHandler);
+          }
+          const finish = (status: number | null, signal: NodeJS.Signals | null | undefined): void => {
+            for (const [shutdownSignal, signalHandler] of signalHandlers) {
+              process.off(shutdownSignal, signalHandler);
+            }
+            deploySignal = signal ?? undefined;
+            resolve(status);
+          };
+          child.on('error', (error) => {
+            console.error(error);
+            finish(1, undefined);
+          });
+          child.on('exit', (code, signal) => {
+            finish(code, signal);
+          });
+        });
       } finally {
         // process.exit skips finally blocks, so the exit-on-failure below stays outside.
         fs.rmSync(secretsDirPath, { force: true, recursive: true });
+      }
+      if (deploySignal) {
+        // Re-raise so the caller observes the same signal-derived exit status.
+        process.kill(process.pid, deploySignal);
+        return;
       }
       if (deployStatus !== 0) {
         console.error(chalk.red(`wrangler deploy failed with exit code ${deployStatus ?? 'unknown'}.`));

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -425,11 +425,11 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
         signalHandlers.set(signal, signalHandler);
         process.on(signal, signalHandler);
       }
-      let deployStatus: number | null;
+      let deployStatus: number | undefined;
       try {
         const secretsFilePath = path.join(secretsDirPath, 'secrets.json');
         fs.writeFileSync(secretsFilePath, JSON.stringify(secrets), { mode: 0o600 });
-        deployStatus = await new Promise<number | null>((resolve) => {
+        deployStatus = await new Promise<number | undefined>((resolve) => {
           wranglerProcess = spawn('wrangler', [...deployArgs, secretsFilePath], {
             cwd: project.dirPath,
             env: deployEnv as NodeJS.ProcessEnv,
@@ -440,7 +440,7 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
             resolve(1);
           });
           wranglerProcess.on('exit', (code, signal) => {
-            resolve(signal ? 1 : code);
+            resolve(signal ? 1 : (code ?? undefined));
           });
         });
       } finally {

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import { readEnvironmentVariables } from '@willbooster/shared-lib-node/src';
@@ -357,10 +358,14 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       );
     }
 
-    // 4. Deploy code and secrets atomically: piping the secrets JSON via stdin avoids both a
-    //    plaintext temp file and a post-deploy secret push that could leave the new version
-    //    running without (or with stale) secrets. Explicitly empty values stay in the payload:
-    //    --secrets-file is additive, so pushing '' is the only way to clear a stale secret.
+    // 4. Deploy code and secrets atomically (no post-deploy secret push that could leave the
+    //    new version running without — or with stale — secrets). The secrets JSON goes through
+    //    a mode-0600 file in a private temporary directory deleted right after the deploy:
+    //    /dev/stdin is NOT reliable here because wrangler reads the secrets file only after
+    //    uploading assets, by which point the piped stdin may already have been consumed —
+    //    observed as a flaky `Could not read file: /dev/stdin` on CI. Explicitly empty values
+    //    stay in the payload: --secrets-file is additive, so pushing '' is the only way to
+    //    clear a stale secret.
     const deployConfigPath = isVinext ? path.join('dist', 'server', 'wrangler.json') : wranglerConfigPath;
     if (isVinext && !argv.dryRun && !fs.existsSync(path.resolve(project.dirPath, deployConfigPath))) {
       console.error(chalk.red(`${deployConfigPath} not found; the vinext build did not produce a deploy config.`));
@@ -375,9 +380,8 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       ...(!isVinext && resolvedConfig.usesEnvSection ? ['--env', envName] : []),
       ...(project.env.WB_VERSION ? ['--var', `WB_VERSION:${project.env.WB_VERSION}`] : []),
       '--secrets-file',
-      '/dev/stdin',
     ];
-    console.info(chalk.cyan(`Running: wrangler ${deployArgs.join(' ')}`));
+    console.info(chalk.cyan(`Running: wrangler ${deployArgs.join(' ')} <temporary secrets file>`));
     if (!argv.dryRun) {
       // Reading binExists prepends node_modules/.bin directories to project.env.PATH,
       // so the direct (non-shell) wrangler spawn below resolves the local binary.
@@ -386,15 +390,25 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       }
       const deployEnv = { ...project.env };
       delete deployEnv.CLOUDFLARE_ENV;
-      const result = spawnSync('wrangler', deployArgs, {
-        cwd: project.dirPath,
-        env: deployEnv as NodeJS.ProcessEnv,
-        input: JSON.stringify(secrets),
-        stdio: ['pipe', 'inherit', 'inherit'],
-      });
-      if (result.status !== 0) {
-        console.error(chalk.red(`wrangler deploy failed with exit code ${result.status ?? 'unknown'}.`));
-        process.exit(result.status ?? 1);
+      // 0o700 directory + 0o600 file: readable only by the deploying user, like the dotenv
+      // files the CI workflow already writes next to it.
+      const secretsDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wb-deploy-'));
+      let deployStatus: number | null;
+      try {
+        const secretsFilePath = path.join(secretsDirPath, 'secrets.json');
+        fs.writeFileSync(secretsFilePath, JSON.stringify(secrets), { mode: 0o600 });
+        deployStatus = spawnSync('wrangler', [...deployArgs, secretsFilePath], {
+          cwd: project.dirPath,
+          env: deployEnv as NodeJS.ProcessEnv,
+          stdio: ['ignore', 'inherit', 'inherit'],
+        }).status;
+      } finally {
+        // process.exit skips finally blocks, so the exit-on-failure below stays outside.
+        fs.rmSync(secretsDirPath, { force: true, recursive: true });
+      }
+      if (deployStatus !== 0) {
+        console.error(chalk.red(`wrangler deploy failed with exit code ${deployStatus ?? 'unknown'}.`));
+        process.exit(deployStatus ?? 1);
       }
     }
 

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -394,30 +394,38 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       // files the CI workflow already writes next to it. wrangler runs through an async spawn
       // (spawnSync would block the event loop, so a shutdown signal would kill the process
       // before any cleanup) and the directory is removed in a finally, so an interrupted
-      // deploy cannot leave the plaintext secrets behind. The shutdown handlers — including
-      // SIGHUP, on which Node also terminates by default — are installed BEFORE the file is
-      // written: a signal arriving before wrangler exists removes the directory and re-raises;
-      // afterwards it is forwarded to wrangler, whose exit resolves the await so the finally
-      // runs before the signal is re-raised below.
+      // deploy cannot leave the plaintext secrets behind. Shutdown handling details:
+      // - Handlers (including SIGHUP, on which Node also terminates by default) are installed
+      //   BEFORE the file is written and use process.on, not once, so a repeated signal cannot
+      //   fall back to default termination and bypass the finally cleanup.
+      // - SIGHUP/SIGQUIT are forwarded to wrangler as SIGTERM: wrangler's launcher relays only
+      //   SIGINT/SIGTERM to its inner Node process, and anything else would orphan a deployment
+      //   that keeps mutating the remote Worker after wb exits.
+      // - The re-raise below uses the signal wb itself received: wrangler catches SIGINT and
+      //   exits numerically (e.g. 143), which must not masquerade as an ordinary failure.
       const secretsDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wb-deploy-'));
       const shutdownSignals = ['SIGHUP', 'SIGINT', 'SIGTERM', 'SIGQUIT'] as const;
       const signalHandlers = new Map<NodeJS.Signals, () => void>();
       let wranglerProcess: ReturnType<typeof spawn> | undefined;
+      let receivedShutdownSignal: NodeJS.Signals | undefined;
       for (const signal of shutdownSignals) {
         const signalHandler = (): void => {
+          receivedShutdownSignal ??= signal;
           if (wranglerProcess) {
-            wranglerProcess.kill(signal);
+            wranglerProcess.kill(signal === 'SIGINT' || signal === 'SIGTERM' ? signal : 'SIGTERM');
           } else {
+            for (const [shutdownSignal, handler] of signalHandlers) {
+              process.off(shutdownSignal, handler);
+            }
             fs.rmSync(secretsDirPath, { force: true, recursive: true });
-            // The once-handler is already removed, so re-raising triggers the default behavior.
+            // With the handlers removed, re-raising triggers the default behavior.
             process.kill(process.pid, signal);
           }
         };
         signalHandlers.set(signal, signalHandler);
-        process.once(signal, signalHandler);
+        process.on(signal, signalHandler);
       }
       let deployStatus: number | null;
-      let deploySignal: NodeJS.Signals | undefined;
       try {
         const secretsFilePath = path.join(secretsDirPath, 'secrets.json');
         fs.writeFileSync(secretsFilePath, JSON.stringify(secrets), { mode: 0o600 });
@@ -427,16 +435,12 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
             env: deployEnv as NodeJS.ProcessEnv,
             stdio: ['ignore', 'inherit', 'inherit'],
           });
-          const finish = (status: number | null, signal: NodeJS.Signals | null | undefined): void => {
-            deploySignal = signal ?? undefined;
-            resolve(status);
-          };
           wranglerProcess.on('error', (error) => {
             console.error(error);
-            finish(1, undefined);
+            resolve(1);
           });
           wranglerProcess.on('exit', (code, signal) => {
-            finish(code, signal);
+            resolve(signal ? 1 : code);
           });
         });
       } finally {
@@ -446,9 +450,9 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
         }
         fs.rmSync(secretsDirPath, { force: true, recursive: true });
       }
-      if (deploySignal) {
+      if (receivedShutdownSignal) {
         // Re-raise so the caller observes the same signal-derived exit status.
-        process.kill(process.pid, deploySignal);
+        process.kill(process.pid, receivedShutdownSignal);
         return;
       }
       if (deployStatus !== 0) {


### PR DESCRIPTION
## Summary

Root-cause fix for the flaky `Could not read file: /dev/stdin` on CI deploys (WillBoosterLab/ai-game-builder run 29335779556; the identical invocation had succeeded two hours earlier): wrangler reads `--secrets-file` only **after** uploading assets, and by then the piped stdin may already have been consumed inside wrangler/Node, so re-opening `/dev/stdin` yields nothing.

The secrets JSON now goes through a mode-0600 file in a private `mkdtemp` (0700) directory passed by path and removed right after the deploy — exposure equals the dotenv files CI already writes to the same disk, and atomicity (code+secrets in one deploy) is unchanged. Shutdown handling was hardened along the way:

- wrangler runs through an async spawn (spawnSync would block the event loop, letting a signal kill the process before any cleanup) with the temp directory removed in a `finally` and the exit-on-failure kept outside it (`process.exit` skips `finally`).
- Handlers for SIGHUP/SIGINT/SIGTERM/SIGQUIT are installed **before** the file is written, use `process.on` (a repeated signal cannot fall back to default termination and bypass cleanup), forward SIGHUP/SIGQUIT to wrangler as SIGTERM (its launcher relays only SIGINT/SIGTERM — anything else orphaned a deployment still mutating the remote Worker), and the re-raise uses the signal wb itself received (wrangler converts SIGINT into a numeric 143 exit).

## Review

`/review-fix agy,claude,codex` ran to "There is no concern." over 4 rounds; all findings (interrupted-deploy file leftovers, SIGHUP coverage, pre-write signal window, orphaned inner wrangler process, SIGINT→143 conversion, repeated-signal bypass) were validated against wrangler 4.107's launcher behavior and fixed. The matching guideline update is WillBooster/agentic-workflows#342 (merged).

## Test plan

- `wb deploy --dry-run` against ai-game-builder prints the new invocation; all 129 wb tests pass; lint/typecheck clean.
- After release: bump wb in ai-game-builder and re-run the staging deploy that flaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
