### PR TITLE
fix(wb): keep test-on-ci in the test environment and stop double-applying D1 migrations

### DIFF
--- a/packages/wb/src/commands/testOnCi.ts
+++ b/packages/wb/src/commands/testOnCi.ts
@@ -45,6 +45,11 @@ export const testOnCiCommand: CommandModule<
 export async function testOnCi(
   argv: ArgumentsCamelCase<InferredOptionTypes<typeof testOnCiBuilder & typeof sharedOptionsBuilder>>
 ): Promise<void> {
+  // Spawned commands re-derive their dotenv cascade from the exported WB_ENV, so an unexported
+  // WB_ENV would let a committed `.env` (e.g. WB_ENV=development) select the development
+  // environment — running the destructive e2e suite against the developer's own database.
+  process.env.WB_ENV ||= 'test';
+
   const projects = await findDescendantProjects(argv);
   if (!projects) {
     console.error(chalk.red('No project found.'));
@@ -53,7 +58,8 @@ export async function testOnCi(
 
   for (const project of projects.descendants) {
     project.env.CI ||= '1';
-    project.env.WB_ENV ||= 'test';
+    // Overwrite, not ||=: project.env already carries the dotenv-derived value.
+    project.env.WB_ENV = process.env.WB_ENV;
 
     const deps = project.packageJson.dependencies ?? {};
     const devDeps = project.packageJson.devDependencies ?? {};

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -6,7 +6,12 @@ import { isProjectEnvironment } from '../../project.js';
 import { buildEnvReaderOptionArgs } from '../../sharedOptionsBuilder.js';
 import { checkAndKillPortProcess } from '../../utils/port.js';
 import { buildShellCommand, buildShellEnvironmentAssignment } from '../../utils/shell.js';
-import { findWranglerConfigPath, getLocalWranglerStateDir, wrapWithLocalD1DatabaseUrl } from '../../utils/wrangler.js';
+import {
+  findD1MigrationsDirPath,
+  findWranglerConfigPath,
+  getLocalWranglerStateDir,
+  wrapWithLocalD1DatabaseUrl,
+} from '../../utils/wrangler.js';
 import type { ScriptArgv } from '../builder.js';
 import { toDevNull } from '../builder.js';
 import { dockerScripts } from '../dockerScripts.js';
@@ -125,10 +130,17 @@ export abstract class BaseScripts {
       isProjectEnvironment(project, 'test') && findWranglerConfigPath(project)
         ? [`rm -Rf "${getLocalWranglerStateDir(project)}"`]
         : [];
+    // A project whose D1 bindings carry wrangler-native migrations applies them with wrangler
+    // (see WorkersScripts / buildD1MigrationsApplyCommand). Running drizzle-kit migrate against
+    // the same local D1 would apply the same SQL twice — drizzle's generated statements are not
+    // idempotent (`CREATE INDEX` without IF NOT EXISTS) — so drizzle stays ORM-only there.
+    const migratesD1WithWrangler = !!findD1MigrationsDirPath(project);
     const migrationCommands = [
       ...wranglerStateWipeCommands,
       ...(project.hasPrisma ? [prismaScripts.migrate(project)] : []),
-      ...(project.hasDrizzle ? [wrapWithLocalD1DatabaseUrl(project, drizzleScripts.migrateForStart(project))] : []),
+      ...(project.hasDrizzle && !migratesD1WithWrangler
+        ? [wrapWithLocalD1DatabaseUrl(project, drizzleScripts.migrateForStart(project))]
+        : []),
     ];
     // Splitting may cut through a `(cd … && …)` subshell, but rejoining with ' && ' and per-piece
     // redirects keeps the script valid, and wb-generated paths never contain '&&'.


### PR DESCRIPTION
## Summary

Two defects surfaced while moving a plain Cloudflare Workers app (WillBooster/moti-ai#784) onto `wb test-on-ci` / `wb deploy`.

1. **`wb test-on-ci` ran in the development environment.** It set `project.env.WB_ENV ||= 'test'`, but `project.env` already carries the value from the committed `.env` (`WB_ENV=development`), and the spawned commands re-derive their dotenv cascade from the *exported* `WB_ENV`, which stayed unset. Consequently a local `bun run test/ci` served the worker from `.wrangler/state` (the developer's dev D1, unwiped) instead of `.wrangler/state-test`, and an e2e suite whose setup resets the database destroyed local dev data. CI was unaffected only because the reusable `test.yml` exports `WB_ENV=test`. Now `test-on-ci` exports `WB_ENV=test` itself (an explicitly exported value still wins) and assigns it to `project.env`.

2. **Double-applied D1 migrations for wrangler-native drizzle apps.** `buildProductionCommand` ran `drizzle-kit migrate` for every drizzle-orm project, including apps that apply their D1 migrations with wrangler (`migrations_dir`), which `WorkersScripts` also applies. Drizzle's generated SQL is not idempotent (`CREATE INDEX` without `IF NOT EXISTS`), so the second mechanism failed. Such projects previously had to point `drizzle.config.ts` at a scratch database as a workaround, which broke `wb db studio`. wb now skips its drizzle-kit migration whenever wrangler-native migrations exist.

## Testing

- `yarn workspace @willbooster/wb run test` (129 passed) and `yarn verify` pass.
- Verified against moti-ai: `bun wb test-on-ci` now uses `.wrangler/state-test`, port 8088, wipes the state dir, and applies only the wrangler-native migrations; 5 unit + 139 e2e tests pass and the dev database is untouched.