### PR TITLE
fix(wb): make deploy's .env.cloudflare values reach the spawned commands

### DIFF
--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -95,9 +95,10 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       console.error(chalk.red('wb deploy currently supports only Cloudflare Workers apps (no wrangler config found).'));
       process.exit(1);
     }
-    // project.env is memoized (a single object per Project instance), so in-place
-    // mutations like the following persist for every later read and spawned command.
-    delete project.env.CLOUDFLARE_ENV;
+    // Only process.env is worth mutating: `project.env` recomposes itself from process.env plus
+    // the dotenv files on every read, so an in-place mutation of it never reaches a later read
+    // or a spawned command. CLOUDFLARE_ENV is already deleted from process.env above; a dotenv
+    // file defining it would still surface, which the explicit `--env` flags below override.
 
     const envName = project.env.WB_ENV;
     if (!envName || envName === 'development' || envName === 'test') {
@@ -109,13 +110,17 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
 
     // CI provides the Cloudflare API token via a .env.cloudflare file (e.g. the reusable deploy
     // workflow's FILE_CONTENT_1); already-exported environment variables win over its values.
+    // The values go into process.env, not project.env: `project.env` recomposes itself from
+    // process.env plus the dotenv files on every read, so an in-place mutation of it would be
+    // dropped before the spawned wrangler/drizzle-kit commands inherit their environment —
+    // wrangler then aborted with "it's necessary to set a CLOUDFLARE_API_TOKEN".
     const cloudflareEnvPath = path.join(project.dirPath, '.env.cloudflare');
     if (fs.existsSync(cloudflareEnvPath)) {
       const parsed = config({ path: cloudflareEnvPath, processEnv: {}, quiet: true }).parsed ?? {};
       for (const [key, value] of Object.entries(parsed)) {
         if (key === 'CLOUDFLARE_ENV') continue;
         // ??= so that an explicitly exported empty value still wins over the file.
-        project.env[key] ??= value;
+        process.env[key] ??= value;
       }
     }
 


### PR DESCRIPTION
`wb deploy` reads `.env.cloudflare` (how the reusable deploy workflow passes `CLOUDFLARE_API_TOKEN`) and merged it into `project.env`. But `Project.env` is a getter that rebuilds `{...process.env, ...dotenvVars}` on every read, so the merged values never reached the spawned `wrangler`/`drizzle-kit` commands. On CI (no wrangler OAuth login) the deploy therefore failed at the first authenticated command with "In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable", even though the token file was written. Verified with a `deploy/post` probe: a value set only in `.env.cloudflare` arrived as `undefined` in the child process.

Merging into `process.env` fixes it (exported values still win via `??=`), and the stale comment claiming `project.env` is memoized is corrected.

## Testing

- `yarn workspace @willbooster/wb run test` (131 passed) and typecheck pass.
- Re-verified in moti-ai: with the fix, a value present only in `.env.cloudflare` reaches the spawned commands.