### PR TITLE
fix(wb): cache Project.env stably so in-place env mutations survive

### DIFF
--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -110,10 +110,10 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
 
     // CI provides the Cloudflare API token via a .env.cloudflare file (e.g. the reusable deploy
     // workflow's FILE_CONTENT_1); already-exported environment variables win over its values.
-    // The values go into process.env, not project.env: `project.env` recomposes itself from
-    // process.env plus the dotenv files on every read, so an in-place mutation of it would be
-    // dropped before the spawned wrangler/drizzle-kit commands inherit their environment —
-    // wrangler then aborted with "it's necessary to set a CLOUDFLARE_API_TOKEN".
+    // The values go into both process.env (inherited by everything wb spawns) and project.env
+    // (the environment wb itself reads and passes explicitly); the latter is a cached snapshot
+    // taken before this point, so writing only to process.env would leave wb's own preflight —
+    // and any command spawned with project.env — without the token.
     const cloudflareEnvPath = path.join(project.dirPath, '.env.cloudflare');
     if (fs.existsSync(cloudflareEnvPath)) {
       const parsed = config({ path: cloudflareEnvPath, processEnv: {}, quiet: true }).parsed ?? {};
@@ -121,6 +121,7 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
         if (key === 'CLOUDFLARE_ENV') continue;
         // ??= so that an explicitly exported empty value still wins over the file.
         process.env[key] ??= value;
+        project.env[key] ??= value;
       }
     }
 

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -108,9 +108,18 @@ export class Project {
     return name.replaceAll('@', '').replaceAll('/', '-');
   }
 
-  @memoizeOne
+  // Cached in a plain field rather than with @memoizeOne: that decorator keys its cache on a hash
+  // of the instance, which changes as other memoized getters populate the instance, so `env` could
+  // silently be recomputed — dropping in-place mutations (e.g. `project.env.PORT ||= …`, or the
+  // secrets `wb deploy` merges from .env.cloudflare) that callers rely on for spawned commands.
+  private envCache: Record<string, string | undefined> | undefined;
+
   get env(): Record<string, string | undefined> {
-    if (!this.loadEnv) return process.env;
+    if (this.envCache) return this.envCache;
+    if (!this.loadEnv) {
+      this.envCache = process.env;
+      return this.envCache;
+    }
 
     const [envVars, envPathAndLoadedEnvVarCountPairs] = readEnvironmentVariables(this.argv, this.dirPath);
     if (!shouldSuppressEnvironmentOutput(this.argv)) {
@@ -118,7 +127,8 @@ export class Project {
         console.info(`Loaded ${count} environment variables from ${envPath}`);
       }
     }
-    return { ...process.env, ...envVars };
+    this.envCache = { ...process.env, ...envVars };
+    return this.envCache;
   }
 
   @memoizeOne


### PR DESCRIPTION
`Project.env` was memoized with `@memoizeOne`, whose cache key is a hash of the instance. That hash changes as other memoized getters populate the instance, so the getter could recompute `{...process.env, ...dotenvVars}` at an arbitrary later read — silently dropping the in-place mutations several call sites depend on (`project.env.PORT ||= …`, `project.env.WB_ENV = …`, and the `.env.cloudflare` values `wb deploy` merges).

Observed as: a CI deploy aborting with `Wrangler authentication (e.g. CLOUDFLARE_API_TOKEN) is required to deploy on CI` even though the reusable `deploy.yml` had written `.env.cloudflare` — and, in another run of the same code, wrangler receiving the token but a `deploy/ci-setup` hook not seeing it.

Caching in a plain field makes the object stable for the process's lifetime, which is what the call sites already assume; `wb deploy` now merges the file into both `process.env` and `project.env`.

## Testing

- `yarn workspace @willbooster/wb run test` (131 passed), `yarn verify` pass.
- Verified in moti-ai that a token present only in `.env.cloudflare` now reaches both wb's own preflight and the spawned wrangler commands.