### PR TITLE
fix(wbfy): keep worker-types management for scripts composing gen-code with a build

### DIFF
--- a/packages/wbfy/src/utils/wranglerTypesCommand.ts
+++ b/packages/wbfy/src/utils/wranglerTypesCommand.ts
@@ -68,11 +68,18 @@ export function selectProjectWranglerTypesGenerator(scripts: PackageJson.Scripts
 function hasNonTransplantableGeneratorPipeline(script: string, scripts: PackageJson.Scripts): boolean {
   const segments = contextFreeCommandSegments(script);
   // Bare generators and wrapper-reached generators form pipelines too: a preparation step that creates
-  // .dev.vars before `wrangler types` must not be bypassed either.
-  const hasReusableGenerator = reachesWranglerTypes(
-    script,
-    scripts,
-    (invocationArgs) => classifyWranglerTypesInvocation(invocationArgs) === 'reusableGenerator'
+  // .dev.vars before `wrangler types` must not be bypassed either. A generator reached only through a
+  // managed gen-code segment does not count: its pipeline is exactly what the managed scripts run, so a
+  // composition like `yarn run gen-code && vite build` bypasses nothing — treating it as a pipeline would
+  // (idempotency-breakingly) disable management right after wbfy itself appended the generator to gen-code.
+  const hasReusableGenerator = segments.some(
+    (segment) =>
+      !isManagedGenCodeSegment(segment, scripts) &&
+      reachesWranglerTypes(
+        segment,
+        scripts,
+        (invocationArgs) => classifyWranglerTypesInvocation(invocationArgs) === 'reusableGenerator'
+      )
   );
   if (!hasReusableGenerator) return false;
   return segments.some(

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -222,6 +222,37 @@ test.each([
   });
 });
 
+// A build script composing gen-code with a build step reaches the generator only through the managed gen-code
+// pipeline, so nothing would be bypassed by reusing the generator. Flagging it as a prerequisite pipeline would
+// disable management on the run right after wbfy itself appended the generator to gen-code (idempotency).
+test('keeps management for a script composing gen-code with a build step', async () => {
+  const wranglerPackageJson = {
+    devDependencies: { wrangler: '4.42.0' },
+    scripts: {
+      'build/core': 'yarn run gen-code && vite build',
+      'gen-code': 'wb gen-code && wrangler types --strict-vars=false',
+      postinstall: 'wb gen-code && wrangler types --strict-vars=false',
+    },
+  };
+  const packageJson = await generatePackageJsonFrom(
+    { scripts: wranglerPackageJson.scripts, devDependencies: wranglerPackageJson.devDependencies },
+    {
+      depending: genI18nTsDepending,
+      isBun: true,
+      isCloudflare: true,
+      doesContainWranglerConfig: true,
+      packageJson: wranglerPackageJson,
+    },
+    { createI18nDir: true }
+  );
+
+  expect(packageJson.scripts).toMatchObject({
+    'build/core': 'yarn run gen-code && vite build',
+    'gen-code': 'bun wb gen-code && wrangler types --strict-vars=false',
+    postinstall: 'wb gen-code && wrangler types --strict-vars=false',
+  });
+});
+
 // wbfy gitignores and untracks worker-configuration.d.ts only where postinstall regenerates it, so a package that
 // cannot run wrangler must not gain the command either.
 test('omits wrangler types when the package does not depend on wrangler', async () => {


### PR DESCRIPTION
## Summary

Applying wbfy twice to a Cloudflare project with a common build composition like `"build/core": "yarn run gen-code && vite build"` was not idempotent:

1. The first run appends the resolved `wrangler types` generator to `gen-code`/`postinstall`, gitignores `worker-configuration.d.ts`, and untracks it — as designed.
2. The second run then saw `build/core` *reaching* a flagged generator (through the now-updated `gen-code`) next to a `vite build` segment, and `hasNonTransplantableGeneratorPipeline` flagged the package as conflicting — reverting the `.gitignore` rule and stripping the generator from `gen-code`, while the declaration file stayed untracked (thousands of lines of untracked noise that nothing ignores).

A generator reached only through a **managed gen-code segment** bypasses nothing: the gen-code pipeline is exactly what the managed scripts run. Only generators running outside managed gen-code segments now count as pipeline candidates. Detection of real prerequisite pipelines (e.g. `node scripts/prepare.js && wrangler types ...`, wrapper scripts with prerequisites) is unchanged — all 81 existing tests still pass, plus a new regression test for the composition case.

Found while applying wbfy to WillBoosterLab/ai-game-builder, which uses `"build/core": "yarn run gen-code && vinext build"`.

## Testing

- `yarn verify` passes.
- `packages/wbfy`: `yarn vitest run test/packageJson.test.ts` — 82/82 passed (81 existing + 1 new regression test).
- Verified against ai-game-builder: rerunning wbfy after the first application now converges (management preserved, no reverts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
