### PR TITLE
fix(wb,wbfy): read .env.cloudflare from the monorepo root and gitignore it

### DIFF
--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -109,6 +109,10 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
     // (the environment wb itself reads and passes explicitly); the latter is a cached snapshot
     // taken before this point, so writing only to process.env would leave wb's own preflight —
     // and any command spawned with project.env — without the token.
+    // Only --include-root-env gates the root lookup, not an explicit --env: --env replaces the
+    // dotenv VARIABLE sources, while .env.cloudflare is a credential sidecar read outside that
+    // cascade (the project's own copy is read regardless of --env, as it always has been).
+    // Gating on --env would make `wb deploy --env <file>` silently stop finding the repo's token.
     const cloudflareEnvVars = readCloudflareEnvFiles(
       project.dirPath,
       argv.includeRootEnv ? project.rootDirPath : undefined

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -83,6 +83,8 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
   async handler(argv: DeployCommandArgv) {
     // A stray exported CLOUDFLARE_ENV would bake the wrong environment into the build and
     // apply the environment suffix twice on deploy; it is re-set explicitly where needed.
+    // A dotenv file defining it still surfaces through project.env, which the explicit `--env`
+    // flags below override.
     delete process.env.CLOUDFLARE_ENV;
 
     const project = findSelfProject(argv);
@@ -95,11 +97,6 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       console.error(chalk.red('wb deploy currently supports only Cloudflare Workers apps (no wrangler config found).'));
       process.exit(1);
     }
-    // Only process.env is worth mutating: `project.env` recomposes itself from process.env plus
-    // the dotenv files on every read, so an in-place mutation of it never reaches a later read
-    // or a spawned command. CLOUDFLARE_ENV is already deleted from process.env above; a dotenv
-    // file defining it would still surface, which the explicit `--env` flags below override.
-
     const envName = project.env.WB_ENV;
     if (!envName || envName === 'development' || envName === 'test') {
       console.error(
@@ -112,7 +109,11 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
     // (the environment wb itself reads and passes explicitly); the latter is a cached snapshot
     // taken before this point, so writing only to process.env would leave wb's own preflight —
     // and any command spawned with project.env — without the token.
-    for (const [key, value] of Object.entries(readCloudflareEnvFiles(project.dirPath, project.rootDirPath))) {
+    const cloudflareEnvVars = readCloudflareEnvFiles(
+      project.dirPath,
+      argv.includeRootEnv ? project.rootDirPath : undefined
+    );
+    for (const [key, value] of Object.entries(cloudflareEnvVars)) {
       // ??= so that an explicitly exported empty value still wins over the file.
       process.env[key] ??= value;
       project.env[key] ??= value;
@@ -518,11 +519,13 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
  * deploy workflow's `file_path_1`), looking beside the Worker's wrangler config and at the
  * monorepo root — `file_path_1` is repo-relative, so both spellings occur in practice.
  * Nearer files win, mirroring the `.env` cascade: a workspace may override the root token,
- * never the reverse. `CLOUDFLARE_ENV` is dropped; it would double-apply the environment suffix.
+ * never the reverse. Pass `rootDirPath` as undefined to read the workspace alone, so that
+ * `--include-root-env=false` isolates this file from the root just as it does the cascade.
+ * `CLOUDFLARE_ENV` is dropped; it would double-apply the environment suffix.
  */
-export function readCloudflareEnvFiles(dirPath: string, rootDirPath: string): Record<string, string> {
+export function readCloudflareEnvFiles(dirPath: string, rootDirPath: string | undefined): Record<string, string> {
   const envVars: Record<string, string> = {};
-  for (const currentDirPath of new Set([dirPath, rootDirPath])) {
+  for (const currentDirPath of new Set(rootDirPath ? [dirPath, rootDirPath] : [dirPath])) {
     const cloudflareEnvPath = path.join(currentDirPath, '.env.cloudflare');
     if (!fs.existsSync(cloudflareEnvPath)) continue;
     const parsed = config({ path: cloudflareEnvPath, processEnv: {}, quiet: true }).parsed ?? {};

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -108,21 +108,14 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       process.exit(1);
     }
 
-    // CI provides the Cloudflare API token via a .env.cloudflare file (e.g. the reusable deploy
-    // workflow's FILE_CONTENT_1); already-exported environment variables win over its values.
     // The values go into both process.env (inherited by everything wb spawns) and project.env
     // (the environment wb itself reads and passes explicitly); the latter is a cached snapshot
     // taken before this point, so writing only to process.env would leave wb's own preflight —
     // and any command spawned with project.env — without the token.
-    const cloudflareEnvPath = path.join(project.dirPath, '.env.cloudflare');
-    if (fs.existsSync(cloudflareEnvPath)) {
-      const parsed = config({ path: cloudflareEnvPath, processEnv: {}, quiet: true }).parsed ?? {};
-      for (const [key, value] of Object.entries(parsed)) {
-        if (key === 'CLOUDFLARE_ENV') continue;
-        // ??= so that an explicitly exported empty value still wins over the file.
-        process.env[key] ??= value;
-        project.env[key] ??= value;
-      }
+    for (const [key, value] of Object.entries(readCloudflareEnvFiles(project.dirPath, project.rootDirPath))) {
+      // ??= so that an explicitly exported empty value still wins over the file.
+      process.env[key] ??= value;
+      project.env[key] ??= value;
     }
 
     let resolvedConfig: ResolvedWranglerConfig | undefined;
@@ -519,6 +512,27 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
     }
   },
 };
+
+/**
+ * Read the Cloudflare API token that CI drops in a `.env.cloudflare` file (e.g. the reusable
+ * deploy workflow's `file_path_1`), looking beside the Worker's wrangler config and at the
+ * monorepo root — `file_path_1` is repo-relative, so both spellings occur in practice.
+ * Nearer files win, mirroring the `.env` cascade: a workspace may override the root token,
+ * never the reverse. `CLOUDFLARE_ENV` is dropped; it would double-apply the environment suffix.
+ */
+export function readCloudflareEnvFiles(dirPath: string, rootDirPath: string): Record<string, string> {
+  const envVars: Record<string, string> = {};
+  for (const currentDirPath of new Set([dirPath, rootDirPath])) {
+    const cloudflareEnvPath = path.join(currentDirPath, '.env.cloudflare');
+    if (!fs.existsSync(cloudflareEnvPath)) continue;
+    const parsed = config({ path: cloudflareEnvPath, processEnv: {}, quiet: true }).parsed ?? {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (key === 'CLOUDFLARE_ENV') continue;
+      envVars[key] ??= value;
+    }
+  }
+  return envVars;
+}
 
 /**
  * Select the secrets to push to the Worker from the dotenv-loaded environment variables:

--- a/packages/wb/test/deploy.test.ts
+++ b/packages/wb/test/deploy.test.ts
@@ -232,6 +232,16 @@ describe('readCloudflareEnvFiles', () => {
     await fs.writeFile(path.join(rootDirPath, '.env.cloudflare'), 'CLOUDFLARE_API_TOKEN=token\n');
     expect(readCloudflareEnvFiles(rootDirPath, rootDirPath)).toEqual({ CLOUDFLARE_API_TOKEN: 'token' });
   });
+
+  it('ignores the root file when the caller opts out of root env files', async () => {
+    // `wb deploy --include-root-env=false` passes rootDirPath as undefined: a caller that
+    // isolates the workspace from root env files must not authenticate with the root's token.
+    await fs.writeFile(path.join(rootDirPath, '.env.cloudflare'), 'CLOUDFLARE_API_TOKEN=root-token\n');
+    expect(readCloudflareEnvFiles(dirPath, undefined)).toEqual({});
+
+    await fs.writeFile(path.join(dirPath, '.env.cloudflare'), 'CLOUDFLARE_API_TOKEN=own-token\n');
+    expect(readCloudflareEnvFiles(dirPath, undefined)).toEqual({ CLOUDFLARE_API_TOKEN: 'own-token' });
+  });
 });
 
 describe('selectWorkerSecrets', () => {

--- a/packages/wb/test/deploy.test.ts
+++ b/packages/wb/test/deploy.test.ts
@@ -5,7 +5,11 @@ import path from 'node:path';
 import { parse as parseDotenv } from 'dotenv';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { selectInheritedRemoteSecretNames, selectWorkerSecrets } from '../src/commands/deploy.js';
+import {
+  readCloudflareEnvFiles,
+  selectInheritedRemoteSecretNames,
+  selectWorkerSecrets,
+} from '../src/commands/deploy.js';
 import { quoteDotenvValue } from '../src/commands/genDevVars.js';
 import {
   collectBindingNames,
@@ -191,6 +195,42 @@ describe('usesWranglerNativeMigrations', () => {
     await fs.writeFile(path.join(dirPath, 'migrations', '0001_init.sql'), 'CREATE TABLE t (id);');
     expect(usesWranglerNativeMigrations({ dirPath }, {})).toBe(true);
     expect(usesWranglerNativeMigrations({ dirPath }, { migrations_dir: 'drizzle' })).toBe(false);
+  });
+});
+
+describe('readCloudflareEnvFiles', () => {
+  let rootDirPath: string;
+  let dirPath: string;
+
+  beforeEach(async () => {
+    rootDirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-deploy-test-'));
+    dirPath = path.join(rootDirPath, 'packages', 'server');
+    await fs.mkdir(dirPath, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(rootDirPath, { force: true, recursive: true });
+  });
+
+  it('reads the file at the monorepo root as well as beside the wrangler config', async () => {
+    expect(readCloudflareEnvFiles(dirPath, rootDirPath)).toEqual({});
+
+    // file_path_1 is repo-relative, so CI commonly writes the token at the root even though the
+    // Worker lives in a workspace; reading only the workspace would silently lose the token.
+    await fs.writeFile(path.join(rootDirPath, '.env.cloudflare'), 'CLOUDFLARE_API_TOKEN=root-token\n');
+    expect(readCloudflareEnvFiles(dirPath, rootDirPath)).toEqual({ CLOUDFLARE_API_TOKEN: 'root-token' });
+
+    await fs.writeFile(
+      path.join(dirPath, '.env.cloudflare'),
+      'CLOUDFLARE_API_TOKEN=own-token\nCLOUDFLARE_ENV=staging\n'
+    );
+    // Nearer wins, and CLOUDFLARE_ENV never leaks through.
+    expect(readCloudflareEnvFiles(dirPath, rootDirPath)).toEqual({ CLOUDFLARE_API_TOKEN: 'own-token' });
+  });
+
+  it('reads a non-monorepo project once rather than twice', async () => {
+    await fs.writeFile(path.join(rootDirPath, '.env.cloudflare'), 'CLOUDFLARE_API_TOKEN=token\n');
+    expect(readCloudflareEnvFiles(rootDirPath, rootDirPath)).toEqual({ CLOUDFLARE_API_TOKEN: 'token' });
   });
 });
 

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -129,7 +129,10 @@ src-tauri/gen/schemas/
     if (config.isCloudflare || rootConfig.isCloudflare) {
       // .dev.vars* hold local secrets for wrangler dev and must never be committed,
       // unlike the committed .env/.env.staging files of the WillBooster convention.
+      // .env.cloudflare carries CLOUDFLARE_API_TOKEN: CI writes it from a secret, and a local
+      // `wb deploy` needs a real token in it, so committing it would leak account credentials.
       headUserContent += `.dev.vars*
+.env.cloudflare
 .wrangler/
 `;
     }


### PR DESCRIPTION
## Why

Two gaps found while migrating [WillBoosterLab/llm-proxy](https://github.com/WillBoosterLab/llm-proxy/pull/748) — a monorepo whose Worker lives in `packages/server` — onto `wb deploy`.

### 1. `.env.cloudflare` was read from the Worker's directory only

`wb deploy` read `.env.cloudflare` from `project.dirPath` alone, while **every other `.env*` file also cascades from the monorepo root** (`readEnvironmentVariables` with `--include-root-env`). `.env.example`, `drizzle.config.*`, and the whole `.env` cascade are all root-aware; this one file was the exception.

That asymmetry is a trap because the reusable deploy workflow's `file_path_1` is **repo-relative**. A monorepo that writes the token to the natural-looking root `.env.cloudflare` — exactly what `ai-game-builder` does, and what the guidelines' example shows — had it silently ignored and the deploy failed to authenticate, with nothing pointing at the path as the cause.

Now both locations are read, **nearest-wins**, mirroring the `.env` cascade: a workspace may override the root token, never the reverse.

### 2. `.env.cloudflare` was not gitignored

wbfy ignores `.dev.vars*` and `.wrangler/` for Cloudflare projects but not `.env.cloudflare` — which carries `CLOUDFLARE_API_TOKEN`. CI writes a real token into it, and a local `wb deploy` needs one too, so committing it leaks account credentials. Repos were hand-adding the rule (`ai-game-builder`'s `.gitignore` has it; `llm-proxy`'s did not).

## What changed

- `wb`: extract `readCloudflareEnvFiles(dirPath, rootDirPath)` and read both locations. Extracted as an exported helper to match how the rest of `deploy.ts` is tested (pure functions, exercised directly).
- `wbfy`: add `.env.cloudflare` to the Cloudflare block in the `.gitignore` generator.

## Tests

Added two cases to `test/deploy.test.ts` covering the root-file pickup, nearest-wins precedence, `CLOUDFLARE_ENV` exclusion, and the non-monorepo case where both paths are the same directory. All 15 pass; `yarn verify` is clean.

This one is worth a permanent test: the failure mode is a silent misconfiguration (token ignored → auth failure with no hint at the cause), and nothing else — types or lint — would catch a regression in path resolution.

## Note for reviewers

`llm-proxy` points `file_path_1` at `packages/server/.env.cloudflare`, which is correct both before and after this change, so the two PRs are independent and can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review pass

`/review-fix` (codex, claude, antigravity; grok failed on a model-id error) surfaced three findings, all now addressed:

- **`--include-root-env=false` did not exclude the root `.env.cloudflare`** (codex). The helper read the root unconditionally, so a caller that explicitly isolated the workspace still consumed the root token. Now gated on the flag, with a test for the opt-out.
- **A stale comment claimed `project.env` recomposes on every read** (codex, claude). False since #949 cached it in `envCache`, and it sat directly above — and contradicted — the `project.env[key] ??= value` merge that #948/#949 added, inviting a maintainer to delete that line as dead code and reintroduce the exact bug those PRs fixed. Removed; its still-accurate `CLOUDFLARE_ENV` caveat moved next to the deletion it qualifies.
- **Rejected:** an `EBADENGINE`-under-Node-22 test failure (antigravity). Not reachable in any supported configuration — `.tool-versions` pins `nodejs 24.15.0`, and the reusable `test.yml` only derives a Node matrix from root `engines` when no `.tool-versions`/`.node-version`/`mise.toml` node entry exists. The agent had run the suite on its own Node 22.

Round 2 (codex, claude) raised two more:

- **Deferred → #955:** the new ignore rule does not help repos that already track `.env.cloudflare`. Real, but not reachable today (no WillBooster/WillBoosterLab repo tracks one), and untracking a credential file needs its own design — the `untrackWorkerTypes` precedent is safe only because postinstall regenerates that file, and untracking does not remediate history, so it must come with rotation guidance.
- **Rejected:** gating the root lookup on an explicit `--env` too. `--env` replaces the dotenv *variable* sources, while `.env.cloudflare` is a credential sidecar read outside that cascade (the project's own copy is read regardless of `--env`, as it always has been). Gating it would make `wb deploy --env <file>` silently stop finding the repo's token — the same silent-auth-failure class this PR fixes. Documented inline.
