### PR TITLE
fix(wb): remove non-running containers before reuse

### DIFF
--- a/packages/wb/src/scripts/dockerScripts.ts
+++ b/packages/wb/src/scripts/dockerScripts.ts
@@ -36,7 +36,7 @@ class DockerScripts {
   }
 
   stop(project: Project): string {
-    return `true $(docker rm -f ${project.dockerImageName} 2> /dev/null)`;
+    return `docker rm -f ${project.dockerImageName} > /dev/null 2>&1 || true`;
   }
 
   stopAll(): string {

--- a/packages/wb/src/scripts/dockerScripts.ts
+++ b/packages/wb/src/scripts/dockerScripts.ts
@@ -36,7 +36,7 @@ class DockerScripts {
   }
 
   stop(project: Project): string {
-    return `true $(docker rm -f $(docker container ls -q -f name=${project.dockerImageName}) 2> /dev/null)`;
+    return `true $(docker rm -f ${project.dockerImageName} 2> /dev/null)`;
   }
 
   stopAll(): string {

--- a/packages/wb/test/scripts/dockerScripts.test.ts
+++ b/packages/wb/test/scripts/dockerScripts.test.ts
@@ -1,0 +1,62 @@
+import childProcess from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { Project } from '../../src/project.js';
+import { dockerScripts } from '../../src/scripts/dockerScripts.js';
+
+describe.runIf(isDockerAvailable())('dockerScripts', () => {
+  it('removes a non-running container before reuse', async () => {
+    const projectDirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-docker-scripts-'));
+    const containerName = `wb-cleanup-test-${randomUUID()}`;
+    await fs.writeFile(path.join(projectDirPath, 'package.json'), `${JSON.stringify({ name: containerName })}\n`);
+    await fs.writeFile(path.join(projectDirPath, 'Dockerfile'), 'FROM scratch\nCMD ["/bin/true"]\n');
+    const project = new Project(projectDirPath, {}, false);
+
+    try {
+      runDocker(['build', '--quiet', '--tag', containerName, projectDirPath]);
+      runDocker(['create', '--name', containerName, containerName]);
+      expect(inspectContainerStatus(containerName)).toBe('created');
+
+      const result = childProcess.spawnSync(dockerScripts.stop(project), {
+        cwd: projectDirPath,
+        encoding: 'utf8',
+        shell: true,
+      });
+
+      expect(result.status).toBe(0);
+      expect(containerExists(containerName)).toBe(false);
+    } finally {
+      childProcess.spawnSync('docker', ['rm', '--force', containerName], { stdio: 'ignore' });
+      childProcess.spawnSync('docker', ['image', 'rm', '--force', containerName], { stdio: 'ignore' });
+      await fs.rm(projectDirPath, { force: true, recursive: true });
+    }
+  }, 30_000);
+});
+
+function isDockerAvailable(): boolean {
+  return childProcess.spawnSync('docker', ['info'], { stdio: 'ignore', timeout: 5000 }).status === 0;
+}
+
+function runDocker(args: string[]): void {
+  const result = childProcess.spawnSync('docker', args, { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || `docker ${args.join(' ')} failed`);
+  }
+}
+
+function inspectContainerStatus(containerName: string): string {
+  return childProcess
+    .execFileSync('docker', ['container', 'inspect', '--format', '{{.State.Status}}', containerName], {
+      encoding: 'utf8',
+    })
+    .trim();
+}
+
+function containerExists(containerName: string): boolean {
+  return childProcess.spawnSync('docker', ['container', 'inspect', containerName], { stdio: 'ignore' }).status === 0;
+}

--- a/packages/wb/test/scripts/dockerScripts.test.ts
+++ b/packages/wb/test/scripts/dockerScripts.test.ts
@@ -44,6 +44,9 @@ function isDockerAvailable(): boolean {
 
 function runDocker(args: string[]): void {
   const result = childProcess.spawnSync('docker', args, { encoding: 'utf8' });
+  if (result.error) {
+    throw result.error;
+  }
   if (result.status !== 0) {
     throw new Error(result.stderr || result.stdout || `docker ${args.join(' ')} failed`);
   }


### PR DESCRIPTION
## Customer Summary

- Prevent repeated Docker-backed wb commands from failing when a previous named container remains in a non-running state.
- Keep the existing container naming convention and command usage unchanged.
- Require no consumer migration.

## Technical Summary

- Remove the project container directly by its existing name instead of first listing only running containers.
- Suppress cleanup output and tolerate missing containers with standard shell redirection and `|| true`.
- Add an integration test with a real non-running container and explicit Docker process error reporting.

## Why

Docker keeps container names reserved after a container stops. The previous pre-start cleanup listed only running containers, so it could miss a non-running container and allow the next `docker run --name ...` to fail. Direct name-based removal handles both running and non-running containers while preserving the current naming behavior.

## Testing

- `yarn workspace @willbooster/wb exec vitest run test/scripts/dockerScripts.test.ts`
- `yarn verify-full`
- GitHub Actions
