### PR TITLE
fix: pin @willbooster/wb devDependency instead of workspace protocol

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "@types/node": "25.6.0",
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
-        "@willbooster/wb": "workspace:*",
+        "@willbooster/wb": "13.28.8",
         "build-ts": "17.1.34",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
@@ -50,7 +50,7 @@
         "@types/node": "25.6.0",
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
-        "@willbooster/wb": "workspace:*",
+        "@willbooster/wb": "13.28.8",
         "blitz": "3.0.2",
         "build-ts": "17.1.34",
         "oxfmt": "0.59.0",
@@ -70,7 +70,7 @@
         "@types/node": "25.6.0",
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
-        "@willbooster/wb": "workspace:*",
+        "@willbooster/wb": "13.28.8",
         "build-ts": "17.1.34",
         "next": "16.2.6",
         "oxfmt": "0.59.0",
@@ -98,7 +98,7 @@
         "@types/node": "25.6.0",
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
-        "@willbooster/wb": "workspace:*",
+        "@willbooster/wb": "13.28.8",
         "build-ts": "17.1.34",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
@@ -129,7 +129,7 @@
         "@types/react-dom": "19.2.3",
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
-        "@willbooster/wb": "workspace:*",
+        "@willbooster/wb": "13.28.8",
         "babel-loader": "10.1.1",
         "build-ts": "17.1.34",
         "oxfmt": "0.59.0",
@@ -217,7 +217,7 @@
         "@types/yargs": "17.0.35",
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
-        "@willbooster/wb": "workspace:*",
+        "@willbooster/wb": "13.28.8",
         "build-ts": "17.1.34",
         "lefthook": "2.1.10",
         "oxfmt": "0.59.0",
@@ -3838,6 +3838,18 @@
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "@types/webpack-sources/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
+    "@willbooster/shared-lib/@willbooster/wb": ["@willbooster/wb@13.28.8", "", { "dependencies": { "chalk": "5.6.2", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fastest-levenshtein": "1.0.16", "globby": "16.2.0", "jsonc-parser": "3.3.1", "kill-port": "2.0.1", "minimal-promise-pool": "6.0.2", "yargs": "18.0.0" }, "bin": { "wb": "bin/index.js" } }, "sha512-SLYMnTPT09mNv7XLRG0UPpYU6BgWUs+aD2cVBAZz8As1KDnpKXVJ8eFOWVryOjZ6kzWv103s1p+kTAM+pHHbgA=="],
+
+    "@willbooster/shared-lib-blitz-next/@willbooster/wb": ["@willbooster/wb@13.28.8", "", { "dependencies": { "chalk": "5.6.2", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fastest-levenshtein": "1.0.16", "globby": "16.2.0", "jsonc-parser": "3.3.1", "kill-port": "2.0.1", "minimal-promise-pool": "6.0.2", "yargs": "18.0.0" }, "bin": { "wb": "bin/index.js" } }, "sha512-SLYMnTPT09mNv7XLRG0UPpYU6BgWUs+aD2cVBAZz8As1KDnpKXVJ8eFOWVryOjZ6kzWv103s1p+kTAM+pHHbgA=="],
+
+    "@willbooster/shared-lib-next/@willbooster/wb": ["@willbooster/wb@13.28.8", "", { "dependencies": { "chalk": "5.6.2", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fastest-levenshtein": "1.0.16", "globby": "16.2.0", "jsonc-parser": "3.3.1", "kill-port": "2.0.1", "minimal-promise-pool": "6.0.2", "yargs": "18.0.0" }, "bin": { "wb": "bin/index.js" } }, "sha512-SLYMnTPT09mNv7XLRG0UPpYU6BgWUs+aD2cVBAZz8As1KDnpKXVJ8eFOWVryOjZ6kzWv103s1p+kTAM+pHHbgA=="],
+
+    "@willbooster/shared-lib-node/@willbooster/wb": ["@willbooster/wb@13.28.8", "", { "dependencies": { "chalk": "5.6.2", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fastest-levenshtein": "1.0.16", "globby": "16.2.0", "jsonc-parser": "3.3.1", "kill-port": "2.0.1", "minimal-promise-pool": "6.0.2", "yargs": "18.0.0" }, "bin": { "wb": "bin/index.js" } }, "sha512-SLYMnTPT09mNv7XLRG0UPpYU6BgWUs+aD2cVBAZz8As1KDnpKXVJ8eFOWVryOjZ6kzWv103s1p+kTAM+pHHbgA=="],
+
+    "@willbooster/shared-lib-react/@willbooster/wb": ["@willbooster/wb@13.28.8", "", { "dependencies": { "chalk": "5.6.2", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fastest-levenshtein": "1.0.16", "globby": "16.2.0", "jsonc-parser": "3.3.1", "kill-port": "2.0.1", "minimal-promise-pool": "6.0.2", "yargs": "18.0.0" }, "bin": { "wb": "bin/index.js" } }, "sha512-SLYMnTPT09mNv7XLRG0UPpYU6BgWUs+aD2cVBAZz8As1KDnpKXVJ8eFOWVryOjZ6kzWv103s1p+kTAM+pHHbgA=="],
+
+    "@willbooster/wbfy/@willbooster/wb": ["@willbooster/wb@13.28.8", "", { "dependencies": { "chalk": "5.6.2", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fastest-levenshtein": "1.0.16", "globby": "16.2.0", "jsonc-parser": "3.3.1", "kill-port": "2.0.1", "minimal-promise-pool": "6.0.2", "yargs": "18.0.0" }, "bin": { "wb": "bin/index.js" } }, "sha512-SLYMnTPT09mNv7XLRG0UPpYU6BgWUs+aD2cVBAZz8As1KDnpKXVJ8eFOWVryOjZ6kzWv103s1p+kTAM+pHHbgA=="],
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -48,7 +48,7 @@
     "@types/node": "25.6.0",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "workspace:*",
+    "@willbooster/wb": "13.28.8",
     "blitz": "3.0.2",
     "build-ts": "17.1.34",
     "oxfmt": "0.59.0",

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -48,7 +48,7 @@
     "@types/node": "25.6.0",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "workspace:*",
+    "@willbooster/wb": "13.28.8",
     "build-ts": "17.1.34",
     "next": "16.2.6",
     "oxfmt": "0.59.0",

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -53,7 +53,7 @@
     "@types/node": "25.6.0",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "workspace:*",
+    "@willbooster/wb": "13.28.8",
     "build-ts": "17.1.34",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -57,7 +57,7 @@
     "@types/react-dom": "19.2.3",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "workspace:*",
+    "@willbooster/wb": "13.28.8",
     "babel-loader": "10.1.1",
     "build-ts": "17.1.34",
     "oxfmt": "0.59.0",

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -48,7 +48,7 @@
     "@types/node": "25.6.0",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "workspace:*",
+    "@willbooster/wb": "13.28.8",
     "build-ts": "17.1.34",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -58,7 +58,7 @@
     "@types/yargs": "17.0.35",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
-    "@willbooster/wb": "workspace:*",
+    "@willbooster/wb": "13.28.8",
     "build-ts": "17.1.34",
     "lefthook": "2.1.10",
     "oxfmt": "0.59.0",


### PR DESCRIPTION
## Summary
- `npm publish` (run by `@semantic-release/npm`) fails with `EUNSUPPORTEDPROTOCOL` on `workspace:*` specifiers, which aborted the v14.0.0 release run (run 29487041246) before any tag was created.
- Pin `@willbooster/wb` back to a concrete version (13.28.8) in the six dependent packages, as before the bun migration; bun installs it from the registry exactly like yarn did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
