### PR TITLE
feat(wbfy): install vinext packages without the minimum-release-age gate

### DIFF
--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -144,6 +144,13 @@ export const bunMinimumReleaseAgeExcludes = [
   'next',
   'react',
   'react-dom',
+  // vinext is still pre-1.0 and its scoped packages release in lockstep, so the whole
+  // set must be listed: excluding only `vinext` still fails because Bun gates the
+  // transitive `@vinext/types`. Bun matches these names literally, so `@vinext/*`
+  // would not work here even though wbfy's own pattern matcher accepts globs.
+  '@vinext/cloudflare',
+  '@vinext/types',
+  'vinext',
 ];
 
 export async function generateBunfigToml(config: PackageConfig): Promise<void> {


### PR DESCRIPTION
## Customer Summary

- Repositories generated or maintained by `wbfy` can now install the vinext framework (`vinext`, `@vinext/types`, `@vinext/cloudflare`) as soon as a version is published, instead of failing until the release is 5 days old.
- Previously `bun add vinext` simply failed in a wbfy-managed repo, which blocked anyone trying to start or update a vinext project.
- No action is needed for existing repositories: the next `wbfy` run refreshes `bunfig.toml` automatically. Nothing else about the 5-day safety window changes — it still applies to every other third-party package.

## Technical Summary

- Adds `vinext`, `@vinext/types`, and `@vinext/cloudflare` to `bunMinimumReleaseAgeExcludes` in `packages/wbfy/src/generators/bunfig.ts` (data-only change, 7 lines).
- That list feeds two paths, so both are covered by the single change: the generated `bunfig.toml` (`install.minimumReleaseAgeExcludes`) and wbfy's own age gate via `shouldApplyPackageAgeGate` in `packages/wbfy/src/generators/packageJson.ts`.
- Two non-obvious constraints, both verified against Bun 1.3.14 rather than assumed, and recorded in a code comment so the list is not "simplified" later:
  - **All three names are required.** Excluding only `vinext` still fails, because Bun gates the transitively resolved `@vinext/types` independently. `@vinext/cloudflare` peer-depends on `vinext` and releases in lockstep.
  - **A `@vinext/*` glob does not work.** Bun matches these entries literally. This is easy to get wrong because wbfy's own `doesPackagePatternMatch` *does* accept `*`, so the glob form looks correct and silently isn't.
- `create-vinext-app` is intentionally excluded: it is a `bunx` scaffolder that never lands in a `package.json`, so the age gate never applies to it.

## Why

- vinext is still pre-1.0 (`1.0.0-beta.2`) and publishes frequently, so the generated 5-day `minimumReleaseAge` window blocks installation outright:

  ```
  error: No version matching "@vinext/types" found for specifier "1.0.0-beta.2"
         (blocked by minimum-release-age: 432000 seconds)
  ```

- An explicit per-package exclusion matches how the file already handles other fast-moving toolchain packages (`typescript`, `oxlint`, `next`, `react`), and keeps the age gate intact for everything else. A glob would have been more concise but does not work (above).

## Testing

- `bun verify` — passes, exit 0, no type or lint errors.
- `bun run vitest run test/bunfig.test.ts test/packageConfig.test.ts` — 5 tests pass.
- Ran `generateBunfigToml` end-to-end into a temp directory and parsed the result with `smol-toml`: valid TOML containing all three entries.
- Used that **generated** `bunfig.toml` to run `bun add vinext@1.0.0-beta.2 @vinext/cloudflare@1.0.0-beta.2`; all three packages resolve at `1.0.0-beta.2`. The identical install failed before this change, which is what confirms the fix works rather than just the config parsing.

## Notes

- No test added: the list is plain data whose behavior belongs to Bun, so a unit test would only re-assert it against a mock. Per the repo's testing guidance, the external facts (glob handling, transitive gating) were verified once manually instead — see the Testing section.
- Not a breaking change; the exclusion list only widens.
