### PR TITLE
feat(wbfy): provision the VERDACCIO_TOKEN secret automatically

### DIFF
--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -62,7 +62,7 @@ interface Job {
   steps?: Step[];
   uses?: string;
   if?: string;
-  secrets?: Record<string, unknown>;
+  secrets?: Record<string, unknown> | 'inherit';
   with?: Record<string, unknown>;
 }
 
@@ -389,10 +389,13 @@ const installCapableReusableWorkflows = new Set(['autofix', 'deploy', 'gen-pr', 
 
 function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   job.with ??= {};
-  job.secrets ??= {};
+  // `secrets: inherit` (parsed by js-yaml as a plain string) already forwards every caller secret
+  // including the ones injected below, so preserve it untouched — property assignments on the
+  // string would throw.
+  const secrets = job.secrets === 'inherit' ? undefined : (job.secrets = job.secrets ?? {});
 
-  if (kind === 'test' || kind === 'release') {
-    job.secrets.GH_TOKEN = '${{ secrets.GITHUB_TOKEN }}';
+  if (secrets && (kind === 'test' || kind === 'release')) {
+    secrets.GH_TOKEN = '${{ secrets.GITHUB_TOKEN }}';
   }
 
   // fnox.toml carries age-encrypted app secrets; CI decrypts them with the FNOX_AGE_KEY repository secret.
@@ -404,25 +407,26 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   const calledReusableWorkflow = /\/reusable-workflows\/\.github\/workflows\/([^/@]+?)\.ya?ml@/u.exec(
     job.uses ?? ''
   )?.[1];
-  if (calledReusableWorkflow && installCapableReusableWorkflows.has(calledReusableWorkflow)) {
+  if (secrets && calledReusableWorkflow && installCapableReusableWorkflows.has(calledReusableWorkflow)) {
     // The callee generates the workspace .npmrc for @willbooster-private/* from VERDACCIO_TOKEN
     // before installing dependencies, which every repository needs regardless of its fnox
     // migration state.
-    job.secrets.VERDACCIO_TOKEN = '${{ secrets.VERDACCIO_TOKEN }}';
+    secrets.VERDACCIO_TOKEN = '${{ secrets.VERDACCIO_TOKEN }}';
     if (fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'))) {
-      job.secrets.FNOX_AGE_KEY = '${{ secrets.FNOX_AGE_KEY }}';
+      secrets.FNOX_AGE_KEY = '${{ secrets.FNOX_AGE_KEY }}';
     }
   }
 
-  if (job.secrets.FIREBASE_TOKEN) {
-    job.secrets.GCP_SA_KEY_JSON_FOR_FIREBASE = '${{ secrets.GCP_SA_KEY_JSON_FOR_FIREBASE }}';
-    delete job.secrets.FIREBASE_TOKEN;
+  if (secrets?.FIREBASE_TOKEN) {
+    secrets.GCP_SA_KEY_JSON_FOR_FIREBASE = '${{ secrets.GCP_SA_KEY_JSON_FOR_FIREBASE }}';
+    delete secrets.FIREBASE_TOKEN;
   }
   if (
-    (job.secrets.DISCORD_WEBHOOK_URL && (kind === 'release' || kind.startsWith('deploy'))) ||
-    (job.with.server_url && kind.startsWith('deploy'))
+    secrets &&
+    ((secrets.DISCORD_WEBHOOK_URL && (kind === 'release' || kind.startsWith('deploy'))) ||
+      (job.with.server_url && kind.startsWith('deploy')))
   ) {
-    job.secrets.DISCORD_WEBHOOK_URL = '${{ secrets.DISCORD_WEBHOOK_URL_FOR_RELEASE }}';
+    secrets.DISCORD_WEBHOOK_URL = '${{ secrets.DISCORD_WEBHOOK_URL_FOR_RELEASE }}';
   }
 
   if (kind === 'sync') {
@@ -453,7 +457,7 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   }
 
   // Don't use `fly deploy --json` since it causes an error
-  if (kind.startsWith('deploy') && job.secrets.FLY_API_TOKEN && typeof job.with.deploy_command === 'string') {
+  if (kind.startsWith('deploy') && secrets?.FLY_API_TOKEN && typeof job.with.deploy_command === 'string') {
     job.with.deploy_command = job.with.deploy_command.replace(/\s+--json/, '');
   }
   if (config.doesContainDockerfile && !job.with.ci_label && kind.startsWith('test')) {
@@ -473,13 +477,15 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   } else {
     delete job.with;
   }
-  if (Object.keys(job.secrets).length > 0) {
-    // Move secrets prop after with prop
-    const newSecrets = sortKeys(job.secrets);
-    delete job.secrets;
-    job.secrets = newSecrets;
-  } else {
-    delete job.secrets;
+  if (secrets) {
+    if (Object.keys(secrets).length > 0) {
+      // Move secrets prop after with prop
+      const newSecrets = sortKeys(secrets);
+      delete job.secrets;
+      job.secrets = newSecrets;
+    } else {
+      delete job.secrets;
+    }
   }
 }
 

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -382,9 +382,10 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
   }
 }
 
-// The reusable workflows that declare FNOX_AGE_KEY under on.workflow_call.secrets
-// (see WillBooster/reusable-workflows). Passing the secret to any other callee is a GitHub error.
-const fnoxAwareReusableWorkflows = new Set(['autofix', 'deploy', 'gen-pr', 'release', 'run-script', 'test']);
+// The reusable workflows that declare FNOX_AGE_KEY and VERDACCIO_TOKEN under
+// on.workflow_call.secrets (see WillBooster/reusable-workflows). Passing either secret to any
+// other callee is a GitHub error.
+const installCapableReusableWorkflows = new Set(['autofix', 'deploy', 'gen-pr', 'release', 'run-script', 'test']);
 
 function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   job.with ??= {};
@@ -403,12 +404,14 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   const calledReusableWorkflow = /\/reusable-workflows\/\.github\/workflows\/([^/@]+?)\.ya?ml@/u.exec(
     job.uses ?? ''
   )?.[1];
-  if (
-    fs.existsSync(path.resolve(config.dirPath, 'fnox.toml')) &&
-    calledReusableWorkflow &&
-    fnoxAwareReusableWorkflows.has(calledReusableWorkflow)
-  ) {
-    job.secrets.FNOX_AGE_KEY = '${{ secrets.FNOX_AGE_KEY }}';
+  if (calledReusableWorkflow && installCapableReusableWorkflows.has(calledReusableWorkflow)) {
+    // The callee generates the workspace .npmrc for @willbooster-private/* from VERDACCIO_TOKEN
+    // before installing dependencies, which every repository needs regardless of its fnox
+    // migration state.
+    job.secrets.VERDACCIO_TOKEN = '${{ secrets.VERDACCIO_TOKEN }}';
+    if (fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'))) {
+      job.secrets.FNOX_AGE_KEY = '${{ secrets.FNOX_AGE_KEY }}';
+    }
   }
 
   if (job.secrets.FIREBASE_TOKEN) {

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -24,8 +24,11 @@ const DEPRECATED_SECRET_NAMES = ['READY_DISCORD_WEBHOOK_URL', 'GH_BOT_PAT', 'PUB
 // The Verdaccio auth token the reusable workflows need as the VERDACCIO_TOKEN secret, age-encrypted
 // for the CI recipient of FNOX_AGE_RECIPIENTS only: this repository is public, so the plaintext must
 // never be committed, and the CI identity is the only one wbfy --env already requires locally.
-// To rotate: in an empty directory whose fnox.toml declares only the CI recipient, run
+// To rotate the TOKEN: in an empty directory whose fnox.toml declares only the CI recipient, run
 // `printf '%s' "$TOKEN" | fnox set VERDACCIO_TOKEN` and copy the generated `value` here.
+// CAUTION: rotating the CI IDENTITY must re-encrypt this value for the new public key in the SAME
+// change as the FNOX_AGE_RECIPIENTS update — decryptVerdaccioToken gates every upload, so a wbfy
+// whose recipient list and ciphertext disagree cannot upload anything (including the new key).
 const ENCRYPTED_VERDACCIO_TOKEN =
   'YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBud2p2dXFLV2N1NEFaR1MvSnBMVG9WcTY3V3RNd0wwZG9NRStiMXRDV2pRCnlEQ21BRDF6QWhzandFQWhJZlZGTWdKZGhJcDNEK1E3czJPUkpUblg1YVEKLT4gbHgpWy1ncmVhc2UgQFxVb1EgNWJEYDl5ayA+bAphc1hoTHAydmc4akFxMnNBWWp1YWhlV0I1aytMOFB6YUloZ0tuaFdqNGcKLS0tIGZVOW1zQ2xveDREOC95RkFnTEFPdmFXc0FkV212bUNnV2Y3cWcxb3hWRFkKR8rA6Rshr0v84bWEG2Mnr9H04HcBZylYGEp7U19Dp1sqwQ1yKls8Rz5QtzY5SjYY/kEfMfp4JMgBexxFTnbI7nl79u5FSOrPce+xrYZFMnZhv06zB8shZgiidqkTdcwU+rGB2ei72VTItox9CqmvpGgeonuTuhOP5+9wOPb2E6IC8FpeZLGHczSYxmuIOPMdt80IrjBfqECcv0u6cWDAOHuzwx4j9tyxl49YgU56lA9XOMA2+mSfeq/dBkTFf9Hap8eLcXzGE25TT/xMWkf6cDIn+z8JpzNuyBQUKggggtztooJ7k7ulkr1JaSyFlVCPIrPNBdo/FDbSy9aG';
 const require = createRequire(import.meta.url);
@@ -33,6 +36,9 @@ const require = createRequire(import.meta.url);
 export async function setupSecrets(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('setupSecrets', async () => {
     const [owner, repo] = gitHubUtil.getOrgAndName(config.repository ?? '');
+    // Deliberately WillBoosterLab-only (including VERDACCIO_TOKEN): WillBooster-org repositories
+    // are provisioned manually. The VERDACCIO_TOKEN reference injected into their workflows is
+    // harmless meanwhile — the reusable workflows skip .npmrc generation when the secret is empty.
     if (!owner || !repo || owner !== 'WillBoosterLab') return;
     if (!hasGitHubToken(owner) || !options.doesUploadEnvVars) return;
 
@@ -90,7 +96,7 @@ async function uploadSecrets(config: PackageConfig, owner: string, repo: string)
     const unsupportedPaths = [...remoteFnoxContents.keys()].filter((relPath) => path.basename(relPath) !== 'fnox.toml');
     if (unsupportedPaths.length > 0) {
       console.error(
-        `Skip uploading FNOX_AGE_KEY because the default branch of ${owner}/${repo} contains unsupported fnox config files: ${unsupportedPaths.join(', ')}. Merge them into the adjacent fnox.toml.`
+        `Skip uploading secrets because the default branch of ${owner}/${repo} contains unsupported fnox config files: ${unsupportedPaths.join(', ')}. Merge them into the adjacent fnox.toml.`
       );
       process.exitCode = 1;
       return;
@@ -98,7 +104,7 @@ async function uploadSecrets(config: PackageConfig, owner: string, repo: string)
     const rootContent = remoteFnoxContents.get('fnox.toml');
     if (!rootContent) {
       console.error(
-        `Skip uploading FNOX_AGE_KEY because the default branch of ${owner}/${repo} has no root fnox.toml. Merge and push the fnox migration to the default branch, then rerun wbfy --env.`
+        `Skip uploading secrets because the default branch of ${owner}/${repo} has no root fnox.toml. Merge and push the fnox migration to the default branch, then rerun wbfy --env.`
       );
       process.exitCode = 1;
       return;
@@ -113,7 +119,7 @@ async function uploadSecrets(config: PackageConfig, owner: string, repo: string)
       const layoutIssue = findFnoxLayoutIssue(content);
       if (layoutIssue) {
         console.error(
-          `Skip uploading FNOX_AGE_KEY because ${relPath} on the default branch ${layoutIssue}. Fix it (wbfy reports the same issue during synchronization), push, and rerun wbfy --env.`
+          `Skip uploading secrets because ${relPath} on the default branch ${layoutIssue}. Fix it (wbfy reports the same issue during synchronization), push, and rerun wbfy --env.`
         );
         process.exitCode = 1;
         return;
@@ -124,7 +130,7 @@ async function uploadSecrets(config: PackageConfig, owner: string, repo: string)
       if (!recipients) {
         if (relPath === 'fnox.toml') {
           console.error(
-            `Skip uploading FNOX_AGE_KEY because fnox.toml on the default branch declares no [providers.age] table.`
+            `Skip uploading secrets because fnox.toml on the default branch declares no [providers.age] table.`
           );
           process.exitCode = 1;
           return;
@@ -143,7 +149,7 @@ async function uploadSecrets(config: PackageConfig, owner: string, repo: string)
       );
       if (missingRecipients.length > 0 || unexpectedRecipients.length > 0) {
         console.error(
-          `Skip uploading FNOX_AGE_KEY because [providers.age].recipients in ${relPath} on the default branch does not match FNOX_AGE_RECIPIENTS exactly (missing: ${missingRecipients
+          `Skip uploading secrets because [providers.age].recipients in ${relPath} on the default branch does not match FNOX_AGE_RECIPIENTS exactly (missing: ${missingRecipients
             .map((recipient) => recipient.publicKey)
             .join(
               ', '
@@ -308,7 +314,7 @@ function readCiAgeSecretKey(): string | undefined {
     content = fs.readFileSync(identityPath, 'utf8');
   } catch {
     console.error(
-      `Failed to upload secrets because ${identityPath} is missing. Copy the existing CI age identity from the team credential store to that path (run \`mkdir -p ~/.config/fnox\` first); the personal ~/.config/fnox/age.txt is deliberately not used. Generate a brand-new identity with age-keygen only when rotating the CI key, and register its public key in FNOX_AGE_RECIPIENTS.`
+      `Failed to upload secrets because ${identityPath} is missing. Copy the existing CI age identity from the team credential store to that path (run \`mkdir -p ~/.config/fnox\` first); the personal ~/.config/fnox/age.txt is deliberately not used. Generate a brand-new identity with age-keygen only when rotating the CI key, register its public key in FNOX_AGE_RECIPIENTS, and re-encrypt ENCRYPTED_VERDACCIO_TOKEN for it in the same change.`
     );
     return undefined;
   }
@@ -369,11 +375,20 @@ VERDACCIO_TOKEN = { provider = "age", value = "${ENCRYPTED_VERDACCIO_TOKEN}" }
       stdio: 'pipe',
       env,
     });
+    // A non-migrated repository pins no fnox through mise, so resolveFnoxCommand may fall back to
+    // a bare `fnox` that is absent from PATH; a failed spawn (status null) must not be reported as
+    // a decryption failure — the advised re-encryption would not fix it.
+    if (proc.error || proc.status === null) {
+      console.error(
+        `Failed to upload secrets because the fnox command (${fnoxCommand}) could not be executed. Install fnox globally (e.g. \`mise use -g fnox\`) and rerun wbfy --env. Reported: ${(proc.error?.message ?? proc.stderr ?? '').trim()}`
+      );
+      return undefined;
+    }
     // `fnox get` appends a newline; the token itself never contains one.
     const token = proc.status === 0 ? proc.stdout.replace(/\n+$/u, '') : '';
     if (!token) {
       console.error(
-        `Failed to upload secrets because the CI age key cannot decrypt the embedded VERDACCIO_TOKEN. Re-encrypt it for the CI recipient (see the comment on ENCRYPTED_VERDACCIO_TOKEN) and release wbfy. fnox reported:\n${(proc.stderr || proc.error?.message || '').trim()}`
+        `Failed to upload secrets because the CI age key cannot decrypt the embedded VERDACCIO_TOKEN. Re-encrypt it for the CI recipient (see the comment on ENCRYPTED_VERDACCIO_TOKEN) and release wbfy. fnox reported:\n${(proc.stderr || '').trim()}`
       );
       return undefined;
     }
@@ -429,7 +444,7 @@ function verifyCiKeyDecryptsAllSecrets(
         );
         if (proc.status !== 0) {
           console.error(
-            `Skip uploading FNOX_AGE_KEY because the CI age key cannot decrypt every secret governed by ${relPath} on the default branch. Run \`fnox reencrypt\` with the full recipient list, push, and rerun wbfy --env. fnox reported:\n${(proc.stderr || proc.error?.message || '').trim()}`
+            `Skip uploading secrets because the CI age key cannot decrypt every secret governed by ${relPath} on the default branch. Run \`fnox reencrypt\` with the full recipient list, push, and rerun wbfy --env. fnox reported:\n${(proc.stderr || proc.error?.message || '').trim()}`
           );
           return false;
         }

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -21,6 +21,13 @@ import type { PackageConfig } from '../packageConfig.js';
 import { getOctokit, gitHubUtil, hasGitHubToken } from '../utils/githubUtil.js';
 
 const DEPRECATED_SECRET_NAMES = ['READY_DISCORD_WEBHOOK_URL', 'GH_BOT_PAT', 'PUBLIC_GH_BOT_PAT'];
+// The Verdaccio auth token the reusable workflows need as the VERDACCIO_TOKEN secret, age-encrypted
+// for the CI recipient of FNOX_AGE_RECIPIENTS only: this repository is public, so the plaintext must
+// never be committed, and the CI identity is the only one wbfy --env already requires locally.
+// To rotate: in an empty directory whose fnox.toml declares only the CI recipient, run
+// `printf '%s' "$TOKEN" | fnox set VERDACCIO_TOKEN` and copy the generated `value` here.
+const ENCRYPTED_VERDACCIO_TOKEN =
+  'YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBud2p2dXFLV2N1NEFaR1MvSnBMVG9WcTY3V3RNd0wwZG9NRStiMXRDV2pRCnlEQ21BRDF6QWhzandFQWhJZlZGTWdKZGhJcDNEK1E3czJPUkpUblg1YVEKLT4gbHgpWy1ncmVhc2UgQFxVb1EgNWJEYDl5ayA+bAphc1hoTHAydmc4akFxMnNBWWp1YWhlV0I1aytMOFB6YUloZ0tuaFdqNGcKLS0tIGZVOW1zQ2xveDREOC95RkFnTEFPdmFXc0FkV212bUNnV2Y3cWcxb3hWRFkKR8rA6Rshr0v84bWEG2Mnr9H04HcBZylYGEp7U19Dp1sqwQ1yKls8Rz5QtzY5SjYY/kEfMfp4JMgBexxFTnbI7nl79u5FSOrPce+xrYZFMnZhv06zB8shZgiidqkTdcwU+rGB2ei72VTItox9CqmvpGgeonuTuhOP5+9wOPb2E6IC8FpeZLGHczSYxmuIOPMdt80IrjBfqECcv0u6cWDAOHuzwx4j9tyxl49YgU56lA9XOMA2+mSfeq/dBkTFf9Hap8eLcXzGE25TT/xMWkf6cDIn+z8JpzNuyBQUKggggtztooJ7k7ulkr1JaSyFlVCPIrPNBdo/FDbSy9aG';
 const require = createRequire(import.meta.url);
 
 export async function setupSecrets(config: PackageConfig): Promise<void> {
@@ -59,6 +66,19 @@ async function uploadSecrets(config: PackageConfig, owner: string, repo: string)
     contents: remoteFnoxContents,
     defaultBranch,
   } = await fetchDefaultBranchFnoxConfigs(octokit, owner, repo);
+  // Verdaccio auth is orthogonal to the fnox migration state (the reusable workflows generate the
+  // workspace .npmrc from the VERDACCIO_TOKEN secret either way), so decrypt the token with the CI
+  // identity up front and upload it on both branches below.
+  const ciAgeKey = readCiAgeSecretKey();
+  if (!ciAgeKey) {
+    process.exitCode = 1;
+    return;
+  }
+  const verdaccioToken = decryptVerdaccioToken(ciAgeKey, config.dirPath);
+  if (!verdaccioToken) {
+    process.exitCode = 1;
+    return;
+  }
   let secretsToUpload: Record<string, string>;
   let obsoleteSecretNames: string[];
   // Choose fnox vs dotenv SOLELY from the remote default branch: an unmerged local migration
@@ -133,25 +153,22 @@ async function uploadSecrets(config: PackageConfig, owner: string, repo: string)
         return;
       }
     }
-    const ageKey = readCiAgeSecretKey();
-    if (!ageKey) {
-      process.exitCode = 1;
-      return;
-    }
     // Matching recipients do not prove the committed ciphertexts were actually re-encrypted for
     // the CI key (e.g. someone hand-added the recipient without `fnox reencrypt`), so decrypt
     // every age secret of the default branch with ONLY the CI key before replacing the secret.
-    if (!verifyCiKeyDecryptsAllSecrets(remoteFnoxContents, ageKey, config.dirPath)) {
+    if (!verifyCiKeyDecryptsAllSecrets(remoteFnoxContents, ciAgeKey, config.dirPath)) {
       process.exitCode = 1;
       return;
     }
-    secretsToUpload = { FNOX_AGE_KEY: ageKey };
+    secretsToUpload = { FNOX_AGE_KEY: ciAgeKey, VERDACCIO_TOKEN: verdaccioToken };
     obsoleteSecretNames = [...DEPRECATED_SECRET_NAMES, 'DOT_ENV', 'DOT_ENV_PRODUCTION'];
   } else {
     // dotenv.config would also inject the values into process.env, leaking this repository's
     // secrets to every later subprocess and repository handled in the same wbfy invocation.
     const envPath = path.resolve(config.dirPath, '.env');
     secretsToUpload = fs.existsSync(envPath) ? dotenv.parse(fs.readFileSync(envPath, 'utf8')) : {};
+    // The decrypted token is the canonical value; a stale copy in .env must not win.
+    secretsToUpload['VERDACCIO_TOKEN'] = verdaccioToken;
     for (const name of ['GH_BOT_PAT', 'GH_BOT_PAT_FOR_WILLBOOSTER', 'GH_BOT_PAT_FOR_WILLBOOSTERLAB']) {
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete secretsToUpload[name];
@@ -291,7 +308,7 @@ function readCiAgeSecretKey(): string | undefined {
     content = fs.readFileSync(identityPath, 'utf8');
   } catch {
     console.error(
-      `Failed to upload FNOX_AGE_KEY because ${identityPath} is missing. Copy the existing CI age identity from the team credential store to that path (run \`mkdir -p ~/.config/fnox\` first); the personal ~/.config/fnox/age.txt is deliberately not used. Generate a brand-new identity with age-keygen only when rotating the CI key, and register its public key in FNOX_AGE_RECIPIENTS.`
+      `Failed to upload secrets because ${identityPath} is missing. Copy the existing CI age identity from the team credential store to that path (run \`mkdir -p ~/.config/fnox\` first); the personal ~/.config/fnox/age.txt is deliberately not used. Generate a brand-new identity with age-keygen only when rotating the CI key, and register its public key in FNOX_AGE_RECIPIENTS.`
     );
     return undefined;
   }
@@ -307,16 +324,63 @@ function readCiAgeSecretKey(): string | undefined {
   const commentedPublicKey = publicKeyLine?.split('public key:')[1]?.trim();
   if (!ciPublicKey || commentedPublicKey !== ciPublicKey) {
     console.error(
-      `Failed to upload FNOX_AGE_KEY because the \`# public key:\` comment in ${identityPath} is missing or differs from the CI age public key (${ciPublicKey}), so the file does not hold the CI-dedicated identity.`
+      `Failed to upload secrets because the \`# public key:\` comment in ${identityPath} is missing or differs from the CI age public key (${ciPublicKey}), so the file does not hold the CI-dedicated identity.`
     );
     return undefined;
   }
   const keyLine = lines.find((line) => line.trim().startsWith('AGE-SECRET-KEY-'));
   if (!keyLine) {
-    console.error(`Failed to upload FNOX_AGE_KEY because ${identityPath} contains no AGE-SECRET-KEY line.`);
+    console.error(`Failed to upload secrets because ${identityPath} contains no AGE-SECRET-KEY line.`);
     return undefined;
   }
   return keyLine.trim();
+}
+
+// Decrypts ENCRYPTED_VERDACCIO_TOKEN with the CI age identity by running `fnox get` on a minimal
+// fnox.toml in a temporary directory, under the same isolation as verifyCiKeyDecryptsAllSecrets
+// (outside any repository so fnox's parent search finds nothing else; isolated HOME with all
+// FNOX_* variables stripped, so ONLY the CI key can contribute to decryption).
+function decryptVerdaccioToken(ciAgeKey: string, repoDirPath: string): string | undefined {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-verdaccio-'));
+  const emptyHomeDirPath = path.join(tempDirPath, 'home');
+  const fnoxCommand = resolveFnoxCommand(repoDirPath);
+  try {
+    fs.mkdirSync(emptyHomeDirPath, { recursive: true });
+    const ciPublicKey = FNOX_AGE_RECIPIENTS.find((recipient) => recipient.name === 'ci')?.publicKey ?? '';
+    fs.writeFileSync(
+      path.join(tempDirPath, 'fnox.toml'),
+      `[providers.age]
+type = "age"
+recipients = ["${ciPublicKey}"]
+
+[secrets]
+VERDACCIO_TOKEN = { provider = "age", value = "${ENCRYPTED_VERDACCIO_TOKEN}" }
+`
+    );
+    const env = {
+      ...Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('FNOX_'))),
+      FNOX_AGE_KEY: ciAgeKey,
+      HOME: emptyHomeDirPath,
+      XDG_CONFIG_HOME: emptyHomeDirPath,
+    };
+    const proc = child_process.spawnSync(fnoxCommand, ['get', '--no-daemon', 'VERDACCIO_TOKEN'], {
+      cwd: tempDirPath,
+      encoding: 'utf8',
+      stdio: 'pipe',
+      env,
+    });
+    // `fnox get` appends a newline; the token itself never contains one.
+    const token = proc.status === 0 ? proc.stdout.replace(/\n+$/u, '') : '';
+    if (!token) {
+      console.error(
+        `Failed to upload secrets because the CI age key cannot decrypt the embedded VERDACCIO_TOKEN. Re-encrypt it for the CI recipient (see the comment on ENCRYPTED_VERDACCIO_TOKEN) and release wbfy. fnox reported:\n${(proc.stderr || proc.error?.message || '').trim()}`
+      );
+      return undefined;
+    }
+    return token;
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
 }
 
 // Proves the CI key alone can decrypt every age secret of the given (remote default-branch) fnox


### PR DESCRIPTION
## Customer Summary

- Setting up the `VERDACCIO_TOKEN` GitHub secret (needed by CI to install private `@willbooster-private/*` packages) is no longer a manual per-repository step: `wbfy --env` now uploads it automatically for WillBoosterLab repositories.
- wbfy-generated caller workflows now pass `VERDACCIO_TOKEN` to the reusable workflows automatically, so private-package installs on CI work without hand-editing workflow files.
- This removes a known operational hazard where a manual command could silently store an empty secret and break CI in a hard-to-diagnose way.

## Technical Summary

- `packages/wbfy/src/github/secret.ts`:
  - Embed the Verdaccio auth token as `ENCRYPTED_VERDACCIO_TOKEN`, an fnox/age ciphertext encrypted for the CI age recipient only (this repository is public; no plaintext is committed). Rotation procedures for both the token and the CI identity are documented on the constant — rotating the CI identity must re-encrypt this value in the same change.
  - `decryptVerdaccioToken` decrypts it via `fnox get` on a minimal `fnox.toml` in a temp directory under the same isolation as the existing CI-key decryptability check (outside any repo, isolated HOME, `FNOX_*` stripped). A failed fnox spawn (missing binary on non-migrated repos) is reported distinctly from a decryption failure.
  - `uploadSecrets` reads the CI identity and decrypts the token before the fnox/dotenv branch and uploads `VERDACCIO_TOKEN` on both paths (on the dotenv path the decrypted value overrides any stale `.env` copy). Fail-closed messages now say "Skip uploading secrets" since they block both secrets. Upload remains deliberately WillBoosterLab-only (WillBooster-org repos are provisioned manually).
- `packages/wbfy/src/generators/workflow.ts`:
  - Inject `VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}` into every caller of the six install-capable reusable workflows (`autofix`, `deploy`, `gen-pr`, `release`, `run-script`, `test`), keyed on the called workflow; `FNOX_AGE_KEY` injection stays gated on `fnox.toml`. The set is renamed to `installCapableReusableWorkflows`.
  - Preserve `secrets: inherit` in caller workflows instead of crashing on property assignment to the string js-yaml parses it into (pre-existing defect for `GH_TOKEN`, widened by the new injection; found in review).

## Why

- The reusable workflows generate the workspace `.npmrc` for the private Verdaccio registry from the `VERDACCIO_TOKEN` secret, but provisioning it was a manual `gh secret set` step per repository with a silent-empty-secret hazard, and the `secrets:` entry had to be hand-added to every caller workflow.
- Embedding the token as CI-recipient-only age ciphertext mirrors the existing `FNOX_AGE_KEY` design (shared PR #963): the public repository holds only ciphertext, and the CI identity wbfy --env already requires is the single decryption key.

## Testing

- Round-trip verified locally: decrypting the embedded ciphertext with only the CI age key in the function's real isolation reproduces the token from `~/.npmrc` (compared via SHA-256).
- `bun verify` passes.
- Multi-agent review (Codex, Claude Code, Antigravity) ran to completion with all findings fixed and re-reviews reporting no concern.

## Notes

- `wbfy --env` still does nothing for WillBooster-org repositories by design; provision their secrets manually.
- Rotating the CI age identity now requires re-encrypting `ENCRYPTED_VERDACCIO_TOKEN` for the new key in the same change as the `FNOX_AGE_RECIPIENTS` update.
