### PR TITLE
fix(wbfy): stop clobbering JSONC configs and confine writes to the repository

### DIFF
--- a/packages/wbfy/src/fixers/prisma.ts
+++ b/packages/wbfy/src/fixers/prisma.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import fg from 'fast-glob';
 
 import { logger } from '../logger.js';
+import { fsUtil } from '../utils/fsUtil.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { globIgnore } from '../utils/globUtil.js';
 
@@ -21,7 +22,7 @@ export async function fixPrismaEnvFiles(config: PackageConfig): Promise<void> {
         }
       );
       if (newContent !== content) {
-        await fs.writeFile(envFilePath, newContent);
+        await fsUtil.writeFileConfined(envFilePath, newContent);
       }
     }
   });

--- a/packages/wbfy/src/fixers/typos.ts
+++ b/packages/wbfy/src/fixers/typos.ts
@@ -22,7 +22,7 @@ export async function fixTypos(packageConfig: PackageConfig): Promise<void> {
     for (const mdFile of docFiles) {
       const filePath = path.join(dirPath, mdFile);
       void promisePool.run(async () => {
-        const content = await fsUtil.readFileIgnoringError(filePath);
+        const content = await fsUtil.readFileIfExists(filePath);
         if (content === undefined) return;
         let newContent = fixTyposInText(content);
         newContent = replaceWithConfig(newContent, packageConfig, 'doc');
@@ -45,7 +45,7 @@ export async function fixTypos(packageConfig: PackageConfig): Promise<void> {
     for (const tsFile of tsFiles) {
       const filePath = path.join(dirPath, tsFile);
       void promisePool.run(async () => {
-        const oldContent = await fsUtil.readFileIgnoringError(filePath);
+        const oldContent = await fsUtil.readFileIfExists(filePath);
         if (oldContent === undefined) return;
         let newContent = fixTyposInCode(oldContent);
         newContent = replaceWithConfig(newContent, packageConfig, 'ts');
@@ -67,7 +67,7 @@ export async function fixTypos(packageConfig: PackageConfig): Promise<void> {
     for (const file of textBasedFiles) {
       const filePath = path.join(dirPath, file);
       void promisePool.run(async () => {
-        const oldContent = await fsUtil.readFileIgnoringError(filePath);
+        const oldContent = await fsUtil.readFileIfExists(filePath);
         if (oldContent === undefined) return;
         let newContent = fixTyposInText(oldContent);
         newContent = replaceWithConfig(newContent, packageConfig, 'text');

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -11,7 +11,7 @@ export async function generateAgentInstructions(rootConfig: PackageConfig, allCo
 
     // Check if AGENTS_EXTRA.md exists and read its content
     const agentsExtraPath = path.resolve(rootConfig.dirPath, 'AGENTS_EXTRA.md');
-    const extraContent = await fsUtil.readFileIgnoringError(agentsExtraPath);
+    const extraContent = await fsUtil.readFileIfExists(agentsExtraPath);
 
     for (const [fileName, toolName] of [
       ['AGENTS.md', 'Codex CLI'],

--- a/packages/wbfy/src/generators/dockerignore.ts
+++ b/packages/wbfy/src/generators/dockerignore.ts
@@ -64,7 +64,7 @@ export async function generateDockerignore(config: PackageConfig): Promise<void>
   return logger.functionIgnoringException('generateDockerignore', async () => {
     const filePath = path.resolve(config.dirPath, '.dockerignore');
     if (config.doesContainDockerfile) {
-      const content = (await fsUtil.readFileIgnoringError(filePath)) ?? '';
+      const content = (await fsUtil.readFileIfExists(filePath)) ?? '';
       const headUserContent = ignoreFileUtil.getHeadUserContent(content);
       const tailUserContent = ignoreFileUtil.getTailUserContent(content);
 

--- a/packages/wbfy/src/generators/geminiConfig.ts
+++ b/packages/wbfy/src/generators/geminiConfig.ts
@@ -54,7 +54,7 @@ export async function generateGeminiConfig(config: PackageConfig, allConfigs: Pa
       },
     });
 
-    const extraContent = await fsUtil.readFileIgnoringError(agentsExtraPath);
+    const extraContent = await fsUtil.readFileIfExists(agentsExtraPath);
     const codingRuleExtraContent = extraContent?.trimStart().startsWith('#') ? undefined : extraContent;
     const reviewLanguageInstruction = config.isPublicRepo
       ? 'Review in English based on the following coding standards.'

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -42,7 +42,7 @@ tmp/
 export async function generateGitignore(config: PackageConfig, rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateGitignore', async () => {
     const filePath = path.resolve(config.dirPath, '.gitignore');
-    const content = (await fsUtil.readFileIgnoringError(filePath)) ?? '';
+    const content = (await fsUtil.readFileIfExists(filePath)) ?? '';
     let headUserContent = ignoreFileUtil.getHeadUserContent(content) + commonContent;
     const tailUserContent = ignoreFileUtil.getTailUserContent(content);
 

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import yaml from 'js-yaml';
 
 import { logger } from '../logger.js';
+import { fsUtil } from '../utils/fsUtil.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { extensions } from '../utils/extensions.js';
 import { getGenI18nTsCommand } from '../utils/genI18nTs.js';
@@ -118,7 +119,7 @@ async function core(config: PackageConfig): Promise<void> {
     delete settings['pre-push'];
   }
   await Promise.all([
-    fs.promises.writeFile(
+    fsUtil.writeFileConfined(
       path.join(config.dirPath, 'lefthook.yml'),
       yaml.dump(settings, {
         lineWidth: -1,

--- a/packages/wbfy/src/generators/miseToml.ts
+++ b/packages/wbfy/src/generators/miseToml.ts
@@ -100,23 +100,28 @@ function readNodeVersionFile(dirPath: string): string | undefined {
   try {
     const version = fs.readFileSync(path.resolve(dirPath, '.node-version'), 'utf8').trim().replace(/^v/u, '');
     return version || undefined;
-  } catch {
-    return undefined;
+  } catch (error) {
+    // An unreadable file must abort instead of being ignored; the file is a migration source.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
   }
 }
 
 function readToolVersions(dirPath: string): Map<string, string[]> {
   const versions = new Map<string, string[]>();
+  let content: string | undefined;
   try {
-    const content = fs.readFileSync(path.resolve(dirPath, '.tool-versions'), 'utf8');
-    for (const line of content.split('\n')) {
-      const [tool, ...toolVersions] = line.replace(/#.*$/u, '').trim().split(/\s+/u);
-      if (tool && toolVersions.length > 0) {
-        versions.set(tool, toolVersions);
-      }
+    content = fs.readFileSync(path.resolve(dirPath, '.tool-versions'), 'utf8');
+  } catch (error) {
+    // Only a repository without .tool-versions has nothing to migrate; an unreadable file must
+    // abort instead of being silently discarded (it is deleted after mise.toml is written).
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  for (const line of content?.split('\n') ?? []) {
+    const [tool, ...toolVersions] = line.replace(/#.*$/u, '').trim().split(/\s+/u);
+    if (tool && toolVersions.length > 0) {
+      versions.set(tool, toolVersions);
     }
-  } catch {
-    // A repository without .tool-versions has nothing to migrate.
   }
   return versions;
 }

--- a/packages/wbfy/src/generators/miseToml.ts
+++ b/packages/wbfy/src/generators/miseToml.ts
@@ -46,8 +46,11 @@ export async function generateMiseToml(config: PackageConfig, currentBunVersion:
     }
     settings.tools = tools;
 
-    await fsUtil.generateFile(miseTomlPath, stringify(settings));
-    await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.tool-versions'), { force: true }));
+    // Delete the migration source only after the replacement actually landed; a refused write
+    // (e.g. a symlinked mise.toml) must not destroy the only tool configuration.
+    if (await fsUtil.generateFile(miseTomlPath, stringify(settings))) {
+      await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.tool-versions'), { force: true }));
+    }
   });
 }
 

--- a/packages/wbfy/src/generators/miseToml.ts
+++ b/packages/wbfy/src/generators/miseToml.ts
@@ -87,9 +87,11 @@ function parseMiseToml(miseTomlPath: string): MiseToml {
   let content: string;
   try {
     content = fs.readFileSync(miseTomlPath, 'utf8');
-  } catch {
-    // A repository without mise.toml starts from an empty configuration.
-    return {};
+  } catch (error) {
+    // Only a repository without mise.toml starts from an empty configuration; an unreadable file
+    // (e.g. permissions) must abort instead of being overwritten with generated settings.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw error;
   }
   return parse(content) as MiseToml;
 }

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -19,7 +19,7 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
   return logger.functionIgnoringException('generateOxfmtConfig', async () => {
     const legacyJsonConfigPath = path.resolve(config.dirPath, '.oxfmtrc.json');
     const filePath = path.resolve(config.dirPath, 'oxfmt.config.ts');
-    const existingContent = await fsUtil.readFileIgnoringError(filePath);
+    const existingContent = await fsUtil.readFileIfExists(filePath);
     const desiredContent = managedConfigBlocks.getConfigContent({
       desiredContent: getConfigContent(config),
       existingContent,

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -25,11 +25,15 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
       existingContent,
       filePath,
     });
-    const promises = [promisePool.run(() => fs.promises.rm(legacyJsonConfigPath, { force: true }))];
-    if (normalizeConfigContent(existingContent) !== normalizeConfigContent(desiredContent)) {
-      promises.push(promisePool.run(() => fsUtil.generateFile(filePath, desiredContent)));
+    // Remove the superseded legacy config only when the replacement landed (or none was needed):
+    // a refused write (e.g. a symlinked config) must not leave the repository with no config.
+    if (
+      normalizeConfigContent(existingContent) !== normalizeConfigContent(desiredContent) &&
+      !(await fsUtil.generateFile(filePath, desiredContent))
+    ) {
+      return;
     }
-    await Promise.all(promises);
+    await promisePool.run(() => fs.promises.rm(legacyJsonConfigPath, { force: true }));
   });
 }
 

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -23,7 +23,7 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
     // managed blocks are still safe to update.
     const shouldPreservePublishedLinterConfig = isPublishedWillboosterConfigsPackage(config);
     const filePath = path.resolve(config.dirPath, 'oxlint.config.ts');
-    const existingContent = await fsUtil.readFileIgnoringError(filePath);
+    const existingContent = await fsUtil.readFileIfExists(filePath);
     const shouldPreserveExistingContent =
       shouldPreservePublishedLinterConfig && existingContent && !managedConfigBlocks.hasManagedBlocks(existingContent);
     const desiredContent = shouldPreserveExistingContent

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -36,6 +36,14 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
           })
         );
 
+    // Remove the superseded legacy configs only when the replacement landed (or none was needed):
+    // a refused write (e.g. a symlinked config) must not leave the repository with no config.
+    if (
+      normalizeConfigContent(existingContent) !== normalizeConfigContent(desiredContent) &&
+      !(await fsUtil.generateFile(filePath, desiredContent))
+    ) {
+      return;
+    }
     const promises: Promise<void>[] = [];
     if (!shouldPreservePublishedLinterConfig) {
       promises.push(
@@ -53,9 +61,6 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
         promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.mjs'), { force: true })),
         promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, 'eslint.config.ts'), { force: true }))
       );
-    }
-    if (normalizeConfigContent(existingContent) !== normalizeConfigContent(desiredContent)) {
-      promises.push(promisePool.run(() => fsUtil.generateFile(filePath, desiredContent)));
     }
     await Promise.all(promises);
   });

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -157,7 +157,9 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
   // before installing the managed dependency updates below. Keep this generated
   // file sorted even when we later run the target repository's formatter so a
   // mid-run interruption never leaves package.json in a partially managed order.
-  await fsUtil.generateFile(filePath, serializePackageJson(jsonObj));
+  // A refused write (e.g. a symlinked package.json) must also abort the dependency installation
+  // below: `bun add` follows the symlink and would modify the file outside the repository.
+  if (!(await fsUtil.generateFile(filePath, serializePackageJson(jsonObj)))) return;
 
   if (!skipAddingDeps) {
     installDependencyUpdates(config, jsonObj, dependencyUpdates, 'bun');

--- a/packages/wbfy/src/generators/prettierignore.ts
+++ b/packages/wbfy/src/generators/prettierignore.ts
@@ -28,7 +28,7 @@ export async function generatePrettierignore(config: PackageConfig): Promise<voi
       await promisePool.run(() => fs.promises.rm(filePath, { force: true }));
       return;
     }
-    const content = (await fsUtil.readFileIgnoringError(filePath)) ?? '';
+    const content = (await fsUtil.readFileIfExists(filePath)) ?? '';
     const headUserContent = ignoreFileUtil.getHeadUserContent(content);
     const tailUserContent = ignoreFileUtil.getTailUserContent(content);
 

--- a/packages/wbfy/src/generators/pyrightConfig.ts
+++ b/packages/wbfy/src/generators/pyrightConfig.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 
 import merge from 'deepmerge';
@@ -6,6 +5,7 @@ import merge from 'deepmerge';
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
+import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { overwriteMerge } from '../utils/mergeUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
@@ -18,12 +18,16 @@ export async function generatePyrightConfigJson(config: PackageConfig): Promise<
   return logger.functionIgnoringException('generatePyrightConfigJson', async () => {
     let newSettings: object = structuredClone(jsonObj);
     const filePath = path.resolve(config.dirPath, 'pyrightconfig.json');
-    try {
-      const oldContent = await fs.promises.readFile(filePath, 'utf8');
-      const oldSettings = JSON.parse(oldContent) as object;
+    const oldContent = await fsUtil.readFileIfExists(filePath);
+    if (oldContent !== undefined && oldContent.trim()) {
+      // pyrightconfig.json allows JSONC; an existing file wbfy cannot parse must be left
+      // untouched instead of being overwritten with the bare template.
+      const oldSettings = jsoncUtil.parseObjectIgnoringError<object>(oldContent);
+      if (!oldSettings) {
+        console.warn(`Skipped generating ${filePath} because the existing content is not parsable as JSONC.`);
+        return;
+      }
       newSettings = merge.all([newSettings, oldSettings, newSettings], { arrayMerge: overwriteMerge });
-    } catch {
-      // do nothing
     }
     const newContent = JSON.stringify(newSettings, undefined, 2);
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));

--- a/packages/wbfy/src/generators/pyrightConfig.ts
+++ b/packages/wbfy/src/generators/pyrightConfig.ts
@@ -7,6 +7,7 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { overwriteMerge } from '../utils/mergeUtil.js';
+import { sortKeys } from '../utils/objectUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
 const jsonObj = {
@@ -19,7 +20,8 @@ export async function generatePyrightConfigJson(config: PackageConfig): Promise<
     let newSettings: object = structuredClone(jsonObj);
     const filePath = path.resolve(config.dirPath, 'pyrightconfig.json');
     const oldContent = await fsUtil.readFileIfExists(filePath);
-    if (oldContent !== undefined && oldContent.trim()) {
+    let originalSettingsJson: string | undefined;
+    if (oldContent !== undefined && !jsoncUtil.isTriviaOnly(oldContent)) {
       // pyrightconfig.json allows JSONC; an existing file wbfy cannot parse must be left
       // untouched instead of being overwritten with the bare template.
       const oldSettings = jsoncUtil.parseObjectIgnoringError<object>(oldContent);
@@ -27,7 +29,13 @@ export async function generatePyrightConfigJson(config: PackageConfig): Promise<
         console.warn(`Skipped generating ${filePath} because the existing content is not parsable as JSONC.`);
         return;
       }
+      originalSettingsJson = JSON.stringify(sortKeys(structuredClone(oldSettings) as Record<string, unknown>));
       newSettings = merge.all([newSettings, oldSettings, newSettings], { arrayMerge: overwriteMerge });
+    }
+    // Skip the write when nothing changes semantically, so JSONC comments and formatting in an
+    // already-clean pyrightconfig.json survive wbfy runs.
+    if (originalSettingsJson === JSON.stringify(sortKeys(structuredClone(newSettings) as Record<string, unknown>))) {
+      return;
     }
     const newContent = JSON.stringify(newSettings, undefined, 2);
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));

--- a/packages/wbfy/src/generators/railwayignore.ts
+++ b/packages/wbfy/src/generators/railwayignore.ts
@@ -12,7 +12,7 @@ const managedScriptsBlock = `scripts/**
 export async function fixRailwayignore(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('fixRailwayignore', async () => {
     const filePath = path.resolve(config.dirPath, '.railwayignore');
-    const content = await fsUtil.readFileIgnoringError(filePath);
+    const content = await fsUtil.readFileIfExists(filePath);
     if (!content) return;
 
     const newContent = content.replace(/^scripts\/$/m, managedScriptsBlock);

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -17,37 +17,73 @@ const jsonObj = {
 };
 
 type Settings = Omit<typeof jsonObj, 'extends'> & {
-  extends?: string[];
+  // Renovate's schema allows a single preset string in addition to an array.
+  extends?: string | string[];
   packageRules?: { matchPackageNames: string[]; enabled?: boolean }[];
 };
+
+// Renovate stops at the first matching config file and renovate.json matches first, so generating
+// renovate.json next to any of these alternative locations would silently shadow the user's
+// config. `.renovaterc.json` is intentionally absent: wbfy migrates it into renovate.json below.
+const shadowedRenovateConfigPaths = [
+  'renovate.jsonc',
+  'renovate.json5',
+  '.github/renovate.json',
+  '.github/renovate.jsonc',
+  '.github/renovate.json5',
+  '.gitlab/renovate.json',
+  '.gitlab/renovate.jsonc',
+  '.gitlab/renovate.json5',
+  '.renovaterc',
+  '.renovaterc.jsonc',
+  '.renovaterc.json5',
+];
 
 export async function generateRenovateJson(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateRenovateJson', async () => {
     let newSettings = structuredClone(jsonObj) as Settings;
     const filePath = path.resolve(config.dirPath, 'renovate.json');
-    // Renovate reads only the first matching config file (renovate.json wins over these variants),
-    // so generating renovate.json next to one of them would silently shadow the user's config.
-    if (
-      ['renovate.jsonc', 'renovate.json5'].some((fileName) => fs.existsSync(path.resolve(config.dirPath, fileName)))
-    ) {
+    if (shadowedRenovateConfigPaths.some((configPath) => fs.existsSync(path.resolve(config.dirPath, configPath)))) {
       return;
     }
-    const oldContent = await fsUtil.readFileIfExists(filePath);
+
+    // Renovate accepts JSONC in renovate.json; an existing file wbfy cannot parse must be left
+    // untouched instead of being overwritten with the bare template.
+    const oldSettingsList: Settings[] = [];
     let originalSettingsJson: string | undefined;
+    const oldContent = await fsUtil.readFileIfExists(filePath);
     if (oldContent !== undefined && !jsoncUtil.isTriviaOnly(oldContent)) {
-      // Renovate accepts JSONC in renovate.json; an existing file wbfy cannot parse must be left
-      // untouched instead of being overwritten with the bare template.
       const oldSettings = jsoncUtil.parseObjectIgnoringError<Settings>(oldContent);
       if (!oldSettings) {
         console.warn(`Skipped generating ${filePath} because the existing content is not parsable as JSONC.`);
         return;
       }
       originalSettingsJson = JSON.stringify(sortKeys(structuredClone(oldSettings) as Record<string, unknown>));
+      oldSettingsList.push(oldSettings);
+    }
+
+    // The legacy .renovaterc.json is superseded by the generated renovate.json, so merge its
+    // settings before it is deleted below.
+    const legacyFilePath = path.resolve(config.dirPath, '.renovaterc.json');
+    const legacyContent = await fsUtil.readFileIfExists(legacyFilePath);
+    if (legacyContent !== undefined && !jsoncUtil.isTriviaOnly(legacyContent)) {
+      const legacySettings = jsoncUtil.parseObjectIgnoringError<Settings>(legacyContent);
+      if (!legacySettings) {
+        console.warn(`Skipped generating ${filePath} because ${legacyFilePath} is not parsable as JSONC.`);
+        return;
+      }
+      oldSettingsList.push(legacySettings);
+    }
+
+    for (const oldSettings of oldSettingsList) {
       newSettings = merge.all([newSettings, oldSettings, newSettings], {
         arrayMerge: overwriteMerge,
       }) as Settings;
-      newSettings.extends = mergeRenovateExtends(jsonObj.extends, oldSettings.extends ?? []);
     }
+    newSettings.extends = mergeRenovateExtends(
+      jsonObj.extends,
+      oldSettingsList.map((oldSettings) => oldSettings.extends)
+    );
 
     // Don't upgrade Next.js automatically
     if (config.depending.blitz) {
@@ -62,7 +98,7 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
     }
 
     await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.dependabot'), { force: true }));
-    await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.renovaterc.json'), { force: true }));
+    await promisePool.run(() => fs.promises.rm(legacyFilePath, { force: true }));
     // Skip the write when nothing changes semantically, so JSONC comments and formatting in an
     // already-clean renovate.json survive wbfy runs.
     if (originalSettingsJson === JSON.stringify(sortKeys(structuredClone(newSettings) as Record<string, unknown>))) {
@@ -73,6 +109,11 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
   });
 }
 
-function mergeRenovateExtends(generatedExtends: string[], existingExtends: string[]): string[] {
+function mergeRenovateExtends(generatedExtends: string[], existingExtendsList: Settings['extends'][]): string[] {
+  // Renovate's schema allows `extends` to be a single preset string; spreading a string would
+  // corrupt it into its individual characters, so normalize each value to an array first.
+  const existingExtends = existingExtendsList.flatMap((value) =>
+    value === undefined ? [] : Array.isArray(value) ? value : [value]
+  );
   return [...new Set([...generatedExtends, ...existingExtends])].filter((item) => item !== '@willbooster');
 }

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -8,6 +8,7 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { overwriteMerge } from '../utils/mergeUtil.js';
+import { sortKeys } from '../utils/objectUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
 const jsonObj = {
@@ -24,12 +25,16 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
   return logger.functionIgnoringException('generateRenovateJson', async () => {
     let newSettings = structuredClone(jsonObj) as Settings;
     const filePath = path.resolve(config.dirPath, 'renovate.json');
-    if (fs.existsSync(`${filePath}5`)) {
-      // Since it is difficult for parsing renovate.json5, we do nothing
+    // Renovate reads only the first matching config file (renovate.json wins over these variants),
+    // so generating renovate.json next to one of them would silently shadow the user's config.
+    if (
+      ['renovate.jsonc', 'renovate.json5'].some((fileName) => fs.existsSync(path.resolve(config.dirPath, fileName)))
+    ) {
       return;
     }
     const oldContent = await fsUtil.readFileIfExists(filePath);
-    if (oldContent !== undefined && oldContent.trim()) {
+    let originalSettingsJson: string | undefined;
+    if (oldContent !== undefined && !jsoncUtil.isTriviaOnly(oldContent)) {
       // Renovate accepts JSONC in renovate.json; an existing file wbfy cannot parse must be left
       // untouched instead of being overwritten with the bare template.
       const oldSettings = jsoncUtil.parseObjectIgnoringError<Settings>(oldContent);
@@ -37,6 +42,7 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
         console.warn(`Skipped generating ${filePath} because the existing content is not parsable as JSONC.`);
         return;
       }
+      originalSettingsJson = JSON.stringify(sortKeys(structuredClone(oldSettings) as Record<string, unknown>));
       newSettings = merge.all([newSettings, oldSettings, newSettings], {
         arrayMerge: overwriteMerge,
       }) as Settings;
@@ -57,6 +63,11 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
 
     await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.dependabot'), { force: true }));
     await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.renovaterc.json'), { force: true }));
+    // Skip the write when nothing changes semantically, so JSONC comments and formatting in an
+    // already-clean renovate.json survive wbfy runs.
+    if (originalSettingsJson === JSON.stringify(sortKeys(structuredClone(newSettings) as Record<string, unknown>))) {
+      return;
+    }
     const newContent = JSON.stringify(newSettings, undefined, 2);
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
   });

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -102,17 +102,17 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
       }
     }
 
-    await promisePool.run(() =>
-      fs.promises.rm(path.resolve(config.dirPath, '.dependabot'), { force: true, recursive: true })
-    );
     // Skip the write when nothing changes semantically, so JSONC comments and formatting in an
     // already-clean renovate.json survive wbfy runs.
     if (originalSettingsJson !== JSON.stringify(sortKeys(structuredClone(newSettings) as Record<string, unknown>))) {
       const newContent = JSON.stringify(newSettings, undefined, 2);
-      // Await the write directly: the superseded .renovaterc.json below must survive when the
-      // confinement guards refuse the write (e.g. renovate.json is a dangling symlink).
+      // Await the write directly: the superseded sources below must survive when the confinement
+      // guards refuse the write (e.g. renovate.json is a dangling symlink).
       if (!(await fsUtil.generateFile(filePath, newContent))) return;
     }
+    await promisePool.run(() =>
+      fs.promises.rm(path.resolve(config.dirPath, '.dependabot'), { force: true, recursive: true })
+    );
     await promisePool.run(() => fs.promises.rm(legacyFilePath, { force: true }));
   });
 }

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -46,25 +46,25 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
     if (shadowedRenovateConfigPaths.some((configPath) => fs.existsSync(path.resolve(config.dirPath, configPath)))) {
       return;
     }
-    // A "renovate" section in package.json is the last entry of Renovate's resolution order, so a
-    // generated renovate.json would shadow it as well.
-    if (config.packageJson?.['renovate']) {
+    const oldContent = await fsUtil.readFileIfExists(filePath);
+    // A "renovate" section in package.json is the LAST entry of Renovate's resolution order, so it
+    // is live (and must not be shadowed by a generated renovate.json) only while renovate.json
+    // does not exist; an existing renovate.json already shadows it and stays managed.
+    if (oldContent === undefined && config.packageJson?.['renovate']) {
       return;
     }
 
     // Renovate accepts JSONC in renovate.json; an existing file wbfy cannot parse must be left
     // untouched instead of being overwritten with the bare template.
-    const oldSettingsList: Settings[] = [];
+    let oldSettings: Settings | undefined;
     let originalSettingsJson: string | undefined;
-    const oldContent = await fsUtil.readFileIfExists(filePath);
     if (oldContent !== undefined && !jsoncUtil.isTriviaOnly(oldContent)) {
-      const oldSettings = jsoncUtil.parseObjectIgnoringError<Settings>(oldContent);
+      oldSettings = jsoncUtil.parseObjectIgnoringError<Settings>(oldContent);
       if (!oldSettings) {
         console.warn(`Skipped generating ${filePath} because the existing content is not parsable as JSONC.`);
         return;
       }
       originalSettingsJson = JSON.stringify(sortKeys(structuredClone(oldSettings) as Record<string, unknown>));
-      oldSettingsList.push(oldSettings);
     }
 
     // A legacy .renovaterc.json is migrated into the generated renovate.json before it is deleted
@@ -73,23 +73,19 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
     const legacyFilePath = path.resolve(config.dirPath, '.renovaterc.json');
     const legacyContent = oldContent === undefined ? await fsUtil.readFileIfExists(legacyFilePath) : undefined;
     if (legacyContent !== undefined && !jsoncUtil.isTriviaOnly(legacyContent)) {
-      const legacySettings = jsoncUtil.parseObjectIgnoringError<Settings>(legacyContent);
-      if (!legacySettings) {
+      oldSettings = jsoncUtil.parseObjectIgnoringError<Settings>(legacyContent);
+      if (!oldSettings) {
         console.warn(`Skipped generating ${filePath} because ${legacyFilePath} is not parsable as JSONC.`);
         return;
       }
-      oldSettingsList.push(legacySettings);
     }
 
-    for (const oldSettings of oldSettingsList) {
+    if (oldSettings) {
       newSettings = merge.all([newSettings, oldSettings, newSettings], {
         arrayMerge: overwriteMerge,
       }) as Settings;
     }
-    newSettings.extends = mergeRenovateExtends(
-      jsonObj.extends,
-      oldSettingsList.map((oldSettings) => oldSettings.extends)
-    );
+    newSettings.extends = mergeRenovateExtends(jsonObj.extends, oldSettings?.extends);
 
     // Don't upgrade Next.js automatically
     if (config.depending.blitz) {
@@ -117,11 +113,10 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
   });
 }
 
-function mergeRenovateExtends(generatedExtends: string[], existingExtendsList: Settings['extends'][]): string[] {
+function mergeRenovateExtends(generatedExtends: string[], existingExtends: Settings['extends']): string[] {
   // Renovate's schema allows `extends` to be a single preset string; spreading a string would
-  // corrupt it into its individual characters, so normalize each value to an array first.
-  const existingExtends = existingExtendsList.flatMap((value) =>
-    value === undefined ? [] : Array.isArray(value) ? value : [value]
-  );
-  return [...new Set([...generatedExtends, ...existingExtends])].filter((item) => item !== '@willbooster');
+  // corrupt it into its individual characters, so normalize it to an array first.
+  const normalizedExtends =
+    existingExtends === undefined ? [] : Array.isArray(existingExtends) ? existingExtends : [existingExtends];
+  return [...new Set([...generatedExtends, ...normalizedExtends])].filter((item) => item !== '@willbooster');
 }

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -6,6 +6,7 @@ import merge from 'deepmerge';
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
+import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { overwriteMerge } from '../utils/mergeUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
@@ -27,15 +28,19 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
       // Since it is difficult for parsing renovate.json5, we do nothing
       return;
     }
-    try {
-      const oldContent = await fs.promises.readFile(filePath, 'utf8');
-      const oldSettings = JSON.parse(oldContent) as Settings;
+    const oldContent = await fsUtil.readFileIfExists(filePath);
+    if (oldContent !== undefined && oldContent.trim()) {
+      // Renovate accepts JSONC in renovate.json; an existing file wbfy cannot parse must be left
+      // untouched instead of being overwritten with the bare template.
+      const oldSettings = jsoncUtil.parseObjectIgnoringError<Settings>(oldContent);
+      if (!oldSettings) {
+        console.warn(`Skipped generating ${filePath} because the existing content is not parsable as JSONC.`);
+        return;
+      }
       newSettings = merge.all([newSettings, oldSettings, newSettings], {
         arrayMerge: overwriteMerge,
       }) as Settings;
       newSettings.extends = mergeRenovateExtends(jsonObj.extends, oldSettings.extends ?? []);
-    } catch {
-      // do nothing
     }
 
     // Don't upgrade Next.js automatically

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -45,14 +45,15 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
   return logger.functionIgnoringException('generateRenovateJson', async () => {
     let newSettings = structuredClone(jsonObj) as Settings;
     const filePath = path.resolve(config.dirPath, 'renovate.json');
-    if (shadowedRenovateConfigPaths.some((configPath) => fs.existsSync(path.resolve(config.dirPath, configPath)))) {
-      return;
-    }
     const oldContent = await fsUtil.readFileIfExists(filePath);
-    // A "renovate" section in package.json is the LAST entry of Renovate's resolution order, so it
-    // is live (and must not be shadowed by a generated renovate.json) only while renovate.json
-    // does not exist; an existing renovate.json already shadows it and stays managed.
-    if (oldContent === undefined && config.packageJson?.['renovate']) {
+    // The shadow checks matter only while renovate.json does not exist: it is FIRST in Renovate's
+    // resolution order, so an existing renovate.json already shadows every alternative (including
+    // a "renovate" section in package.json, the LAST entry) and must stay managed.
+    if (
+      oldContent === undefined &&
+      (shadowedRenovateConfigPaths.some((configPath) => fs.existsSync(path.resolve(config.dirPath, configPath))) ||
+        config.packageJson?.['renovate'])
+    ) {
       return;
     }
 
@@ -104,14 +105,15 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
     await promisePool.run(() =>
       fs.promises.rm(path.resolve(config.dirPath, '.dependabot'), { force: true, recursive: true })
     );
-    await promisePool.run(() => fs.promises.rm(legacyFilePath, { force: true }));
     // Skip the write when nothing changes semantically, so JSONC comments and formatting in an
     // already-clean renovate.json survive wbfy runs.
-    if (originalSettingsJson === JSON.stringify(sortKeys(structuredClone(newSettings) as Record<string, unknown>))) {
-      return;
+    if (originalSettingsJson !== JSON.stringify(sortKeys(structuredClone(newSettings) as Record<string, unknown>))) {
+      const newContent = JSON.stringify(newSettings, undefined, 2);
+      // Await the write directly: the superseded .renovaterc.json below must survive when the
+      // confinement guards refuse the write (e.g. renovate.json is a dangling symlink).
+      if (!(await fsUtil.generateFile(filePath, newContent))) return;
     }
-    const newContent = JSON.stringify(newSettings, undefined, 2);
-    await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
+    await promisePool.run(() => fs.promises.rm(legacyFilePath, { force: true }));
   });
 }
 

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -51,7 +51,11 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
     // a "renovate" section in package.json, the LAST entry) and must stay managed.
     if (
       oldContent === undefined &&
-      (shadowedRenovateConfigPaths.some((configPath) => fs.existsSync(path.resolve(config.dirPath, configPath))) ||
+      // lstat instead of existsSync: a dangling symlink still names an alternative config location
+      // that would resurface (and be shadowed) once its target is restored.
+      (shadowedRenovateConfigPaths.some(
+        (configPath) => !!fs.lstatSync(path.resolve(config.dirPath, configPath), { throwIfNoEntry: false })
+      ) ||
         config.packageJson?.['renovate'])
     ) {
       return;

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -46,6 +46,11 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
     if (shadowedRenovateConfigPaths.some((configPath) => fs.existsSync(path.resolve(config.dirPath, configPath)))) {
       return;
     }
+    // A "renovate" section in package.json is the last entry of Renovate's resolution order, so a
+    // generated renovate.json would shadow it as well.
+    if (config.packageJson?.['renovate']) {
+      return;
+    }
 
     // Renovate accepts JSONC in renovate.json; an existing file wbfy cannot parse must be left
     // untouched instead of being overwritten with the bare template.
@@ -62,10 +67,11 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
       oldSettingsList.push(oldSettings);
     }
 
-    // The legacy .renovaterc.json is superseded by the generated renovate.json, so merge its
-    // settings before it is deleted below.
+    // A legacy .renovaterc.json is migrated into the generated renovate.json before it is deleted
+    // below — but only when renovate.json does not exist yet: renovate.json resolves first, so a
+    // .renovaterc.json next to it is dead config whose settings must not be resurrected.
     const legacyFilePath = path.resolve(config.dirPath, '.renovaterc.json');
-    const legacyContent = await fsUtil.readFileIfExists(legacyFilePath);
+    const legacyContent = oldContent === undefined ? await fsUtil.readFileIfExists(legacyFilePath) : undefined;
     if (legacyContent !== undefined && !jsoncUtil.isTriviaOnly(legacyContent)) {
       const legacySettings = jsoncUtil.parseObjectIgnoringError<Settings>(legacyContent);
       if (!legacySettings) {
@@ -97,7 +103,9 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
       }
     }
 
-    await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.dependabot'), { force: true }));
+    await promisePool.run(() =>
+      fs.promises.rm(path.resolve(config.dirPath, '.dependabot'), { force: true, recursive: true })
+    );
     await promisePool.run(() => fs.promises.rm(legacyFilePath, { force: true }));
     // Skip the write when nothing changes semantically, so JSONC comments and formatting in an
     // already-clean renovate.json survive wbfy runs.

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -25,6 +25,8 @@ type Settings = Omit<typeof jsonObj, 'extends'> & {
 // Renovate stops at the first matching config file and renovate.json matches first, so generating
 // renovate.json next to any of these alternative locations would silently shadow the user's
 // config. `.renovaterc.json` is intentionally absent: wbfy migrates it into renovate.json below.
+// The list is deliberately platform-agnostic: wbfy manages GitHub-hosted repositories, and bailing
+// on a config for another platform is a safe no-op rather than a missed generation.
 const shadowedRenovateConfigPaths = [
   'renovate.jsonc',
   'renovate.json5',

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -111,7 +111,6 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
       // rootDir="src", and include=["src/**/*"], so preserving noEmit=false or
       // rootDir="src" here would only break non-src type-aware lint coverage.
       newSettings.compilerOptions = { ...newSettings.compilerOptions, ...existingEmitMetadata };
-      ensureTsExtensionEmitCompatibility(newSettings.compilerOptions);
 
       const mergedTypes = [...new Set([...filterExistingTypes(existingTypes, generatedTypes), ...generatedTypes])];
       if (mergedTypes.length > 0) {
@@ -290,15 +289,6 @@ function filterExistingTypes(existingTypes: string[], generatedTypes: string[]):
 
 function isGeneratedTestGlobalType(typeName: string): boolean {
   return typeName === 'cypress' || typeName === 'jest' || typeName === 'mocha' || typeName === 'vitest/globals';
-}
-
-function ensureTsExtensionEmitCompatibility(compilerOptions: TsConfigJson.CompilerOptions | undefined): void {
-  if (!compilerOptions) return;
-  if (compilerOptions.noEmit !== false || compilerOptions.emitDeclarationOnly === true) return;
-
-  // @tsconfig/bun enables allowImportingTsExtensions, which TypeScript permits
-  // during emit only when relative TS extensions are rewritten.
-  compilerOptions.rewriteRelativeImportExtensions = true;
 }
 
 function deleteLegacyModuleSettings(compilerOptions: TsConfigJson.CompilerOptions | undefined): void {

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -83,8 +83,8 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     const filePath = path.resolve(config.dirPath, 'tsconfig.json');
     const existingContent = await fsUtil.readFileIfExists(filePath);
     let originalSettingsJson: string | undefined;
-    // An empty (or whitespace-only) file carries no configuration, so treat it like a missing one.
-    if (existingContent !== undefined && existingContent.trim()) {
+    // A file with no configuration (empty or comment-only) is treated like a missing one, as tsc does.
+    if (existingContent !== undefined && !jsoncUtil.isTriviaOnly(existingContent)) {
       const oldSettings = jsoncUtil.parseObjectIgnoringError<TsConfigJson>(existingContent);
       // An existing tsconfig.json wbfy cannot parse must be left untouched: writing the
       // generated settings without merging would silently discard the project's configuration.
@@ -149,7 +149,7 @@ async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promi
   // node10 resolver spellings that older projects commonly inherited.
   const filePath = path.resolve(config.dirPath, 'tsconfig.json');
   const existingContent = await fsUtil.readFileIfExists(filePath);
-  if (existingContent === undefined || !existingContent.trim()) return;
+  if (existingContent === undefined || jsoncUtil.isTriviaOnly(existingContent)) return;
   const settings = jsoncUtil.parseObjectIgnoringError<TsConfigJson>(existingContent);
   if (!settings) {
     console.warn(`Skipped cleaning up ${filePath} because the existing content is not parsable as JSONC.`);

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -2,13 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import merge from 'deepmerge';
-import type { ParseError } from 'jsonc-parser';
-import { parse as parseJsonc } from 'jsonc-parser';
 import type { TsConfigJson } from 'type-fest';
 
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
+import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { combineMerge } from '../utils/mergeUtil.js';
 import { sortKeys } from '../utils/objectUtil.js';
 import { promisePool } from '../utils/promisePool.js';
@@ -82,12 +81,18 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     }
 
     const filePath = path.resolve(config.dirPath, 'tsconfig.json');
-    const existingContent = await fs.promises.readFile(filePath, 'utf8').catch(() => {});
-    if (existingContent !== undefined) {
-      const oldSettings = parseTsconfigJsonc(existingContent);
+    const existingContent = await fsUtil.readFileIfExists(filePath);
+    let originalSettingsJson: string | undefined;
+    // An empty (or whitespace-only) file carries no configuration, so treat it like a missing one.
+    if (existingContent !== undefined && existingContent.trim()) {
+      const oldSettings = jsoncUtil.parseObjectIgnoringError<TsConfigJson>(existingContent);
       // An existing tsconfig.json wbfy cannot parse must be left untouched: writing the
       // generated settings without merging would silently discard the project's configuration.
-      if (!oldSettings) return;
+      if (!oldSettings) {
+        console.warn(`Skipped generating ${filePath} because the existing content is not parsable as JSONC.`);
+        return;
+      }
+      originalSettingsJson = JSON.stringify(sortKeys(structuredClone(oldSettings)));
       const existingTypes = normalizeStringArray(oldSettings.compilerOptions?.types);
       const existingEmitMetadata = pickExistingEmitMetadata(oldSettings.compilerOptions);
       newSettings.extends = mergeTsconfigExtends(newSettings.extends, oldSettings.extends);
@@ -131,6 +136,9 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     if (config.depending.reactNative) {
       delete newSettings.compilerOptions?.verbatimModuleSyntax;
     }
+    // Skip the write when nothing changes semantically, so JSONC comments and formatting in an
+    // already-up-to-date tsconfig.json survive wbfy runs.
+    if (originalSettingsJson === JSON.stringify(newSettings)) return;
     const newContent = JSON.stringify(newSettings, undefined, 2);
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
   });
@@ -140,26 +148,22 @@ async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promi
   // Next/Blitz own their tsconfig shape, but TypeScript 6 no longer accepts
   // node10 resolver spellings that older projects commonly inherited.
   const filePath = path.resolve(config.dirPath, 'tsconfig.json');
-  const existingContent = await fs.promises.readFile(filePath, 'utf8').catch(() => {});
-  if (existingContent === undefined) return;
-  const settings = parseTsconfigJsonc(existingContent);
-  if (!settings) return;
+  const existingContent = await fsUtil.readFileIfExists(filePath);
+  if (existingContent === undefined || !existingContent.trim()) return;
+  const settings = jsoncUtil.parseObjectIgnoringError<TsConfigJson>(existingContent);
+  if (!settings) {
+    console.warn(`Skipped cleaning up ${filePath} because the existing content is not parsable as JSONC.`);
+    return;
+  }
+  const originalSettingsJson = JSON.stringify(settings);
   normalizeNextTsconfigModuleSettings(settings);
   normalizeNextTsconfigPathAliases(settings.compilerOptions);
   addScriptsIncludeForFrameworkProject(settings);
   addUndiciTypesPathMapping(settings, config);
+  // Skip the write when nothing changes semantically, so JSONC comments and formatting in an
+  // already-clean tsconfig.json survive wbfy runs.
+  if (JSON.stringify(settings) === originalSettingsJson) return;
   await promisePool.run(() => fsUtil.generateFile(filePath, JSON.stringify(settings, undefined, 2)));
-}
-
-/**
- * tsconfig.json allows JSONC, so read it with jsonc-parser instead of JSON.parse. jsonc-parser is
- * fault tolerant and returns a partial object for malformed input, which must not be merged as if
- * it were the project's configuration; reject any parse error.
- */
-function parseTsconfigJsonc(content: string): TsConfigJson | undefined {
-  const parseErrors: ParseError[] = [];
-  const settings = parseJsonc(content, parseErrors, { allowTrailingComma: true }) as TsConfigJson | undefined;
-  return parseErrors.length === 0 && settings && typeof settings === 'object' ? settings : undefined;
 }
 
 /**

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import merge from 'deepmerge';
+import type { ParseError } from 'jsonc-parser';
+import { parse as parseJsonc } from 'jsonc-parser';
 import type { TsConfigJson } from 'type-fest';
 
 import { logger } from '../logger.js';
@@ -80,9 +82,12 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     }
 
     const filePath = path.resolve(config.dirPath, 'tsconfig.json');
-    try {
-      const existingContent = await fs.promises.readFile(filePath, 'utf8');
-      const oldSettings = JSON.parse(existingContent) as TsConfigJson;
+    const existingContent = await fs.promises.readFile(filePath, 'utf8').catch(() => {});
+    if (existingContent !== undefined) {
+      const oldSettings = parseTsconfigJsonc(existingContent);
+      // An existing tsconfig.json wbfy cannot parse must be left untouched: writing the
+      // generated settings without merging would silently discard the project's configuration.
+      if (!oldSettings) return;
       const existingTypes = normalizeStringArray(oldSettings.compilerOptions?.types);
       const existingEmitMetadata = pickExistingEmitMetadata(oldSettings.compilerOptions);
       newSettings.extends = mergeTsconfigExtends(newSettings.extends, oldSettings.extends);
@@ -112,8 +117,6 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
       if (shouldDeleteTypeRoots(generatedTypes)) {
         delete newSettings.compilerOptions.typeRoots;
       }
-    } catch {
-      // do nothing
     }
     addUndiciTypesPathMapping(newSettings, config);
     sortKeys(newSettings);
@@ -134,18 +137,29 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
 }
 
 async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promise<void> {
+  // Next/Blitz own their tsconfig shape, but TypeScript 6 no longer accepts
+  // node10 resolver spellings that older projects commonly inherited.
   const filePath = path.resolve(config.dirPath, 'tsconfig.json');
-  try {
-    const settings = JSON.parse(await fs.promises.readFile(filePath, 'utf8')) as TsConfigJson;
-    normalizeNextTsconfigModuleSettings(settings);
-    normalizeNextTsconfigPathAliases(settings.compilerOptions);
-    addScriptsIncludeForFrameworkProject(settings);
-    addUndiciTypesPathMapping(settings, config);
-    await promisePool.run(() => fsUtil.generateFile(filePath, JSON.stringify(settings, undefined, 2)));
-  } catch {
-    // Next/Blitz own their tsconfig shape, but TypeScript 6 no longer accepts
-    // node10 resolver spellings that older projects commonly inherited.
-  }
+  const existingContent = await fs.promises.readFile(filePath, 'utf8').catch(() => {});
+  if (existingContent === undefined) return;
+  const settings = parseTsconfigJsonc(existingContent);
+  if (!settings) return;
+  normalizeNextTsconfigModuleSettings(settings);
+  normalizeNextTsconfigPathAliases(settings.compilerOptions);
+  addScriptsIncludeForFrameworkProject(settings);
+  addUndiciTypesPathMapping(settings, config);
+  await promisePool.run(() => fsUtil.generateFile(filePath, JSON.stringify(settings, undefined, 2)));
+}
+
+/**
+ * tsconfig.json allows JSONC, so read it with jsonc-parser instead of JSON.parse. jsonc-parser is
+ * fault tolerant and returns a partial object for malformed input, which must not be merged as if
+ * it were the project's configuration; reject any parse error.
+ */
+function parseTsconfigJsonc(content: string): TsConfigJson | undefined {
+  const parseErrors: ParseError[] = [];
+  const settings = parseJsonc(content, parseErrors, { allowTrailingComma: true }) as TsConfigJson | undefined;
+  return parseErrors.length === 0 && settings && typeof settings === 'object' ? settings : undefined;
 }
 
 /**

--- a/packages/wbfy/src/generators/vscodeSettings.ts
+++ b/packages/wbfy/src/generators/vscodeSettings.ts
@@ -22,7 +22,7 @@ export async function generateVscodeSettings(config: PackageConfig): Promise<voi
   return logger.functionIgnoringException('generateVscodeSettings', async () => {
     const filePath = path.resolve(config.dirPath, '.vscode', 'settings.json');
     const existingContent = await fsUtil.readFileIfExists(filePath);
-    if (existingContent === undefined || !existingContent.trim()) return;
+    if (existingContent === undefined || jsoncUtil.isTriviaOnly(existingContent)) return;
     // .vscode/settings.json is JSONC by definition; JSON.parse would make wbfy silently skip
     // commented files, leaving the settings it intends to remove in place.
     const parsedSettings = jsoncUtil.parseObjectIgnoringError<object>(existingContent);

--- a/packages/wbfy/src/generators/vscodeSettings.ts
+++ b/packages/wbfy/src/generators/vscodeSettings.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 
 import merge from 'deepmerge';
@@ -6,6 +5,7 @@ import merge from 'deepmerge';
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
+import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { sortKeys } from '../utils/objectUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
@@ -20,33 +20,41 @@ const excludeFilePatterns = [
 
 export async function generateVscodeSettings(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateVscodeSettings', async () => {
-    try {
-      const filePath = path.resolve(config.dirPath, '.vscode', 'settings.json');
-      const existingContent = await fs.promises.readFile(filePath, 'utf8');
-      let settings = JSON.parse(existingContent) as object;
-      for (const excludeFilePattern of excludeFilePatterns) {
-        settings = merge.all([settings, excludeSetting(excludeFilePattern)]);
-      }
-      if (config.doesContainPoetryLock || config.doesContainUvLock) {
-        settings = merge.all([settings, excludeSetting('**/.venv/**')]);
-      }
-      if (config.depending.next) {
-        settings = merge.all([settings, excludeSetting('**/.next/**')]);
-      }
-      // LLMによるvibe codingでは、自動フォーマットやコードアクションを無効化することで
-      // 生成されたコードの元の形式を維持できる
-      if ('editor.codeActionsOnSave' in settings) {
-        delete settings['editor.codeActionsOnSave'];
-      }
-      if ('editor.formatOnSave' in settings) {
-        delete settings['editor.formatOnSave'];
-      }
-      sortKeys(settings as Record<string, unknown>);
-      const newContent = JSON.stringify(settings, undefined, 2);
-      await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
-    } catch {
-      // do nothing
+    const filePath = path.resolve(config.dirPath, '.vscode', 'settings.json');
+    const existingContent = await fsUtil.readFileIfExists(filePath);
+    if (existingContent === undefined || !existingContent.trim()) return;
+    // .vscode/settings.json is JSONC by definition; JSON.parse would make wbfy silently skip
+    // commented files, leaving the settings it intends to remove in place.
+    const parsedSettings = jsoncUtil.parseObjectIgnoringError<object>(existingContent);
+    if (!parsedSettings) {
+      console.warn(`Skipped updating ${filePath} because the existing content is not parsable as JSONC.`);
+      return;
     }
+    const originalSettingsJson = JSON.stringify(sortKeys(structuredClone(parsedSettings) as Record<string, unknown>));
+    let settings = parsedSettings;
+    for (const excludeFilePattern of excludeFilePatterns) {
+      settings = merge.all([settings, excludeSetting(excludeFilePattern)]);
+    }
+    if (config.doesContainPoetryLock || config.doesContainUvLock) {
+      settings = merge.all([settings, excludeSetting('**/.venv/**')]);
+    }
+    if (config.depending.next) {
+      settings = merge.all([settings, excludeSetting('**/.next/**')]);
+    }
+    // LLMによるvibe codingでは、自動フォーマットやコードアクションを無効化することで
+    // 生成されたコードの元の形式を維持できる
+    if ('editor.codeActionsOnSave' in settings) {
+      delete settings['editor.codeActionsOnSave'];
+    }
+    if ('editor.formatOnSave' in settings) {
+      delete settings['editor.formatOnSave'];
+    }
+    sortKeys(settings as Record<string, unknown>);
+    // Skip the write when nothing changes semantically, so JSONC comments and formatting in an
+    // already-clean settings.json survive wbfy runs.
+    if (JSON.stringify(settings) === originalSettingsJson) return;
+    const newContent = JSON.stringify(settings, undefined, 2);
+    await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
   });
 }
 

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -274,12 +274,18 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
 
   let newSettings = structuredClone(kind in workflows ? workflows[kind as keyof typeof workflows] : {}) as Workflow;
 
-  try {
-    const oldContent = await fs.promises.readFile(filePath, 'utf8');
-    const oldSettings = yaml.load(oldContent) as Workflow;
+  const oldContent = await fsUtil.readFileIfExists(filePath);
+  if (oldContent !== undefined) {
+    let oldSettings: Workflow;
+    try {
+      oldSettings = yaml.load(oldContent) as Workflow;
+    } catch {
+      // An existing workflow wbfy cannot parse must be left untouched: writing the template
+      // without merging would silently discard the repository's workflow.
+      console.warn(`Skipped generating ${filePath} because the existing content is not parsable as YAML.`);
+      return;
+    }
     newSettings = merge.all([newSettings, oldSettings, newSettings], { arrayMerge: combineMerge }) as Workflow;
-  } catch {
-    // do nothing
   }
 
   // Skip a broken workflow

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -9,6 +9,7 @@ import merge from 'deepmerge';
 import yaml from 'js-yaml';
 
 import { logger } from '../logger.js';
+import { fsUtil } from '../utils/fsUtil.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { combineMerge } from '../utils/mergeUtil.js';
 import { moveToBottom, sortKeys } from '../utils/objectUtil.js';
@@ -516,7 +517,7 @@ async function writeYaml(newSettings: Workflow, filePath: string): Promise<void>
   const yamlText = removeTrailingSpaces(
     yaml.dump(newSettings, { lineWidth: -1, noCompatMode: true, styles: { '!!null': 'empty' } })
   );
-  await fs.promises.writeFile(filePath, yamlText);
+  await fsUtil.writeFileConfined(filePath, yamlText);
 }
 
 function removeTrailingSpaces(text: string): string {

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -142,6 +142,26 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
     const dirents = (await ignoreErrorAsync(() => fs.promises.readdir(packagesDirPath, { withFileTypes: true }))) ?? [];
     const subDirPaths = dirents.filter((d) => d.isDirectory()).map((d) => path.join(packagesDirPath, d.name));
 
+    // Refused writes on core managed files would leave the migration half-applied (e.g. Yarn state
+    // removed but bunfig.toml unchanged, or a test directory renamed without its script), so skip
+    // the repository BEFORE any mutation when one of them is a symlink or resolves outside it.
+    const managedFilePaths = [
+      ...['bunfig.toml', 'lefthook.yml', 'package.json', 'tsconfig.json'].map((name) =>
+        path.resolve(rootDirPath, name)
+      ),
+      ...subDirPaths.flatMap((subDirPath) =>
+        ['package.json', 'tsconfig.json'].map((name) => path.resolve(subDirPath, name))
+      ),
+    ];
+    const writableResults = await Promise.all(
+      managedFilePaths.map((filePath) => fsUtil.isConfinedWritablePath(filePath))
+    );
+    if (writableResults.includes(false)) {
+      console.error(`Skip ${rootDirPath}: a managed config file is a symlink or resolves outside the repository.`);
+      hasInvalidPackageConfig = true;
+      continue;
+    }
+
     await fixTestDirectoriesUpdatingPackageJson([rootDirPath, ...subDirPaths]);
 
     const rootConfig = await getPackageConfig(rootDirPath);

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -122,6 +122,9 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
 
   let hasInvalidPackageConfig = false;
   for (const rootDirPath of paths) {
+    // Confine every generated file to this repository (see fsUtil.generateFile). Set BEFORE any
+    // fixer writes, and reset on every iteration so a multi-path run never keeps the previous root.
+    fsUtil.setRootDirPath(fs.existsSync(rootDirPath) ? rootDirPath : undefined);
     // Read-only preflight before ANY fixer mutates the repository: Yarn configuration without an
     // automatic Bun translation must abort the whole migration for this path, not just the file
     // removal — otherwise wbfy would leave a half-migrated repository that neither tool can build.
@@ -150,8 +153,6 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
       hasInvalidPackageConfig = true;
       continue;
     }
-    // Confine every generated file to this repository (see fsUtil.generateFile).
-    fsUtil.setRootDirPath(rootDirPath);
     const abbreviationPromise = fixTypos(rootConfig);
 
     const nullableSubPackageConfigs = await Promise.all(subDirPaths.map((subDirPath) => getPackageConfig(subDirPath)));

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -50,6 +50,7 @@ import { options } from './options.js';
 import type { PackageConfig } from './packageConfig.js';
 import { generatesWorkerTypes, getPackageConfig } from './packageConfig.js';
 import { assertSafeDependencySources } from './utils/dependencySourcePolicy.js';
+import { fsUtil } from './utils/fsUtil.js';
 import { doesContainJsOrTs } from './utils/packageCapabilities.js';
 import { promisePool } from './utils/promisePool.js';
 import { spawnSync, spawnSyncAndReturnStatus, spawnSyncAndReturnStdout } from './utils/spawnUtil.js';
@@ -149,6 +150,8 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
       hasInvalidPackageConfig = true;
       continue;
     }
+    // Confine every generated file to this repository (see fsUtil.generateFile).
+    fsUtil.setRootDirPath(rootDirPath);
     const abbreviationPromise = fixTypos(rootConfig);
 
     const nullableSubPackageConfigs = await Promise.all(subDirPaths.map((subDirPath) => getPackageConfig(subDirPath)));

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -334,9 +334,9 @@ function areTrackedCleanRegularFiles(dirPath: string, fileNames: string[]): bool
   );
 }
 
-// `wrangler types` generates from `secrets.required` only since wrangler 4.77.0 (announced 2026-03-24, the 4.77.0
-// release date); older wranglers warn about the unexpected field and keep inferring from .dev.vars.
-const minimumWranglerVersionForRequiredSecrets = '4.77.0';
+// `wrangler types` generates from `secrets.required` since wrangler 4.70.0 (4.77.0 only added deploy/upload
+// validation of the field); older wranglers warn about the unexpected field and keep inferring from .dev.vars.
+const minimumWranglerVersionForRequiredSecrets = '4.70.0';
 
 function declaresSupportedRequiredSecrets(config: PackageConfig): boolean {
   const wranglerVersionRange =
@@ -381,15 +381,18 @@ function wranglerConfigDeclaresRequiredSecrets(dirPath: string): boolean {
 // A declaration at any config level replaces the .dev.vars/.env inference: `wrangler types` aggregates
 // per-environment secrets into the generated type (Cloudflare changelog 2026-03-24).
 function declaresRequiredSecretsAnywhere(config: WranglerConfigSecretsSubtree): boolean {
-  if (declaresRequiredSecrets(config.secrets)) return true;
-  return Object.values(config.env ?? {}).some((envConfig) => declaresRequiredSecrets(envConfig?.secrets));
+  if (declaresSecrets(config.secrets)) return true;
+  return Object.values(config.env ?? {}).some((envConfig) => declaresSecrets(envConfig?.secrets));
 }
 
-// The parsed config comes from an unvalidated file, so check the documented `string[]` shape at
-// runtime: a malformed declaration (e.g. a plain string) must not prove reproducibility.
-function declaresRequiredSecrets(secrets: WranglerConfigSecretsSubtree['secrets']): boolean {
-  const required: unknown = secrets?.required;
-  return Array.isArray(required) && required.length > 0 && required.every((name) => typeof name === 'string');
+// Defining `secrets` at any config level makes `wrangler types` use it exclusively instead of
+// inferring from .dev.vars/.env, so even an empty declaration is reproducible. The parsed config
+// comes from an unvalidated file, so check the documented `string[]` shape at runtime: a malformed
+// declaration (e.g. a plain string) must not prove reproducibility.
+function declaresSecrets(secrets: WranglerConfigSecretsSubtree['secrets']): boolean {
+  if (secrets === undefined || secrets === null || typeof secrets !== 'object') return false;
+  const required: unknown = secrets.required;
+  return required === undefined || (Array.isArray(required) && required.every((name) => typeof name === 'string'));
 }
 
 /**

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -3,8 +3,6 @@ import fsp from 'node:fs/promises';
 import path from 'node:path';
 
 import fg from 'fast-glob';
-import type { ParseError } from 'jsonc-parser';
-import { parse as parseJsonc } from 'jsonc-parser';
 import semver from 'semver';
 import { simpleGit } from 'simple-git';
 import { parse as parseToml } from 'smol-toml';
@@ -13,6 +11,7 @@ import { z } from 'zod';
 
 import { getOctokit, gitHubUtil } from './utils/githubUtil.js';
 import { globIgnore } from './utils/globUtil.js';
+import { jsoncUtil } from './utils/jsoncUtil.js';
 import { spawnSyncAndReturnStdout } from './utils/spawnUtil.js';
 import { selectProjectWranglerTypesGenerator } from './utils/wranglerTypesCommand.js';
 
@@ -362,13 +361,11 @@ function wranglerConfigDeclaresRequiredSecrets(dirPath: string): boolean {
     for (const fileName of ['wrangler.jsonc', 'wrangler.json']) {
       const filePath = path.resolve(dirPath, fileName);
       if (!fs.existsSync(filePath)) continue;
-      // jsonc-parser is fault tolerant and would return a partial object for malformed input,
-      // which cannot prove a declaration; reject any parse error.
-      const parseErrors: ParseError[] = [];
-      const config = parseJsonc(fs.readFileSync(filePath, 'utf8'), parseErrors, { allowTrailingComma: true }) as
-        | WranglerConfigSecretsSubtree
-        | undefined;
-      return parseErrors.length === 0 && !!config && declaresRequiredSecretsAnywhere(config);
+      // A config that does not parse cannot prove a declaration.
+      const config = jsoncUtil.parseObjectIgnoringError<WranglerConfigSecretsSubtree>(
+        fs.readFileSync(filePath, 'utf8')
+      );
+      return !!config && declaresRequiredSecretsAnywhere(config);
     }
     const tomlPath = path.resolve(dirPath, 'wrangler.toml');
     if (fs.existsSync(tomlPath)) {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -303,6 +303,9 @@ export function generatesWorkerTypes(config: PackageConfig): boolean {
  */
 function hasReproducibleWorkerTypesInference(config: PackageConfig): boolean {
   const dirPath = config.dirPath;
+  // With a secrets declaration, `wrangler types` reads only the wrangler config, so a missing or
+  // stale config on CI fails the generation LOUDLY instead of silently inferring a wrong Env; the
+  // tracked-clean checks below guard only the silent-drift hazard of the dotenv-inference path.
   if (declaresSupportedRequiredSecrets(config)) return true;
   // The wrangler config itself drives the generation, so an untracked, modified, or symlinked config makes the
   // generated file irreproducible whatever the dotenv inputs say.
@@ -390,7 +393,7 @@ function declaresRequiredSecretsAnywhere(config: WranglerConfigSecretsSubtree): 
 // comes from an unvalidated file, so check the documented `string[]` shape at runtime: a malformed
 // declaration (e.g. a plain string) must not prove reproducibility.
 function declaresSecrets(secrets: WranglerConfigSecretsSubtree['secrets']): boolean {
-  if (secrets === undefined || secrets === null || typeof secrets !== 'object') return false;
+  if (secrets === undefined || secrets === null || typeof secrets !== 'object' || Array.isArray(secrets)) return false;
   const required: unknown = secrets.required;
   return required === undefined || (Array.isArray(required) && required.every((name) => typeof name === 'string'));
 }

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -381,8 +381,15 @@ function wranglerConfigDeclaresRequiredSecrets(dirPath: string): boolean {
 // A declaration at any config level replaces the .dev.vars/.env inference: `wrangler types` aggregates
 // per-environment secrets into the generated type (Cloudflare changelog 2026-03-24).
 function declaresRequiredSecretsAnywhere(config: WranglerConfigSecretsSubtree): boolean {
-  if ((config.secrets?.required?.length ?? 0) > 0) return true;
-  return Object.values(config.env ?? {}).some((envConfig) => (envConfig?.secrets?.required?.length ?? 0) > 0);
+  if (declaresRequiredSecrets(config.secrets)) return true;
+  return Object.values(config.env ?? {}).some((envConfig) => declaresRequiredSecrets(envConfig?.secrets));
+}
+
+// The parsed config comes from an unvalidated file, so check the documented `string[]` shape at
+// runtime: a malformed declaration (e.g. a plain string) must not prove reproducibility.
+function declaresRequiredSecrets(secrets: WranglerConfigSecretsSubtree['secrets']): boolean {
+  const required: unknown = secrets?.required;
+  return Array.isArray(required) && required.length > 0 && required.every((name) => typeof name === 'string');
 }
 
 /**

--- a/packages/wbfy/src/utils/fsUtil.ts
+++ b/packages/wbfy/src/utils/fsUtil.ts
@@ -9,6 +9,18 @@ export const fsUtil = {
       // do nothing
     }
   },
+  /**
+   * Returns undefined only when the file does not exist. Other failures (e.g. permissions) are
+   * rethrown so callers regenerating config files never overwrite content they could not read.
+   */
+  async readFileIfExists(filePath: string): Promise<string | undefined> {
+    try {
+      return await fs.promises.readFile(filePath, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
+    }
+  },
   async generateFile(filePath: string, content: string): Promise<void> {
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
     let normalizedContent = content.trim();

--- a/packages/wbfy/src/utils/fsUtil.ts
+++ b/packages/wbfy/src/utils/fsUtil.ts
@@ -22,6 +22,13 @@ export const fsUtil = {
     }
   },
   async generateFile(filePath: string, content: string): Promise<void> {
+    // Never write through a symlink: a (possibly dangling) link committed in the target repository
+    // could redirect the write outside it.
+    const stats = await fs.promises.lstat(filePath).catch(() => {});
+    if (stats?.isSymbolicLink()) {
+      console.warn(`Skipped generating ${filePath} because it is a symbolic link.`);
+      return;
+    }
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
     let normalizedContent = content.trim();
     if (normalizedContent) {

--- a/packages/wbfy/src/utils/fsUtil.ts
+++ b/packages/wbfy/src/utils/fsUtil.ts
@@ -8,13 +8,6 @@ export const fsUtil = {
   setRootDirPath(rootDirPath: string | undefined): void {
     realRootDirPath = rootDirPath === undefined ? undefined : fs.realpathSync(rootDirPath);
   },
-  async readFileIgnoringError(filePath: string): Promise<string | undefined> {
-    try {
-      return await fs.promises.readFile(filePath, 'utf8');
-    } catch {
-      // do nothing
-    }
-  },
   /**
    * Returns undefined only when the file does not exist. Other failures (e.g. permissions) are
    * rethrown so callers regenerating config files never overwrite content they could not read.

--- a/packages/wbfy/src/utils/fsUtil.ts
+++ b/packages/wbfy/src/utils/fsUtil.ts
@@ -27,27 +27,15 @@ export const fsUtil = {
       throw error;
     }
   },
-  async generateFile(filePath: string, content: string): Promise<void> {
-    // Never write through a symlink: a (possibly dangling) link committed in the target repository
-    // could redirect the write outside it.
-    const stats = await fs.promises.lstat(filePath).catch(() => {});
-    if (stats?.isSymbolicLink()) {
-      console.warn(`Skipped generating ${filePath} because it is a symbolic link.`);
-      return;
-    }
-    // A symlinked parent directory would also redirect the write outside the repository, so
-    // require the closest existing ancestor to resolve inside the root set by the CLI entry point.
-    if (realRootDirPath !== undefined) {
-      let ancestorPath = path.dirname(filePath);
-      while (!fs.existsSync(ancestorPath)) {
-        ancestorPath = path.dirname(ancestorPath);
-      }
-      const realAncestorPath = await fs.promises.realpath(ancestorPath);
-      if (realAncestorPath !== realRootDirPath && !realAncestorPath.startsWith(realRootDirPath + path.sep)) {
-        console.warn(`Skipped generating ${filePath} because it resolves outside the repository.`);
-        return;
-      }
-    }
+  /** Writes content verbatim, applying the same symlink/repository-containment guards as generateFile. */
+  async writeFileConfined(filePath: string, content: string): Promise<boolean> {
+    if (!(await isConfinedWritablePath(filePath))) return false;
+    await fs.promises.writeFile(filePath, content);
+    return true;
+  },
+  /** Returns whether the file was actually generated (false when the confinement guards skip it). */
+  async generateFile(filePath: string, content: string): Promise<boolean> {
+    if (!(await isConfinedWritablePath(filePath))) return false;
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
     let normalizedContent = content.trim();
     if (normalizedContent) {
@@ -55,5 +43,30 @@ export const fsUtil = {
     }
     await fs.promises.writeFile(filePath, normalizedContent);
     console.log(`Generated/Updated ${filePath}`);
+    return true;
   },
 };
+
+async function isConfinedWritablePath(filePath: string): Promise<boolean> {
+  // Never write through a symlink: a (possibly dangling) link committed in the target repository
+  // could redirect the write outside it.
+  const stats = await fs.promises.lstat(filePath).catch(() => {});
+  if (stats?.isSymbolicLink()) {
+    console.warn(`Skipped writing ${filePath} because it is a symbolic link.`);
+    return false;
+  }
+  // A symlinked parent directory would also redirect the write outside the repository, so
+  // require the closest existing ancestor to resolve inside the root set by the CLI entry point.
+  if (realRootDirPath !== undefined) {
+    let ancestorPath = path.dirname(filePath);
+    while (!fs.existsSync(ancestorPath)) {
+      ancestorPath = path.dirname(ancestorPath);
+    }
+    const realAncestorPath = await fs.promises.realpath(ancestorPath);
+    if (realAncestorPath !== realRootDirPath && !realAncestorPath.startsWith(realRootDirPath + path.sep)) {
+      console.warn(`Skipped writing ${filePath} because it resolves outside the repository.`);
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/wbfy/src/utils/fsUtil.ts
+++ b/packages/wbfy/src/utils/fsUtil.ts
@@ -27,6 +27,10 @@ export const fsUtil = {
       throw error;
     }
   },
+  /** Tells whether a write to filePath would pass the symlink/repository-containment guards. */
+  async isConfinedWritablePath(filePath: string): Promise<boolean> {
+    return await isConfinedWritablePath(filePath);
+  },
   /** Writes content verbatim, applying the same symlink/repository-containment guards as generateFile. */
   async writeFileConfined(filePath: string, content: string): Promise<boolean> {
     if (!(await isConfinedWritablePath(filePath))) return false;

--- a/packages/wbfy/src/utils/fsUtil.ts
+++ b/packages/wbfy/src/utils/fsUtil.ts
@@ -1,7 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+let realRootDirPath: string | undefined;
+
 export const fsUtil = {
+  /** Confines generateFile writes to the repository rooted at rootDirPath (undefined disables it). */
+  setRootDirPath(rootDirPath: string | undefined): void {
+    realRootDirPath = rootDirPath === undefined ? undefined : fs.realpathSync(rootDirPath);
+  },
   async readFileIgnoringError(filePath: string): Promise<string | undefined> {
     try {
       return await fs.promises.readFile(filePath, 'utf8');
@@ -28,6 +34,19 @@ export const fsUtil = {
     if (stats?.isSymbolicLink()) {
       console.warn(`Skipped generating ${filePath} because it is a symbolic link.`);
       return;
+    }
+    // A symlinked parent directory would also redirect the write outside the repository, so
+    // require the closest existing ancestor to resolve inside the root set by the CLI entry point.
+    if (realRootDirPath !== undefined) {
+      let ancestorPath = path.dirname(filePath);
+      while (!fs.existsSync(ancestorPath)) {
+        ancestorPath = path.dirname(ancestorPath);
+      }
+      const realAncestorPath = await fs.promises.realpath(ancestorPath);
+      if (realAncestorPath !== realRootDirPath && !realAncestorPath.startsWith(realRootDirPath + path.sep)) {
+        console.warn(`Skipped generating ${filePath} because it resolves outside the repository.`);
+        return;
+      }
     }
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
     let normalizedContent = content.trim();

--- a/packages/wbfy/src/utils/jsoncUtil.ts
+++ b/packages/wbfy/src/utils/jsoncUtil.ts
@@ -1,14 +1,33 @@
 import type { ParseError } from 'jsonc-parser';
-import { parse as parseJsonc, stripComments } from 'jsonc-parser';
+import { createScanner, parse as parseJsonc } from 'jsonc-parser';
+
+// jsonc-parser declares SyntaxKind/ScanError as ambient const enums, which cannot be imported
+// under verbatimModuleSyntax; mirror the needed member values locally.
+const syntaxKind = { lineCommentTrivia: 12, blockCommentTrivia: 13, lineBreakTrivia: 14, trivia: 15, eof: 17 };
+const scanErrorNone = 0;
 
 export const jsoncUtil = {
   /**
-   * Tells whether the content holds no configuration at all — only whitespace, comments, and/or a
-   * BOM. tsc treats such a tsconfig.json as an empty config, so generators should treat it like a
-   * missing file (and generate defaults) instead of refusing to manage it.
+   * Tells whether the content holds no configuration at all — only whitespace, complete comments,
+   * and/or a BOM. tsc treats such a tsconfig.json as an empty config, so generators should treat
+   * it like a missing file (and generate defaults) instead of refusing to manage it. Lexically
+   * broken trivia (e.g. an unterminated block comment) is NOT trivia-only: the file must be left
+   * untouched rather than overwritten with defaults.
    */
   isTriviaOnly(content: string): boolean {
-    return !stripComments(content.replace(/^\uFEFF/, '')).trim();
+    const scanner = createScanner(content.replace(/^\uFEFF/, ''));
+    for (let kind: number = scanner.scan(); kind !== syntaxKind.eof; kind = scanner.scan()) {
+      if (
+        (scanner.getTokenError() as number) !== scanErrorNone ||
+        (kind !== syntaxKind.lineCommentTrivia &&
+          kind !== syntaxKind.blockCommentTrivia &&
+          kind !== syntaxKind.trivia &&
+          kind !== syntaxKind.lineBreakTrivia)
+      ) {
+        return false;
+      }
+    }
+    return true;
   },
   /**
    * Parses a JSONC (JSON with comments) object from config files such as tsconfig.json,

--- a/packages/wbfy/src/utils/jsoncUtil.ts
+++ b/packages/wbfy/src/utils/jsoncUtil.ts
@@ -1,7 +1,15 @@
 import type { ParseError } from 'jsonc-parser';
-import { parse as parseJsonc } from 'jsonc-parser';
+import { parse as parseJsonc, stripComments } from 'jsonc-parser';
 
 export const jsoncUtil = {
+  /**
+   * Tells whether the content holds no configuration at all — only whitespace, comments, and/or a
+   * BOM. tsc treats such a tsconfig.json as an empty config, so generators should treat it like a
+   * missing file (and generate defaults) instead of refusing to manage it.
+   */
+  isTriviaOnly(content: string): boolean {
+    return !stripComments(content.replace(/^\uFEFF/, '')).trim();
+  },
   /**
    * Parses a JSONC (JSON with comments) object from config files such as tsconfig.json,
    * pyrightconfig.json, renovate.json, .vscode/settings.json, and wrangler.jsonc.

--- a/packages/wbfy/src/utils/jsoncUtil.ts
+++ b/packages/wbfy/src/utils/jsoncUtil.ts
@@ -1,0 +1,23 @@
+import type { ParseError } from 'jsonc-parser';
+import { parse as parseJsonc } from 'jsonc-parser';
+
+export const jsoncUtil = {
+  /**
+   * Parses a JSONC (JSON with comments) object from config files such as tsconfig.json,
+   * pyrightconfig.json, renovate.json, .vscode/settings.json, and wrangler.jsonc.
+   *
+   * jsonc-parser is fault tolerant and returns a partial object for malformed input, which must
+   * not be treated as the file's configuration; reject any parse error instead. A leading BOM is
+   * stripped because TypeScript accepts BOM'd config files while jsonc-parser reports the BOM as
+   * a parse error.
+   */
+  parseObjectIgnoringError<T extends object>(content: string): T | undefined {
+    const parseErrors: ParseError[] = [];
+    const value = parseJsonc(content.replace(/^\uFEFF/, ''), parseErrors, { allowTrailingComma: true }) as
+      | T
+      | undefined;
+    return parseErrors.length === 0 && !!value && typeof value === 'object' && !Array.isArray(value)
+      ? value
+      : undefined;
+  },
+};

--- a/packages/wbfy/test/fsUtil.test.ts
+++ b/packages/wbfy/test/fsUtil.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { fsUtil } from '../src/utils/fsUtil.js';
+
+test('generateFile refuses to write through a symlinked parent directory', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-fsutil-'));
+  try {
+    const repoDirPath = path.join(tempDirPath, 'repo');
+    const outsideDirPath = path.join(tempDirPath, 'outside');
+    fs.mkdirSync(repoDirPath);
+    fs.mkdirSync(outsideDirPath);
+    fs.symlinkSync(outsideDirPath, path.join(repoDirPath, '.vscode'));
+    fsUtil.setRootDirPath(repoDirPath);
+    await fsUtil.generateFile(path.join(repoDirPath, '.vscode', 'settings.json'), '{}');
+    expect(fs.existsSync(path.join(outsideDirPath, 'settings.json'))).toBe(false);
+  } finally {
+    fsUtil.setRootDirPath(undefined);
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('generateFile writes normally inside the confined repository root', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-fsutil-'));
+  try {
+    fsUtil.setRootDirPath(tempDirPath);
+    const filePath = path.join(tempDirPath, '.vscode', 'settings.json');
+    await fsUtil.generateFile(filePath, '{}');
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('{}\n');
+  } finally {
+    fsUtil.setRootDirPath(undefined);
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -177,7 +177,7 @@ test('uses stable age-gated versions for generated dependencies when skipping in
 });
 
 test('appends wrangler types to gen-code and postinstall for Cloudflare projects', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: {}, ...wranglerPackageJson },
     {
@@ -202,7 +202,7 @@ test.each([
   ['postinstall', { postinstall: 'wb gen-code && wrangler types --strict-vars=false' }],
   ['a script of its own', { 'gen-types': 'wrangler types --strict-vars=false' }],
 ])('preserves a project-specific wrangler types invocation kept in %s', async (_description, scripts) => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts, ...wranglerPackageJson },
     {
@@ -278,7 +278,7 @@ test('omits wrangler types when the package owns no wrangler config', async () =
 // `wrangler types --check` validates freshness and generates nothing, and a positional output path generates a
 // different file than the worker-configuration.d.ts wbfy manages, so neither can serve as the shared generator.
 test('ignores non-generating and custom-output wrangler types invocations when resolving the command', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     {
       scripts: {
@@ -305,7 +305,7 @@ test('ignores non-generating and custom-output wrangler types invocations when r
 // Appending the resolved command to a postinstall that already generates through a wrapper script would generate
 // the ~15k-line file twice per install.
 test('does not append wrangler types to a postinstall that generates through a wrapper script', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     {
       scripts: {
@@ -323,7 +323,7 @@ test('does not append wrangler types to a postinstall that generates through a w
 // detectWranglerConfig does not see a custom --config path, so wbfy does not manage the file — but overwriting the
 // project's own postinstall invocation would leave fresh checkouts without worker types.
 test('preserves a wrangler types invocation with a custom config path when overwriting postinstall', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     {
       scripts: { postinstall: 'wb gen-code && wrangler types --config config/worker.jsonc' },
@@ -345,7 +345,7 @@ test('preserves a wrangler types invocation with a custom config path when overw
 // falling back to .env) is committed, absent, or overridden by a top-level `secrets.required` declaration; wbfy
 // must not manage (generate, ignore, untrack) a file CI would regenerate differently.
 test('omits wrangler types when an uncommitted .dev.vars drives the Env inference', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: {}, ...wranglerPackageJson },
     {
@@ -362,8 +362,8 @@ test('omits wrangler types when an uncommitted .dev.vars drives the Env inferenc
 });
 
 test('keeps wrangler types when secrets.required makes the Env inference reproducible', async () => {
-  // 4.77.0 is the first wrangler that generates types from secrets.required instead of .dev.vars.
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.77.0' } };
+  // 4.70.0 is the first wrangler that generates types from secrets.required instead of .dev.vars.
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.70.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: {}, ...wranglerPackageJson },
     {
@@ -391,7 +391,7 @@ test('keeps wrangler types when secrets.required makes the Env inference reprodu
 // A declaration at any config level replaces the .dev.vars/.env inference: wrangler aggregates per-environment
 // secrets into the generated type.
 test('keeps wrangler types when an env-level secrets.required makes the Env inference reproducible', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.77.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.70.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: {}, ...wranglerPackageJson },
     {
@@ -412,10 +412,10 @@ test('keeps wrangler types when an env-level secrets.required makes the Env infe
   expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
 });
 
-// Wranglers older than 4.77.0 warn about the unexpected top-level `secrets` field and keep inferring from
+// Wranglers older than 4.70.0 warn about the unexpected top-level `secrets` field and keep inferring from
 // .dev.vars, so the declaration must not count as a reproducible inference source for them.
 test('ignores secrets.required when the wrangler dependency predates its support', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: {}, ...wranglerPackageJson },
     {
@@ -439,7 +439,7 @@ test('ignores secrets.required when the wrangler dependency predates its support
 // Running the documented code-generation entry point must produce the same declarations as postinstall,
 // even when wbfy would not create the gen-code script from scratch.
 test('appends wrangler types to a project-specific gen-code script', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'gen-code': 'tsx scripts/genRoutes.ts' }, ...wranglerPackageJson },
     { isCloudflare: true, doesContainWranglerConfig: true, packageJson: wranglerPackageJson }
@@ -454,7 +454,7 @@ test('appends wrangler types to a project-specific gen-code script', async () =>
 // Only a command-position invocation counts: shell text that merely mentions the words must not be
 // selected as the shared generator.
 test('does not treat shell text mentioning wrangler types as the generator command', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { help: 'echo wrangler types --strict-vars=false' }, ...wranglerPackageJson },
     {
@@ -474,7 +474,7 @@ test('does not treat shell text mentioning wrangler types as the generator comma
 // --check=true generates nothing and a custom positional path writes another file, so neither is selected as
 // the shared generator; the managed default applies instead.
 test('ignores non-conflicting but non-generating wrangler types invocations when resolving the command', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'check-types': 'wrangler types --check=true' }, ...wranglerPackageJson },
     {
@@ -522,7 +522,7 @@ test.each([
 // Commands after a `cd` run somewhere else and generate another package's file, so they neither qualify as this
 // package's generator nor block the managed default.
 test('ignores wrangler types invocations that follow a cd', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'gen-other': 'cd ../other && wrangler types --strict-vars=false' }, ...wranglerPackageJson },
     {
@@ -539,7 +539,7 @@ test('ignores wrangler types invocations that follow a cd', async () => {
 
 // Shell redirections are not wrangler arguments and must not disqualify (or truncate) the project's invocation.
 test('reuses a wrangler types invocation followed by a shell redirection', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'gen-types': 'wrangler types --strict-vars=false > /dev/null' }, ...wranglerPackageJson },
     {
@@ -557,7 +557,7 @@ test('reuses a wrangler types invocation followed by a shell redirection', async
 // Wrangler's documented default output path is exactly ./worker-configuration.d.ts, so naming it explicitly
 // must not discard the project's flags.
 test('reuses a wrangler types invocation that names the default output path explicitly', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     {
       scripts: { 'gen-types': 'wrangler types ./worker-configuration.d.ts --strict-vars=false' },
@@ -580,7 +580,7 @@ test('reuses a wrangler types invocation that names the default output path expl
 // --help/--version generate nothing, so they can never be selected as the shared generator (a selected
 // `wrangler types --help` would have allowed untracking a declaration nothing recreates).
 test('ignores help-only wrangler types invocations when resolving the command', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'types-help': 'wrangler types --help' }, ...wranglerPackageJson },
     {
@@ -597,7 +597,7 @@ test('ignores help-only wrangler types invocations when resolving the command', 
 
 // Boolean options accept a space-separated literal, which must not be misread as a positional output path.
 test('reuses a wrangler types invocation with a space-separated boolean option', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'gen-types': 'wrangler types --strict-vars false' }, ...wranglerPackageJson },
     {
@@ -614,7 +614,7 @@ test('reuses a wrangler types invocation with a space-separated boolean option',
 
 // Wrapper detection must survive environment assignments and runner flags around the script name.
 test('detects generation through an env-prefixed wrapper postinstall', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     {
       scripts: {
@@ -632,7 +632,7 @@ test('detects generation through an env-prefixed wrapper postinstall', async () 
 // An appended generator after a directory-changing postinstall would run in the other directory, so it must
 // run first instead.
 test('prepends the generator to a directory-changing postinstall', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { postinstall: 'cd ../tools && yarn build' }, ...wranglerPackageJson },
     { isCloudflare: true, doesContainWranglerConfig: true, packageJson: wranglerPackageJson }
@@ -644,7 +644,7 @@ test('prepends the generator to a directory-changing postinstall', async () => {
 // `--check` is a boolean option: only its enabled forms suppress generation, so `--check=false` is an ordinary
 // generating invocation whose flags must be preserved.
 test('reuses a wrangler types invocation with --check=false', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'gen-types': 'wrangler types --check=false --strict-vars=false' }, ...wranglerPackageJson },
     {
@@ -733,7 +733,7 @@ test('recognizes a conflicting invocation behind a no-op cd', async () => {
 // A quoted `&&` is argument text; splitting inside it would fabricate a generator command that was never run
 // (and whose trailing quote breaks the shell).
 test('does not select a wrangler types invocation quoted inside another command', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { greet: 'echo "run setup && wrangler types --strict-vars=false"' }, ...wranglerPackageJson },
     {
@@ -751,7 +751,7 @@ test('does not select a wrangler types invocation quoted inside another command'
 // Wrangler also layers .env.local (and environment-specific variants) into the Env inference, so an uncommitted
 // one makes the generated file irreproducible even when .dev.vars and .env are absent.
 test('omits wrangler types when an uncommitted .env.local drives the Env inference', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: {}, ...wranglerPackageJson },
     {
@@ -813,7 +813,7 @@ test('keeps generation prerequisites when rewriting postinstall', async () => {
 
 // `--cwd .` still runs in this package's directory, so the invocation is an ordinary local generator.
 test('reuses a wrangler types invocation with a no-op --cwd', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'gen-types': 'wrangler types --cwd . --strict-vars=false' }, ...wranglerPackageJson },
     {
@@ -831,7 +831,7 @@ test('reuses a wrangler types invocation with a no-op --cwd', async () => {
 // Quoted environment values contain spaces; whitespace-only tokenization would push the assignment into the
 // command position and miss the generator.
 test('recognizes a generator prefixed by a quoted environment assignment', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const genTypes = 'NODE_OPTIONS="--conditions=workerd --no-warnings" wrangler types --strict-vars=false';
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'gen-types': genTypes }, ...wranglerPackageJson },
@@ -1112,7 +1112,7 @@ test('treats a backgrounded invocation as unmodeled', async () => {
 // A check-only custom gen-code fails while the gitignored file is absent, so the generator must run first,
 // mirroring the postinstall ordering rule.
 test('prepends the generator to a check-only custom gen-code script', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'gen-code': 'wrangler types --check' }, ...wranglerPackageJson },
     { isCloudflare: true, doesContainWranglerConfig: true, packageJson: wranglerPackageJson }
@@ -1185,7 +1185,7 @@ test('treats a quoted command word invocation as unmodeled', async () => {
 // A trailing shell comment is not a positional output path; the flags before it must be reused — without the
 // comment, which would swallow anything composed after the reused command.
 test('reuses a wrangler types invocation followed by a shell comment', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'gen-types': 'wrangler types --strict-vars=false # keep loose vars' }, ...wranglerPackageJson },
     {
@@ -1278,7 +1278,7 @@ test('recognizes a conflicting invocation behind a normalized no-op cd', async (
 
 // The wrangler config itself drives the generation, so an uncommitted config makes the file irreproducible.
 test('omits wrangler types when the wrangler config is uncommitted', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: {}, ...wranglerPackageJson },
     {
@@ -1337,7 +1337,7 @@ test('skips worker-types management for a prerequisite pipeline with a bare gene
 
 // Quoting does not enable the check: `--check 'false'` still generates and its flags must be preserved.
 test('reuses a wrangler types invocation with a quoted false check literal', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { 'gen-types': "wrangler types --strict-vars=false --check 'false'" }, ...wranglerPackageJson },
     {
@@ -1354,7 +1354,7 @@ test('reuses a wrangler types invocation with a quoted false check literal', asy
 
 // `wrangler types --check` fails while the gitignored file is still absent, so the generator must run first.
 test('prepends the generator to a check-only postinstall', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     { scripts: { postinstall: 'wrangler types --check' }, ...wranglerPackageJson },
     { isCloudflare: true, doesContainWranglerConfig: true, packageJson: wranglerPackageJson }
@@ -1366,7 +1366,7 @@ test('prepends the generator to a check-only postinstall', async () => {
 // A custom --config layout is not managed by wbfy, but the project's own generation — even behind a wrapper
 // script — must survive the postinstall rewrite.
 test('preserves a wrapper script invoking wrangler types with a custom config when overwriting postinstall', async () => {
-  const wranglerPackageJson = { devDependencies: { wrangler: '4.42.0' } };
+  const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
     {
       scripts: {

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -44,21 +44,59 @@ test('drops removed node10 resolver spellings regardless of casing', async () =>
   expect(compilerOptions.moduleResolution).toBeUndefined();
 });
 
+test('merges settings from a tsconfig containing JSONC comments instead of replacing the file', async () => {
+  const compilerOptions = await generateCompilerOptionsFromContent(`{
+  "compilerOptions": {
+    // explains why the mapping exists
+    "paths": {
+      "undici-types": ["./node_modules/undici-types"]
+    },
+  }
+}`);
+  expect(compilerOptions.paths).toEqual({ 'undici-types': ['./node_modules/undici-types'] });
+});
+
+test('leaves an unparseable tsconfig untouched', async () => {
+  const brokenContent = '{ "compilerOptions": { "paths": ';
+  await withTempTsconfig(brokenContent, async (filePath, config) => {
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    expect(fs.readFileSync(filePath, 'utf8')).toBe(brokenContent);
+  });
+});
+
 async function generateCompilerOptionsFrom(
   existingTsconfig: object,
   dependingOverrides: Partial<PackageConfig['depending']> = {}
 ): Promise<Record<string, unknown>> {
-  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-tsconfig-'));
-  try {
-    fs.writeFileSync(path.join(tempDirPath, 'tsconfig.json'), JSON.stringify(existingTsconfig));
-    const config = createConfig({ dirPath: tempDirPath, isRoot: true, doesContainTypeScript: true });
+  return generateCompilerOptionsFromContent(JSON.stringify(existingTsconfig), dependingOverrides);
+}
+
+async function generateCompilerOptionsFromContent(
+  existingContent: string,
+  dependingOverrides: Partial<PackageConfig['depending']> = {}
+): Promise<Record<string, unknown>> {
+  return withTempTsconfig(existingContent, async (filePath, config) => {
     Object.assign(config.depending, dependingOverrides);
     await generateTsconfig(config);
     await promisePool.promiseAll();
-    const generated = JSON.parse(fs.readFileSync(path.join(tempDirPath, 'tsconfig.json'), 'utf8')) as {
+    const generated = JSON.parse(fs.readFileSync(filePath, 'utf8')) as {
       compilerOptions?: Record<string, unknown>;
     };
     return generated.compilerOptions ?? {};
+  });
+}
+
+async function withTempTsconfig<T>(
+  existingContent: string,
+  runTest: (filePath: string, config: PackageConfig) => Promise<T>
+): Promise<T> {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-tsconfig-'));
+  try {
+    const filePath = path.join(tempDirPath, 'tsconfig.json');
+    fs.writeFileSync(filePath, existingContent);
+    const config = createConfig({ dirPath: tempDirPath, isRoot: true, doesContainTypeScript: true });
+    return await runTest(filePath, config);
   } finally {
     fs.rmSync(tempDirPath, { recursive: true, force: true });
   }

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -65,6 +65,40 @@ test('leaves an unparseable tsconfig untouched', async () => {
   });
 });
 
+test('initializes an empty tsconfig with the generated settings', async () => {
+  await withTempTsconfig('', async (filePath, config) => {
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    const generated = JSON.parse(fs.readFileSync(filePath, 'utf8')) as { compilerOptions?: object };
+    expect(generated.compilerOptions).toBeDefined();
+  });
+});
+
+test('merges settings from a tsconfig with a UTF-8 BOM instead of skipping it', async () => {
+  const compilerOptions = await generateCompilerOptionsFromContent(
+    '\uFEFF' + JSON.stringify({ compilerOptions: { paths: { 'undici-types': ['./node_modules/undici-types'] } } })
+  );
+  expect(compilerOptions.paths).toEqual({ 'undici-types': ['./node_modules/undici-types'] });
+});
+
+test('keeps a commented Next tsconfig byte-identical when no cleanup is needed', async () => {
+  const commentedContent = `{
+  "compilerOptions": {
+    // explains why the mapping exists
+    "moduleResolution": "bundler",
+    "paths": {
+      "undici-types": ["./node_modules/undici-types/index.d.ts"]
+    }
+  }
+}`;
+  await withTempTsconfig(commentedContent, async (filePath, config) => {
+    config.depending.next = true;
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    expect(fs.readFileSync(filePath, 'utf8')).toBe(commentedContent);
+  });
+});
+
 async function generateCompilerOptionsFrom(
   existingTsconfig: object,
   dependingOverrides: Partial<PackageConfig['depending']> = {}

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -74,6 +74,27 @@ test('initializes an empty tsconfig with the generated settings', async () => {
   });
 });
 
+test('initializes a comment-only tsconfig with the generated settings', async () => {
+  await withTempTsconfig('// intentionally empty\n', async (filePath, config) => {
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    const generated = JSON.parse(fs.readFileSync(filePath, 'utf8')) as { compilerOptions?: object };
+    expect(generated.compilerOptions).toBeDefined();
+  });
+});
+
+test('keeps a commented tsconfig byte-identical when the settings are already up to date', async () => {
+  await withTempTsconfig('', async (filePath, config) => {
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    const commented = fs.readFileSync(filePath, 'utf8').replace('{\n', '{\n  // explains the setup\n');
+    fs.writeFileSync(filePath, commented);
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    expect(fs.readFileSync(filePath, 'utf8')).toBe(commented);
+  });
+});
+
 test('merges settings from a tsconfig with a UTF-8 BOM instead of skipping it', async () => {
   const compilerOptions = await generateCompilerOptionsFromContent(
     '\uFEFF' + JSON.stringify({ compilerOptions: { paths: { 'undici-types': ['./node_modules/undici-types'] } } })

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -74,6 +74,29 @@ test('initializes an empty tsconfig with the generated settings', async () => {
   });
 });
 
+test('leaves a tsconfig with an unterminated block comment untouched', async () => {
+  const brokenContent = '/* unfinished';
+  await withTempTsconfig(brokenContent, async (filePath, config) => {
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    expect(fs.readFileSync(filePath, 'utf8')).toBe(brokenContent);
+  });
+});
+
+test('does not write through a dangling tsconfig.json symlink', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-tsconfig-'));
+  try {
+    const targetPath = path.join(tempDirPath, 'outside.json');
+    fs.symlinkSync(targetPath, path.join(tempDirPath, 'tsconfig.json'));
+    const config = createConfig({ dirPath: tempDirPath, isRoot: true, doesContainTypeScript: true });
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    expect(fs.existsSync(targetPath)).toBe(false);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('initializes a comment-only tsconfig with the generated settings', async () => {
   await withTempTsconfig('// intentionally empty\n', async (filePath, config) => {
     await generateTsconfig(config);


### PR DESCRIPTION
Close #969

## Customer Summary

- Running `wbfy` no longer wipes configuration files that contain comments: `tsconfig.json`, `pyrightconfig.json`, `renovate.json`, and `.vscode/settings.json` are now parsed as JSONC and merged instead of being replaced with bare templates.
- Comments and formatting in already-up-to-date config files survive wbfy runs, and files wbfy cannot safely read, parse, or write are left untouched with a warning instead of being overwritten or deleted.
- Repositories using alternative Renovate config locations (renovate.jsonc/json5, .github/.gitlab variants, .renovaterc*, or a package.json "renovate" section) are no longer silently shadowed by a generated renovate.json.

## Technical Summary

- Extract `jsoncUtil` (BOM stripping, array rejection, parse-error rejection, scanner-based trivia detection) and use it in the tsconfig, pyright, renovate, and VS Code settings generators plus the wrangler secrets check, replacing `JSON.parse`-in-try patterns whose `generateFile` write sat outside the try.
- Add a semantic no-change skip-write guard (sorted-key JSON.stringify comparison) to all four JSONC generators so comments survive on clean files; empty/comment-only files are initialized like missing ones, matching tsc.
- Confine all generated writes to the repository: `fsUtil.generateFile`/`writeFileConfined` refuse symlinked targets and parents resolving outside the root (set per CLI path iteration before any mutation), core managed files are preflighted so a refused write cannot leave a migration half-applied, and legacy-file cleanups (.tool-versions, .renovaterc.json, .dependabot, old lint configs) run only after the replacement write succeeds.
- Read config files via `readFileIfExists` (ENOENT only, replacing the all-error-swallowing helper) so unreadable files abort their generator; unparseable workflow YAML is left untouched instead of being replaced by the template.
- Renovate generator: gate all shadow bails on renovate.json being absent (it resolves first), migrate `.renovaterc.json` only when it is the live config, normalize string-valued `extends`, detect dangling symlinks via lstat, and fix the `.dependabot` removal (needs `recursive: true`).
- Wrangler secrets: runtime-validate `secrets.required` as a string array (rejecting arrays/strings), accept empty declarations (defining `secrets` disables dotenv inference), and lower the version floor to 4.70.0, which introduced secrets-based `wrangler types` (4.77.0 only added deploy validation).
- Remove the unreachable `ensureTsExtensionEmitCompatibility` (generated tsconfigs always force `noEmit: true`).

## Why

- Found while migrating WillBoosterLab/llm-proxy to Bun isolated installs (#969): two explanatory `//` lines in `tsconfig.json` made the next wbfy run delete 15 lines of compiler options. Multi-agent review then surfaced the same clobber shape in sibling generators and adjacent file-safety gaps, fixed here; the remaining symlink/hard-link hardening is tracked in #971.

## Testing

- `bun vitest run` in `packages/wbfy`: 108 tests pass, including new coverage for JSONC comment merging, byte-identical no-change runs, unparseable/unterminated-comment/BOM/empty/comment-only inputs, dangling-symlink refusal, symlinked-parent confinement, and the wrangler 4.70.0/4.69.0 boundary.
- `bun verify` at the repository root passes; behaviors additionally verified with focused generator probes (string extends normalization, .renovaterc.json migration, shadow bails, .dependabot directory removal).

## Notes

- Comments are preserved only when a file needs no changes; when settings change, the file is re-serialized and comments are dropped by design (wbfy owns managed files).
- Follow-up hardening (confined reads of migration sources, confined removal in workflow cleanup, hard-link-safe atomic writes, permission-aware preflight) is tracked in #971.
