### PR TITLE
fix: stop wbfy's isolated-install output from breaking managed repositories

### DIFF
--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -101,6 +101,7 @@ export const bunMinimumReleaseAgeExcludes = [
   // ---------- START: We believe our packages are safe ----------
   '@exercode/problem-utils',
   '@willbooster-private/agentic-workflows',
+  '@willbooster-private/llm-proxy',
   '@willbooster/agent-skills',
   '@willbooster/babel-configs',
   '@willbooster/monaco-loader',
@@ -108,6 +109,7 @@ export const bunMinimumReleaseAgeExcludes = [
   '@willbooster/oxfmt-config',
   '@willbooster/oxlint-config',
   '@willbooster/prettier-config',
+  '@willbooster/react-frame-component',
   '@willbooster/renovate-config',
   '@willbooster/shared-lib',
   '@willbooster/shared-lib-blitz-next',
@@ -145,6 +147,9 @@ export const bunMinimumReleaseAgeExcludes = [
   'next',
   'react',
   'react-dom',
+  // Repos pin react-is via resolutions in lockstep with react, so a fresh react release must
+  // resolve immediately like react/react-dom above.
+  'react-is',
   // vinext is still pre-1.0 and its scoped packages release in lockstep, so the whole
   // set must be listed: excluding only `vinext` still fails because Bun gates the
   // transitive `@vinext/types`. Bun matches these names literally, so `@vinext/*`
@@ -152,6 +157,7 @@ export const bunMinimumReleaseAgeExcludes = [
   '@vinext/cloudflare',
   '@vinext/types',
   'vinext',
+  'vinext-progress',
 ];
 
 export type BunLinker = 'isolated' | 'hoisted';

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -122,6 +122,7 @@ export const bunMinimumReleaseAgeExcludes = [
   'build-ts',
   'gen-i18n-ts',
   'one-way-git-sync',
+  'vinext-progress',
   // ---------- END: We believe our packages are safe ----------
 
   // wbfy pins these tooling packages and may apply them immediately after a
@@ -157,7 +158,6 @@ export const bunMinimumReleaseAgeExcludes = [
   '@vinext/cloudflare',
   '@vinext/types',
   'vinext',
-  'vinext-progress',
 ];
 
 export type BunLinker = 'isolated' | 'hoisted';

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -306,10 +306,10 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
   postMergeCommands.push(String.raw`run_if_changed "${toolsChangedPattern}" "mise install"`);
   const installCommand = 'bun install';
   const rmNextDirectory = config.depending.blitz || config.depending.next ? ' && rm -Rf .next' : '';
-  // bun.lock-only merges (Renovate lockfile maintenance), bunfig.toml changes (linker, registry,
-  // hoisting), and patch edits all change the installed tree without touching package.json.
+  // bun.lock-only merges (Renovate lockfile maintenance), bunfig.toml / .npmrc changes (linker,
+  // registry, hoisting), and patch edits all change the installed tree without touching package.json.
   postMergeCommands.push(
-    String.raw`run_if_changed "(package\.json|bun\.lock|bunfig\.toml|patches/)" "${installCommand}${rmNextDirectory}"`
+    String.raw`run_if_changed "(package\.json|bun\.lock|bunfig\.toml|\.npmrc|patches/)" "${installCommand}${rmNextDirectory}"`
   );
   if (config.doesContainPoetryLock) {
     postMergeCommands.push(String.raw`run_if_changed "poetry\.lock" "poetry install"`);

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -306,7 +306,11 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
   postMergeCommands.push(String.raw`run_if_changed "${toolsChangedPattern}" "mise install"`);
   const installCommand = 'bun install';
   const rmNextDirectory = config.depending.blitz || config.depending.next ? ' && rm -Rf .next' : '';
-  postMergeCommands.push(String.raw`run_if_changed "package\.json" "${installCommand}${rmNextDirectory}"`);
+  // bun.lock-only merges (Renovate lockfile maintenance), bunfig.toml changes (linker, registry,
+  // hoisting), and patch edits all change the installed tree without touching package.json.
+  postMergeCommands.push(
+    String.raw`run_if_changed "(package\.json|bun\.lock|bunfig\.toml|patches/)" "${installCommand}${rmNextDirectory}"`
+  );
   if (config.doesContainPoetryLock) {
     postMergeCommands.push(String.raw`run_if_changed "poetry\.lock" "poetry install"`);
   }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -652,9 +652,6 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
   ];
 
   const existingTrusted = bunJsonObj.trustedDependencies;
-  // An explicitly empty list is a deliberate block-everything policy; deleting it would silently
-  // re-enable Bun's default allow-list, so it is preserved when wbfy has nothing to add.
-  if (existingTrusted?.length === 0 && requiredWbfyPackages.length === 0) return;
   const customTrustedPackages = (existingTrusted ?? []).filter(
     (pkg) => pkg !== lefthookDependency && !wbfyTrustedPackages.has(pkg)
   );
@@ -666,7 +663,11 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
     bunJsonObj.trustedDependencies = [
       ...new Set([...customTrustedPackages, ...requiredWbfyPackages, lefthookDependency]),
     ].toSorted();
-  } else {
+  } else if (existingTrusted?.some((pkg) => wbfyTrustedPackages.has(pkg))) {
+    // Only a list wbfy itself authored is cleaned up once its packages are gone; wbfy always
+    // writes a chakra/drizzle entry alongside lefthook, so that entry marks its provenance. Any
+    // other explicit list — empty, or e.g. ["lefthook"] alone — is a user policy whose deletion
+    // would silently widen script execution to Bun's default allow-list.
     delete bunJsonObj.trustedDependencies;
   }
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -610,12 +610,15 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
   if (!config.isRoot) return;
   const bunJsonObj = jsonObj as WritablePackageJson & { trustedDependencies?: string[] };
   // Bun installs optional and peer dependencies by default, so all declaration sections count.
-  const declaredDependencies = new Map<string, string>();
+  // Every declared range is kept per package: a root declaration must not mask a workspace one
+  // (e.g. root @chakra-ui/cli v2 alongside a workspace on v3).
+  const declaredDependencies = new Map<string, string[]>();
   const addDeclaredDependencies = (packageJson: PackageJson): void => {
     for (const section of dependencyDeclarationSections) {
       for (const [dependencyName, versionRange] of Object.entries(packageJson[section] ?? {})) {
-        if (typeof versionRange === 'string' && !declaredDependencies.has(dependencyName)) {
-          declaredDependencies.set(dependencyName, versionRange);
+        if (typeof versionRange === 'string') {
+          declaredDependencies.get(dependencyName)?.push(versionRange) ??
+            declaredDependencies.set(dependencyName, [versionRange]);
         }
       }
     }
@@ -635,12 +638,12 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
   // Only @chakra-ui/cli v3's `chakra typegen` writes into the installed @chakra-ui/react;
   // v2's `chakra-cli tokens` writes into @chakra-ui/styled-system instead, so trusting
   // @chakra-ui/react there would force a useless project-local copy without fixing gen-code.
-  const chakraCliMajor = /\d+/u.exec(declaredDependencies.get('@chakra-ui/cli') ?? '')?.[0];
+  const hasChakraCliV3 = (declaredDependencies.get('@chakra-ui/cli') ?? []).some(
+    (versionRange) => Number(/\d+/u.exec(versionRange)?.[0]) >= 3
+  );
   const wbfyTrustedPackages = new Set(['@chakra-ui/react', 'drizzle-kit']);
   const requiredWbfyPackages = [
-    ...(chakraCliMajor !== undefined && Number(chakraCliMajor) >= 3 && declaredDependencies.has('@chakra-ui/react')
-      ? ['@chakra-ui/react']
-      : []),
+    ...(hasChakraCliV3 && declaredDependencies.has('@chakra-ui/react') ? ['@chakra-ui/react'] : []),
     ...(declaredDependencies.has('drizzle-kit') ? ['drizzle-kit'] : []),
   ];
 

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -144,7 +144,7 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
 
   await removeDeprecatedStuff(config, jsonObj);
   await updateScripts(config, jsonObj);
-  ensureTrustedDependencies(config, jsonObj);
+  await ensureTrustedDependencies(config, jsonObj);
   moveManagedToolDependenciesToDevDependencies(jsonObj);
   const dependencyUpdates = await applyPackageJsonConventions(config, rootConfig, jsonObj);
   await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
@@ -596,10 +596,35 @@ function doesSeedCommandUseBuildTs(seedCommand: unknown): boolean {
  * Listing them in `trustedDependencies` makes Bun materialize a per-project copy under
  * `node_modules/.bun/`, whose walk-up reaches the project's node_modules.
  */
-function ensureTrustedDependencies(config: PackageConfig, jsonObj: WritablePackageJson): void {
+async function ensureTrustedDependencies(config: PackageConfig, jsonObj: WritablePackageJson): Promise<void> {
+  // Bun consults trustedDependencies in the workspace root's package.json only, so the list is
+  // managed there and must cover dependencies declared anywhere in the repository.
+  if (!config.isRoot) return;
+  const declaredDependencies = new Set([
+    ...Object.keys(jsonObj.dependencies ?? {}),
+    ...Object.keys(jsonObj.devDependencies ?? {}),
+  ]);
+  for (const workspaceDir of getWorkspacePackageDirs(config).values()) {
+    try {
+      const workspacePackageJson = JSON.parse(
+        await fs.promises.readFile(path.resolve(config.dirPath, workspaceDir, 'package.json'), 'utf8')
+      ) as PackageJson;
+      for (const dependencyName of [
+        ...Object.keys(workspacePackageJson.dependencies ?? {}),
+        ...Object.keys(workspacePackageJson.devDependencies ?? {}),
+      ]) {
+        declaredDependencies.add(dependencyName);
+      }
+    } catch {
+      // ignore unreadable workspace package.json
+    }
+  }
   const requiredPackages = [
-    ...(config.depending.chakra ? ['@chakra-ui/react'] : []),
-    ...(config.depending.drizzle ? ['drizzle-kit'] : []),
+    // Only chakra typegen (enabled by @chakra-ui/cli) mutates the installed @chakra-ui/react.
+    ...(declaredDependencies.has('@chakra-ui/cli') && declaredDependencies.has('@chakra-ui/react')
+      ? ['@chakra-ui/react']
+      : []),
+    ...(declaredDependencies.has('drizzle-kit') ? ['drizzle-kit'] : []),
   ];
   if (requiredPackages.length === 0) return;
   // An explicit trustedDependencies list REPLACES Bun's default allow-list instead of extending

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -587,41 +587,68 @@ function doesSeedCommandUseBuildTs(seedCommand: unknown): boolean {
   return typeof seedCommand === 'string' && /(?<![\w-])build-ts(?![\w-])/u.test(seedCommand);
 }
 
+const dependencyDeclarationSections = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+
+/**
+ * Forces store-incompatible packages to stay project-local under Bun's global store
+ * (`globalStore = true` in the generated bunfig.toml): `chakra typegen` (run by `wb gen-code`)
+ * writes generated types into the installed @chakra-ui/react package, which would otherwise
+ * mutate the machine-wide store shared across repositories, and drizzle-kit requires drizzle-orm
+ * without declaring it, which the store realpath places beyond a plain node_modules walk-up.
+ * Listing them in `trustedDependencies` makes Bun materialize a per-project copy under
+ * `node_modules/.bun/`, whose sibling `node_modules/.bun/node_modules/` links every installed
+ * package and therefore resolves the undeclared requires.
+ */
 async function ensureTrustedDependencies(config: PackageConfig, jsonObj: WritablePackageJson): Promise<void> {
   // Bun consults trustedDependencies in the workspace root's package.json only, so the list is
   // managed there and must cover dependencies declared anywhere in the repository.
   if (!config.isRoot) return;
   const bunJsonObj = jsonObj as WritablePackageJson & { trustedDependencies?: string[] };
-  const declaredDependencies = new Set([
-    ...Object.keys(jsonObj.dependencies ?? {}),
-    ...Object.keys(jsonObj.devDependencies ?? {}),
-  ]);
+  // Bun installs optional and peer dependencies by default, so all declaration sections count.
+  const declaredDependencies = new Map<string, string>();
+  const addDeclaredDependencies = (packageJson: PackageJson): void => {
+    for (const section of dependencyDeclarationSections) {
+      for (const [dependencyName, versionRange] of Object.entries(packageJson[section] ?? {})) {
+        if (typeof versionRange === 'string' && !declaredDependencies.has(dependencyName)) {
+          declaredDependencies.set(dependencyName, versionRange);
+        }
+      }
+    }
+  };
+  addDeclaredDependencies(jsonObj);
   for (const workspaceDir of getWorkspacePackageDirs(config).values()) {
     try {
-      const workspacePackageJson = JSON.parse(
-        await fs.promises.readFile(path.resolve(config.dirPath, workspaceDir, 'package.json'), 'utf8')
-      ) as PackageJson;
-      for (const dependencyName of [
-        ...Object.keys(workspacePackageJson.dependencies ?? {}),
-        ...Object.keys(workspacePackageJson.devDependencies ?? {}),
-      ]) {
-        declaredDependencies.add(dependencyName);
-      }
+      addDeclaredDependencies(
+        JSON.parse(
+          await fs.promises.readFile(path.resolve(config.dirPath, workspaceDir, 'package.json'), 'utf8')
+        ) as PackageJson
+      );
     } catch {
       // ignore unreadable workspace package.json
     }
   }
+  // Only @chakra-ui/cli v3's `chakra typegen` writes into the installed @chakra-ui/react;
+  // v2's `chakra-cli tokens` writes into @chakra-ui/styled-system instead, so trusting
+  // @chakra-ui/react there would force a useless project-local copy without fixing gen-code.
+  const chakraCliMajor = /\d+/u.exec(declaredDependencies.get('@chakra-ui/cli') ?? '')?.[0];
   const wbfyTrustedPackages = new Set(['@chakra-ui/react', 'drizzle-kit']);
   const requiredWbfyPackages = [
-    // Only chakra typegen (enabled by @chakra-ui/cli) mutates the installed @chakra-ui/react.
-    ...(declaredDependencies.has('@chakra-ui/cli') && declaredDependencies.has('@chakra-ui/react')
+    ...(chakraCliMajor !== undefined && Number(chakraCliMajor) >= 3 && declaredDependencies.has('@chakra-ui/react')
       ? ['@chakra-ui/react']
       : []),
     ...(declaredDependencies.has('drizzle-kit') ? ['drizzle-kit'] : []),
   ];
 
-  const existingTrusted = bunJsonObj.trustedDependencies ?? [];
-  const customTrustedPackages = existingTrusted.filter(
+  const existingTrusted = bunJsonObj.trustedDependencies;
+  // An explicitly empty list is a deliberate block-everything policy; deleting it would silently
+  // re-enable Bun's default allow-list, so it is preserved when wbfy has nothing to add.
+  if (existingTrusted?.length === 0 && requiredWbfyPackages.length === 0) return;
+  const customTrustedPackages = (existingTrusted ?? []).filter(
     (pkg) => pkg !== lefthookDependency && !wbfyTrustedPackages.has(pkg)
   );
 

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -47,6 +47,12 @@ const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
 const lefthookDependency = 'lefthook';
 const defaultGenI18nTsScript = 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP';
+// wb's auto-cascade env resolves `WB_ENV || NODE_ENV || 'development'`, but build-ts inlines
+// `process.env.NODE_ENV` to "production" in wb's published bundle, so an unset WB_ENV makes wb
+// load the production .env/fnox profiles (and e.g. .wrangler/state-production) on developer
+// machines. Local-facing generated scripts therefore default WB_ENV to development explicitly,
+// while still respecting an explicitly supplied WB_ENV (CI and deploy workflows set their own).
+const developmentWbEnvPrefix = 'WB_ENV=${WB_ENV:-development} ';
 // The exact format-code commands old wbfy versions generated for JS/TS repos.
 const legacyOxfmtFormatCodeScripts = new Set([
   'oxfmt --write --no-error-on-unmatched-pattern .',
@@ -144,6 +150,7 @@ async function core(config: PackageConfig, rootConfig: PackageConfig, skipAdding
 
   await removeDeprecatedStuff(config, jsonObj);
   await updateScripts(config, jsonObj);
+  ensureTrustedDependencies(config, jsonObj);
   moveManagedToolDependenciesToDevDependencies(jsonObj);
   const dependencyUpdates = await applyPackageJsonConventions(config, rootConfig, jsonObj);
   await normalizePackageMetadata(config, rootConfig, jsonObj, dependencyUpdates);
@@ -229,7 +236,7 @@ function updatePostinstallScript(scripts: PackageJson.Scripts, wranglerTypes: st
     const preservedSegments = involvesWranglerTypes
       ? postinstallSegments.filter((segment) => segment !== '' && !isManagedGenCodeSegment(segment, scripts))
       : [];
-    scripts.postinstall = ['wb gen-code', ...preservedSegments].join(' && ');
+    scripts.postinstall = [`${developmentWbEnvPrefix}wb gen-code`, ...preservedSegments].join(' && ');
   } else if (scripts.postinstall?.includes('gen-i18n-ts')) {
     delete scripts.postinstall;
   }
@@ -586,6 +593,27 @@ function doesSeedCommandUseBuildTs(seedCommand: unknown): boolean {
   return typeof seedCommand === 'string' && /(?<![\w-])build-ts(?![\w-])/u.test(seedCommand);
 }
 
+/**
+ * Forces store-incompatible packages to stay project-local under Bun's global store
+ * (`globalStore = true` in the generated bunfig.toml): `chakra typegen` (run by `wb gen-code`)
+ * writes generated types into the installed @chakra-ui/react package, which would otherwise
+ * mutate the machine-wide store shared across repositories, and drizzle-kit requires drizzle-orm
+ * without declaring it, which the store's realpath places beyond Node's node_modules walk-up.
+ * Listing them in `trustedDependencies` makes Bun materialize a per-project copy under
+ * `node_modules/.bun/`, whose walk-up reaches the project's node_modules.
+ */
+function ensureTrustedDependencies(config: PackageConfig, jsonObj: WritablePackageJson): void {
+  const requiredPackages = [
+    ...(config.depending.chakra ? ['@chakra-ui/react'] : []),
+    ...(config.depending.drizzle ? ['drizzle-kit'] : []),
+  ];
+  if (requiredPackages.length === 0) return;
+  const bunJsonObj = jsonObj as WritablePackageJson & { trustedDependencies?: string[] };
+  bunJsonObj.trustedDependencies = [
+    ...new Set([...(bunJsonObj.trustedDependencies ?? []), ...requiredPackages]),
+  ].toSorted();
+}
+
 async function normalizePackageMetadata(
   config: PackageConfig,
   rootConfig: PackageConfig,
@@ -681,7 +709,7 @@ async function normalizePackageMetadata(
   if (genCodeScript?.includes('No code generation needed')) {
     delete jsonObj.scripts['gen-code'];
   } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
-    jsonObj.scripts['gen-code'] = appendWranglerTypes('bun wb gen-code', wranglerTypes);
+    jsonObj.scripts['gen-code'] = appendWranglerTypes(`${developmentWbEnvPrefix}bun wb gen-code`, wranglerTypes);
   } else if (
     genCodeScript &&
     wranglerTypes &&
@@ -1375,7 +1403,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
     verify: 'bun wb verify',
     'verify-full': 'bun wb verify --full',
   };
-  applyDatabaseScripts(config, scripts, oldScripts, `bun ${getWbDatabaseCommand(config)}`);
+  applyDatabaseScripts(config, scripts, oldScripts, `${developmentWbEnvPrefix}bun ${getWbDatabaseCommand(config)}`);
   applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
   if (!hasTypecheck) {
     delete scripts.typecheck;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -587,19 +587,11 @@ function doesSeedCommandUseBuildTs(seedCommand: unknown): boolean {
   return typeof seedCommand === 'string' && /(?<![\w-])build-ts(?![\w-])/u.test(seedCommand);
 }
 
-/**
- * Forces store-incompatible packages to stay project-local under Bun's global store
- * (`globalStore = true` in the generated bunfig.toml): `chakra typegen` (run by `wb gen-code`)
- * writes generated types into the installed @chakra-ui/react package, which would otherwise
- * mutate the machine-wide store shared across repositories, and drizzle-kit requires drizzle-orm
- * without declaring it, which the store's realpath places beyond Node's node_modules walk-up.
- * Listing them in `trustedDependencies` makes Bun materialize a per-project copy under
- * `node_modules/.bun/`, whose walk-up reaches the project's node_modules.
- */
 async function ensureTrustedDependencies(config: PackageConfig, jsonObj: WritablePackageJson): Promise<void> {
   // Bun consults trustedDependencies in the workspace root's package.json only, so the list is
   // managed there and must cover dependencies declared anywhere in the repository.
   if (!config.isRoot) return;
+  const bunJsonObj = jsonObj as WritablePackageJson & { trustedDependencies?: string[] };
   const declaredDependencies = new Set([
     ...Object.keys(jsonObj.dependencies ?? {}),
     ...Object.keys(jsonObj.devDependencies ?? {}),
@@ -619,22 +611,30 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
       // ignore unreadable workspace package.json
     }
   }
-  const requiredPackages = [
+  const wbfyTrustedPackages = new Set(['@chakra-ui/react', 'drizzle-kit']);
+  const requiredWbfyPackages = [
     // Only chakra typegen (enabled by @chakra-ui/cli) mutates the installed @chakra-ui/react.
     ...(declaredDependencies.has('@chakra-ui/cli') && declaredDependencies.has('@chakra-ui/react')
       ? ['@chakra-ui/react']
       : []),
     ...(declaredDependencies.has('drizzle-kit') ? ['drizzle-kit'] : []),
   ];
-  if (requiredPackages.length === 0) return;
-  // An explicit trustedDependencies list REPLACES Bun's default allow-list instead of extending
-  // it, silently blocking lifecycle scripts of packages the default list trusts — lefthook's
-  // postinstall in every managed repository — so it must come along whenever the field is set.
-  requiredPackages.push(lefthookDependency);
-  const bunJsonObj = jsonObj as WritablePackageJson & { trustedDependencies?: string[] };
-  bunJsonObj.trustedDependencies = [
-    ...new Set([...(bunJsonObj.trustedDependencies ?? []), ...requiredPackages]),
-  ].toSorted();
+
+  const existingTrusted = bunJsonObj.trustedDependencies ?? [];
+  const customTrustedPackages = existingTrusted.filter(
+    (pkg) => pkg !== lefthookDependency && !wbfyTrustedPackages.has(pkg)
+  );
+
+  if (customTrustedPackages.length > 0 || requiredWbfyPackages.length > 0) {
+    // An explicit trustedDependencies list REPLACES Bun's default allow-list instead of extending
+    // it, silently blocking lifecycle scripts of packages the default list trusts — lefthook's
+    // postinstall in every managed repository — so it must come along whenever the field is set.
+    bunJsonObj.trustedDependencies = [
+      ...new Set([...customTrustedPackages, ...requiredWbfyPackages, lefthookDependency]),
+    ].toSorted();
+  } else {
+    delete bunJsonObj.trustedDependencies;
+  }
 }
 
 async function normalizePackageMetadata(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -628,12 +628,10 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
     }
   };
   addDeclaredDependencies(jsonObj);
-  for (const workspaceDir of getWorkspacePackageDirs(config).values()) {
+  for (const packageJsonPath of getWorkspacePackageJsonPaths(config)) {
     try {
       addDeclaredDependencies(
-        JSON.parse(
-          await fs.promises.readFile(path.resolve(config.dirPath, workspaceDir, 'package.json'), 'utf8')
-        ) as PackageJson
+        JSON.parse(await fs.promises.readFile(path.resolve(config.dirPath, packageJsonPath), 'utf8')) as PackageJson
       );
     } catch {
       // ignore unreadable workspace package.json
@@ -642,8 +640,10 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
   // Only @chakra-ui/cli v3's `chakra typegen` writes into the installed @chakra-ui/react;
   // v2's `chakra-cli tokens` writes into @chakra-ui/styled-system instead, so trusting
   // @chakra-ui/react there would force a useless project-local copy without fixing gen-code.
+  // Mirror wb gen-code's classification: only a range whose leading major parses to 2 selects the
+  // v2 command, so digitless specs like `latest` or catalog references count as v3.
   const hasChakraCliV3 = (declaredDependencies.get('@chakra-ui/cli') ?? []).some(
-    (versionRange) => Number(/\d+/u.exec(versionRange)?.[0]) >= 3
+    (versionRange) => /\d+/u.exec(versionRange)?.[0] !== '2'
   );
   const wbfyTrustedPackages = new Set(['@chakra-ui/react', 'drizzle-kit']);
   const requiredWbfyPackages = [
@@ -1317,6 +1317,27 @@ export function getWorkspacePackageDirs(rootConfig: PackageConfig): Map<string, 
   if (cached) return cached;
 
   const workspaceDirsByName = new Map<string, string>();
+  for (const packageJsonPath of getWorkspacePackageJsonPaths(rootConfig)) {
+    try {
+      const workspacePackageJson = JSON.parse(
+        fs.readFileSync(path.resolve(rootConfig.dirPath, packageJsonPath), 'utf8')
+      ) as PackageJson;
+      if (workspacePackageJson.name) {
+        workspaceDirsByName.set(workspacePackageJson.name, path.posix.dirname(packageJsonPath));
+      }
+    } catch {
+      // ignore unparsable workspace package.json
+    }
+  }
+  workspacePackageDirsCache.set(rootConfig.dirPath, workspaceDirsByName);
+  return workspaceDirsByName;
+}
+
+/**
+ * Every workspace package.json path (relative to the monorepo root), including manifests without
+ * a `name` field — wbfy names those later, so dependency scans must not skip them.
+ */
+function getWorkspacePackageJsonPaths(rootConfig: PackageConfig): string[] {
   // applyPackageJsonConventions forces `packages/*` into every monorepo's workspaces, but it may
   // not have written the root package.json yet, so mirror that normalization here.
   const workspacePatterns = [
@@ -1343,24 +1364,11 @@ export function getWorkspacePackageDirs(rootConfig: PackageConfig): Map<string, 
     );
   // followSymbolicLinks: false — a workspace symlink pointing outside the repository must not be
   // treated as a workspace directory (removeNodeModules would delete through it).
-  for (const packageJsonPath of fg.globSync(packageJsonGlobs, {
+  return fg.globSync(packageJsonGlobs, {
     cwd: rootConfig.dirPath,
     followSymbolicLinks: false,
     ignore: ['**/node_modules/**'],
-  })) {
-    try {
-      const workspacePackageJson = JSON.parse(
-        fs.readFileSync(path.resolve(rootConfig.dirPath, packageJsonPath), 'utf8')
-      ) as PackageJson;
-      if (workspacePackageJson.name) {
-        workspaceDirsByName.set(workspacePackageJson.name, path.posix.dirname(packageJsonPath));
-      }
-    } catch {
-      // ignore unparsable workspace package.json
-    }
-  }
-  workspacePackageDirsCache.set(rootConfig.dirPath, workspaceDirsByName);
-  return workspaceDirsByName;
+  });
 }
 
 function shouldUpdateExistingManagedDependency(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -617,8 +617,12 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
     for (const section of dependencyDeclarationSections) {
       for (const [dependencyName, versionRange] of Object.entries(packageJson[section] ?? {})) {
         if (typeof versionRange === 'string') {
-          declaredDependencies.get(dependencyName)?.push(versionRange) ??
+          const versionRanges = declaredDependencies.get(dependencyName);
+          if (versionRanges) {
+            versionRanges.push(versionRange);
+          } else {
             declaredDependencies.set(dependencyName, [versionRange]);
+          }
         }
       }
     }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -47,12 +47,6 @@ const wbDependency = '@willbooster/wb';
 const buildTsDependency = 'build-ts';
 const lefthookDependency = 'lefthook';
 const defaultGenI18nTsScript = 'gen-i18n-ts -i i18n -o src/__generated__/i18n.ts -d ja-JP';
-// wb's auto-cascade env resolves `WB_ENV || NODE_ENV || 'development'`, but build-ts inlines
-// `process.env.NODE_ENV` to "production" in wb's published bundle, so an unset WB_ENV makes wb
-// load the production .env/fnox profiles (and e.g. .wrangler/state-production) on developer
-// machines. Local-facing generated scripts therefore default WB_ENV to development explicitly,
-// while still respecting an explicitly supplied WB_ENV (CI and deploy workflows set their own).
-const developmentWbEnvPrefix = 'WB_ENV=${WB_ENV:-development} ';
 // The exact format-code commands old wbfy versions generated for JS/TS repos.
 const legacyOxfmtFormatCodeScripts = new Set([
   'oxfmt --write --no-error-on-unmatched-pattern .',
@@ -236,7 +230,7 @@ function updatePostinstallScript(scripts: PackageJson.Scripts, wranglerTypes: st
     const preservedSegments = involvesWranglerTypes
       ? postinstallSegments.filter((segment) => segment !== '' && !isManagedGenCodeSegment(segment, scripts))
       : [];
-    scripts.postinstall = [`${developmentWbEnvPrefix}wb gen-code`, ...preservedSegments].join(' && ');
+    scripts.postinstall = ['wb gen-code', ...preservedSegments].join(' && ');
   } else if (scripts.postinstall?.includes('gen-i18n-ts')) {
     delete scripts.postinstall;
   }
@@ -713,7 +707,7 @@ async function normalizePackageMetadata(
   if (genCodeScript?.includes('No code generation needed')) {
     delete jsonObj.scripts['gen-code'];
   } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
-    jsonObj.scripts['gen-code'] = appendWranglerTypes(`${developmentWbEnvPrefix}bun wb gen-code`, wranglerTypes);
+    jsonObj.scripts['gen-code'] = appendWranglerTypes('bun wb gen-code', wranglerTypes);
   } else if (
     genCodeScript &&
     wranglerTypes &&
@@ -1407,7 +1401,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
     verify: 'bun wb verify',
     'verify-full': 'bun wb verify --full',
   };
-  applyDatabaseScripts(config, scripts, oldScripts, `${developmentWbEnvPrefix}bun ${getWbDatabaseCommand(config)}`);
+  applyDatabaseScripts(config, scripts, oldScripts, `bun ${getWbDatabaseCommand(config)}`);
   applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
   if (!hasTypecheck) {
     delete scripts.typecheck;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -608,6 +608,10 @@ function ensureTrustedDependencies(config: PackageConfig, jsonObj: WritablePacka
     ...(config.depending.drizzle ? ['drizzle-kit'] : []),
   ];
   if (requiredPackages.length === 0) return;
+  // An explicit trustedDependencies list REPLACES Bun's default allow-list instead of extending
+  // it, silently blocking lifecycle scripts of packages the default list trusts — lefthook's
+  // postinstall in every managed repository — so it must come along whenever the field is set.
+  requiredPackages.push(lefthookDependency);
   const bunJsonObj = jsonObj as WritablePackageJson & { trustedDependencies?: string[] };
   bunJsonObj.trustedDependencies = [
     ...new Set([...(bunJsonObj.trustedDependencies ?? []), ...requiredPackages]),

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -220,62 +220,44 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
       if (!entry.isFile() || !isObsoleteGenPrWorkflowFileName(entry.name)) continue;
       await promisePool.run(() => fs.promises.rm(path.join(workflowsPath, entry.name), { force: true }));
     }
-    // GitHub accepts both .yml and .yaml workflow files, but every managed-name operation below
-    // (autofix suppression, release cleanup, deploy-production detection, the mandatory names)
-    // works on the .yml spelling, so .yaml files are canonicalized to .yml up front instead of
-    // being silently left stale. When both spellings exist, the .yaml file is left untouched:
-    // merging two workflow definitions is ambiguous, and renaming over the .yml would discard it.
-    const workflowEntries = entries.filter(
-      (entry) => entry.isFile() && /\.ya?ml$/u.test(entry.name) && !isObsoleteGenPrWorkflowFileName(entry.name)
-    );
-    // Same-repository reusable workflows are referenced by their exact file path
-    // (`uses: ./.github/workflows/<name>.yaml`), so renaming a referenced file would break every
-    // caller; such files are left under their original name (and skipped, as before this support).
-    const isReferencedByAnotherWorkflow = async (fileName: string): Promise<boolean> => {
-      for (const other of workflowEntries) {
-        if (other.name === fileName) continue;
-        const content = await fsUtil.readFileIfExists(path.join(workflowsPath, other.name));
-        if (content?.includes(fileName)) return true;
+    // GitHub accepts both .yml and .yaml workflow files, and a workflow's file name is its public
+    // identity (badge URLs, the workflow REST API, same-repository `uses:` references), so .yaml
+    // files are processed under their own name instead of being renamed or silently left stale.
+    // Each kind maps to the one file that carries it; when both spellings exist the .yml wins and
+    // the .yaml twin is left untouched, since merging two workflow definitions is ambiguous.
+    const fileNamesByKind = new Map<string, string>();
+    for (const entry of entries) {
+      if (!entry.isFile() || !/\.ya?ml$/u.test(entry.name) || isObsoleteGenPrWorkflowFileName(entry.name)) continue;
+      const kind = entry.name.replace(/\.ya?ml$/u, '');
+      const existingFileName = fileNamesByKind.get(kind);
+      if (existingFileName === undefined || existingFileName.endsWith('.yaml')) {
+        fileNamesByKind.set(kind, entry.name);
       }
-      return false;
-    };
-    const discoveredFileNames: string[] = [];
-    for (const entry of workflowEntries) {
-      if (entry.name.endsWith('.yml')) {
-        discoveredFileNames.push(entry.name);
-        continue;
-      }
-      const ymlFileName = entry.name.replace(/\.yaml$/u, '.yml');
-      if (fs.existsSync(path.join(workflowsPath, ymlFileName)) || (await isReferencedByAnotherWorkflow(entry.name))) {
-        continue;
-      }
-      await fs.promises.rename(path.join(workflowsPath, entry.name), path.join(workflowsPath, ymlFileName));
-      discoveredFileNames.push(ymlFileName);
     }
-    const fileNameSet = new Set([
-      'test.yml',
-      'autofix.yml',
-      'semantic-pr.yml',
-      'close-comment.yml',
-      ...discoveredFileNames,
-    ]);
+    const mandatoryKinds = ['test', 'autofix', 'semantic-pr', 'close-comment'];
     if (rootConfig.depending.semanticRelease) {
-      fileNameSet.add('release.yml');
+      mandatoryKinds.push('release');
     }
     if (rootConfig.cargoTomlDirPaths.length > 0) {
-      fileNameSet.add('test-rust.yml');
+      mandatoryKinds.push('test-rust');
+    }
+    for (const kind of mandatoryKinds) {
+      if (!fileNamesByKind.has(kind)) {
+        fileNamesByKind.set(kind, `${kind}.yml`);
+      }
     }
     if (!rootConfig.isPublicRepo) {
       // The reusable test workflow already fixes and pushes code on private repos,
       // so a separate autofix workflow only duplicates the same process.
-      fileNameSet.delete('autofix.yml');
-      await promisePool.run(() => fs.promises.rm(path.join(workflowsPath, 'autofix.yml'), { force: true }));
+      fileNamesByKind.delete('autofix');
+      for (const autofixFileName of ['autofix.yml', 'autofix.yaml']) {
+        await promisePool.run(() => fs.promises.rm(path.join(workflowsPath, autofixFileName), { force: true }));
+      }
     }
 
-    for (const fileName of fileNameSet) {
+    for (const [kind, fileName] of fileNamesByKind) {
       // 実際はKnownKind以外の値も代入されることに注意
-      const kind = path.basename(fileName, '.yml') as KnownKind;
-      await promisePool.run(() => writeWorkflowYaml(rootConfig, workflowsPath, kind));
+      await promisePool.run(() => writeWorkflowYaml(rootConfig, workflowsPath, kind as KnownKind, fileName));
     }
   });
 }
@@ -288,9 +270,16 @@ function isObsoleteGenPrWorkflowFileName(fileName: string): boolean {
   return /^gen-pr(?:-.+)?\.ya?ml$/u.test(fileName);
 }
 
-async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, kind: KnownKind): Promise<void> {
-  const filePath = path.join(workflowsPath, `${kind}.yml`);
-  const deployProductionWorkflowExists = fs.existsSync(path.join(workflowsPath, 'deploy-production.yml'));
+async function writeWorkflowYaml(
+  config: PackageConfig,
+  workflowsPath: string,
+  kind: KnownKind,
+  fileName = `${kind}.yml`
+): Promise<void> {
+  const filePath = path.join(workflowsPath, fileName);
+  const deployProductionFileName = ['deploy-production.yml', 'deploy-production.yaml'].find((deployFileName) =>
+    fs.existsSync(path.join(workflowsPath, deployFileName))
+  );
 
   if (kind === 'autofix') {
     await writeYaml(generateAutofixWorkflow(config), filePath);
@@ -346,11 +335,11 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
     }
   }
 
-  if (kind === 'release' && newSettings.jobs.release && deployProductionWorkflowExists) {
+  if (kind === 'release' && newSettings.jobs.release && deployProductionFileName) {
     newSettings.permissions ??= {};
     newSettings.permissions.actions = 'write';
     newSettings.jobs.release.with ??= {};
-    newSettings.jobs.release.with.trigger_deploy_workflow = 'deploy-production.yml';
+    newSettings.jobs.release.with.trigger_deploy_workflow = deployProductionFileName;
   }
 
   let isReusableWorkflow = false;
@@ -370,8 +359,8 @@ async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, k
       } else if (newSettings.on?.push && config.release.branches.length > 0) {
         newSettings.on.push.branches = config.release.branches;
       } else {
-        // Don't use release.yml if release branch is not specified
-        await fs.promises.rm(path.join(workflowsPath, 'release.yml'), { force: true });
+        // Don't use the release workflow if release branch is not specified
+        await fs.promises.rm(filePath, { force: true });
         return;
       }
       if (config.isPublicRepo) {

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -225,15 +225,30 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
     // works on the .yml spelling, so .yaml files are canonicalized to .yml up front instead of
     // being silently left stale. When both spellings exist, the .yaml file is left untouched:
     // merging two workflow definitions is ambiguous, and renaming over the .yml would discard it.
+    const workflowEntries = entries.filter(
+      (entry) => entry.isFile() && /\.ya?ml$/u.test(entry.name) && !isObsoleteGenPrWorkflowFileName(entry.name)
+    );
+    // Same-repository reusable workflows are referenced by their exact file path
+    // (`uses: ./.github/workflows/<name>.yaml`), so renaming a referenced file would break every
+    // caller; such files are left under their original name (and skipped, as before this support).
+    const isReferencedByAnotherWorkflow = async (fileName: string): Promise<boolean> => {
+      for (const other of workflowEntries) {
+        if (other.name === fileName) continue;
+        const content = await fsUtil.readFileIfExists(path.join(workflowsPath, other.name));
+        if (content?.includes(fileName)) return true;
+      }
+      return false;
+    };
     const discoveredFileNames: string[] = [];
-    for (const entry of entries) {
-      if (!entry.isFile() || !/\.ya?ml$/u.test(entry.name) || isObsoleteGenPrWorkflowFileName(entry.name)) continue;
+    for (const entry of workflowEntries) {
       if (entry.name.endsWith('.yml')) {
         discoveredFileNames.push(entry.name);
         continue;
       }
       const ymlFileName = entry.name.replace(/\.yaml$/u, '.yml');
-      if (fs.existsSync(path.join(workflowsPath, ymlFileName))) continue;
+      if (fs.existsSync(path.join(workflowsPath, ymlFileName)) || (await isReferencedByAnotherWorkflow(entry.name))) {
+        continue;
+      }
       await fs.promises.rename(path.join(workflowsPath, entry.name), path.join(workflowsPath, ymlFileName));
       discoveredFileNames.push(ymlFileName);
     }

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -220,18 +220,29 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
       if (!entry.isFile() || !isObsoleteGenPrWorkflowFileName(entry.name)) continue;
       await promisePool.run(() => fs.promises.rm(path.join(workflowsPath, entry.name), { force: true }));
     }
+    // GitHub accepts both .yml and .yaml workflow files, but every managed-name operation below
+    // (autofix suppression, release cleanup, deploy-production detection, the mandatory names)
+    // works on the .yml spelling, so .yaml files are canonicalized to .yml up front instead of
+    // being silently left stale. When both spellings exist, the .yaml file is left untouched:
+    // merging two workflow definitions is ambiguous, and renaming over the .yml would discard it.
+    const discoveredFileNames: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !/\.ya?ml$/u.test(entry.name) || isObsoleteGenPrWorkflowFileName(entry.name)) continue;
+      if (entry.name.endsWith('.yml')) {
+        discoveredFileNames.push(entry.name);
+        continue;
+      }
+      const ymlFileName = entry.name.replace(/\.yaml$/u, '.yml');
+      if (fs.existsSync(path.join(workflowsPath, ymlFileName))) continue;
+      await fs.promises.rename(path.join(workflowsPath, entry.name), path.join(workflowsPath, ymlFileName));
+      discoveredFileNames.push(ymlFileName);
+    }
     const fileNameSet = new Set([
       'test.yml',
       'autofix.yml',
       'semantic-pr.yml',
       'close-comment.yml',
-      // GitHub accepts both .yml and .yaml workflow files, so custom .yaml workflows must be
-      // normalized too (e.g. their reusable-workflow secrets), not silently left stale.
-      ...entries
-        .filter(
-          (dirent) => dirent.isFile() && /\.ya?ml$/u.test(dirent.name) && !isObsoleteGenPrWorkflowFileName(dirent.name)
-        )
-        .map((dirent) => dirent.name),
+      ...discoveredFileNames,
     ]);
     if (rootConfig.depending.semanticRelease) {
       fileNameSet.add('release.yml');
@@ -248,8 +259,8 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
 
     for (const fileName of fileNameSet) {
       // 実際はKnownKind以外の値も代入されることに注意
-      const kind = fileName.replace(/\.ya?ml$/u, '') as KnownKind;
-      await promisePool.run(() => writeWorkflowYaml(rootConfig, workflowsPath, kind, fileName));
+      const kind = path.basename(fileName, '.yml') as KnownKind;
+      await promisePool.run(() => writeWorkflowYaml(rootConfig, workflowsPath, kind));
     }
   });
 }
@@ -262,13 +273,8 @@ function isObsoleteGenPrWorkflowFileName(fileName: string): boolean {
   return /^gen-pr(?:-.+)?\.ya?ml$/u.test(fileName);
 }
 
-async function writeWorkflowYaml(
-  config: PackageConfig,
-  workflowsPath: string,
-  kind: KnownKind,
-  fileName = `${kind}.yml`
-): Promise<void> {
-  const filePath = path.join(workflowsPath, fileName);
+async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, kind: KnownKind): Promise<void> {
+  const filePath = path.join(workflowsPath, `${kind}.yml`);
   const deployProductionWorkflowExists = fs.existsSync(path.join(workflowsPath, 'deploy-production.yml'));
 
   if (kind === 'autofix') {

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -302,6 +302,12 @@ async function writeWorkflowYaml(
       console.warn(`Skipped generating ${filePath} because the existing content is not parsable as YAML.`);
       return;
     }
+    // yaml.load returns undefined for empty/comment-only files and non-objects for scalar
+    // documents without throwing; deepmerge would crash on them.
+    if (typeof oldSettings !== 'object' || oldSettings === null || Array.isArray(oldSettings)) {
+      console.warn(`Skipped generating ${filePath} because the existing content is not a workflow.`);
+      return;
+    }
     newSettings = merge.all([newSettings, oldSettings, newSettings], { arrayMerge: combineMerge }) as Workflow;
   }
 
@@ -390,10 +396,13 @@ async function writeWorkflowYaml(
   await writeYaml(newSettings, filePath);
 
   if (kind === 'sync') {
-    await fs.promises.rm(path.join(workflowsPath, 'sync-init.yml'), { force: true });
+    for (const syncInitFileName of ['sync-init.yml', 'sync-init.yaml']) {
+      await fs.promises.rm(path.join(workflowsPath, syncInitFileName), { force: true });
+    }
     if (!newSettings.jobs.sync?.with) return;
 
-    // Generate sync-force.yml based on sync.yml if it exists.
+    // Generate the force-sync workflow based on the sync workflow if it exists, keeping the
+    // spelling of an existing sync-force file so its identity (badge URLs, API) is preserved.
     newSettings.jobs['sync-force'] = newSettings.jobs.sync;
     const params = newSettings.jobs.sync.with.sync_params_without_dest;
     if (typeof params !== 'string') return;
@@ -402,7 +411,12 @@ async function writeWorkflowYaml(
     newSettings.name = 'Force to Sync';
     newSettings.on = { workflow_dispatch: null };
     delete newSettings.jobs.sync;
-    await writeYaml(newSettings, path.join(workflowsPath, 'sync-force.yml'));
+    const syncForceFileName =
+      !fs.existsSync(path.join(workflowsPath, 'sync-force.yml')) &&
+      fs.existsSync(path.join(workflowsPath, 'sync-force.yaml'))
+        ? 'sync-force.yaml'
+        : 'sync-force.yml';
+    await writeYaml(newSettings, path.join(workflowsPath, syncForceFileName));
   }
 }
 

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -225,9 +225,11 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
       'autofix.yml',
       'semantic-pr.yml',
       'close-comment.yml',
+      // GitHub accepts both .yml and .yaml workflow files, so custom .yaml workflows must be
+      // normalized too (e.g. their reusable-workflow secrets), not silently left stale.
       ...entries
         .filter(
-          (dirent) => dirent.isFile() && dirent.name.endsWith('.yml') && !isObsoleteGenPrWorkflowFileName(dirent.name)
+          (dirent) => dirent.isFile() && /\.ya?ml$/u.test(dirent.name) && !isObsoleteGenPrWorkflowFileName(dirent.name)
         )
         .map((dirent) => dirent.name),
     ]);
@@ -246,8 +248,8 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
 
     for (const fileName of fileNameSet) {
       // 実際はKnownKind以外の値も代入されることに注意
-      const kind = path.basename(fileName, '.yml') as KnownKind;
-      await promisePool.run(() => writeWorkflowYaml(rootConfig, workflowsPath, kind));
+      const kind = fileName.replace(/\.ya?ml$/u, '') as KnownKind;
+      await promisePool.run(() => writeWorkflowYaml(rootConfig, workflowsPath, kind, fileName));
     }
   });
 }
@@ -260,8 +262,13 @@ function isObsoleteGenPrWorkflowFileName(fileName: string): boolean {
   return /^gen-pr(?:-.+)?\.ya?ml$/u.test(fileName);
 }
 
-async function writeWorkflowYaml(config: PackageConfig, workflowsPath: string, kind: KnownKind): Promise<void> {
-  const filePath = path.join(workflowsPath, `${kind}.yml`);
+async function writeWorkflowYaml(
+  config: PackageConfig,
+  workflowsPath: string,
+  kind: KnownKind,
+  fileName = `${kind}.yml`
+): Promise<void> {
+  const filePath = path.join(workflowsPath, fileName);
   const deployProductionWorkflowExists = fs.existsSync(path.join(workflowsPath, 'deploy-production.yml'));
 
   if (kind === 'autofix') {
@@ -411,7 +418,11 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   // callee does not declare. The legacy DOT_ENV pass-through is deliberately kept: FNOX_AGE_KEY
   // provisioning can be skipped (no --env, missing token or age identity), and the pass-through keeps
   // CI working from the still-existing DOT_ENV secret until the fnox migration completes.
-  const calledReusableWorkflow = /\/reusable-workflows\/\.github\/workflows\/([^/@]+?)\.ya?ml@/u.exec(
+  // Only an @main callee is known to follow the current secret contract: a workflow pinned to an
+  // older tag or SHA may still declare NPM_TOKEN (and not VERDACCIO_TOKEN), and GitHub rejects a
+  // caller whose secrets do not match the selected revision's declarations, so pinned callers keep
+  // their secrets untouched.
+  const calledReusableWorkflow = /\/reusable-workflows\/\.github\/workflows\/([^/@]+?)\.ya?ml@main$/u.exec(
     job.uses ?? ''
   )?.[1];
   if (secrets && calledReusableWorkflow && installCapableReusableWorkflows.has(calledReusableWorkflow)) {

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -246,6 +246,13 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
         fileNamesByKind.set(kind, `${kind}.yml`);
       }
     }
+    if (fileNamesByKind.has('sync')) {
+      // The sync workflow's generation owns these files (it rewrites the force-sync workflow and
+      // deletes the obsolete sync-init one), so processing them as independent kinds would race
+      // concurrent writes on the same paths.
+      fileNamesByKind.delete('sync-force');
+      fileNamesByKind.delete('sync-init');
+    }
     if (!rootConfig.isPublicRepo) {
       // The reusable test workflow already fixes and pushes code on private repos,
       // so a separate autofix workflow only duplicates the same process.

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -423,6 +423,12 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
       secrets.FNOX_AGE_KEY = '${{ secrets.FNOX_AGE_KEY }}';
     }
   }
+  // reusable-workflows replaced the NPM_TOKEN secret declaration with VERDACCIO_TOKEN; GitHub
+  // rejects passing an undeclared secret to a reusable workflow with a startup_failure that emits
+  // no check runs, so a leftover NPM_TOKEN silently disables every calling workflow.
+  if (secrets && calledReusableWorkflow) {
+    delete secrets.NPM_TOKEN;
+  }
 
   if (secrets?.FIREBASE_TOKEN) {
     secrets.GCP_SA_KEY_JSON_FOR_FIREBASE = '${{ secrets.GCP_SA_KEY_JSON_FOR_FIREBASE }}';

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -11,6 +11,7 @@ interface GeneratedPackageJson {
   dependencies?: Record<string, string | undefined>;
   devDependencies?: Record<string, string | undefined>;
   scripts?: Record<string, string | undefined>;
+  trustedDependencies?: string[];
 }
 
 const genI18nTsDepending = {
@@ -1497,6 +1498,61 @@ test('never generates --bun scripts', async () => {
       expect(command).not.toContain('--bun');
     }
   }
+});
+
+test('manages trustedDependencies correctly when store-incompatible packages are present', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      dependencies: {
+        'drizzle-kit': '1.0.0',
+      },
+    },
+    { isRoot: true }
+  );
+
+  expect(packageJson).toMatchObject({
+    trustedDependencies: ['drizzle-kit', 'lefthook'],
+  });
+});
+
+test('ensures lefthook is included if custom trustedDependencies exist', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      dependencies: {},
+      trustedDependencies: ['some-custom-dependency'],
+    },
+    { isRoot: true }
+  );
+
+  expect(packageJson).toMatchObject({
+    trustedDependencies: ['lefthook', 'some-custom-dependency'],
+  });
+});
+
+test('cleans up wbfy-managed trustedDependencies when they are no longer declared', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      dependencies: {},
+      trustedDependencies: ['@chakra-ui/react', 'drizzle-kit', 'lefthook'],
+    },
+    { isRoot: true }
+  );
+
+  expect(packageJson.trustedDependencies).toBeUndefined();
+});
+
+test('preserves custom trustedDependencies while cleaning up wbfy-managed ones', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      dependencies: {},
+      trustedDependencies: ['@chakra-ui/react', 'custom-pkg', 'drizzle-kit'],
+    },
+    { isRoot: true }
+  );
+
+  expect(packageJson).toMatchObject({
+    trustedDependencies: ['custom-pkg', 'lefthook'],
+  });
 });
 
 async function generatePackageJsonFrom(

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1555,6 +1555,34 @@ test('preserves custom trustedDependencies while cleaning up wbfy-managed ones',
   });
 });
 
+// An explicitly empty list is a deliberate block-everything policy; deleting it would re-enable
+// Bun's default allow-list.
+test('preserves an explicitly empty trustedDependencies list', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      dependencies: {},
+      trustedDependencies: [],
+    },
+    { isRoot: true }
+  );
+
+  expect(packageJson.trustedDependencies).toEqual([]);
+});
+
+// @chakra-ui/cli v2's `chakra-cli tokens` writes into @chakra-ui/styled-system, not
+// @chakra-ui/react, so trusting @chakra-ui/react there would be inert.
+test('does not trust @chakra-ui/react for @chakra-ui/cli v2', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      dependencies: { '@chakra-ui/react': '^2.10.9' },
+      devDependencies: { '@chakra-ui/cli': '^2.5.8' },
+    },
+    { isRoot: true }
+  );
+
+  expect(packageJson.trustedDependencies).toBeUndefined();
+});
+
 async function generatePackageJsonFrom(
   initialPackageJson: Record<string, unknown>,
   configOverrides: Parameters<typeof createConfig>[0] = {},

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -35,8 +35,8 @@ test('replaces default gen-i18n-ts postinstall with managed wb gen-code scripts'
 
   expect(packageJson.scripts).toMatchObject({
     cleanup: 'bun wb lint --fix --format',
-    'gen-code': 'bun wb gen-code',
-    postinstall: 'wb gen-code',
+    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code',
+    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code',
   });
   expect(packageJson.scripts?.['gen-i18n-ts']).toBeUndefined();
 });
@@ -55,8 +55,8 @@ test('does not restore missing default gen-i18n-ts script with managed wb gen-co
 
   expect(packageJson.scripts).toMatchObject({
     cleanup: 'bun wb lint --fix --format',
-    'gen-code': 'bun wb gen-code',
-    postinstall: 'wb gen-code',
+    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code',
+    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code',
   });
   expect(packageJson.scripts?.['gen-i18n-ts']).toBeUndefined();
 });
@@ -76,7 +76,7 @@ test('keeps custom gen-i18n-ts scripts while adding wb gen-code', async () => {
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'bun wb gen-code',
+    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code',
     'gen-i18n-ts': 'gen-i18n-ts -i locales -o src/i18n.ts -d en-US',
   });
 });
@@ -98,7 +98,7 @@ test.each([
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 test('keeps build-ts as a runtime dependency when prisma seed uses it', async () => {
@@ -190,8 +190,8 @@ test('appends wrangler types to gen-code and postinstall for Cloudflare projects
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'bun wb gen-code && bunx wrangler types',
-    postinstall: 'wb gen-code && bunx wrangler types',
+    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code && bunx wrangler types',
+    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types',
   });
 });
 
@@ -215,8 +215,8 @@ test.each([
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'bun wb gen-code && wrangler types --strict-vars=false',
-    postinstall: 'wb gen-code && wrangler types --strict-vars=false',
+    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code && wrangler types --strict-vars=false',
+    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false',
   });
 });
 
@@ -245,8 +245,8 @@ test('keeps management for a script composing gen-code with a build step', async
 
   expect(packageJson.scripts).toMatchObject({
     'build/core': 'bun run gen-code && vite build',
-    'gen-code': 'bun wb gen-code && wrangler types --strict-vars=false',
-    postinstall: 'wb gen-code && wrangler types --strict-vars=false',
+    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code && wrangler types --strict-vars=false',
+    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false',
   });
 });
 
@@ -259,7 +259,7 @@ test('omits wrangler types when the package does not depend on wrangler', async 
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // `wrangler types` exits non-zero without a wrangler config, which would break `install` for the whole repository.
@@ -271,8 +271,8 @@ test('omits wrangler types when the package owns no wrangler config', async () =
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.['gen-code']).toBe('bun wb gen-code');
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.['gen-code']).toBe('WB_ENV=${WB_ENV:-development} bun wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // `wrangler types --check` validates freshness and generates nothing, and a positional output path generates a
@@ -297,8 +297,8 @@ test('ignores non-generating and custom-output wrangler types invocations when r
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'bun wb gen-code && bunx wrangler types',
-    postinstall: 'wb gen-code && bunx wrangler types',
+    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code && bunx wrangler types',
+    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types',
   });
 });
 
@@ -338,7 +338,9 @@ test('preserves a wrangler types invocation with a custom config path when overw
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --config config/worker.jsonc');
+  expect(packageJson.scripts?.postinstall).toBe(
+    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --config config/worker.jsonc'
+  );
 });
 
 // The generated file is a pure function of committed inputs only when the `Env` inference source (.dev.vars,
@@ -358,7 +360,7 @@ test('omits wrangler types when an uncommitted .dev.vars drives the Env inferenc
     { createI18nDir: true, files: { '.dev.vars': 'AUTH_SECRET=local-secret\n', 'wrangler.jsonc': '{}' } }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 test('keeps wrangler types when secrets.required makes the Env inference reproducible', async () => {
@@ -385,7 +387,7 @@ test('keeps wrangler types when secrets.required makes the Env inference reprodu
     }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
 });
 
 // A declaration at any config level replaces the .dev.vars/.env inference: wrangler aggregates per-environment
@@ -409,7 +411,7 @@ test('keeps wrangler types when an env-level secrets.required makes the Env infe
     }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
 });
 
 // Wranglers older than 4.70.0 warn about the unexpected top-level `secrets` field and keep inferring from
@@ -433,7 +435,7 @@ test('ignores secrets.required when the wrangler dependency predates its support
     }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // Running the documented code-generation entry point must produce the same declarations as postinstall,
@@ -447,7 +449,7 @@ test('appends wrangler types to a project-specific gen-code script', async () =>
 
   expect(packageJson.scripts).toMatchObject({
     'gen-code': 'tsx scripts/genRoutes.ts && bunx wrangler types',
-    postinstall: 'wb gen-code && bunx wrangler types',
+    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types',
   });
 });
 
@@ -466,7 +468,7 @@ test('does not treat shell text mentioning wrangler types as the generator comma
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
 });
 
 // --cwd/--config/--env change the config, output directory, or .dev.vars inference inputs away from the ones the
@@ -486,7 +488,7 @@ test('ignores non-conflicting but non-generating wrangler types invocations when
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
 });
 
 // An invocation that writes the managed default file from inputs wbfy cannot validate (--config, --env,
@@ -514,7 +516,7 @@ test.each([
       { createI18nDir: true }
     );
 
-    expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+    expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
     expect(packageJson.scripts?.['gen-types']).toBe(genTypes);
   }
 );
@@ -534,7 +536,7 @@ test('ignores wrangler types invocations that follow a cd', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
 });
 
 // Shell redirections are not wrangler arguments and must not disqualify (or truncate) the project's invocation.
@@ -551,7 +553,9 @@ test('reuses a wrangler types invocation followed by a shell redirection', async
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --strict-vars=false > /dev/null');
+  expect(packageJson.scripts?.postinstall).toBe(
+    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false > /dev/null'
+  );
 });
 
 // Wrangler's documented default output path is exactly ./worker-configuration.d.ts, so naming it explicitly
@@ -573,7 +577,7 @@ test('reuses a wrangler types invocation that names the default output path expl
   );
 
   expect(packageJson.scripts?.postinstall).toBe(
-    'wb gen-code && wrangler types ./worker-configuration.d.ts --strict-vars=false'
+    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types ./worker-configuration.d.ts --strict-vars=false'
   );
 });
 
@@ -592,7 +596,7 @@ test('ignores help-only wrangler types invocations when resolving the command', 
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
 });
 
 // Boolean options accept a space-separated literal, which must not be misread as a positional output path.
@@ -609,7 +613,9 @@ test('reuses a wrangler types invocation with a space-separated boolean option',
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --strict-vars false');
+  expect(packageJson.scripts?.postinstall).toBe(
+    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars false'
+  );
 });
 
 // Wrapper detection must survive environment assignments and runner flags around the script name.
@@ -656,7 +662,9 @@ test('reuses a wrangler types invocation with --check=false', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --check=false --strict-vars=false');
+  expect(packageJson.scripts?.postinstall).toBe(
+    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --check=false --strict-vars=false'
+  );
 });
 
 // postinstall shapes the file after every install, so its generator wins over other scripts' flagged
@@ -681,8 +689,8 @@ test('prefers the generator postinstall already runs over other scripts', async 
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'bun wb gen-code && wrangler types --env-interface AppEnv',
-    postinstall: 'wb gen-code && wrangler types --env-interface AppEnv',
+    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code && wrangler types --env-interface AppEnv',
+    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --env-interface AppEnv',
   });
 });
 
@@ -707,7 +715,7 @@ test('skips worker-types management when distinct flagged generators leave no de
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // `cd .` never leaves the package directory, so a conflicting invocation behind it must still be seen.
@@ -727,7 +735,7 @@ test('recognizes a conflicting invocation behind a no-op cd', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // A quoted `&&` is argument text; splitting inside it would fabricate a generator command that was never run
@@ -745,7 +753,7 @@ test('does not select a wrangler types invocation quoted inside another command'
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
 });
 
 // Wrangler also layers .env.local (and environment-specific variants) into the Env inference, so an uncommitted
@@ -763,7 +771,7 @@ test('omits wrangler types when an uncommitted .env.local drives the Env inferen
     { createI18nDir: true, files: { '.env.local': 'LOCAL_ONLY_SECRET=local-value\n', 'wrangler.jsonc': '{}' } }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // Subshells and pipes are not modeled by the segment parser: splitting them apart would fabricate malformed
@@ -784,7 +792,7 @@ test('skips worker-types management when a wrangler types command sits in a subs
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
   expect(packageJson.scripts?.['gen-other']).toBe('(cd ../other && wrangler types --strict-vars=false)');
 });
 
@@ -807,7 +815,7 @@ test('keeps generation prerequisites when rewriting postinstall', async () => {
   );
 
   expect(packageJson.scripts?.postinstall).toBe(
-    'wb gen-code && node scripts/prepareTypes.js && wrangler types --strict-vars=false'
+    'WB_ENV=${WB_ENV:-development} wb gen-code && node scripts/prepareTypes.js && wrangler types --strict-vars=false'
   );
 });
 
@@ -825,7 +833,9 @@ test('reuses a wrangler types invocation with a no-op --cwd', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --cwd . --strict-vars=false');
+  expect(packageJson.scripts?.postinstall).toBe(
+    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --cwd . --strict-vars=false'
+  );
 });
 
 // Quoted environment values contain spaces; whitespace-only tokenization would push the assignment into the
@@ -844,7 +854,7 @@ test('recognizes a generator prefixed by a quoted environment assignment', async
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${genTypes}`);
+  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${genTypes}`);
 });
 
 // Pipes are not modeled by the parser, so a piped conflicting invocation must disable management (and survive
@@ -863,7 +873,7 @@ test('skips worker-types management for a piped custom-config invocation', async
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
 });
 
 // `yarn --cwd . gen-types` runs this package's script; the option value must not be mistaken for the script name.
@@ -886,7 +896,7 @@ test('preserves a wrapper invoked through a runner option with a value', async (
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && yarn --cwd . gen-types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && yarn --cwd . gen-types');
 });
 
 // A gen-code wrapper is interchangeable with `wb gen-code` only when the gen-code script is the managed
@@ -906,7 +916,7 @@ test('preserves a gen-code wrapper whose script is a custom pipeline', async () 
 
   expect(packageJson.scripts).toMatchObject({
     'gen-code': 'node scripts/prepareTypes.js && wrangler types --strict-vars=false',
-    postinstall: 'wb gen-code && bun run gen-code',
+    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && bun run gen-code',
   });
 });
 
@@ -926,7 +936,7 @@ test('treats a workspace-selected invocation as non-local', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
 });
 
 // A gen-code wrapper hiding a custom-config invocation is not interchangeable with `wb gen-code`.
@@ -945,7 +955,7 @@ test('preserves a gen-code wrapper whose script includes a custom-config invocat
 
   expect(packageJson.scripts).toMatchObject({
     'gen-code': 'wb gen-code && wrangler types --config config/worker.jsonc',
-    postinstall: 'wb gen-code && bun run gen-code',
+    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && bun run gen-code',
   });
 });
 
@@ -965,7 +975,7 @@ test('preserves an unparseable generating postinstall verbatim', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
 });
 
 // Reusing only the generator segment of a prerequisite pipeline outside postinstall would bypass the
@@ -986,7 +996,7 @@ test('skips worker-types management when the generator pipeline has prerequisite
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // `npm exec -- wb gen-code` is the managed code generation; the rewrite must not run it a second time.
@@ -1006,7 +1016,9 @@ test('recognizes an exec-form wb gen-code segment when rewriting postinstall', a
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --strict-vars=false');
+  expect(packageJson.scripts?.postinstall).toBe(
+    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false'
+  );
 });
 
 // Forwarded wrapper arguments (`npm run gen-types -- --check`) change the effective invocation, so the wrapper
@@ -1027,7 +1039,9 @@ test('treats a wrapper forwarding arguments as unmodeled', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && npm run gen-types -- --check');
+  expect(packageJson.scripts?.postinstall).toBe(
+    'WB_ENV=${WB_ENV:-development} wb gen-code && npm run gen-types -- --check'
+  );
 });
 
 // `npm --workspaces exec ...` runs in every workspace, not (only) this package.
@@ -1045,7 +1059,7 @@ test('treats an all-workspaces invocation as non-local', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
 });
 
 // A generator behind a real `cd` belongs to another directory: the package stays managed (the local generator
@@ -1064,7 +1078,9 @@ test('preserves a directory-changing generating postinstall verbatim', async () 
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`bunx wrangler types && wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(
+    `bunx wrangler types && WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`
+  );
 });
 
 // `npm run wrangler types` invokes the package script called `wrangler` with `types` as an argument, never the
@@ -1085,7 +1101,7 @@ test('does not treat npm run with a wrangler-named script as a generator', async
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && npm run wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && npm run wrangler types');
 });
 
 // A backgrounding `&` changes shell grammar in ways the parser does not model, so such invocations disable
@@ -1106,7 +1122,7 @@ test('treats a backgrounded invocation as unmodeled', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // A check-only custom gen-code fails while the gitignored file is absent, so the generator must run first,
@@ -1139,7 +1155,7 @@ test('keeps management when a custom-config invocation follows a cd', async () =
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
 });
 
 // `wb gen-code ; wrangler types --config ...` is a compound command, not the plain managed invocation, and must
@@ -1158,7 +1174,7 @@ test('does not discard a compound segment starting with wb gen-code', async () =
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
 });
 
 // A syntactically quoted command word (`"wrangler" types`) executes wrangler but evades tokenization, so the
@@ -1179,7 +1195,7 @@ test('treats a quoted command word invocation as unmodeled', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // A trailing shell comment is not a positional output path; the flags before it must be reused — without the
@@ -1197,7 +1213,9 @@ test('reuses a wrangler types invocation followed by a shell comment', async () 
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --strict-vars=false');
+  expect(packageJson.scripts?.postinstall).toBe(
+    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false'
+  );
 });
 
 // Shell quoting does not change an argument's value: `'--config'` still selects another config.
@@ -1217,7 +1235,7 @@ test('classifies a quoted option name like its unquoted form', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // Double quotes do not suppress command substitution, so `echo "$(wrangler types ...)"` still generates and
@@ -1236,7 +1254,7 @@ test('preserves a command-substitution invocation inside double quotes', async (
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
 });
 
 // A plain wrapper of an unmodeled target must also be preserved, or the only install-time generation is lost.
@@ -1253,7 +1271,7 @@ test('preserves a plain wrapper whose target uses unsupported shell syntax', asy
     { isCloudflare: true, doesContainWranglerConfig: true, packageJson: wranglerPackageJson }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bun run gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bun run gen-code');
 });
 
 // `cd ./.` never leaves the package directory, so a conflicting invocation behind it must still be seen.
@@ -1273,7 +1291,7 @@ test('recognizes a conflicting invocation behind a normalized no-op cd', async (
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // The wrangler config itself drives the generation, so an uncommitted config makes the file irreproducible.
@@ -1291,7 +1309,7 @@ test('omits wrangler types when the wrangler config is uncommitted', async () =>
     { createI18nDir: true, files: { 'wrangler.jsonc': '{ "name": "app" }' } }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // Global wrangler options may precede the subcommand; such forms cannot be modeled and must survive verbatim.
@@ -1311,7 +1329,7 @@ test('preserves a wrapper around a global-option wrangler invocation', async () 
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bun run gen-types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bun run gen-types');
 });
 
 // A bare generator behind a prerequisite is a pipeline too; bypassing the preparation step could emit an Env
@@ -1332,7 +1350,7 @@ test('skips worker-types management for a prerequisite pipeline with a bare gene
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
 });
 
 // Quoting does not enable the check: `--check 'false'` still generates and its flags must be preserved.
@@ -1349,7 +1367,9 @@ test('reuses a wrangler types invocation with a quoted false check literal', asy
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe("wb gen-code && wrangler types --strict-vars=false --check 'false'");
+  expect(packageJson.scripts?.postinstall).toBe(
+    "WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false --check 'false'"
+  );
 });
 
 // `wrangler types --check` fails while the gitignored file is still absent, so the generator must run first.
@@ -1384,7 +1404,7 @@ test('preserves a wrapper script invoking wrangler types with a custom config wh
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bun run gen-types');
+  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bun run gen-types');
 });
 
 test('keeps custom database scripts for drizzle projects', async () => {
@@ -1398,9 +1418,9 @@ test('keeps custom database scripts for drizzle projects', async () => {
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'db-create-migration': 'bun wb db migrate-dev',
+    'db-create-migration': 'WB_ENV=${WB_ENV:-development} bun wb db migrate-dev',
     'db-migrate': 'bun scripts/runDrizzleMigrationsToAllClients.ts',
-    'db-view': 'bun wb db studio',
+    'db-view': 'WB_ENV=${WB_ENV:-development} bun wb db studio',
   });
 });
 

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -35,8 +35,8 @@ test('replaces default gen-i18n-ts postinstall with managed wb gen-code scripts'
 
   expect(packageJson.scripts).toMatchObject({
     cleanup: 'bun wb lint --fix --format',
-    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code',
-    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code',
+    'gen-code': 'bun wb gen-code',
+    postinstall: 'wb gen-code',
   });
   expect(packageJson.scripts?.['gen-i18n-ts']).toBeUndefined();
 });
@@ -55,8 +55,8 @@ test('does not restore missing default gen-i18n-ts script with managed wb gen-co
 
   expect(packageJson.scripts).toMatchObject({
     cleanup: 'bun wb lint --fix --format',
-    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code',
-    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code',
+    'gen-code': 'bun wb gen-code',
+    postinstall: 'wb gen-code',
   });
   expect(packageJson.scripts?.['gen-i18n-ts']).toBeUndefined();
 });
@@ -76,7 +76,7 @@ test('keeps custom gen-i18n-ts scripts while adding wb gen-code', async () => {
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code',
+    'gen-code': 'bun wb gen-code',
     'gen-i18n-ts': 'gen-i18n-ts -i locales -o src/i18n.ts -d en-US',
   });
 });
@@ -98,7 +98,7 @@ test.each([
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 test('keeps build-ts as a runtime dependency when prisma seed uses it', async () => {
@@ -190,8 +190,8 @@ test('appends wrangler types to gen-code and postinstall for Cloudflare projects
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code && bunx wrangler types',
-    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types',
+    'gen-code': 'bun wb gen-code && bunx wrangler types',
+    postinstall: 'wb gen-code && bunx wrangler types',
   });
 });
 
@@ -215,8 +215,8 @@ test.each([
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code && wrangler types --strict-vars=false',
-    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false',
+    'gen-code': 'bun wb gen-code && wrangler types --strict-vars=false',
+    postinstall: 'wb gen-code && wrangler types --strict-vars=false',
   });
 });
 
@@ -245,8 +245,8 @@ test('keeps management for a script composing gen-code with a build step', async
 
   expect(packageJson.scripts).toMatchObject({
     'build/core': 'bun run gen-code && vite build',
-    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code && wrangler types --strict-vars=false',
-    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false',
+    'gen-code': 'bun wb gen-code && wrangler types --strict-vars=false',
+    postinstall: 'wb gen-code && wrangler types --strict-vars=false',
   });
 });
 
@@ -259,7 +259,7 @@ test('omits wrangler types when the package does not depend on wrangler', async 
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // `wrangler types` exits non-zero without a wrangler config, which would break `install` for the whole repository.
@@ -271,8 +271,8 @@ test('omits wrangler types when the package owns no wrangler config', async () =
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.['gen-code']).toBe('WB_ENV=${WB_ENV:-development} bun wb gen-code');
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.['gen-code']).toBe('bun wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // `wrangler types --check` validates freshness and generates nothing, and a positional output path generates a
@@ -297,8 +297,8 @@ test('ignores non-generating and custom-output wrangler types invocations when r
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code && bunx wrangler types',
-    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types',
+    'gen-code': 'bun wb gen-code && bunx wrangler types',
+    postinstall: 'wb gen-code && bunx wrangler types',
   });
 });
 
@@ -338,9 +338,7 @@ test('preserves a wrangler types invocation with a custom config path when overw
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(
-    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --config config/worker.jsonc'
-  );
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --config config/worker.jsonc');
 });
 
 // The generated file is a pure function of committed inputs only when the `Env` inference source (.dev.vars,
@@ -360,7 +358,7 @@ test('omits wrangler types when an uncommitted .dev.vars drives the Env inferenc
     { createI18nDir: true, files: { '.dev.vars': 'AUTH_SECRET=local-secret\n', 'wrangler.jsonc': '{}' } }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 test('keeps wrangler types when secrets.required makes the Env inference reproducible', async () => {
@@ -387,7 +385,7 @@ test('keeps wrangler types when secrets.required makes the Env inference reprodu
     }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
 });
 
 // A declaration at any config level replaces the .dev.vars/.env inference: wrangler aggregates per-environment
@@ -411,7 +409,7 @@ test('keeps wrangler types when an env-level secrets.required makes the Env infe
     }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
 });
 
 // Wranglers older than 4.70.0 warn about the unexpected top-level `secrets` field and keep inferring from
@@ -435,7 +433,7 @@ test('ignores secrets.required when the wrangler dependency predates its support
     }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // Running the documented code-generation entry point must produce the same declarations as postinstall,
@@ -449,7 +447,7 @@ test('appends wrangler types to a project-specific gen-code script', async () =>
 
   expect(packageJson.scripts).toMatchObject({
     'gen-code': 'tsx scripts/genRoutes.ts && bunx wrangler types',
-    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types',
+    postinstall: 'wb gen-code && bunx wrangler types',
   });
 });
 
@@ -468,7 +466,7 @@ test('does not treat shell text mentioning wrangler types as the generator comma
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
 });
 
 // --cwd/--config/--env change the config, output directory, or .dev.vars inference inputs away from the ones the
@@ -488,7 +486,7 @@ test('ignores non-conflicting but non-generating wrangler types invocations when
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
 });
 
 // An invocation that writes the managed default file from inputs wbfy cannot validate (--config, --env,
@@ -516,7 +514,7 @@ test.each([
       { createI18nDir: true }
     );
 
-    expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+    expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
     expect(packageJson.scripts?.['gen-types']).toBe(genTypes);
   }
 );
@@ -536,7 +534,7 @@ test('ignores wrangler types invocations that follow a cd', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
 });
 
 // Shell redirections are not wrangler arguments and must not disqualify (or truncate) the project's invocation.
@@ -553,9 +551,7 @@ test('reuses a wrangler types invocation followed by a shell redirection', async
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(
-    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false > /dev/null'
-  );
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --strict-vars=false > /dev/null');
 });
 
 // Wrangler's documented default output path is exactly ./worker-configuration.d.ts, so naming it explicitly
@@ -577,7 +573,7 @@ test('reuses a wrangler types invocation that names the default output path expl
   );
 
   expect(packageJson.scripts?.postinstall).toBe(
-    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types ./worker-configuration.d.ts --strict-vars=false'
+    'wb gen-code && wrangler types ./worker-configuration.d.ts --strict-vars=false'
   );
 });
 
@@ -596,7 +592,7 @@ test('ignores help-only wrangler types invocations when resolving the command', 
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
 });
 
 // Boolean options accept a space-separated literal, which must not be misread as a positional output path.
@@ -613,9 +609,7 @@ test('reuses a wrangler types invocation with a space-separated boolean option',
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(
-    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars false'
-  );
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --strict-vars false');
 });
 
 // Wrapper detection must survive environment assignments and runner flags around the script name.
@@ -662,9 +656,7 @@ test('reuses a wrangler types invocation with --check=false', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(
-    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --check=false --strict-vars=false'
-  );
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --check=false --strict-vars=false');
 });
 
 // postinstall shapes the file after every install, so its generator wins over other scripts' flagged
@@ -689,8 +681,8 @@ test('prefers the generator postinstall already runs over other scripts', async 
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'WB_ENV=${WB_ENV:-development} bun wb gen-code && wrangler types --env-interface AppEnv',
-    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --env-interface AppEnv',
+    'gen-code': 'bun wb gen-code && wrangler types --env-interface AppEnv',
+    postinstall: 'wb gen-code && wrangler types --env-interface AppEnv',
   });
 });
 
@@ -715,7 +707,7 @@ test('skips worker-types management when distinct flagged generators leave no de
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // `cd .` never leaves the package directory, so a conflicting invocation behind it must still be seen.
@@ -735,7 +727,7 @@ test('recognizes a conflicting invocation behind a no-op cd', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // A quoted `&&` is argument text; splitting inside it would fabricate a generator command that was never run
@@ -753,7 +745,7 @@ test('does not select a wrangler types invocation quoted inside another command'
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
 });
 
 // Wrangler also layers .env.local (and environment-specific variants) into the Env inference, so an uncommitted
@@ -771,7 +763,7 @@ test('omits wrangler types when an uncommitted .env.local drives the Env inferen
     { createI18nDir: true, files: { '.env.local': 'LOCAL_ONLY_SECRET=local-value\n', 'wrangler.jsonc': '{}' } }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // Subshells and pipes are not modeled by the segment parser: splitting them apart would fabricate malformed
@@ -792,7 +784,7 @@ test('skips worker-types management when a wrangler types command sits in a subs
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
   expect(packageJson.scripts?.['gen-other']).toBe('(cd ../other && wrangler types --strict-vars=false)');
 });
 
@@ -815,7 +807,7 @@ test('keeps generation prerequisites when rewriting postinstall', async () => {
   );
 
   expect(packageJson.scripts?.postinstall).toBe(
-    'WB_ENV=${WB_ENV:-development} wb gen-code && node scripts/prepareTypes.js && wrangler types --strict-vars=false'
+    'wb gen-code && node scripts/prepareTypes.js && wrangler types --strict-vars=false'
   );
 });
 
@@ -833,9 +825,7 @@ test('reuses a wrangler types invocation with a no-op --cwd', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(
-    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --cwd . --strict-vars=false'
-  );
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --cwd . --strict-vars=false');
 });
 
 // Quoted environment values contain spaces; whitespace-only tokenization would push the assignment into the
@@ -854,7 +844,7 @@ test('recognizes a generator prefixed by a quoted environment assignment', async
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${genTypes}`);
+  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${genTypes}`);
 });
 
 // Pipes are not modeled by the parser, so a piped conflicting invocation must disable management (and survive
@@ -873,7 +863,7 @@ test('skips worker-types management for a piped custom-config invocation', async
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
 });
 
 // `yarn --cwd . gen-types` runs this package's script; the option value must not be mistaken for the script name.
@@ -896,7 +886,7 @@ test('preserves a wrapper invoked through a runner option with a value', async (
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && yarn --cwd . gen-types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && yarn --cwd . gen-types');
 });
 
 // A gen-code wrapper is interchangeable with `wb gen-code` only when the gen-code script is the managed
@@ -916,7 +906,7 @@ test('preserves a gen-code wrapper whose script is a custom pipeline', async () 
 
   expect(packageJson.scripts).toMatchObject({
     'gen-code': 'node scripts/prepareTypes.js && wrangler types --strict-vars=false',
-    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && bun run gen-code',
+    postinstall: 'wb gen-code && bun run gen-code',
   });
 });
 
@@ -936,7 +926,7 @@ test('treats a workspace-selected invocation as non-local', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
 });
 
 // A gen-code wrapper hiding a custom-config invocation is not interchangeable with `wb gen-code`.
@@ -955,7 +945,7 @@ test('preserves a gen-code wrapper whose script includes a custom-config invocat
 
   expect(packageJson.scripts).toMatchObject({
     'gen-code': 'wb gen-code && wrangler types --config config/worker.jsonc',
-    postinstall: 'WB_ENV=${WB_ENV:-development} wb gen-code && bun run gen-code',
+    postinstall: 'wb gen-code && bun run gen-code',
   });
 });
 
@@ -975,7 +965,7 @@ test('preserves an unparseable generating postinstall verbatim', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
 });
 
 // Reusing only the generator segment of a prerequisite pipeline outside postinstall would bypass the
@@ -996,7 +986,7 @@ test('skips worker-types management when the generator pipeline has prerequisite
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // `npm exec -- wb gen-code` is the managed code generation; the rewrite must not run it a second time.
@@ -1016,9 +1006,7 @@ test('recognizes an exec-form wb gen-code segment when rewriting postinstall', a
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(
-    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false'
-  );
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --strict-vars=false');
 });
 
 // Forwarded wrapper arguments (`npm run gen-types -- --check`) change the effective invocation, so the wrapper
@@ -1039,9 +1027,7 @@ test('treats a wrapper forwarding arguments as unmodeled', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(
-    'WB_ENV=${WB_ENV:-development} wb gen-code && npm run gen-types -- --check'
-  );
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && npm run gen-types -- --check');
 });
 
 // `npm --workspaces exec ...` runs in every workspace, not (only) this package.
@@ -1059,7 +1045,7 @@ test('treats an all-workspaces invocation as non-local', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
 });
 
 // A generator behind a real `cd` belongs to another directory: the package stays managed (the local generator
@@ -1078,9 +1064,7 @@ test('preserves a directory-changing generating postinstall verbatim', async () 
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(
-    `bunx wrangler types && WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`
-  );
+  expect(packageJson.scripts?.postinstall).toBe(`bunx wrangler types && wb gen-code && ${postinstall}`);
 });
 
 // `npm run wrangler types` invokes the package script called `wrangler` with `types` as an argument, never the
@@ -1101,7 +1085,7 @@ test('does not treat npm run with a wrangler-named script as a generator', async
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && npm run wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && npm run wrangler types');
 });
 
 // A backgrounding `&` changes shell grammar in ways the parser does not model, so such invocations disable
@@ -1122,7 +1106,7 @@ test('treats a backgrounded invocation as unmodeled', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // A check-only custom gen-code fails while the gitignored file is absent, so the generator must run first,
@@ -1155,7 +1139,7 @@ test('keeps management when a custom-config invocation follows a cd', async () =
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bunx wrangler types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bunx wrangler types');
 });
 
 // `wb gen-code ; wrangler types --config ...` is a compound command, not the plain managed invocation, and must
@@ -1174,7 +1158,7 @@ test('does not discard a compound segment starting with wb gen-code', async () =
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
 });
 
 // A syntactically quoted command word (`"wrangler" types`) executes wrangler but evades tokenization, so the
@@ -1195,7 +1179,7 @@ test('treats a quoted command word invocation as unmodeled', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // A trailing shell comment is not a positional output path; the flags before it must be reused — without the
@@ -1213,9 +1197,7 @@ test('reuses a wrangler types invocation followed by a shell comment', async () 
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(
-    'WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false'
-  );
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --strict-vars=false');
 });
 
 // Shell quoting does not change an argument's value: `'--config'` still selects another config.
@@ -1235,7 +1217,7 @@ test('classifies a quoted option name like its unquoted form', async () => {
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // Double quotes do not suppress command substitution, so `echo "$(wrangler types ...)"` still generates and
@@ -1254,7 +1236,7 @@ test('preserves a command-substitution invocation inside double quotes', async (
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`WB_ENV=\${WB_ENV:-development} wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
 });
 
 // A plain wrapper of an unmodeled target must also be preserved, or the only install-time generation is lost.
@@ -1271,7 +1253,7 @@ test('preserves a plain wrapper whose target uses unsupported shell syntax', asy
     { isCloudflare: true, doesContainWranglerConfig: true, packageJson: wranglerPackageJson }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bun run gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bun run gen-code');
 });
 
 // `cd ./.` never leaves the package directory, so a conflicting invocation behind it must still be seen.
@@ -1291,7 +1273,7 @@ test('recognizes a conflicting invocation behind a normalized no-op cd', async (
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // The wrangler config itself drives the generation, so an uncommitted config makes the file irreproducible.
@@ -1309,7 +1291,7 @@ test('omits wrangler types when the wrangler config is uncommitted', async () =>
     { createI18nDir: true, files: { 'wrangler.jsonc': '{ "name": "app" }' } }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // Global wrangler options may precede the subcommand; such forms cannot be modeled and must survive verbatim.
@@ -1329,7 +1311,7 @@ test('preserves a wrapper around a global-option wrangler invocation', async () 
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bun run gen-types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bun run gen-types');
 });
 
 // A bare generator behind a prerequisite is a pipeline too; bypassing the preparation step could emit an Env
@@ -1350,7 +1332,7 @@ test('skips worker-types management for a prerequisite pipeline with a bare gene
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
 // Quoting does not enable the check: `--check 'false'` still generates and its flags must be preserved.
@@ -1367,9 +1349,7 @@ test('reuses a wrangler types invocation with a quoted false check literal', asy
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(
-    "WB_ENV=${WB_ENV:-development} wb gen-code && wrangler types --strict-vars=false --check 'false'"
-  );
+  expect(packageJson.scripts?.postinstall).toBe("wb gen-code && wrangler types --strict-vars=false --check 'false'");
 });
 
 // `wrangler types --check` fails while the gitignored file is still absent, so the generator must run first.
@@ -1404,7 +1384,7 @@ test('preserves a wrapper script invoking wrangler types with a custom config wh
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('WB_ENV=${WB_ENV:-development} wb gen-code && bun run gen-types');
+  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bun run gen-types');
 });
 
 test('keeps custom database scripts for drizzle projects', async () => {
@@ -1418,9 +1398,9 @@ test('keeps custom database scripts for drizzle projects', async () => {
   );
 
   expect(packageJson.scripts).toMatchObject({
-    'db-create-migration': 'WB_ENV=${WB_ENV:-development} bun wb db migrate-dev',
+    'db-create-migration': 'bun wb db migrate-dev',
     'db-migrate': 'bun scripts/runDrizzleMigrationsToAllClients.ts',
-    'db-view': 'WB_ENV=${WB_ENV:-development} bun wb db studio',
+    'db-view': 'bun wb db studio',
   });
 });
 


### PR DESCRIPTION
## Technical Summary

Fixes regressions found while migrating WillBoosterLab/ai-game-builder to the isolated linker + global store (WillBoosterLab/ai-game-builder#690), then hardened by a multi-agent review loop (8 rounds).

### Isolated-install fixes

- **packageJson**: manage `trustedDependencies` in the workspace root's package.json (the only place Bun reads it), derived from dependencies declared anywhere in the repository across all four declaration sections. `@chakra-ui/react` is trusted only when a declared `@chakra-ui/cli` is v3 (classification mirrors wb gen-code: only a leading major of 2 selects the v2 command) — v3's `typegen` writes into the installed package, which would otherwise mutate the machine-wide store; `drizzle-kit` is trusted when declared (it requires `drizzle-orm` without declaring it, unreachable from the store's realpath). `lefthook` always accompanies the list because an explicit list replaces Bun's default allow-list. Stale wbfy-authored lists are cleaned up, while user-authored lists (explicitly empty, or without a chakra/drizzle marker) are preserved.
- **bunfig**: add `@willbooster-private/llm-proxy`, `@willbooster/react-frame-component`, `vinext-progress` (first-party), and `react-is` (resolutions-locksteps with react) to `minimumReleaseAgeExcludes`; Bun's age gate blocks even exact pins on re-resolution.
- **lefthook**: widen the post-merge install trigger to `bun.lock` / `bunfig.toml` / `.npmrc` / `patches/`.
- **workflow**: delete leftover `NPM_TOKEN` secret pass-throughs and apply reusable-workflow secret management only to `@main` callees (pinned revisions may follow the old secret contract, and GitHub rejects mismatched caller secrets with a startup_failure that emits no check runs).

### Workflow generator hardening (from the review loop)

- Normalize custom `.yaml` workflows in place, keeping their file identity (badge URLs, workflow REST API, same-repo `uses:` references): each kind maps to the file that carries it, `.yml` preferred when both spellings exist; autofix suppression, release cleanup, deploy-production detection, and sync-init/sync-force handling are all extension-aware.
- Skip merging workflows whose YAML loads to a non-object (empty/comment-only files) instead of crashing deepmerge.
- Let the sync workflow own sync-force/sync-init generation to avoid concurrent writes to the same paths.

### Deferred

- An explicit `trustedDependencies` list revokes Bun's default 367-entry allow-list for every other package (e.g. `@railway/cli`'s binary-downloading postinstall): #975.

## Testing

- `bun run test` in packages/wbfy (114 tests) passes.
- `bun verify` at the repo root passes.
- This wbfy build was applied to WillBooster/cheerlings, WillBoosterLab/ai-game-builder, and WillBoosterLab/llm-proxy (all merged with green CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
