### PR TITLE
fix: keep NODE_ENV a runtime read in the env cascade default

### DIFF
--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -67,12 +67,17 @@ export function readEnvironmentVariables(
   }
 ): [Record<string, string>, [string, string[]][]] {
   let envPaths = (argv.env ?? []).map((envPath) => path.resolve(cwd, envPath.toString()));
+  // Read NODE_ENV through an alias, never as the `process.env.NODE_ENV` member expression:
+  // bundlers replace that exact expression at build time (rolldown/build-ts inline it as
+  // 'production'), which constant-folds the fallback below and made the published wb select
+  // the production profile whenever WB_ENV was unset.
+  const runtimeEnv = process.env;
   const cascade =
     argv.cascadeEnv ??
     (argv.cascadeNodeEnv
-      ? process.env.NODE_ENV || 'development'
+      ? runtimeEnv.NODE_ENV || 'development'
       : argv.autoCascadeEnv
-        ? process.env.WB_ENV || process.env.NODE_ENV || 'development'
+        ? runtimeEnv.WB_ENV || runtimeEnv.NODE_ENV || 'development'
         : undefined);
   if (typeof cascade === 'string') {
     if (envPaths.length === 0) {
@@ -93,7 +98,7 @@ export function readEnvironmentVariables(
   envPaths = envPaths.filter((envPath) => fs.existsSync(envPath)).map((envPath) => path.relative(cwd, envPath));
   const shouldSuppressOutput = shouldSuppressEnvironmentOutput(argv);
   if (argv.verbose && !shouldSuppressOutput) {
-    console.info(`WB_ENV: ${process.env.WB_ENV}, NODE_ENV: ${process.env.NODE_ENV}`);
+    console.info(`WB_ENV: ${runtimeEnv.WB_ENV}, NODE_ENV: ${runtimeEnv.NODE_ENV}`);
     console.info('Reading env files:', envPaths.join(', '));
   }
 

--- a/packages/shared-lib-node/test/buildDist.ts
+++ b/packages/shared-lib-node/test/buildDist.ts
@@ -1,0 +1,5 @@
+import { execFileSync } from 'node:child_process';
+
+export default function buildDist(): void {
+  execFileSync('bun', ['run', 'build'], { stdio: 'inherit' });
+}

--- a/packages/shared-lib-node/test/envDist.test.ts
+++ b/packages/shared-lib-node/test/envDist.test.ts
@@ -1,6 +1,6 @@
 import childProcess from 'node:child_process';
 
-import { beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 // Bundlers (build-ts/rolldown) replace the `process.env.NODE_ENV` member expression with the
 // literal 'production' at build time, which constant-folds the auto-cascade default
@@ -8,12 +8,8 @@ import { beforeAll, describe, expect, it } from 'vitest';
 // every wb command select the production profile when WB_ENV was unset). The source avoids the
 // foldable expression via an alias of `process.env`, but only the built artifact can prove the
 // workaround still defeats the bundler, so this suite exercises dist/env.js in a child process.
+// dist/ is built once for the whole run by the globalSetup in vitest.config.ts.
 describe('bundled env cascade', () => {
-  beforeAll(() => {
-    const result = childProcess.spawnSync('bun', ['run', 'build'], { encoding: 'utf8', stdio: 'inherit' });
-    expect(result.status).toBe(0);
-  }, 120_000);
-
   it('defaults --auto-cascade-env to development in the built artifact when WB_ENV and NODE_ENV are unset', () => {
     const script = `
       import { readEnvironmentVariables } from './dist/env.js';

--- a/packages/shared-lib-node/test/envDist.test.ts
+++ b/packages/shared-lib-node/test/envDist.test.ts
@@ -1,0 +1,33 @@
+import childProcess from 'node:child_process';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// Bundlers (build-ts/rolldown) replace the `process.env.NODE_ENV` member expression with the
+// literal 'production' at build time, which constant-folds the auto-cascade default
+// `WB_ENV || NODE_ENV || 'development'` into 'production' (this shipped in wb 14.0.0 and made
+// every wb command select the production profile when WB_ENV was unset). The source avoids the
+// foldable expression via an alias of `process.env`, but only the built artifact can prove the
+// workaround still defeats the bundler, so this suite exercises dist/env.js in a child process.
+describe('bundled env cascade', () => {
+  beforeAll(() => {
+    const result = childProcess.spawnSync('bun', ['run', 'build'], { encoding: 'utf8', stdio: 'inherit' });
+    expect(result.status).toBe(0);
+  }, 120_000);
+
+  it('defaults --auto-cascade-env to development in the built artifact when WB_ENV and NODE_ENV are unset', () => {
+    const script = `
+      import { readEnvironmentVariables } from './dist/env.js';
+      const [envVars] = readEnvironmentVariables({ autoCascadeEnv: true, quietEnv: true }, 'test/fixtures/app1');
+      console.log(JSON.stringify(envVars));
+    `;
+    const env = { ...process.env };
+    delete env.WB_ENV;
+    delete env.NODE_ENV;
+    const result = childProcess.spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+      encoding: 'utf8',
+      env,
+    });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ ENV: 'development1' });
+  });
+});

--- a/packages/shared-lib-node/test/envDist.test.ts
+++ b/packages/shared-lib-node/test/envDist.test.ts
@@ -19,11 +19,17 @@ describe('bundled env cascade', () => {
     const env = { ...process.env };
     delete env.WB_ENV;
     delete env.NODE_ENV;
+    // readEnvironmentVariables skips keys already present in process.env, so ambient values
+    // for the fixture's own keys would drop them from the result and fail the assertion.
+    delete env.ENV;
+    delete env.PORT;
+    delete env.NAME;
     const result = childProcess.spawnSync(process.execPath, ['--input-type=module', '-e', script], {
       encoding: 'utf8',
       env,
     });
-    expect(result.status).toBe(0);
+    // Surface the child's stderr: on failure it carries the whole diagnosis (broken dist, import error).
+    expect({ status: result.status, stderr: result.stderr }).toMatchObject({ status: 0 });
     expect(JSON.parse(result.stdout)).toMatchObject({ ENV: 'development1' });
   });
 });

--- a/packages/shared-lib-node/test/spawn.killOnExit.sigterm.test.ts
+++ b/packages/shared-lib-node/test/spawn.killOnExit.sigterm.test.ts
@@ -1,10 +1,10 @@
-import { spawn, spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { beforeAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { isProcessRunning, wait, waitForProcessStopped } from '../../../test/processUtils.js';
 import { spawnAsync } from '../src/spawn.js';
@@ -13,13 +13,7 @@ import { treeKill } from '../src/treeKill.js';
 describe('spawnAsync killOnExit with SIGTERM', () => {
   const pidsToCleanUp = new Set<number>();
 
-  beforeAll(() => {
-    const result = spawnSync('yarn', ['build'], {
-      encoding: 'utf8',
-      stdio: 'inherit',
-    });
-    expect(result.status).toBe(0);
-  });
+  // dist/ is built once for the whole run by the globalSetup in vitest.config.ts.
 
   afterEach(async () => {
     for (const pid of pidsToCleanUp) {

--- a/packages/shared-lib-node/vitest.config.ts
+++ b/packages/shared-lib-node/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // envDist.test.ts and spawn.killOnExit.sigterm.test.ts both exercise dist/. Build it once
+    // here instead of per-file beforeAll hooks: vitest runs test files in parallel workers and
+    // build-ts deletes dist/ before writing, so concurrent rebuilds make another worker's
+    // dist import fail with ERR_MODULE_NOT_FOUND.
+    globalSetup: './test/buildDist.ts',
+  },
+});


### PR DESCRIPTION
## Summary

公開されている wb 14.0.0 では、`readEnvironmentVariables` の auto-cascade デフォルト `WB_ENV || NODE_ENV || 'development'` が **`'production'` に定数畳み込み**されています。build-ts(rolldown)がビルド時に `process.env.NODE_ENV` メンバー式を `'production'` に置換するためです(build-ts は `process.env.NODE_ENV ||= 'production'` を設定してからバンドル)。

dist の実際のコード:

```js
o = n.cascadeEnv ?? (n.cascadeNodeEnv ? `production` : n.autoCascadeEnv ? process.env.WB_ENV || `production` : void 0)
```

その結果、**WB_ENV 未設定のあらゆる wb コマンドが production プロファイルを選択**します。WillBooster/cheerlings の fnox 移行中に実際に発生し、`wb gen-dev-vars` がローカルの `.dev.vars` に production の fnox シークレットを書き込みました(`wb db reset` 等に波及していたらより危険でした)。

## Fix

`process.env` をローカル変数に束縛してから `NODE_ENV` を読むことで、バンドラの define 置換(構文上の `process.env.NODE_ENV` 完全一致)を回避します。修正後の wb をローカルでビルドし、dist が `o.NODE_ENV || 'development'` のランタイム読み取りに戻ることを確認済み。shared-lib-node のテスト 35 件パス。

## Test plan

- [x] `packages/shared-lib-node` のテストがパス
- [x] `packages/wb` を `bun run build` し、dist の cascade 式が NODE_ENV をランタイムで読むことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
