### PR TITLE
fix(wbfy): restore Bun's default trusted-dependency semantics in generated lists

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -25,6 +25,7 @@ import {
 import { fsUtil } from '../utils/fsUtil.js';
 import { gitHubUtil } from '../utils/githubUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
+import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { combineMerge } from '../utils/mergeUtil.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
@@ -645,31 +646,98 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
   const hasChakraCliV3 = (declaredDependencies.get('@chakra-ui/cli') ?? []).some(
     (versionRange) => /\d+/u.exec(versionRange)?.[0] !== '2'
   );
-  const wbfyTrustedPackages = new Set(['@chakra-ui/react', 'drizzle-kit']);
   const requiredWbfyPackages = [
     ...(hasChakraCliV3 && declaredDependencies.has('@chakra-ui/react') ? ['@chakra-ui/react'] : []),
     ...(declaredDependencies.has('drizzle-kit') ? ['drizzle-kit'] : []),
   ];
 
+  // wbfy fully owns this field: a package whose lifecycle scripts must run gets added to wbfy
+  // itself instead of to individual repositories, so unmanaged entries are always removed.
   const existingTrusted = bunJsonObj.trustedDependencies;
-  const customTrustedPackages = (existingTrusted ?? []).filter(
-    (pkg) => pkg !== lefthookDependency && !wbfyTrustedPackages.has(pkg)
-  );
-
-  if (customTrustedPackages.length > 0 || requiredWbfyPackages.length > 0) {
-    // An explicit trustedDependencies list REPLACES Bun's default allow-list instead of extending
-    // it, silently blocking lifecycle scripts of packages the default list trusts — lefthook's
-    // postinstall in every managed repository — so it must come along whenever the field is set.
-    bunJsonObj.trustedDependencies = [
-      ...new Set([...customTrustedPackages, ...requiredWbfyPackages, lefthookDependency]),
-    ].toSorted();
-  } else if (existingTrusted?.some((pkg) => wbfyTrustedPackages.has(pkg))) {
-    // Only a list wbfy itself authored is cleaned up once its packages are gone; wbfy always
-    // writes a chakra/drizzle entry alongside lefthook, so that entry marks its provenance. Any
-    // other explicit list — empty, or e.g. ["lefthook"] alone — is a user policy whose deletion
-    // would silently widen script execution to Bun's default allow-list.
-    delete bunJsonObj.trustedDependencies;
+  if (requiredWbfyPackages.length === 0) {
+    if (existingTrusted !== undefined) {
+      // Deleting the field restores Bun's full default allow-list, so only entries outside that
+      // list actually lose their lifecycle scripts.
+      warnAboutRemovedTrustedDependencies(config, existingTrusted, new Set());
+      delete bunJsonObj.trustedDependencies;
+    }
+    return;
   }
+
+  // An explicit trustedDependencies list REPLACES Bun's default allow-list instead of extending
+  // it, and Bun prints no warning for the postinstalls it consequently skips (e.g. @railway/cli
+  // downloads its binary in postinstall and exits 1 without one). Restore the default semantics
+  // by re-adding every installed package the default list would have trusted.
+  const defaultTrustedDependencies = getDefaultTrustedDependencies(config);
+  const installedPackages = await getInstalledPackageNames(config, declaredDependencies);
+  const restoredDefaultPackages = defaultTrustedDependencies
+    ? [...installedPackages].filter((pkg) => defaultTrustedDependencies.has(pkg))
+    : [];
+  // lefthook is appended unconditionally: this runs before wbfy adds it to devDependencies, so
+  // neither the lockfile nor the declared dependencies are guaranteed to contain it yet.
+  const newTrustedPackages = new Set([...requiredWbfyPackages, lefthookDependency, ...restoredDefaultPackages]);
+  warnAboutRemovedTrustedDependencies(config, existingTrusted ?? [], newTrustedPackages);
+  bunJsonObj.trustedDependencies = [...newTrustedPackages].toSorted();
+}
+
+function warnAboutRemovedTrustedDependencies(
+  config: PackageConfig,
+  existingTrusted: readonly string[],
+  keptPackages: ReadonlySet<string>
+): void {
+  // A default-trusted entry never loses anything by removal: while the package is installed the
+  // kept list (or, when the field is deleted, Bun's own default list) still trusts it.
+  const defaultTrustedDependencies = getDefaultTrustedDependencies(config);
+  const removedPackages = existingTrusted.filter(
+    (pkg) => !keptPackages.has(pkg) && !defaultTrustedDependencies?.has(pkg)
+  );
+  if (removedPackages.length > 0) {
+    console.warn(
+      `Removing unmanaged trustedDependencies entries: ${removedPackages.join(', ')}. wbfy owns this field; if their lifecycle scripts are required, add the packages to wbfy itself.`
+    );
+  }
+}
+
+let cachedDefaultTrustedDependencies: Set<string> | undefined;
+
+/** Fetches Bun's default trusted-dependency allow-list from the Bun version installing the repository. */
+function getDefaultTrustedDependencies(config: PackageConfig): Set<string> | undefined {
+  cachedDefaultTrustedDependencies ??= new Set(
+    [...spawnSyncAndReturnStdout('bun', ['pm', 'default-trusted'], config.dirPath).matchAll(/^\s*-\s+(\S+)$/gmu)].map(
+      (match) => match[1] as string
+    )
+  );
+  if (cachedDefaultTrustedDependencies.size === 0) {
+    console.warn('Failed to read the default allow-list via `bun pm default-trusted`.');
+    return undefined;
+  }
+  return cachedDefaultTrustedDependencies;
+}
+
+async function getInstalledPackageNames(
+  config: PackageConfig,
+  declaredDependencies: ReadonlyMap<string, string[]>
+): Promise<Set<string>> {
+  // The lockfile covers transitive dependencies (e.g. @railway/cli arriving via a private
+  // package), which declared dependencies alone would miss.
+  try {
+    const lockContent = await fs.promises.readFile(path.resolve(config.dirPath, 'bun.lock'), 'utf8');
+    // bun.lock is JSONC (trailing commas). Each packages entry's first element is "<name>@<version>".
+    const lock = jsoncUtil.parseObjectIgnoringError<{ packages?: Record<string, unknown[]> }>(lockContent);
+    const installedPackages = new Set<string>();
+    for (const entry of Object.values(lock?.packages ?? {})) {
+      const resolution = entry[0];
+      if (typeof resolution !== 'string') continue;
+      const atIndex = resolution.lastIndexOf('@');
+      if (atIndex > 0) installedPackages.add(resolution.slice(0, atIndex));
+    }
+    if (installedPackages.size > 0) return installedPackages;
+  } catch {
+    // fall through to declared dependencies
+  }
+  // Before the first `bun install` no lockfile exists; the next wbfy run converges via the
+  // refreshed lockfile.
+  return new Set(declaredDependencies.keys());
 }
 
 async function normalizePackageMetadata(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -680,6 +680,10 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
   bunJsonObj.trustedDependencies = [...newTrustedPackages].toSorted();
 }
 
+// The packages wbfy itself may write into trustedDependencies; their removal is managed cleanup,
+// never a loss of user policy.
+const wbfyManagedTrustedDependencies = new Set(['@chakra-ui/react', 'drizzle-kit', lefthookDependency]);
+
 function warnAboutRemovedTrustedDependencies(
   config: PackageConfig,
   existingTrusted: readonly string[],
@@ -689,7 +693,7 @@ function warnAboutRemovedTrustedDependencies(
   // kept list (or, when the field is deleted, Bun's own default list) still trusts it.
   const defaultTrustedDependencies = getDefaultTrustedDependencies(config);
   const removedPackages = existingTrusted.filter(
-    (pkg) => !keptPackages.has(pkg) && !defaultTrustedDependencies?.has(pkg)
+    (pkg) => !keptPackages.has(pkg) && !wbfyManagedTrustedDependencies.has(pkg) && !defaultTrustedDependencies?.has(pkg)
   );
   if (removedPackages.length > 0) {
     console.warn(
@@ -718,26 +722,37 @@ async function getInstalledPackageNames(
   config: PackageConfig,
   declaredDependencies: ReadonlyMap<string, string[]>
 ): Promise<Set<string>> {
+  // Declared dependencies seed the result: this runs before the final lockfile refresh (and
+  // `--skip-deps` skips the pre-generation install probe entirely), so a stale lockfile must not
+  // hide newly declared packages from the trust list.
+  const installedPackages = new Set(declaredDependencies.keys());
+  const lockPath = path.resolve(config.dirPath, 'bun.lock');
+  // Bun keeps using a legacy binary bun.lockb unless explicitly migrated
+  // (https://bun.sh/docs/pm/lockfile), so convert it here without touching node_modules; the
+  // read below then picks up the migrated text lockfile.
+  if (!fs.existsSync(lockPath) && fs.existsSync(path.resolve(config.dirPath, 'bun.lockb'))) {
+    spawnSync('bun', ['install', '--save-text-lockfile', '--frozen-lockfile', '--lockfile-only'], config.dirPath);
+  }
   // The lockfile covers transitive dependencies (e.g. @railway/cli arriving via a private
   // package), which declared dependencies alone would miss.
   try {
-    const lockContent = await fs.promises.readFile(path.resolve(config.dirPath, 'bun.lock'), 'utf8');
-    // bun.lock is JSONC (trailing commas). Each packages entry's first element is "<name>@<version>".
+    const lockContent = await fs.promises.readFile(lockPath, 'utf8');
+    // bun.lock is JSONC (trailing commas). Each packages entry's first element is
+    // "<name>@<resolution>".
     const lock = jsoncUtil.parseObjectIgnoringError<{ packages?: Record<string, unknown[]> }>(lockContent);
-    const installedPackages = new Set<string>();
     for (const entry of Object.values(lock?.packages ?? {})) {
       const resolution = entry[0];
       if (typeof resolution !== 'string') continue;
-      const atIndex = resolution.lastIndexOf('@');
-      if (atIndex > 0) installedPackages.add(resolution.slice(0, atIndex));
+      // The resolution part may itself contain '@' (e.g. "node-pty@git+ssh://git@github.com/…"),
+      // so split at the first '@' past the optional leading scope marker.
+      const separatorIndex = resolution.indexOf('@', 1);
+      if (separatorIndex > 0) installedPackages.add(resolution.slice(0, separatorIndex));
     }
-    if (installedPackages.size > 0) return installedPackages;
   } catch {
-    // fall through to declared dependencies
+    // Before the first `bun install` no lockfile exists; transitive dependencies are restored on
+    // the next wbfy run via the refreshed lockfile.
   }
-  // Before the first `bun install` no lockfile exists; the next wbfy run converges via the
-  // refreshed lockfile.
-  return new Set(declaredDependencies.keys());
+  return installedPackages;
 }
 
 async function normalizePackageMetadata(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -710,11 +710,14 @@ let cachedDefaultTrustedDependencies: Set<string> | undefined;
 /** Fetches Bun's default trusted-dependency allow-list from the Bun version installing the repository. */
 function getDefaultTrustedDependencies(config: PackageConfig): Set<string> | undefined {
   if (!cachedDefaultTrustedDependencies) {
-    const parsedDependencies = new Set(
-      [...spawnSyncAndReturnStdout('bun', ['pm', 'default-trusted'], config.dirPath).matchAll(/^\s*-\s+(\S+)$/gmu)].map(
-        (match) => match[1] as string
-      )
+    // Bun colorizes the list markers when FORCE_COLOR is set (e.g. by test runners on CI), so
+    // ANSI escape sequences must be stripped before parsing.
+    const stdout = spawnSyncAndReturnStdout('bun', ['pm', 'default-trusted'], config.dirPath).replaceAll(
+      // oxlint-disable-next-line no-control-regex -- matching ANSI escape sequences requires the ESC control character
+      /\u001B\[[0-9;]*m/gu,
+      ''
     );
+    const parsedDependencies = new Set([...stdout.matchAll(/^\s*-\s+(\S+)$/gmu)].map((match) => match[1] as string));
     if (parsedDependencies.size === 0) {
       // Do not cache the failure: a target-local problem (e.g. an unreadable package.json) must
       // not deny the default list to every later target of a multi-path run.

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -25,7 +25,6 @@ import {
 import { fsUtil } from '../utils/fsUtil.js';
 import { gitHubUtil } from '../utils/githubUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
-import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { combineMerge } from '../utils/mergeUtil.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
@@ -652,7 +651,9 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
   ];
 
   // wbfy fully owns this field: a package whose lifecycle scripts must run gets added to wbfy
-  // itself instead of to individual repositories, so unmanaged entries are always removed.
+  // itself instead of to individual repositories, so unmanaged entries are always removed —
+  // including an explicitly empty deny-all list, whose deletion deliberately restores Bun's
+  // default allow-list (the ownership policy chosen in #975).
   const existingTrusted = bunJsonObj.trustedDependencies;
   if (requiredWbfyPackages.length === 0) {
     if (existingTrusted !== undefined) {
@@ -666,16 +667,18 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
 
   // An explicit trustedDependencies list REPLACES Bun's default allow-list instead of extending
   // it, and Bun prints no warning for the postinstalls it consequently skips (e.g. @railway/cli
-  // downloads its binary in postinstall and exits 1 without one). Restore the default semantics
-  // by re-adding every installed package the default list would have trusted.
+  // downloads its binary in postinstall and exits 1 without one). Include the ENTIRE default list:
+  // entries for packages that are not installed are inert, and this is the only representation
+  // that stays correct for transitive dependencies the final `bun install` resolves after this
+  // runs — an intersection with a missing or stale lockfile would silently drop them.
   const defaultTrustedDependencies = getDefaultTrustedDependencies(config);
-  const installedPackages = await getInstalledPackageNames(config, declaredDependencies);
-  const restoredDefaultPackages = defaultTrustedDependencies
-    ? [...installedPackages].filter((pkg) => defaultTrustedDependencies.has(pkg))
-    : [];
-  // lefthook is appended unconditionally: this runs before wbfy adds it to devDependencies, so
-  // neither the lockfile nor the declared dependencies are guaranteed to contain it yet.
-  const newTrustedPackages = new Set([...requiredWbfyPackages, lefthookDependency, ...restoredDefaultPackages]);
+  // lefthook is appended explicitly so the default-list lookup failing cannot drop it: it is
+  // required in every managed repository.
+  const newTrustedPackages = new Set([
+    ...requiredWbfyPackages,
+    lefthookDependency,
+    ...(defaultTrustedDependencies ?? []),
+  ]);
   warnAboutRemovedTrustedDependencies(config, existingTrusted ?? [], newTrustedPackages);
   bunJsonObj.trustedDependencies = [...newTrustedPackages].toSorted();
 }
@@ -706,53 +709,21 @@ let cachedDefaultTrustedDependencies: Set<string> | undefined;
 
 /** Fetches Bun's default trusted-dependency allow-list from the Bun version installing the repository. */
 function getDefaultTrustedDependencies(config: PackageConfig): Set<string> | undefined {
-  cachedDefaultTrustedDependencies ??= new Set(
-    [...spawnSyncAndReturnStdout('bun', ['pm', 'default-trusted'], config.dirPath).matchAll(/^\s*-\s+(\S+)$/gmu)].map(
-      (match) => match[1] as string
-    )
-  );
-  if (cachedDefaultTrustedDependencies.size === 0) {
-    console.warn('Failed to read the default allow-list via `bun pm default-trusted`.');
-    return undefined;
+  if (!cachedDefaultTrustedDependencies) {
+    const parsedDependencies = new Set(
+      [...spawnSyncAndReturnStdout('bun', ['pm', 'default-trusted'], config.dirPath).matchAll(/^\s*-\s+(\S+)$/gmu)].map(
+        (match) => match[1] as string
+      )
+    );
+    if (parsedDependencies.size === 0) {
+      // Do not cache the failure: a target-local problem (e.g. an unreadable package.json) must
+      // not deny the default list to every later target of a multi-path run.
+      console.warn('Failed to read the default allow-list via `bun pm default-trusted`.');
+      return undefined;
+    }
+    cachedDefaultTrustedDependencies = parsedDependencies;
   }
   return cachedDefaultTrustedDependencies;
-}
-
-async function getInstalledPackageNames(
-  config: PackageConfig,
-  declaredDependencies: ReadonlyMap<string, string[]>
-): Promise<Set<string>> {
-  // Declared dependencies seed the result: this runs before the final lockfile refresh (and
-  // `--skip-deps` skips the pre-generation install probe entirely), so a stale lockfile must not
-  // hide newly declared packages from the trust list.
-  const installedPackages = new Set(declaredDependencies.keys());
-  const lockPath = path.resolve(config.dirPath, 'bun.lock');
-  // Bun keeps using a legacy binary bun.lockb unless explicitly migrated
-  // (https://bun.sh/docs/pm/lockfile), so convert it here without touching node_modules; the
-  // read below then picks up the migrated text lockfile.
-  if (!fs.existsSync(lockPath) && fs.existsSync(path.resolve(config.dirPath, 'bun.lockb'))) {
-    spawnSync('bun', ['install', '--save-text-lockfile', '--frozen-lockfile', '--lockfile-only'], config.dirPath);
-  }
-  // The lockfile covers transitive dependencies (e.g. @railway/cli arriving via a private
-  // package), which declared dependencies alone would miss.
-  try {
-    const lockContent = await fs.promises.readFile(lockPath, 'utf8');
-    // bun.lock is JSONC (trailing commas). Each packages entry's first element is
-    // "<name>@<resolution>".
-    const lock = jsoncUtil.parseObjectIgnoringError<{ packages?: Record<string, unknown[]> }>(lockContent);
-    for (const entry of Object.values(lock?.packages ?? {})) {
-      const resolution = entry[0];
-      if (typeof resolution !== 'string') continue;
-      // The resolution part may itself contain '@' (e.g. "node-pty@git+ssh://git@github.com/…"),
-      // so split at the first '@' past the optional leading scope marker.
-      const separatorIndex = resolution.indexOf('@', 1);
-      if (separatorIndex > 0) installedPackages.add(resolution.slice(0, separatorIndex));
-    }
-  } catch {
-    // Before the first `bun install` no lockfile exists; transitive dependencies are restored on
-    // the next wbfy run via the refreshed lockfile.
-  }
-  return installedPackages;
 }
 
 async function normalizePackageMetadata(

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -74,7 +74,8 @@ async function main(): Promise<void> {
         alias: 'e',
       },
       skipDeps: {
-        description: 'Skip dependency installation',
+        description:
+          'Skip adding managed dependencies and the linker probe (the final `bun install` refreshing the lockfile still runs)',
         type: 'boolean',
         default: false,
         alias: 'd',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1515,7 +1515,9 @@ test('manages trustedDependencies correctly when store-incompatible packages are
   });
 });
 
-test('ensures lefthook is included if custom trustedDependencies exist', async () => {
+// wbfy fully owns trustedDependencies: packages whose lifecycle scripts must run get added to
+// wbfy itself, so unmanaged entries are removed and the field is deleted when wbfy needs nothing.
+test('removes custom trustedDependencies and deletes the field when wbfy needs no entries', async () => {
   const packageJson = await generatePackageJsonFrom(
     {
       dependencies: {},
@@ -1524,8 +1526,32 @@ test('ensures lefthook is included if custom trustedDependencies exist', async (
     { isRoot: true }
   );
 
+  expect(packageJson.trustedDependencies).toBeUndefined();
+});
+
+// An explicit trustedDependencies list replaces Bun's default allow-list, so wbfy must re-add
+// every installed package (including transitive ones from bun.lock) that the default list trusts.
+test('restores default-trusted installed packages when writing trustedDependencies', async () => {
+  const bunLock = `{
+  "lockfileVersion": 1,
+  "packages": {
+    "@railway/cli": ["@railway/cli@4.10.0", "", {}, "sha512-dummy"],
+    "esbuild": ["esbuild@0.25.0", "", {}, "sha512-dummy"],
+    "drizzle-kit": ["drizzle-kit@1.0.0", "", {}, "sha512-dummy"],
+  },
+}`;
+  const packageJson = await generatePackageJsonFrom(
+    {
+      dependencies: {
+        'drizzle-kit': '1.0.0',
+      },
+    },
+    { isRoot: true },
+    { files: { 'bun.lock': bunLock } }
+  );
+
   expect(packageJson).toMatchObject({
-    trustedDependencies: ['lefthook', 'some-custom-dependency'],
+    trustedDependencies: ['@railway/cli', 'drizzle-kit', 'esbuild', 'lefthook'],
   });
 });
 
@@ -1541,7 +1567,7 @@ test('cleans up wbfy-managed trustedDependencies when they are no longer declare
   expect(packageJson.trustedDependencies).toBeUndefined();
 });
 
-test('preserves custom trustedDependencies while cleaning up wbfy-managed ones', async () => {
+test('removes custom trustedDependencies while cleaning up wbfy-managed ones', async () => {
   const packageJson = await generatePackageJsonFrom(
     {
       dependencies: {},
@@ -1550,14 +1576,12 @@ test('preserves custom trustedDependencies while cleaning up wbfy-managed ones',
     { isRoot: true }
   );
 
-  expect(packageJson).toMatchObject({
-    trustedDependencies: ['custom-pkg', 'lefthook'],
-  });
+  expect(packageJson.trustedDependencies).toBeUndefined();
 });
 
-// An explicitly empty list is a deliberate block-everything policy; deleting it would re-enable
-// Bun's default allow-list.
-test('preserves an explicitly empty trustedDependencies list', async () => {
+// Even an explicitly empty (block-everything) list is user policy wbfy overrides: the field is
+// wbfy-owned, and deleting it restores Bun's default allow-list.
+test('deletes an explicitly empty trustedDependencies list', async () => {
   const packageJson = await generatePackageJsonFrom(
     {
       dependencies: {},
@@ -1566,7 +1590,7 @@ test('preserves an explicitly empty trustedDependencies list', async () => {
     { isRoot: true }
   );
 
-  expect(packageJson.trustedDependencies).toEqual([]);
+  expect(packageJson.trustedDependencies).toBeUndefined();
 });
 
 // @chakra-ui/cli v2's `chakra-cli tokens` writes into @chakra-ui/styled-system, not

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1510,9 +1510,8 @@ test('manages trustedDependencies correctly when store-incompatible packages are
     { isRoot: true }
   );
 
-  expect(packageJson).toMatchObject({
-    trustedDependencies: ['drizzle-kit', 'lefthook'],
-  });
+  expect(packageJson.trustedDependencies).toEqual(expect.arrayContaining(['drizzle-kit', 'lefthook']));
+  expect(packageJson.trustedDependencies).toEqual([...(packageJson.trustedDependencies ?? [])].toSorted());
 });
 
 // wbfy fully owns trustedDependencies: packages whose lifecycle scripts must run get added to
@@ -1529,81 +1528,27 @@ test('removes custom trustedDependencies and deletes the field when wbfy needs n
   expect(packageJson.trustedDependencies).toBeUndefined();
 });
 
-// An explicit trustedDependencies list replaces Bun's default allow-list, so wbfy must re-add
-// every installed package (including transitive ones from bun.lock) that the default list trusts.
-test('restores default-trusted installed packages when writing trustedDependencies', async () => {
-  const bunLock = `{
-  "lockfileVersion": 1,
-  "packages": {
-    "@railway/cli": ["@railway/cli@4.10.0", "", {}, "sha512-dummy"],
-    "esbuild": ["esbuild@0.25.0", "", {}, "sha512-dummy"],
-    "drizzle-kit": ["drizzle-kit@1.0.0", "", {}, "sha512-dummy"],
-  },
-}`;
+// An explicit trustedDependencies list replaces Bun's default allow-list, so wbfy writes the
+// ENTIRE default list alongside its own entries: uninstalled entries are inert, and no
+// intersection with a (possibly missing or stale) lockfile can cover the transitive dependencies
+// the final `bun install` resolves only after generation.
+test('writes the entire default allow-list alongside wbfy-managed packages', async () => {
   const packageJson = await generatePackageJsonFrom(
     {
       dependencies: {
         'drizzle-kit': '1.0.0',
       },
+      trustedDependencies: ['some-custom-dependency'],
     },
-    { isRoot: true },
-    { files: { 'bun.lock': bunLock } }
+    { isRoot: true }
   );
 
-  expect(packageJson).toMatchObject({
-    trustedDependencies: ['@railway/cli', 'drizzle-kit', 'esbuild', 'lefthook'],
-  });
-});
-
-// The trust list is generated before the final lockfile refresh, so a stale bun.lock must not
-// hide newly declared default-trusted packages.
-test('unions declared dependencies with a stale bun.lock', async () => {
-  const bunLock = `{
-  "lockfileVersion": 1,
-  "packages": {
-    "drizzle-kit": ["drizzle-kit@1.0.0", "", {}, "sha512-dummy"],
-  },
-}`;
-  const packageJson = await generatePackageJsonFrom(
-    {
-      dependencies: {
-        '@railway/cli': '4.10.0',
-        'drizzle-kit': '1.0.0',
-      },
-    },
-    { isRoot: true },
-    { files: { 'bun.lock': bunLock } }
+  // Default-trusted packages must be present even though nothing is installed here.
+  expect(packageJson.trustedDependencies).toEqual(
+    expect.arrayContaining(['@railway/cli', 'drizzle-kit', 'esbuild', 'lefthook', 'node-pty'])
   );
-
-  expect(packageJson).toMatchObject({
-    trustedDependencies: ['@railway/cli', 'drizzle-kit', 'lefthook'],
-  });
-});
-
-// Bun serializes Git dependencies as "<name>@git+ssh://git@github.com/…", so the name must be
-// split at the first '@' past the scope, not the last one.
-test('parses package names from Git URL resolutions in bun.lock', async () => {
-  const bunLock = `{
-  "lockfileVersion": 1,
-  "packages": {
-    "drizzle-kit": ["drizzle-kit@1.0.0", "", {}, "sha512-dummy"],
-    "node-pty": ["node-pty@git+ssh://git@github.com/microsoft/node-pty.git#1def577", {}],
-    "@cdktf/node-pty-prebuilt-multiarch": ["@cdktf/node-pty-prebuilt-multiarch@0.11.0", "", {}, "sha512-dummy"],
-  },
-}`;
-  const packageJson = await generatePackageJsonFrom(
-    {
-      dependencies: {
-        'drizzle-kit': '1.0.0',
-      },
-    },
-    { isRoot: true },
-    { files: { 'bun.lock': bunLock } }
-  );
-
-  expect(packageJson).toMatchObject({
-    trustedDependencies: ['@cdktf/node-pty-prebuilt-multiarch', 'drizzle-kit', 'lefthook', 'node-pty'],
-  });
+  expect(packageJson.trustedDependencies?.length).toBeGreaterThan(300);
+  expect(packageJson.trustedDependencies).not.toContain('some-custom-dependency');
 });
 
 test('cleans up wbfy-managed trustedDependencies when they are no longer declared', async () => {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1555,6 +1555,57 @@ test('restores default-trusted installed packages when writing trustedDependenci
   });
 });
 
+// The trust list is generated before the final lockfile refresh, so a stale bun.lock must not
+// hide newly declared default-trusted packages.
+test('unions declared dependencies with a stale bun.lock', async () => {
+  const bunLock = `{
+  "lockfileVersion": 1,
+  "packages": {
+    "drizzle-kit": ["drizzle-kit@1.0.0", "", {}, "sha512-dummy"],
+  },
+}`;
+  const packageJson = await generatePackageJsonFrom(
+    {
+      dependencies: {
+        '@railway/cli': '4.10.0',
+        'drizzle-kit': '1.0.0',
+      },
+    },
+    { isRoot: true },
+    { files: { 'bun.lock': bunLock } }
+  );
+
+  expect(packageJson).toMatchObject({
+    trustedDependencies: ['@railway/cli', 'drizzle-kit', 'lefthook'],
+  });
+});
+
+// Bun serializes Git dependencies as "<name>@git+ssh://git@github.com/…", so the name must be
+// split at the first '@' past the scope, not the last one.
+test('parses package names from Git URL resolutions in bun.lock', async () => {
+  const bunLock = `{
+  "lockfileVersion": 1,
+  "packages": {
+    "drizzle-kit": ["drizzle-kit@1.0.0", "", {}, "sha512-dummy"],
+    "node-pty": ["node-pty@git+ssh://git@github.com/microsoft/node-pty.git#1def577", {}],
+    "@cdktf/node-pty-prebuilt-multiarch": ["@cdktf/node-pty-prebuilt-multiarch@0.11.0", "", {}, "sha512-dummy"],
+  },
+}`;
+  const packageJson = await generatePackageJsonFrom(
+    {
+      dependencies: {
+        'drizzle-kit': '1.0.0',
+      },
+    },
+    { isRoot: true },
+    { files: { 'bun.lock': bunLock } }
+  );
+
+  expect(packageJson).toMatchObject({
+    trustedDependencies: ['@cdktf/node-pty-prebuilt-multiarch', 'drizzle-kit', 'lefthook', 'node-pty'],
+  });
+});
+
 test('cleans up wbfy-managed trustedDependencies when they are no longer declared', async () => {
   const packageJson = await generatePackageJsonFrom(
     {


### PR DESCRIPTION
Close #975

## Customer Summary

- Repositories managed by wbfy no longer silently lose install-time setup steps (postinstall scripts) of packages Bun trusts by default — previously, tools such as the Railway CLI could end up broken (`railway --version` exiting with an error) after installation.
- wbfy now fully owns the `trustedDependencies` setting in managed repositories: entries added by hand are removed with a console warning, and packages that genuinely need install scripts must be added to wbfy itself.

## Technical Summary

- `ensureTrustedDependencies` (packages/wbfy/src/generators/packageJson.ts) now writes Bun's ENTIRE default allow-list — fetched at runtime via `bun pm default-trusted`, with ANSI escapes stripped (Vitest sets FORCE_COLOR on GitHub Actions) — plus wbfy-required entries (`@chakra-ui/react` for Chakra CLI v3, `drizzle-kit`, `lefthook`) whenever the field is written. Uninstalled entries are inert, so this exactly restores default semantics including for transitive dependencies the final `bun install` resolves only after generation (a lockfile intersection is provably incomplete at that point).
- When wbfy needs no entries, the field is always deleted (restoring Bun's default allow-list), including user-authored and explicitly empty lists; removed entries that actually lose lifecycle scripts trigger a `console.warn`.
- A failed `bun pm default-trusted` lookup is not cached (so one target of a multi-path run cannot poison later targets) and degrades to the previous lefthook-only compensation with a warning.
- The `--skip-deps` option description now states that the final lockfile-refreshing `bun install` still runs.

## Why

- An explicit `trustedDependencies` list REPLACES Bun's default allow-list (367 entries on Bun 1.3.14) instead of extending it, and Bun prints no warning for the postinstalls it consequently skips; wbfy compensated only for `lefthook`, so packages like `@railway/cli` (which downloads its binary in postinstall) silently broke in managed repos.
- Writing the full default list was chosen over intersecting with installed packages because the trust list is generated before the final `bun install` resolves transitive dependencies, so any intersection with a missing or stale lockfile silently drops them (reproduced by multi-agent review with a transitive `@railway/cli`).

## Testing

- `bun verify-full` passes (89 packageJson tests, including new coverage that the generated list contains the default allow-list plus wbfy entries, removes custom entries, and deletes the field when unneeded).
- Reproduced and fixed the CI-only parser failure locally via `FORCE_COLOR=1 bun run vitest run test/packageJson.test.ts`.
- Multi-agent review (`review-fix`, 4 rounds: Codex, Claude Code, Antigravity) converged to "No concern".

## Notes

- Rolling this out rewrites `trustedDependencies` in managed repos; repos that genuinely need a custom entry will warn on the next wbfy run, and those packages should then be added to wbfy's managed list.
- The generated list tracks the Bun version running wbfy; a Bun upgrade adding new default-trusted packages is picked up on the next wbfy run.
