### PR TITLE
feat: pin concrete tool versions in mise.toml and name fnox age recipients

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
 node = "24.15.0"
 bun = "1.3.14"
-fnox = "latest"
+fnox = "1.30.0"

--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -356,7 +356,10 @@ function replaceAgeRecipients(content: string): string {
   // validation in the caller then fails the run safely with instructions instead of corrupting
   // the file.
   const lines = content.split('\n');
-  const headerIndex = lines.findIndex((line) => /^\s*\[\s*providers\.age\s*\]\s*(?:#.*)?$/u.test(line));
+  // TOML permits whitespace around dotted-key components, so `[providers . age]` equals
+  // `[providers.age]`; quoted-key spellings remain unmatched and fall through to the caller's
+  // re-parse validation, which fails the run safely.
+  const headerIndex = lines.findIndex((line) => /^\s*\[\s*providers\s*\.\s*age\s*\]\s*(?:#.*)?$/u.test(line));
   if (headerIndex !== -1) {
     let endIndex = lines.length;
     for (let index = headerIndex + 1; index < lines.length; index++) {

--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -341,7 +341,12 @@ export function readFnoxAgeRecipients(fnoxTomlContent: string): Set<string> | un
 }
 
 function replaceAgeRecipients(content: string): string {
-  const recipientsText = `recipients = [${FNOX_AGE_RECIPIENTS.map((recipient) => `"${recipient.publicKey}"`).join(', ')}]`;
+  // Trailing name comments let humans tell whose key each recipient is without consulting wbfy.
+  const recipientsText = `recipients = [\n${FNOX_AGE_RECIPIENTS.map(
+    (recipient) => `  "${recipient.publicKey}", # ${recipient.name}`
+  ).join('\n')}\n]`;
+  // TOML forbids newlines and comments inside inline tables, so the inline form stays single-line.
+  const inlineRecipientsText = `recipients = [${FNOX_AGE_RECIPIENTS.map((recipient) => `"${recipient.publicKey}"`).join(', ')}]`;
   // Standard form: a [providers.age] table (possibly with a trailing comment). Scan line-wise so
   // that a `[` inside a comment or a string never terminates the table early; the table ends at
   // the next line-start table header. The assignment match is line-anchored so a commented-out
@@ -371,7 +376,7 @@ function replaceAgeRecipients(content: string): string {
   // Inline form: age = { type = "age", recipients = [...] } inside a [providers] table.
   const withReplacedInline = content.replace(
     /(\bage\s*=\s*\{[^}]*?)recipients\s*=\s*\[[^\]]*\]/u,
-    `$1${recipientsText}`
+    `$1${inlineRecipientsText}`
   );
   if (withReplacedInline !== content) return withReplacedInline;
   return `${content.trimEnd()}\n\n[providers.age]\ntype = "age"\n${recipientsText}\n`;

--- a/packages/wbfy/src/generators/miseToml.ts
+++ b/packages/wbfy/src/generators/miseToml.ts
@@ -8,6 +8,7 @@ import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
+import { spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
 
 interface MiseToml {
   tools?: Record<string, unknown>;
@@ -39,10 +40,10 @@ export async function generateMiseToml(config: PackageConfig, currentBunVersion:
     }
     // Ensure Node.js and Bun are always pinned: generated hooks and CI run `mise install`, and an
     // unpinned Node would come from whatever happens to be on PATH.
-    tools.node = tools.node ?? readNodeVersionFile(config.dirPath) ?? 'latest';
+    tools.node = pinConcreteToolVersion('node', tools.node ?? readNodeVersionFile(config.dirPath), config.dirPath);
     tools.bun = liftOutdatedBunVersion(tools.bun ?? 'latest', currentBunVersion);
     if (fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'))) {
-      tools.fnox = tools.fnox ?? 'latest';
+      tools.fnox = pinConcreteToolVersion('fnox', tools.fnox, config.dirPath);
     }
     settings.tools = tools;
 
@@ -81,6 +82,25 @@ function liftOutdatedBunVersion(bunVersion: unknown, currentBunVersion: string):
     return { ...bunVersion, version: liftOutdatedBunVersion(bunVersion.version, currentBunVersion) };
   }
   return bunVersion;
+}
+
+/**
+ * Replaces an unpinned selector (`latest`, a range such as "24", an alias, or a missing entry)
+ * with the newest concrete version mise resolves for it, because the repository-structure
+ * standard requires concrete pins: CI installs whatever an unpinned selector resolves to at run
+ * time, so builds drift across runs. Exact versions are kept as-is, and non-string forms (mise's
+ * array and `{ version = "…" }` forms) are user-managed and left untouched. When mise is
+ * unavailable or cannot resolve the selector (e.g. offline), the original selector is kept —
+ * an unpinned tool is better than a broken configuration.
+ */
+function pinConcreteToolVersion(tool: string, version: unknown, cwd: string): unknown {
+  if (version !== undefined && (typeof version !== 'string' || semver.valid(version))) return version;
+  // With no meaningful selector, Node.js pins to the latest LTS (matching the reusable workflows'
+  // `lts/*` fallback) rather than the newest release.
+  const defaultSelector = tool === 'node' ? 'node@lts' : tool;
+  const selector = typeof version === 'string' && version !== 'latest' ? `${tool}@${version}` : defaultSelector;
+  const resolvedVersion = spawnSyncAndReturnStdout('mise', ['latest', selector], cwd);
+  return semver.valid(resolvedVersion) ? resolvedVersion : (version ?? 'latest');
 }
 
 function parseMiseToml(miseTomlPath: string): MiseToml {

--- a/packages/wbfy/src/generators/miseToml.ts
+++ b/packages/wbfy/src/generators/miseToml.ts
@@ -95,10 +95,13 @@ function liftOutdatedBunVersion(bunVersion: unknown, currentBunVersion: string):
  */
 function pinConcreteToolVersion(tool: string, version: unknown, cwd: string): unknown {
   if (version !== undefined && (typeof version !== 'string' || semver.valid(version))) return version;
+  // mise supports `prefix:` selectors in mise.toml/.tool-versions, but `mise latest` rejects the
+  // prefix and needs the bare range (`mise latest node@prefix:24` fails; `node@24` resolves).
+  const range = typeof version === 'string' ? version.replace(/^prefix:/u, '') : undefined;
   // With no meaningful selector, Node.js pins to the latest LTS (matching the reusable workflows'
   // `lts/*` fallback) rather than the newest release.
   const defaultSelector = tool === 'node' ? 'node@lts' : tool;
-  const selector = typeof version === 'string' && version !== 'latest' ? `${tool}@${version}` : defaultSelector;
+  const selector = range && range !== 'latest' ? `${tool}@${range}` : defaultSelector;
   const resolvedVersion = spawnSyncAndReturnStdout('mise', ['latest', selector], cwd);
   return semver.valid(resolvedVersion) ? resolvedVersion : (version ?? 'latest');
 }

--- a/packages/wbfy/src/generators/miseToml.ts
+++ b/packages/wbfy/src/generators/miseToml.ts
@@ -95,9 +95,11 @@ function liftOutdatedBunVersion(bunVersion: unknown, currentBunVersion: string):
  */
 function pinConcreteToolVersion(tool: string, version: unknown, cwd: string): unknown {
   if (version !== undefined && (typeof version !== 'string' || semver.valid(version))) return version;
-  // mise supports `prefix:` selectors in mise.toml/.tool-versions, but `mise latest` rejects the
-  // prefix and needs the bare range (`mise latest node@prefix:24` fails; `node@24` resolves).
-  const range = typeof version === 'string' ? version.replace(/^prefix:/u, '') : undefined;
+  // Normalize selector forms `mise latest` cannot resolve even though mise configuration accepts
+  // them: `prefix:24` is rejected outright while `24` resolves, and `lts/*` (idiomatic in
+  // .node-version files) yields empty output while `lts` resolves. Modifier selectors such as
+  // `sub-2:lts` stay unresolvable and fall back to the original selector below.
+  const range = typeof version === 'string' ? version.replace(/^prefix:/u, '').replace(/\/\*$/u, '') : undefined;
   // With no meaningful selector, Node.js pins to the latest LTS (matching the reusable workflows'
   // `lts/*` fallback) rather than the newest release.
   const defaultSelector = tool === 'node' ? 'node@lts' : tool;


### PR DESCRIPTION
## Summary

- `generateMiseToml` now pins concrete versions instead of leaving `latest`: unpinned `node`/`fnox` selectors are resolved via `mise latest` (Node.js resolves `node@lts`, matching the reusable workflows' `lts/*` fallback). Selector forms `mise latest` cannot take are normalized first — `prefix:24` → `24` (mise rejects the prefix outright) and `lts/*` → `lts` (mise returns empty output for the raw form) — while exact pins, mise's array/object forms, and unresolvable modifier selectors (e.g. `sub-2:lts`, or running offline) keep their original value. This closes the "wbfy currently writes `latest` for `bun`/`fnox` — a wbfy fix is tracked separately" gap noted in the org guidelines.
- `generateFnoxToml` now writes the age recipients as a multiline list with trailing `# <name>` comments (e.g. `# exkazuu`, `# ci`), matching the format the mise+fnox guidelines document; the inline-table form keeps a single line because TOML forbids comments inside inline tables. The rewrite still only happens when the recipient set changed, so in-sync repositories see no churn. The `[providers.age]` header matcher also accepts TOML-valid whitespace around the dot (`[providers . age]`) now; quoted-key spellings still fall through to the safe re-parse failure.
- Repo hygiene: pin `fnox = "1.30.0"` in this repository's `mise.toml` (shared-lib-node's env tests spawn the `fnox` binary, so the pin is required, but it was `latest`), and remove the root `.npmrc` containing only the npm-era `legacy-peer-deps=true`, which Bun ignores and nothing references.

## Verification

- `bun verify` passes; CI green.
- `mise latest node@lts` / `mise latest fnox` / `mise latest node@24` confirmed to emit bare concrete versions, `mise latest node@prefix:24` confirmed to fail, and `mise latest 'node@lts/*'` confirmed to emit empty output.
- The generated multiline recipients block and the whitespace-tolerant header regex were validated with smol-toml / targeted regex tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
