### PR TITLE
feat: verify org-managed secrets for WillBooster-org repos instead of silence

### DIFF
--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -68,30 +68,51 @@ export async function setupSecrets(config: PackageConfig): Promise<void> {
 // are manual org-admin operations by policy.
 async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, repo: string): Promise<void> {
   const octokit = getOctokit(owner);
-  const { contents: remoteFnoxContents } = await fetchDefaultBranchFnoxConfigs(octokit, owner, repo);
   const requiredNames = ['VERDACCIO_TOKEN'];
-  if (remoteFnoxContents.size > 0) requiredNames.push('FNOX_AGE_KEY');
+  // Only a ROOT fnox.toml makes CI need FNOX_AGE_KEY (nested fixtures without an age provider
+  // neither need nor own the key, and workflow generation keys FNOX_AGE_KEY injection on the root
+  // file too), so probe that single path instead of enumerating the whole tree — the recursive
+  // scanner uploadSecrets needs for ciphertext verification fails on trees GitHub truncates.
+  if (await defaultBranchHasRootFnoxToml(octokit, owner, repo)) requiredNames.push('FNOX_AGE_KEY');
+  // Deliberately based on the LOCAL working tree, unlike the remote-based fnox probe: a wrangler
+  // config added on a feature branch will need CLOUDFLARE_API_TOKEN as soon as it merges, and
+  // surfacing the missing org secret before the deploy workflow lands is the point of this check.
   if (containsWranglerConfig(config.dirPath)) requiredNames.push('CLOUDFLARE_API_TOKEN');
 
-  const orgResponse = await octokit.request('GET /repos/{owner}/{repo}/actions/organization-secrets', {
-    owner,
-    repo,
-    per_page: 100,
-  });
-  const orgVisibleNames = new Set(orgResponse.data.secrets.map((secret) => secret.name));
-  const repoResponse = await octokit.request('GET /repos/{owner}/{repo}/actions/secrets', {
-    owner,
-    repo,
-    per_page: 100,
-  });
-  const repoLevelNames = new Set(repoResponse.data.secrets.map((secret) => secret.name));
+  // GitHub allows far more than one page of secrets, so paginate instead of trusting page one
+  // (this Octokit instance carries no paginate plugin, hence the manual loops).
+  const orgVisibleNames = new Set<string>();
+  for (let page = 1; ; page++) {
+    const response = await octokit.request('GET /repos/{owner}/{repo}/actions/organization-secrets', {
+      owner,
+      repo,
+      per_page: 100,
+      page,
+    });
+    for (const secret of response.data.secrets) orgVisibleNames.add(secret.name);
+    if (response.data.secrets.length < 100) break;
+  }
+  const repoLevelNames = new Set<string>();
+  for (let page = 1; ; page++) {
+    const response = await octokit.request('GET /repos/{owner}/{repo}/actions/secrets', {
+      owner,
+      repo,
+      per_page: 100,
+      page,
+    });
+    for (const secret of response.data.secrets) repoLevelNames.add(secret.name);
+    if (response.data.secrets.length < 100) break;
+  }
 
+  // process.exitCode is process-global and may already be 1 from an earlier repository in the
+  // same wbfy invocation, so gate this repository's success message on a local flag.
+  let verified = true;
   for (const name of requiredNames) {
     if (!orgVisibleNames.has(name)) {
       console.error(
         `The organization secret ${name} is not visible to ${owner}/${repo}. Ask a WillBooster org admin to register it as an organization secret (or extend its repository access to this repository) — do NOT create a repository-level copy.${repoLevelNames.has(name) ? ` A repository-level ${name} currently keeps CI working, but it violates the org-secret policy and must be deleted once the organization secret is visible.` : ''}`
       );
-      process.exitCode = 1;
+      verified = false;
     }
   }
   // A repository secret silently overrides a same-named organization secret, so a stale
@@ -101,13 +122,31 @@ async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, rep
       console.error(
         `The repository-level secret ${name} in ${owner}/${repo} shadows the organization secret of the same name. After confirming the organization value is current, delete the repository-level copy manually (e.g. \`gh secret delete ${name} --repo ${owner}/${repo}\`); wbfy deliberately never deletes it.`
       );
-      process.exitCode = 1;
+      verified = false;
     }
   }
-  if (process.exitCode !== 1) {
+  if (verified) {
     console.info(
       `Confirmed the organization secrets required by ${owner}/${repo} are visible: ${requiredNames.join(', ')}.`
     );
+  } else {
+    process.exitCode = 1;
+  }
+}
+
+// A single-path existence probe of the remote default branch; verification needs only this
+// boolean, not the full fnox contents uploadSecrets enumerates.
+async function defaultBranchHasRootFnoxToml(
+  octokit: ReturnType<typeof getOctokit>,
+  owner: string,
+  repo: string
+): Promise<boolean> {
+  try {
+    await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', { owner, repo, path: 'fnox.toml' });
+    return true;
+  } catch (error) {
+    if ((error as { status?: number } | undefined)?.status === 404) return false;
+    throw error;
   }
 }
 
@@ -121,8 +160,10 @@ function containsWranglerConfig(rootDirPath: string): boolean {
       for (const entry of fs.readdirSync(groupDirPath, { withFileTypes: true })) {
         if (entry.isDirectory()) candidateDirPaths.push(path.join(groupDirPath, entry.name));
       }
-    } catch {
-      // A repository without that workspace group simply has nothing to scan there.
+    } catch (error) {
+      // Only a missing workspace group is benign; an unreadable one (e.g. EACCES) could hide a
+      // Worker and must fail the run loudly instead of silently passing verification.
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
     }
   }
   return candidateDirPaths.some((dirPath) =>

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -69,14 +69,12 @@ export async function setupSecrets(config: PackageConfig): Promise<void> {
 async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, repo: string): Promise<void> {
   const octokit = getOctokit(owner);
   const requiredNames = ['VERDACCIO_TOKEN'];
-  // Only a ROOT fnox.toml makes CI need FNOX_AGE_KEY (nested fixtures without an age provider
-  // neither need nor own the key, and workflow generation keys FNOX_AGE_KEY injection on the root
-  // file too), so probe that single path instead of enumerating the whole tree — the recursive
-  // scanner uploadSecrets needs for ciphertext verification fails on trees GitHub truncates.
-  if (await defaultBranchHasRootFnoxToml(octokit, owner, repo)) requiredNames.push('FNOX_AGE_KEY');
-  // Deliberately based on the LOCAL working tree, unlike the remote-based fnox probe: a wrangler
-  // config added on a feature branch will need CLOUDFLARE_API_TOKEN as soon as it merges, and
-  // surfacing the missing org secret before the deploy workflow lands is the point of this check.
+  // Both requirement checks are deliberately based on the LOCAL working tree: workflow generation
+  // keys FNOX_AGE_KEY injection on the local root fnox.toml too, and a config added on a feature
+  // branch will need its secret as soon as it merges — surfacing the missing org secret before
+  // the change lands is the point of this verification. Only a ROOT fnox.toml counts (nested
+  // fixtures without an age provider neither need nor own the key).
+  if (fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'))) requiredNames.push('FNOX_AGE_KEY');
   if (containsWranglerConfig(config.dirPath)) requiredNames.push('CLOUDFLARE_API_TOKEN');
 
   // GitHub allows far more than one page of secrets, so paginate instead of trusting page one
@@ -131,22 +129,6 @@ async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, rep
     );
   } else {
     process.exitCode = 1;
-  }
-}
-
-// A single-path existence probe of the remote default branch; verification needs only this
-// boolean, not the full fnox contents uploadSecrets enumerates.
-async function defaultBranchHasRootFnoxToml(
-  octokit: ReturnType<typeof getOctokit>,
-  owner: string,
-  repo: string
-): Promise<boolean> {
-  try {
-    await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', { owner, repo, path: 'fnox.toml' });
-    return true;
-  } catch (error) {
-    if ((error as { status?: number } | undefined)?.status === 404) return false;
-    throw error;
   }
 }
 

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -47,7 +47,16 @@ export async function setupSecrets(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('setupSecrets', async () => {
     const [owner, repo] = gitHubUtil.getOrgAndName(config.repository ?? '');
     if (!owner || !repo || (owner !== 'WillBooster' && owner !== 'WillBoosterLab')) return;
-    if (!hasGitHubToken(owner) || !options.doesUploadEnvVars) return;
+    if (!options.doesUploadEnvVars) return;
+    // --env explicitly requested secret handling, so a missing credential is a failure, not a
+    // silent skip that would report success without verifying or uploading anything.
+    if (!hasGitHubToken(owner)) {
+      console.error(
+        `--env was requested but no GitHub credential for ${owner} is available (set the org PAT environment variable or authenticate \`gh\`). Secrets were neither verified nor uploaded.`
+      );
+      process.exitCode = 1;
+      return;
+    }
 
     // The user explicitly requested secret handling (--env), so any failure — including
     // filesystem/validation errors before the GitHub requests — must fail the run instead of
@@ -79,7 +88,7 @@ async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, rep
 
   // GitHub allows far more than one page of secrets, so paginate instead of trusting page one
   // (this Octokit instance carries no paginate plugin, hence the manual loops).
-  const orgVisibleNames = new Set<string>();
+  const assignedOrgNames: string[] = [];
   for (let page = 1; ; page++) {
     const response = await octokit.request('GET /repos/{owner}/{repo}/actions/organization-secrets', {
       owner,
@@ -87,9 +96,14 @@ async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, rep
       per_page: 100,
       page,
     });
-    for (const secret of response.data.secrets) orgVisibleNames.add(secret.name);
+    for (const secret of response.data.secrets) assignedOrgNames.push(secret.name);
     if (response.data.secrets.length < 100) break;
   }
+  // A workflow run can use only the first 100 organization secrets sorted alphabetically, so an
+  // assigned-but-beyond-limit secret is NOT usable and must not pass verification (nor justify
+  // deleting a repository-level fallback that is the only working source).
+  const usableOrgNames = new Set([...assignedOrgNames].toSorted().slice(0, 100));
+  const assignedButUnusableNames = new Set(assignedOrgNames.filter((name) => !usableOrgNames.has(name)));
   const repoLevelNames = new Set<string>();
   for (let page = 1; ; page++) {
     const response = await octokit.request('GET /repos/{owner}/{repo}/actions/secrets', {
@@ -106,17 +120,20 @@ async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, rep
   // same wbfy invocation, so gate this repository's success message on a local flag.
   let verified = true;
   for (const name of requiredNames) {
-    if (!orgVisibleNames.has(name)) {
+    if (!usableOrgNames.has(name)) {
       console.error(
-        `The organization secret ${name} is not visible to ${owner}/${repo}. Ask a WillBooster org admin to register it as an organization secret (or extend its repository access to this repository) — do NOT create a repository-level copy.${repoLevelNames.has(name) ? ` A repository-level ${name} currently keeps CI working, but it violates the org-secret policy and must be deleted once the organization secret is visible.` : ''}`
+        assignedButUnusableNames.has(name)
+          ? `The organization secret ${name} is assigned to ${owner}/${repo} but falls beyond the 100-organization-secret limit a workflow run can use (only the alphabetically first 100 are usable). Ask a WillBooster org admin to prune the assigned organization secrets.`
+          : `The organization secret ${name} is not visible to ${owner}/${repo}. Ask a WillBooster org admin to register it as an organization secret (or extend its repository access to this repository) — do NOT create a repository-level copy.${repoLevelNames.has(name) ? ` A repository-level ${name} currently keeps CI working, but it violates the org-secret policy and must be deleted once the organization secret is visible.` : ''}`
       );
       verified = false;
     }
   }
   // A repository secret silently overrides a same-named organization secret, so a stale
-  // repository-level copy would keep winning even after the admin rotates the org value.
+  // repository-level copy would keep winning even after the admin rotates the org value. Only a
+  // genuinely workflow-usable organization secret justifies deleting the repository fallback.
   for (const name of ORG_MANAGED_SECRET_NAMES) {
-    if (orgVisibleNames.has(name) && repoLevelNames.has(name)) {
+    if (usableOrgNames.has(name) && repoLevelNames.has(name)) {
       console.error(
         `The repository-level secret ${name} in ${owner}/${repo} shadows the organization secret of the same name. After confirming the organization value is current, delete the repository-level copy manually (e.g. \`gh secret delete ${name} --repo ${owner}/${repo}\`); wbfy deliberately never deletes it.`
       );

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -155,14 +155,19 @@ function containsWranglerConfig(rootDirPath: string): boolean {
   const candidateDirPaths = [rootDirPath];
   for (const groupDirName of ['packages', 'apps']) {
     const groupDirPath = path.join(rootDirPath, groupDirName);
+    let stats;
     try {
-      for (const entry of fs.readdirSync(groupDirPath, { withFileTypes: true })) {
-        if (entry.isDirectory()) candidateDirPaths.push(path.join(groupDirPath, entry.name));
-      }
+      stats = fs.lstatSync(groupDirPath);
     } catch (error) {
-      // Only a missing workspace group is benign; an unreadable one (e.g. EACCES) could hide a
-      // Worker and must fail the run loudly instead of silently passing verification.
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw error;
+    }
+    // A plain file or symlink named packages/apps is not a workspace group (wbfy's workspace
+    // discovery does not follow symlinks either); an unreadable REAL directory still throws below
+    // and fails the run loudly, since it could hide a Worker.
+    if (!stats.isDirectory()) continue;
+    for (const entry of fs.readdirSync(groupDirPath, { withFileTypes: true })) {
+      if (entry.isDirectory()) candidateDirPaths.push(path.join(groupDirPath, entry.name));
     }
   }
   return candidateDirPaths.some((dirPath) =>

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -33,25 +33,101 @@ const ENCRYPTED_VERDACCIO_TOKEN =
   'YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBud2p2dXFLV2N1NEFaR1MvSnBMVG9WcTY3V3RNd0wwZG9NRStiMXRDV2pRCnlEQ21BRDF6QWhzandFQWhJZlZGTWdKZGhJcDNEK1E3czJPUkpUblg1YVEKLT4gbHgpWy1ncmVhc2UgQFxVb1EgNWJEYDl5ayA+bAphc1hoTHAydmc4akFxMnNBWWp1YWhlV0I1aytMOFB6YUloZ0tuaFdqNGcKLS0tIGZVOW1zQ2xveDREOC95RkFnTEFPdmFXc0FkV212bUNnV2Y3cWcxb3hWRFkKR8rA6Rshr0v84bWEG2Mnr9H04HcBZylYGEp7U19Dp1sqwQ1yKls8Rz5QtzY5SjYY/kEfMfp4JMgBexxFTnbI7nl79u5FSOrPce+xrYZFMnZhv06zB8shZgiidqkTdcwU+rGB2ei72VTItox9CqmvpGgeonuTuhOP5+9wOPb2E6IC8FpeZLGHczSYxmuIOPMdt80IrjBfqECcv0u6cWDAOHuzwx4j9tyxl49YgU56lA9XOMA2+mSfeq/dBkTFf9Hap8eLcXzGE25TT/xMWkf6cDIn+z8JpzNuyBQUKggggtztooJ7k7ulkr1JaSyFlVCPIrPNBdo/FDbSy9aG';
 const require = createRequire(import.meta.url);
 
+// Secret management is deliberately ASYMMETRIC between the two organizations:
+// - WillBooster (paid plan): CLOUDFLARE_API_TOKEN / FNOX_AGE_KEY / VERDACCIO_TOKEN are
+//   ORGANIZATION secrets registered manually by an org admin, with per-repository visibility.
+//   wbfy must never create, update, or delete them (neither at the org level nor as
+//   repository-level copies) — it only verifies availability and reports what the admin must do.
+// - WillBoosterLab (free plan): GitHub Free cannot share organization secrets with private
+//   repositories, so wbfy --env keeps provisioning FNOX_AGE_KEY / VERDACCIO_TOKEN as repository
+//   secrets automatically.
+const ORG_MANAGED_SECRET_NAMES = ['CLOUDFLARE_API_TOKEN', 'FNOX_AGE_KEY', 'VERDACCIO_TOKEN'];
+
 export async function setupSecrets(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('setupSecrets', async () => {
     const [owner, repo] = gitHubUtil.getOrgAndName(config.repository ?? '');
-    // Deliberately WillBoosterLab-only (including VERDACCIO_TOKEN): WillBooster-org repositories
-    // are provisioned manually. The VERDACCIO_TOKEN reference injected into their workflows is
-    // harmless meanwhile — the reusable workflows skip .npmrc generation when the secret is empty.
-    if (!owner || !repo || owner !== 'WillBoosterLab') return;
+    if (!owner || !repo || (owner !== 'WillBooster' && owner !== 'WillBoosterLab')) return;
     if (!hasGitHubToken(owner) || !options.doesUploadEnvVars) return;
 
-    // The user explicitly requested a secret upload (--env), so any failure — including
+    // The user explicitly requested secret handling (--env), so any failure — including
     // filesystem/validation errors before the GitHub requests — must fail the run instead of
     // being swallowed by functionIgnoringException.
     try {
-      await uploadSecrets(config, owner, repo);
+      await (owner === 'WillBooster'
+        ? verifyOrgManagedSecrets(config, owner, repo)
+        : uploadSecrets(config, owner, repo));
     } catch (error) {
-      console.error('Failed to upload secrets due to:', (error as Error | undefined)?.stack ?? error);
+      console.error('Failed to handle secrets due to:', (error as Error | undefined)?.stack ?? error);
       process.exitCode = 1;
     }
   });
+}
+
+// Verifies that every org-managed secret this WillBooster-org repository needs is visible to it
+// as an ORGANIZATION secret, without mutating anything: registration and repository visibility
+// are manual org-admin operations by policy.
+async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, repo: string): Promise<void> {
+  const octokit = getOctokit(owner);
+  const { contents: remoteFnoxContents } = await fetchDefaultBranchFnoxConfigs(octokit, owner, repo);
+  const requiredNames = ['VERDACCIO_TOKEN'];
+  if (remoteFnoxContents.size > 0) requiredNames.push('FNOX_AGE_KEY');
+  if (containsWranglerConfig(config.dirPath)) requiredNames.push('CLOUDFLARE_API_TOKEN');
+
+  const orgResponse = await octokit.request('GET /repos/{owner}/{repo}/actions/organization-secrets', {
+    owner,
+    repo,
+    per_page: 100,
+  });
+  const orgVisibleNames = new Set(orgResponse.data.secrets.map((secret) => secret.name));
+  const repoResponse = await octokit.request('GET /repos/{owner}/{repo}/actions/secrets', {
+    owner,
+    repo,
+    per_page: 100,
+  });
+  const repoLevelNames = new Set(repoResponse.data.secrets.map((secret) => secret.name));
+
+  for (const name of requiredNames) {
+    if (!orgVisibleNames.has(name)) {
+      console.error(
+        `The organization secret ${name} is not visible to ${owner}/${repo}. Ask a WillBooster org admin to register it as an organization secret (or extend its repository access to this repository) — do NOT create a repository-level copy.${repoLevelNames.has(name) ? ` A repository-level ${name} currently keeps CI working, but it violates the org-secret policy and must be deleted once the organization secret is visible.` : ''}`
+      );
+      process.exitCode = 1;
+    }
+  }
+  // A repository secret silently overrides a same-named organization secret, so a stale
+  // repository-level copy would keep winning even after the admin rotates the org value.
+  for (const name of ORG_MANAGED_SECRET_NAMES) {
+    if (orgVisibleNames.has(name) && repoLevelNames.has(name)) {
+      console.error(
+        `The repository-level secret ${name} in ${owner}/${repo} shadows the organization secret of the same name. After confirming the organization value is current, delete the repository-level copy manually (e.g. \`gh secret delete ${name} --repo ${owner}/${repo}\`); wbfy deliberately never deletes it.`
+      );
+      process.exitCode = 1;
+    }
+  }
+  if (process.exitCode !== 1) {
+    console.info(
+      `Confirmed the organization secrets required by ${owner}/${repo} are visible: ${requiredNames.join(', ')}.`
+    );
+  }
+}
+
+// Detects a Cloudflare Workers deployment (root or a directly nested workspace) to decide whether
+// CLOUDFLARE_API_TOKEN is required; deeper layouts are out of wbfy's supported structure.
+function containsWranglerConfig(rootDirPath: string): boolean {
+  const candidateDirPaths = [rootDirPath];
+  for (const groupDirName of ['packages', 'apps']) {
+    const groupDirPath = path.join(rootDirPath, groupDirName);
+    try {
+      for (const entry of fs.readdirSync(groupDirPath, { withFileTypes: true })) {
+        if (entry.isDirectory()) candidateDirPaths.push(path.join(groupDirPath, entry.name));
+      }
+    } catch {
+      // A repository without that workspace group simply has nothing to scan there.
+    }
+  }
+  return candidateDirPaths.some((dirPath) =>
+    ['wrangler.jsonc', 'wrangler.json', 'wrangler.toml'].some((fileName) => fs.existsSync(path.join(dirPath, fileName)))
+  );
 }
 
 async function uploadSecrets(config: PackageConfig, owner: string, repo: string): Promise<void> {


### PR DESCRIPTION
## Summary

Secret management is **asymmetric** between the two organizations, and wbfy now encodes that explicitly:

- **WillBooster (paid plan)**: `CLOUDFLARE_API_TOKEN` / `FNOX_AGE_KEY` / `VERDACCIO_TOKEN` are **organization secrets**, registered manually by an org admin with per-repository visibility. wbfy must never create, update, or delete them (neither org-level nor as repository-level copies).
- **WillBoosterLab (free plan)**: GitHub Free cannot share organization secrets with private repositories, so `wbfy --env` keeps its existing automatic provisioning of `FNOX_AGE_KEY` / `VERDACCIO_TOKEN` as repository secrets (the `uploadSecrets` path is untouched).

Concretely, `wbfy --env` on a WillBooster-org repository — which previously **silently did nothing** — now:

- determines which org-managed secrets the repository needs from the LOCAL working tree, matching workflow generation (`VERDACCIO_TOKEN` always; `FNOX_AGE_KEY` when a root `fnox.toml` exists; `CLOUDFLARE_API_TOKEN` when a wrangler config exists at the root or in a real, non-symlinked `packages/*` / `apps/*` workspace directory), so feature-branch migrations surface missing org secrets before they land,
- verifies each is visible via `GET /repos/{owner}/{repo}/actions/organization-secrets` (paginated), counting only the alphabetically first 100 assigned organization secrets as workflow-usable per GitHub's limit, and failing loudly with org-admin instructions when one is missing or beyond the limit,
- flags repository-level copies that shadow a genuinely usable same-named organization secret (a repository secret silently overrides the org secret), telling the operator to delete the copy manually,
- fails loudly when `--env` is requested without a usable GitHub credential (previously a silent no-op),
- and mutates nothing.

## Verification

- `bun run typecheck` in `packages/wbfy` passes; CI green.
- The `organization-secrets` endpoint behavior was confirmed against live repositories (cheerlings sees the org-visible `CLOUDFLARE_API_TOKEN`/`VERDACCIO_TOKEN`; `FNOX_AGE_KEY` is not yet an organization secret and currently exists only as repository-level copies).
- Multi-agent review (Codex / Claude Code / Antigravity) ran to "no concern" over four rounds; fixes included the local-tree basis for the fnox probe, the 100-org-secret workflow limit, credential-missing fail-loud, ENOTDIR/symlink-safe workspace scanning, and pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
