### PR TITLE
feat(wbfy): auto-fix repository-config gaps found in the org-wide consistency audit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
         "@willbooster/wb": "14.0.0",
-        "build-ts": "17.1.34",
+        "build-ts": "17.1.36",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
         "oxlint-tsgolint": "0.25.0",
@@ -60,7 +60,7 @@
         "@willbooster/oxlint-config": "1.4.8",
         "@willbooster/wb": "14.0.0",
         "blitz": "3.0.2",
-        "build-ts": "17.1.34",
+        "build-ts": "17.1.36",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
         "oxlint-tsgolint": "0.25.0",
@@ -81,7 +81,7 @@
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
         "@willbooster/wb": "14.0.0",
-        "build-ts": "17.1.34",
+        "build-ts": "17.1.36",
         "next": "16.2.6",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
@@ -111,7 +111,7 @@
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
         "@willbooster/wb": "14.0.0",
-        "build-ts": "17.1.34",
+        "build-ts": "17.1.36",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
         "oxlint-tsgolint": "0.25.0",
@@ -145,7 +145,7 @@
         "@willbooster/oxlint-config": "1.4.8",
         "@willbooster/wb": "14.0.0",
         "babel-loader": "10.1.1",
-        "build-ts": "17.1.34",
+        "build-ts": "17.1.36",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
         "oxlint-tsgolint": "0.25.0",
@@ -190,7 +190,7 @@
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
         "at-decorators": "7.1.0",
-        "build-ts": "17.1.34",
+        "build-ts": "17.1.36",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
         "oxlint-tsgolint": "0.25.0",
@@ -236,7 +236,7 @@
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
         "@willbooster/wb": "14.0.0",
-        "build-ts": "17.1.34",
+        "build-ts": "17.1.36",
         "lefthook": "2.1.10",
         "oxfmt": "0.59.0",
         "oxlint": "1.74.0",
@@ -1449,7 +1449,7 @@
 
     "buffer-xor": ["buffer-xor@1.0.3", "", {}, "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="],
 
-    "build-ts": ["build-ts@17.1.34", "", { "dependencies": { "@babel/core": "8.0.1", "@babel/plugin-proposal-decorators": "8.0.2", "@babel/plugin-transform-explicit-resource-management": "8.0.1", "@babel/preset-env": "8.0.2", "@babel/preset-react": "8.0.1", "@babel/preset-typescript": "8.0.1", "@willbooster/shared-lib-node": "8.6.1", "babel-plugin-polyfill-corejs3": "1.0.0", "core-js": "3.49.0", "core-js-pure": "3.49.0", "magic-string": "0.30.21", "oxc-parser": "0.138.0", "rolldown": "1.1.4", "signal-exit": "4.1.0", "tsx": "4.23.0", "typescript": "7.0.2", "yargs": "18.0.0" }, "bin": { "build-ts": "bin/index.js" } }, "sha512-4Ts7jT5kvewmocYANRW6k+lcmex6PzPH9TYg/U4X/yYCLqaVQ8uLdknSvEF/1ZTWzvLEJ4POzR2QVvmBptyFPw=="],
+    "build-ts": ["build-ts@17.1.36", "", { "dependencies": { "@babel/core": "8.0.1", "@babel/plugin-proposal-decorators": "8.0.2", "@babel/plugin-transform-explicit-resource-management": "8.0.1", "@babel/preset-env": "8.0.2", "@babel/preset-react": "8.0.1", "@babel/preset-typescript": "8.0.1", "@willbooster/shared-lib-node": "8.6.1", "babel-plugin-polyfill-corejs3": "1.0.0", "core-js": "3.49.0", "core-js-pure": "3.49.0", "magic-string": "0.30.21", "oxc-parser": "0.138.0", "rolldown": "1.1.5", "signal-exit": "4.1.0", "tsx": "4.23.1", "typescript": "7.0.2", "yargs": "18.0.0" }, "bin": { "build-ts": "bin/index.js" } }, "sha512-UzK+wAqaOjekODfVU/kz2Xr7is1aS8TFQr8LU05fsegvfhAHhKCBj+gkhac09d88F0VvIPR3zg9lETCiXf3aGQ=="],
 
     "builtin-status-codes": ["builtin-status-codes@3.0.0", "", {}, "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="],
 
@@ -3145,7 +3145,7 @@
 
     "tslog": ["tslog@4.9.0", "", {}, "sha512-YEb55YxukbKO0bSAAsd9eSnw6RA0e3jt3cniZ00wj9offySAbp20lBrjOh1OTn11L51r58V4kFy8h7dMPnbpmg=="],
 
-    "tsx": ["tsx@4.23.0", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w=="],
+    "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
 
     "tty-browserify": ["tty-browserify@0.0.0", "", {}, "sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw=="],
 
@@ -3927,7 +3927,7 @@
 
     "build-ts/@willbooster/shared-lib-node": ["@willbooster/shared-lib-node@8.6.1", "", { "dependencies": { "dotenv": "17.4.2", "dotenv-expand": "13.0.0" } }, "sha512-2vdp+2uZyqWU91WNM7DRA+3fBscA21yoSGSWM2WVzP5vd+mTWH+wFc27Cnfwfqutl0Nrw0NtP5ViIlIgGKqWtQ=="],
 
-    "build-ts/rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
+    "build-ts/rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
     "cacache/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
@@ -6295,37 +6295,37 @@
 
     "build-ts/@babel/plugin-proposal-decorators/@babel/plugin-syntax-decorators": ["@babel/plugin-syntax-decorators@8.0.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^8.0.1" }, "peerDependencies": { "@babel/core": "^8.0.0" } }, "sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw=="],
 
-    "build-ts/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
+    "build-ts/rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
-    "build-ts/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.4", "", { "os": "android", "cpu": "arm64" }, "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="],
+    "build-ts/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
 
-    "build-ts/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ=="],
+    "build-ts/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
 
-    "build-ts/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg=="],
+    "build-ts/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
 
-    "build-ts/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ=="],
+    "build-ts/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
 
-    "build-ts/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.4", "", { "os": "linux", "cpu": "arm" }, "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA=="],
+    "build-ts/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
 
-    "build-ts/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w=="],
+    "build-ts/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
 
-    "build-ts/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng=="],
+    "build-ts/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
 
-    "build-ts/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg=="],
+    "build-ts/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
 
-    "build-ts/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ=="],
+    "build-ts/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
 
-    "build-ts/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw=="],
+    "build-ts/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
 
-    "build-ts/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ=="],
+    "build-ts/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
 
-    "build-ts/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.4", "", { "os": "none", "cpu": "arm64" }, "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA=="],
+    "build-ts/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
 
-    "build-ts/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.4", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg=="],
+    "build-ts/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
 
-    "build-ts/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA=="],
+    "build-ts/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
 
-    "build-ts/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ=="],
+    "build-ts/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
 
     "build-ts/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 

--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -51,7 +51,7 @@
     "@willbooster/oxlint-config": "1.4.8",
     "@willbooster/wb": "14.0.0",
     "blitz": "3.0.2",
-    "build-ts": "17.1.34",
+    "build-ts": "17.1.36",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",
     "oxlint-tsgolint": "0.25.0",

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -50,7 +50,7 @@
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
     "@willbooster/wb": "14.0.0",
-    "build-ts": "17.1.34",
+    "build-ts": "17.1.36",
     "next": "16.2.6",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -55,7 +55,7 @@
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
     "@willbooster/wb": "14.0.0",
-    "build-ts": "17.1.34",
+    "build-ts": "17.1.36",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",
     "oxlint-tsgolint": "0.25.0",

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -61,7 +61,7 @@
     "@willbooster/oxlint-config": "1.4.8",
     "@willbooster/wb": "14.0.0",
     "babel-loader": "10.1.1",
-    "build-ts": "17.1.34",
+    "build-ts": "17.1.36",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",
     "oxlint-tsgolint": "0.25.0",

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -50,7 +50,7 @@
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
     "@willbooster/wb": "14.0.0",
-    "build-ts": "17.1.34",
+    "build-ts": "17.1.36",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",
     "oxlint-tsgolint": "0.25.0",

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -55,7 +55,7 @@
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
     "at-decorators": "7.1.0",
-    "build-ts": "17.1.34",
+    "build-ts": "17.1.36",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",
     "oxlint-tsgolint": "0.25.0",

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -59,7 +59,7 @@
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",
     "@willbooster/wb": "14.0.0",
-    "build-ts": "17.1.34",
+    "build-ts": "17.1.36",
     "lefthook": "2.1.10",
     "oxfmt": "0.59.0",
     "oxlint": "1.74.0",

--- a/packages/wbfy/src/generators/gitattributes.ts
+++ b/packages/wbfy/src/generators/gitattributes.ts
@@ -9,6 +9,10 @@ import { promisePool } from '../utils/promisePool.js';
 // cf. https://bun.sh/guides/install/git-diff-bun-lockfile
 const newContent = `* text=auto
 
+# The macOS template's \`Icon\\r\\r\` rule needs its literal carriage returns: \`text=auto\`
+# normalization strips one CR per checkin, degrading the rule until it matches nothing.
+.gitignore -text
+
 *.lockb binary diff=lockb
 *.vcproj text eol=crlf
 

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -213,7 +213,9 @@ src-tauri/gen/schemas/
     // so deleting it would un-ignore files.
     const managedContent = headUserContent.slice(userHeadContent.length);
     const managedLines = new Set(
-      [...managedContent.split('\n'), ...generated.split('\n')].filter((line) => line && !line.startsWith('#'))
+      [...managedContent.split('\n'), ...generated.split('\n')]
+        .map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line))
+        .filter((line) => line && !line.startsWith('#'))
     );
     const dedupedUserHeadContent = userHeadContent
       .split('\n')

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { logger } from '../logger.js';
 import { options } from '../options.js';
-import { generatesWorkerTypes, type PackageConfig } from '../packageConfig.js';
+import { consumesGeneratedWorkerTypes, generatesWorkerTypes, type PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { ignoreFileUtil } from '../utils/ignoreFileUtil.js';
 import { promisePool } from '../utils/promisePool.js';
@@ -144,10 +144,12 @@ src-tauri/gen/schemas/
     if (generatesWorkerTypes(config)) {
       headUserContent += `/worker-configuration.d.ts
 `;
-    } else if (config.doesContainWranglerConfig) {
-      // On a worker-types opt-out the ignore rule above disappears, so an already-generated file
-      // would surface as untracked noise on every checkout — delete it, but only an UNTRACKED
-      // copy (a tracked one is the user's own file, not wbfy's leftover).
+    } else if (config.doesContainWranglerConfig && !consumesGeneratedWorkerTypes(config)) {
+      // On a genuine worker-types opt-out (nothing consumes the generated file — the same gate as
+      // the postinstall strip; generatesWorkerTypes alone is false for unrelated reasons such as a
+      // missing local wrangler dependency, where the file may still be consumed) the ignore rule
+      // above disappears, so an already-generated file would surface as untracked noise on every
+      // checkout — delete it, but only an UNTRACKED copy (a tracked one is the user's own file).
       const workerTypesPath = path.resolve(config.dirPath, 'worker-configuration.d.ts');
       if (
         fs.existsSync(workerTypesPath) &&

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -8,6 +8,7 @@ import { generatesWorkerTypes, type PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { ignoreFileUtil } from '../utils/ignoreFileUtil.js';
 import { promisePool } from '../utils/promisePool.js';
+import { spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
 
 // Do not remove `windows`: generated .gitignore files must keep ignoring Windows-created local artifacts.
 const defaultNames = ['windows', 'macos', 'linux', 'jetbrains', 'visualstudiocode', 'emacs', 'vim', 'yarn'];
@@ -143,6 +144,17 @@ src-tauri/gen/schemas/
     if (generatesWorkerTypes(config)) {
       headUserContent += `/worker-configuration.d.ts
 `;
+    } else if (config.doesContainWranglerConfig) {
+      // On a worker-types opt-out the ignore rule above disappears, so an already-generated file
+      // would surface as untracked noise on every checkout — delete it, but only an UNTRACKED
+      // copy (a tracked one is the user's own file, not wbfy's leftover).
+      const workerTypesPath = path.resolve(config.dirPath, 'worker-configuration.d.ts');
+      if (
+        fs.existsSync(workerTypesPath) &&
+        !spawnSyncAndReturnStdout('git', ['ls-files', '--', 'worker-configuration.d.ts'], config.dirPath).trim()
+      ) {
+        await promisePool.run(() => fs.promises.rm(workerTypesPath, { force: true }));
+      }
     }
     if (rootConfig.depending.vinext || config.depending.vinext) {
       headUserContent += `.vinext/

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -43,7 +43,8 @@ export async function generateGitignore(config: PackageConfig, rootConfig: Packa
   return logger.functionIgnoringException('generateGitignore', async () => {
     const filePath = path.resolve(config.dirPath, '.gitignore');
     const content = (await fsUtil.readFileIfExists(filePath)) ?? '';
-    let headUserContent = ignoreFileUtil.getHeadUserContent(content) + commonContent;
+    const userHeadContent = ignoreFileUtil.getHeadUserContent(content);
+    let headUserContent = userHeadContent + commonContent;
     const tailUserContent = ignoreFileUtil.getTailUserContent(content);
 
     const names = [...defaultNames];
@@ -203,7 +204,21 @@ src-tauri/gen/schemas/
     if (rootConfig.depending.reactNative || config.depending.reactNative || config.doesContainPubspecYaml) {
       generated = generated.replaceAll(/^(.idea\/.+)$/gm, '$1\nandroid/$1');
     }
-    const newContent = headUserContent + '\n' + generated + tailUserContent;
+    // Drop user-section lines that duplicate a managed pattern verbatim, so hand-added entries
+    // (e.g. a pre-migration `.wrangler/`) do not linger once wbfy manages the same rule.
+    const managedContent = headUserContent.slice(userHeadContent.length);
+    const managedLines = new Set(managedContent.split('\n').filter((line) => line && !line.startsWith('#')));
+    const removeManagedDuplicates = (text: string): string =>
+      text
+        .split('\n')
+        .filter((line) => !managedLines.has(line))
+        .join('\n');
+    const newContent =
+      removeManagedDuplicates(userHeadContent) +
+      managedContent +
+      '\n' +
+      generated +
+      removeManagedDuplicates(tailUserContent);
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
   });
 }

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -204,21 +204,23 @@ src-tauri/gen/schemas/
     if (rootConfig.depending.reactNative || config.depending.reactNative || config.doesContainPubspecYaml) {
       generated = generated.replaceAll(/^(.idea\/.+)$/gm, '$1\nandroid/$1');
     }
-    // Drop user-section lines that duplicate a managed pattern verbatim, so hand-added entries
-    // (e.g. a pre-migration `.wrangler/`) do not linger once wbfy manages the same rule.
+    // Drop HEAD user-section lines that duplicate a managed or template pattern verbatim, so
+    // hand-added entries (e.g. a pre-migration `.wrangler/`) do not linger once wbfy manages the
+    // same rule. Removing a head duplicate cannot change semantics: git honors the LAST matching
+    // rule and the managed/template copy always comes after the head. The TAIL section is left
+    // untouched — a tail rule comes after every managed rule and may deliberately re-assert a
+    // pattern over an earlier negation (e.g. `!.env.production` followed by `.env.production`),
+    // so deleting it would un-ignore files.
     const managedContent = headUserContent.slice(userHeadContent.length);
-    const managedLines = new Set(managedContent.split('\n').filter((line) => line && !line.startsWith('#')));
-    const removeManagedDuplicates = (text: string): string =>
-      text
-        .split('\n')
-        .filter((line) => !managedLines.has(line))
-        .join('\n');
-    const newContent =
-      removeManagedDuplicates(userHeadContent) +
-      managedContent +
-      '\n' +
-      generated +
-      removeManagedDuplicates(tailUserContent);
+    const managedLines = new Set(
+      [...managedContent.split('\n'), ...generated.split('\n')].filter((line) => line && !line.startsWith('#'))
+    );
+    const dedupedUserHeadContent = userHeadContent
+      .split('\n')
+      // Tolerate CRLF user content (now preserved by the generated `.gitignore -text` attribute).
+      .filter((line) => !managedLines.has(line.endsWith('\r') ? line.slice(0, -1) : line))
+      .join('\n');
+    const newContent = dedupedUserHeadContent + managedContent + '\n' + generated + tailUserContent;
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
   });
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1005,8 +1005,13 @@ function addPackageJsonDependencies(
     // A private package whose monorepo contains this dependency as a workspace must reference it
     // via the workspace protocol: pinning a registry version makes Bun shadow the same-name
     // workspace and skip installing the workspace's own dependencies. (Published packages instead
-    // pin a concrete version because `npm publish` rejects `workspace:*` specifiers.)
-    if (jsonObj.private && getWorkspacePackageDirs(rootConfig).has(dependency)) {
+    // pin a concrete version because `npm publish` rejects `workspace:*` specifiers — but an
+    // EXISTING `workspace:` declaration is always kept: overwriting it with a registry release
+    // would silently break the local workspace link.)
+    if (
+      getWorkspacePackageDirs(rootConfig).has(dependency) &&
+      (jsonObj.private || packageJsonDependencies[dependency]?.startsWith('workspace:'))
+    ) {
       packageJsonDependencies[dependency] = 'workspace:*';
       continue;
     }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -10,7 +10,7 @@ import type { PackageJson, SetRequired } from 'type-fest';
 
 import { getLatestCommitHash } from '../github/commit.js';
 import { logger } from '../logger.js';
-import { generatesWorkerTypes, type PackageConfig } from '../packageConfig.js';
+import { consumesGeneratedWorkerTypes, generatesWorkerTypes, type PackageConfig } from '../packageConfig.js';
 import {
   classifyWranglerTypesInvocation,
   isManagedGenCodeSegment,
@@ -210,7 +210,27 @@ function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
   }
 }
 
-function updatePostinstallScript(scripts: PackageJson.Scripts, wranglerTypes: string | undefined): void {
+function updatePostinstallScript(
+  scripts: PackageJson.Scripts,
+  wranglerTypes: string | undefined,
+  removesObsoleteWranglerTypes: boolean
+): void {
+  // On a worker-types opt-out (a wrangler package whose TypeScript project no longer consumes the
+  // generated file), strip the generating default-output invocations wbfy used to manage from
+  // postinstall — otherwise every install keeps recreating the now-unignored ~500KB file. Custom
+  // pipelines (non-default output, wrappers, unmodeled shells) are classified differently and stay.
+  if (removesObsoleteWranglerTypes && scripts.postinstall) {
+    const remaining = splitCommandSegments(scripts.postinstall).filter((segment) => {
+      if (segment === '') return false;
+      const invocationArgs = parseWranglerTypesInvocation(segment);
+      return !invocationArgs || classifyWranglerTypesInvocation(invocationArgs) !== 'reusableGenerator';
+    });
+    if (remaining.length > 0) {
+      scripts.postinstall = remaining.join(' && ');
+    } else {
+      delete scripts.postinstall;
+    }
+  }
   if (scripts['gen-code']) {
     // Keep the project's own worker-types pipeline (prerequisites included — e.g. `node scripts/prepareTypes.js
     // && wrangler types ...`) when rewriting postinstall: dropping a prerequisite would leave fresh checkouts
@@ -850,7 +870,11 @@ async function normalizePackageMetadata(
         : appendWranglerTypes(genCodeScript, wranglerTypes);
   }
   normalizeGenI18nTsScript(config, jsonObj);
-  updatePostinstallScript(jsonObj.scripts, wranglerTypes);
+  updatePostinstallScript(
+    jsonObj.scripts,
+    wranglerTypes,
+    config.doesContainWranglerConfig && !wranglerTypes && !consumesGeneratedWorkerTypes(config)
+  );
 
   if (!jsonObj.dependencies.prettier) {
     // Because @types/prettier blocks prettier execution.
@@ -1020,14 +1044,18 @@ function addPackageJsonDependencies(
     // EXISTING `workspace:` declaration is always kept: overwriting it with a registry release
     // would silently break the local workspace link.)
 
-    if (getWorkspacePackageDirs(rootConfig).has(dependency)) {
+    // A declared `workspace:` specifier always wins, whether or not the workspace map sees the
+    // package: running wbfy on a monorepo SUBDIRECTORY hides the parent's workspaces, so the map
+    // alone cannot be trusted to detect a local workspace link.
+    if (packageJsonDependencies[dependency]?.startsWith('workspace:')) {
       if (jsonObj.private) {
         packageJsonDependencies[dependency] = 'workspace:*';
-        continue;
       }
-      if (packageJsonDependencies[dependency]?.startsWith('workspace:')) {
-        continue;
-      }
+      continue;
+    }
+    if (jsonObj.private && getWorkspacePackageDirs(rootConfig).has(dependency)) {
+      packageJsonDependencies[dependency] = 'workspace:*';
+      continue;
     }
     const shouldUpdateExistingDependency = shouldUpdateExistingManagedDependency(
       config,

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -481,10 +481,16 @@ async function applyPackageJsonConventions(
   }
 
   if (!isWbPackage(jsonObj)) {
-    if (shouldKeepWbAsRuntimeDependency(jsonObj)) {
-      dependencies.push(wbDependency);
-    } else {
-      devDependencies.push(wbDependency);
+    // A `workspace:` specifier depends on the wb developed in this repository (e.g.
+    // WillBooster/shared itself); installing the latest registry release over it would silently
+    // replace the local build with a published one, so leave such a declaration untouched.
+    const wbSpecifier = jsonObj.dependencies[wbDependency] ?? jsonObj.devDependencies[wbDependency];
+    if (!wbSpecifier?.startsWith('workspace:')) {
+      if (shouldKeepWbAsRuntimeDependency(jsonObj)) {
+        dependencies.push(wbDependency);
+      } else {
+        devDependencies.push(wbDependency);
+      }
     }
   }
   // build-ts owns TypeScript execution and declaration emit. wbfy must always

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -918,7 +918,7 @@ function addDependencyVersionsToPackageJson(
     rootConfig,
     jsonObj,
     packageJsonDependencies,
-    [...dependencyUpdates.dependencies, ...getExistingManagedDependencies(packageJsonDependencies)],
+    [...dependencyUpdates.dependencies, ...getExistingManagedDependencies(packageJsonDependencies, jsonObj)],
     skipAddingDeps
   );
   dependencyUpdates.devDependencies = dependencyUpdates.devDependencies.filter((dep) => !packageJsonDependencies[dep]);
@@ -927,13 +927,24 @@ function addDependencyVersionsToPackageJson(
     rootConfig,
     jsonObj,
     packageJsonDevDependencies,
-    [...dependencyUpdates.devDependencies, ...getExistingManagedDependencies(packageJsonDevDependencies)],
+    [...dependencyUpdates.devDependencies, ...getExistingManagedDependencies(packageJsonDevDependencies, jsonObj)],
     skipAddingDeps
   );
 }
 
-function getExistingManagedDependencies(packageJsonDependencies: Partial<Record<string, string>>): string[] {
-  return Object.keys(packageJsonDependencies).filter((dependency) => managedDependencyNames.has(dependency));
+function getExistingManagedDependencies(
+  packageJsonDependencies: Partial<Record<string, string>>,
+  jsonObj: PackageJson
+): string[] {
+  return Object.keys(packageJsonDependencies).filter(
+    (dependency) =>
+      managedDependencyNames.has(dependency) &&
+      // A public package's `workspace:` specifier must never be re-managed via a registry install
+      // (private ones are normalized to `workspace:*` later). This also covers running wbfy on a
+      // monorepo SUBDIRECTORY, where the parent's workspaces are invisible and the workspace-map
+      // guard in addPackageJsonDependencies cannot protect the specifier.
+      (jsonObj.private || !packageJsonDependencies[dependency]?.startsWith('workspace:'))
+  );
 }
 
 function removeEmptyDependencySections(jsonObj: PackageJson): void {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1008,12 +1008,15 @@ function addPackageJsonDependencies(
     // pin a concrete version because `npm publish` rejects `workspace:*` specifiers — but an
     // EXISTING `workspace:` declaration is always kept: overwriting it with a registry release
     // would silently break the local workspace link.)
-    if (
-      getWorkspacePackageDirs(rootConfig).has(dependency) &&
-      (jsonObj.private || packageJsonDependencies[dependency]?.startsWith('workspace:'))
-    ) {
-      packageJsonDependencies[dependency] = 'workspace:*';
-      continue;
+
+    if (getWorkspacePackageDirs(rootConfig).has(dependency)) {
+      if (jsonObj.private) {
+        packageJsonDependencies[dependency] = 'workspace:*';
+        continue;
+      }
+      if (packageJsonDependencies[dependency]?.startsWith('workspace:')) {
+        continue;
+      }
     }
     const shouldUpdateExistingDependency = shouldUpdateExistingManagedDependency(
       config,

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
+import { getOctokit } from '../utils/githubUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
 const semanticReleaseBadge =
@@ -30,6 +31,10 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
       if (!repository) continue;
       const badge = `[![${badgeName}](https://github.com/${repository}/actions/workflows/${fileName}/badge.svg)](https://github.com/${repository}/actions/workflows/${fileName})`;
       if (fs.existsSync(path.resolve(config.dirPath, `.github/workflows/${fileName}`))) {
+        // GitHub's badge endpoint returns 404 until the workflow has at least one run, so a badge
+        // for a dispatch-only deploy workflow that has never run renders as a broken image.
+        // Test workflows run on every PR, so only deploy badges need the guard.
+        if (fileName.startsWith('deploy') && !(await hasAnyWorkflowRun(repository, fileName))) continue;
         newContent = removeGitHubActionsBadge(newContent, badgeName, fileName);
         newContent = insertBadge(newContent, badge);
       }
@@ -37,6 +42,24 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
 
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
   });
+}
+
+async function hasAnyWorkflowRun(repository: string, workflowFileName: string): Promise<boolean> {
+  const [owner, repo] = repository.split('/');
+  if (!owner || !repo) return true;
+  try {
+    const response = await getOctokit(owner).request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
+      owner,
+      repo,
+      workflow_id: workflowFileName,
+      per_page: 1,
+    });
+    return response.data.total_count > 0;
+  } catch {
+    // Keep the pre-guard behavior (insert the badge) when the check itself cannot run,
+    // e.g. offline or without a GitHub token.
+    return true;
+  }
 }
 
 export function insertBadge(readme: string, badge: string): string {

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
-import { getOctokit } from '../utils/githubUtil.js';
+import { getOctokit, hasGitHubToken } from '../utils/githubUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
 const semanticReleaseBadge =
@@ -49,6 +49,9 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
 async function hasAnyWorkflowRun(repository: string, workflowFileName: string): Promise<boolean> {
   const [owner, repo] = repository.split('/');
   if (!owner || !repo) return true;
+  // GitHub answers 404 (not 401/403) for private resources accessed without authorization, so an
+  // unauthenticated 404 cannot distinguish "no runs" from "no access" — keep the badge then.
+  if (!hasGitHubToken(owner)) return true;
   try {
     const response = await getOctokit(owner).request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
       owner,

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
-import { getOctokit, hasGitHubToken } from '../utils/githubUtil.js';
+import { getOctokit } from '../utils/githubUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
 const semanticReleaseBadge =
@@ -37,7 +37,8 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
         // GitHub's badge endpoint returns 404 until the workflow has at least one run, so a badge
         // for a dispatch-only deploy workflow that has never run renders as a broken image.
         // Test workflows run on every PR, so only deploy badges need the guard.
-        if (fileName.startsWith('deploy') && !(await hasAnyWorkflowRun(repository, fileName))) continue;
+        if (fileName.startsWith('deploy') && !(await hasAnyWorkflowRun(repository, fileName, config.isPublicRepo)))
+          continue;
         newContent = insertBadge(newContent, badge);
       }
     }
@@ -46,12 +47,13 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
   });
 }
 
-async function hasAnyWorkflowRun(repository: string, workflowFileName: string): Promise<boolean> {
+async function hasAnyWorkflowRun(
+  repository: string,
+  workflowFileName: string,
+  isPublicRepo: boolean
+): Promise<boolean> {
   const [owner, repo] = repository.split('/');
   if (!owner || !repo) return true;
-  // GitHub answers 404 (not 401/403) for private resources accessed without authorization, so an
-  // unauthenticated 404 cannot distinguish "no runs" from "no access" — keep the badge then.
-  if (!hasGitHubToken(owner)) return true;
   try {
     const response = await getOctokit(owner).request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
       owner,
@@ -61,11 +63,12 @@ async function hasAnyWorkflowRun(repository: string, workflowFileName: string): 
     });
     return response.data.total_count > 0;
   } catch (error) {
-    // GitHub resolves the file name against the REMOTE repository, so a locally added workflow
-    // that has never been pushed yields 404 — its badge would be broken too, exactly like zero runs.
-    if ((error as { status?: number }).status === 404) return false;
-    // Keep the pre-guard behavior (insert the badge) when the check itself cannot run,
-    // e.g. offline or without a GitHub token.
+    // For a PUBLIC repository the runs endpoint needs no authorization, so 404 reliably means the
+    // workflow is absent from the remote (e.g. added locally, never pushed) — like zero runs, its
+    // badge would render broken. For a PRIVATE repository GitHub also answers 404 when the token
+    // is missing or under-scoped, so 404 is ambiguous there and the badge is kept.
+    if ((error as { status?: number }).status === 404 && isPublicRepo) return false;
+    // Keep the pre-guard behavior (insert the badge) when the check itself cannot run.
     return true;
   }
 }

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -31,11 +31,13 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
       if (!repository) continue;
       const badge = `[![${badgeName}](https://github.com/${repository}/actions/workflows/${fileName}/badge.svg)](https://github.com/${repository}/actions/workflows/${fileName})`;
       if (fs.existsSync(path.resolve(config.dirPath, `.github/workflows/${fileName}`))) {
+        // Always drop the existing badge first, so a stale broken badge is removed even when the
+        // guard below skips re-inserting it.
+        newContent = removeGitHubActionsBadge(newContent, badgeName, fileName);
         // GitHub's badge endpoint returns 404 until the workflow has at least one run, so a badge
         // for a dispatch-only deploy workflow that has never run renders as a broken image.
         // Test workflows run on every PR, so only deploy badges need the guard.
         if (fileName.startsWith('deploy') && !(await hasAnyWorkflowRun(repository, fileName))) continue;
-        newContent = removeGitHubActionsBadge(newContent, badgeName, fileName);
         newContent = insertBadge(newContent, badge);
       }
     }
@@ -55,7 +57,10 @@ async function hasAnyWorkflowRun(repository: string, workflowFileName: string): 
       per_page: 1,
     });
     return response.data.total_count > 0;
-  } catch {
+  } catch (error) {
+    // GitHub resolves the file name against the REMOTE repository, so a locally added workflow
+    // that has never been pushed yields 404 — its badge would be broken too, exactly like zero runs.
+    if ((error as { status?: number }).status === 404) return false;
     // Keep the pre-guard behavior (insert the badge) when the check itself cannot run,
     // e.g. offline or without a GitHub token.
     return true;

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -178,8 +178,17 @@ function addUndiciTypesPathMapping(settings: TsConfigJson, config: PackageConfig
   // for every TypeScript project except React Native, which uses @tsconfig/react-native instead.
   const types = settings.compilerOptions?.types;
   if (types ? !types.includes('bun') : config.depending.reactNative) return;
-  // Keep a repo-local mapping (e.g. patched types) when the project already declares one.
-  if (settings.compilerOptions?.paths?.['undici-types']) return;
+  const existingMapping = settings.compilerOptions?.paths?.['undici-types'];
+  if (existingMapping) {
+    // Normalize the package-directory form older wbfy versions generated: it resolves through the
+    // package's `types` condition today but breaks once TypeScript needs the concrete file. Any
+    // other value is a deliberate repo-local mapping (e.g. patched types) and must be kept.
+    const legacyDirMapping = `${getRootDir(config)}/node_modules/undici-types`;
+    if (existingMapping.length === 1 && existingMapping[0] === legacyDirMapping) {
+      settings.compilerOptions!.paths!['undici-types'] = [`${legacyDirMapping}/index.d.ts`];
+    }
+    return;
+  }
 
   settings.compilerOptions ??= {};
   settings.compilerOptions.paths = {

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -356,25 +356,27 @@ async function writeWorkflowYaml(
   }
 
   let isReusableWorkflow = false;
-  const calledReusableWorkflows = new Set<string>();
   for (const job of Object.values(newSettings.jobs)) {
     // Ignore non-reusable workflows
     if (!job.uses?.includes('/reusable-workflows/')) continue;
 
-    const calledReusableWorkflow = normalizeJob(config, job, kind);
-    if (calledReusableWorkflow) calledReusableWorkflows.add(calledReusableWorkflow);
+    normalizeJob(config, job, kind);
     isReusableWorkflow = true;
   }
   if (!isReusableWorkflow) return;
 
-  // Deploy and scheduled-script callers need no repository writes: the called reusable workflow
-  // inherits the caller's token permissions, and repositories default the token to write, so an
-  // undeclared permissions block silently over-privileges deployments. Only default it — a
-  // workflow that declares its own permissions keeps them.
+  // Deploy callers need no repository writes: the called reusable workflow inherits the caller's
+  // token permissions, repositories default the token to write, and the reusable deploy workflow
+  // performs no GITHUB_TOKEN writes. A top-level permissions block applies to EVERY job and
+  // resets unspecified scopes to none, so inject the read-only default only when each job is an
+  // @main call of the reusable deploy workflow — an inline job or a pinned callee may
+  // legitimately need writes, and run-script callers execute arbitrary package scripts that may
+  // push commits. Only default it — a workflow that declares its own permissions keeps them.
+  const jobs = Object.values(newSettings.jobs);
   if (
     !newSettings.permissions &&
-    calledReusableWorkflows.size > 0 &&
-    [...calledReusableWorkflows].every((name) => name === 'deploy' || name === 'run-script')
+    jobs.length > 0 &&
+    jobs.every((job) => /\/reusable-workflows\/\.github\/workflows\/deploy\.ya?ml@main$/u.test(job.uses ?? ''))
   ) {
     newSettings.permissions = { contents: 'read' };
   }
@@ -446,8 +448,7 @@ async function writeWorkflowYaml(
 // other callee is a GitHub error.
 const installCapableReusableWorkflows = new Set(['autofix', 'deploy', 'gen-pr', 'release', 'run-script', 'test']);
 
-/** Returns the basename of the called `@main` reusable workflow, or undefined for other callees. */
-function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): string | undefined {
+function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   job.with ??= {};
   // `secrets: inherit` (parsed by js-yaml as a plain string) already forwards every caller secret
   // including the ones injected below, so preserve it untouched — property assignments on the
@@ -557,7 +558,6 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): string 
       delete job.secrets;
     }
   }
-  return calledReusableWorkflow;
 }
 
 function generateAutofixWorkflow(config: PackageConfig): Workflow {

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -356,14 +356,28 @@ async function writeWorkflowYaml(
   }
 
   let isReusableWorkflow = false;
+  const calledReusableWorkflows = new Set<string>();
   for (const job of Object.values(newSettings.jobs)) {
     // Ignore non-reusable workflows
     if (!job.uses?.includes('/reusable-workflows/')) continue;
 
-    normalizeJob(config, job, kind);
+    const calledReusableWorkflow = normalizeJob(config, job, kind);
+    if (calledReusableWorkflow) calledReusableWorkflows.add(calledReusableWorkflow);
     isReusableWorkflow = true;
   }
   if (!isReusableWorkflow) return;
+
+  // Deploy and scheduled-script callers need no repository writes: the called reusable workflow
+  // inherits the caller's token permissions, and repositories default the token to write, so an
+  // undeclared permissions block silently over-privileges deployments. Only default it — a
+  // workflow that declares its own permissions keeps them.
+  if (
+    !newSettings.permissions &&
+    calledReusableWorkflows.size > 0 &&
+    [...calledReusableWorkflows].every((name) => name === 'deploy' || name === 'run-script')
+  ) {
+    newSettings.permissions = { contents: 'read' };
+  }
 
   switch (kind) {
     case 'release': {
@@ -432,7 +446,8 @@ async function writeWorkflowYaml(
 // other callee is a GitHub error.
 const installCapableReusableWorkflows = new Set(['autofix', 'deploy', 'gen-pr', 'release', 'run-script', 'test']);
 
-function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
+/** Returns the basename of the called `@main` reusable workflow, or undefined for other callees. */
+function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): string | undefined {
   job.with ??= {};
   // `secrets: inherit` (parsed by js-yaml as a plain string) already forwards every caller secret
   // including the ones injected below, so preserve it untouched — property assignments on the
@@ -542,6 +557,7 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
       delete job.secrets;
     }
   }
+  return calledReusableWorkflow;
 }
 
 function generateAutofixWorkflow(config: PackageConfig): Workflow {

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -367,19 +367,17 @@ async function writeWorkflowYaml(
 
   // Deploy callers need no repository writes: the called reusable workflow inherits the caller's
   // token permissions, repositories default the token to write, and the reusable deploy workflow
-  // at main performs no GITHUB_TOKEN writes. A top-level permissions block applies to EVERY job
-  // and resets unspecified scopes to none, so inject the read-only default only when each job is
-  // an @main call of the reusable deploy workflow — an inline job may need writes, a PINNED
-  // callee follows an older revision whose write needs are unaudited, and run-script callers
-  // execute arbitrary package scripts that may push commits. Only default it — a workflow that
-  // declares its own permissions keeps them (OIDC deploys always do, for id-token).
-  const jobs = Object.values(newSettings.jobs);
-  if (
-    !newSettings.permissions &&
-    jobs.length > 0 &&
-    jobs.every((job) => /\/reusable-workflows\/\.github\/workflows\/deploy\.ya?ml@main$/u.test(job.uses ?? ''))
-  ) {
-    newSettings.permissions = { contents: 'read' };
+  // at main performs no GITHUB_TOKEN writes. The read-only default is injected at the JOB level
+  // (job permissions do not affect sibling jobs, so inline jobs or pinned callees — whose write
+  // needs are unaudited — keep theirs), and only when neither the workflow nor the job declares
+  // its own permissions (OIDC deploys always do, for id-token). run-script callers are excluded
+  // because arbitrary package scripts may push commits.
+  if (!newSettings.permissions) {
+    for (const job of Object.values(newSettings.jobs)) {
+      if (!job.permissions && /\/reusable-workflows\/\.github\/workflows\/deploy\.ya?ml@main$/u.test(job.uses ?? '')) {
+        job.permissions = { contents: 'read' };
+      }
+    }
   }
 
   switch (kind) {

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -376,7 +376,7 @@ async function writeWorkflowYaml(
   if (
     !newSettings.permissions &&
     jobs.length > 0 &&
-    jobs.every((job) => /\/reusable-workflows\/\.github\/workflows\/deploy\.ya?ml@main$/u.test(job.uses ?? ''))
+    jobs.every((job) => /\/reusable-workflows\/\.github\/workflows\/deploy\.ya?ml@\S+$/u.test(job.uses ?? ''))
   ) {
     newSettings.permissions = { contents: 'read' };
   }

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -367,16 +367,17 @@ async function writeWorkflowYaml(
 
   // Deploy callers need no repository writes: the called reusable workflow inherits the caller's
   // token permissions, repositories default the token to write, and the reusable deploy workflow
-  // performs no GITHUB_TOKEN writes. A top-level permissions block applies to EVERY job and
-  // resets unspecified scopes to none, so inject the read-only default only when each job is an
-  // @main call of the reusable deploy workflow — an inline job or a pinned callee may
-  // legitimately need writes, and run-script callers execute arbitrary package scripts that may
-  // push commits. Only default it — a workflow that declares its own permissions keeps them.
+  // at main performs no GITHUB_TOKEN writes. A top-level permissions block applies to EVERY job
+  // and resets unspecified scopes to none, so inject the read-only default only when each job is
+  // an @main call of the reusable deploy workflow — an inline job may need writes, a PINNED
+  // callee follows an older revision whose write needs are unaudited, and run-script callers
+  // execute arbitrary package scripts that may push commits. Only default it — a workflow that
+  // declares its own permissions keeps them (OIDC deploys always do, for id-token).
   const jobs = Object.values(newSettings.jobs);
   if (
     !newSettings.permissions &&
     jobs.length > 0 &&
-    jobs.every((job) => /\/reusable-workflows\/\.github\/workflows\/deploy\.ya?ml@\S+$/u.test(job.uses ?? ''))
+    jobs.every((job) => /\/reusable-workflows\/\.github\/workflows\/deploy\.ya?ml@main$/u.test(job.uses ?? ''))
   ) {
     newSettings.permissions = { contents: 'read' };
   }

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -296,34 +296,61 @@ export function generatesWorkerTypes(config: PackageConfig): boolean {
 }
 
 /**
- * A package whose tsconfig cannot include worker-configuration.d.ts (e.g. one on a hand-maintained minimal `Env`
- * with `types: ["bun"]`, the standard escape when the ambient wrangler globals conflict with the `@types/bun`
- * globals its tests need) gains nothing from regenerating the ~500KB file on every install, so wbfy leaves such
- * packages unmanaged instead of re-adding the generation step. The `files`/`include`/`exclude` set is resolved
- * through relative `extends` chains (child keys override parent keys, matching tsc; package-name extends such as
- * `@tsconfig/bun` define no file set, so they contribute nothing); whenever the effective set cannot be
- * determined (missing or unparseable tsconfig, or TypeScript's default `**` inclusion), the current managed
- * behavior is kept.
+ * A package whose TypeScript project cannot include worker-configuration.d.ts (e.g. one on a hand-maintained
+ * minimal `Env` with `types: ["bun"]`, the standard escape when the ambient wrangler globals conflict with the
+ * `@types/bun` globals its tests need) gains nothing from regenerating the ~500KB file on every install, so wbfy
+ * leaves such packages unmanaged instead of re-adding the generation step. Consumption is detected two ways:
+ * a textual `worker-configuration` reference in any tracked file of the package (covers imports, triple-slash
+ * references, and explicit tsconfig entries), or a `files`/`include`/`exclude` set that can match the file —
+ * resolved through relative `extends` chains with each pattern kept relative to the config that declared it,
+ * matching tsc. Whenever the effective set cannot be determined (missing or unparseable tsconfig, package-name
+ * `extends` presets, or TypeScript's default `**` inclusion), the current managed behavior is kept.
  */
 export function consumesGeneratedWorkerTypes(config: Pick<PackageConfig, 'dirPath'>): boolean {
-  const fileSet = resolveTsconfigFileSet(path.resolve(config.dirPath, 'tsconfig.json'), 5);
+  // `git grep` searches tracked files only, so the gitignored generated file itself never matches.
+  const grepResult = spawnSyncAndReturnStdout('git', ['grep', '-l', 'worker-configuration', '--', '.'], config.dirPath);
+  if (grepResult.trim()) return true;
+
+  const workerTypesPath = path.resolve(config.dirPath, 'worker-configuration.d.ts');
+  const fileSet = resolveTsconfigFileSet(path.resolve(config.dirPath, 'tsconfig.json'), config.dirPath, 5);
   if (!fileSet) return true;
-  const matches = (patterns: unknown): boolean =>
-    Array.isArray(patterns) &&
-    patterns.some((pattern) => typeof pattern === 'string' && tsconfigPatternCouldMatchWorkerTypes(pattern));
+  const matches = (patternSet: TsconfigPatternSet | undefined): boolean => {
+    if (!patternSet || !Array.isArray(patternSet.patterns)) return false;
+    const relativePath = path.relative(patternSet.baseDirPath, workerTypesPath).replaceAll('\\', '/');
+    return patternSet.patterns.some((pattern) => {
+      if (typeof pattern !== 'string') return false;
+      // `${configDir}`-prefixed patterns were expanded to absolute paths at resolve time.
+      if (path.isAbsolute(pattern)) return tsconfigPatternCouldMatchPath(pattern, workerTypesPath);
+      if (relativePath.startsWith('..')) return false;
+      return tsconfigPatternCouldMatchPath(pattern, relativePath);
+    });
+  };
   // `files` entries are always part of the program, even when `exclude` matches them.
   if (matches(fileSet.files)) return true;
   if (matches(fileSet.exclude)) return false;
   // Neither include nor files declared: TypeScript's default `**` inclusion covers the file.
-  if (!Array.isArray(fileSet.include) && !Array.isArray(fileSet.files)) return true;
+  if (!fileSet.include && !fileSet.files) return true;
   return matches(fileSet.include);
+}
+
+interface TsconfigPatternSet {
+  /** Directory of the config that declared the patterns; tsc resolves them relative to it. */
+  baseDirPath: string;
+  patterns: unknown;
+}
+
+interface TsconfigFileSet {
+  exclude?: TsconfigPatternSet;
+  files?: TsconfigPatternSet;
+  include?: TsconfigPatternSet;
 }
 
 /** Resolves files/include/exclude through relative `extends` chains; undefined when unreadable. */
 function resolveTsconfigFileSet(
   filePath: string,
+  consumerDirPath: string,
   remainingDepth: number
-): { exclude?: unknown; files?: unknown; include?: unknown } | undefined {
+): TsconfigFileSet | undefined {
   if (remainingDepth <= 0) return undefined;
   let content: string;
   try {
@@ -338,18 +365,35 @@ function resolveTsconfigFileSet(
     include?: unknown;
   }>(content);
   if (!tsconfig) return undefined;
-  const fileSet = { exclude: tsconfig.exclude, files: tsconfig.files, include: tsconfig.include };
+  const dirPath = path.dirname(filePath);
+  // `${configDir}` resolves to the directory of the ROOT (consuming) config, wherever it appears.
+  const toPatternSet = (patterns: unknown): TsconfigPatternSet | undefined =>
+    Array.isArray(patterns)
+      ? {
+          baseDirPath: dirPath,
+          patterns: patterns.map((pattern) =>
+            typeof pattern === 'string' && pattern.startsWith('${configDir}')
+              ? path.join(consumerDirPath, pattern.slice('${configDir}'.length))
+              : pattern
+          ),
+        }
+      : undefined;
+  const fileSet: TsconfigFileSet = {
+    exclude: toPatternSet(tsconfig.exclude),
+    files: toPatternSet(tsconfig.files),
+    include: toPatternSet(tsconfig.include),
+  };
   const parents =
     typeof tsconfig.extends === 'string' ? [tsconfig.extends] : Array.isArray(tsconfig.extends) ? tsconfig.extends : [];
   // With an `extends` array, later entries override earlier ones, and the child overrides all —
   // so fill each still-missing key from the last parent that defines it.
   for (const parent of parents.toReversed()) {
-    if (fileSet.exclude !== undefined && fileSet.files !== undefined && fileSet.include !== undefined) break;
+    if (fileSet.exclude && fileSet.files && fileSet.include) break;
     // Package-name extends (e.g. `@tsconfig/bun`) are compilerOptions presets without file sets.
     if (typeof parent !== 'string' || !parent.startsWith('.')) continue;
-    let parentPath = path.resolve(path.dirname(filePath), parent);
+    let parentPath = path.resolve(dirPath, parent);
     if (!fs.existsSync(parentPath) && fs.existsSync(`${parentPath}.json`)) parentPath += '.json';
-    const parentFileSet = resolveTsconfigFileSet(parentPath, remainingDepth - 1);
+    const parentFileSet = resolveTsconfigFileSet(parentPath, consumerDirPath, remainingDepth - 1);
     if (!parentFileSet) continue;
     fileSet.exclude ??= parentFileSet.exclude;
     fileSet.files ??= parentFileSet.files;
@@ -358,10 +402,9 @@ function resolveTsconfigFileSet(
   return fileSet;
 }
 
-function tsconfigPatternCouldMatchWorkerTypes(pattern: string): boolean {
+function tsconfigPatternCouldMatchPath(pattern: string, targetPath: string): boolean {
   const normalized = pattern.replace(/^\.\//u, '');
-  // A bare `.` include covers everything under the package root, where worker-configuration.d.ts lives;
-  // a plain directory segment (e.g. `src`) cannot contain the root-level file.
+  // A bare `.` include covers everything under the config's directory.
   if (normalized === '' || normalized === '.') return true;
   const segments = normalized.split('/').filter((segment) => segment !== '');
   const regexSource = segments
@@ -375,7 +418,7 @@ function tsconfigPatternCouldMatchWorkerTypes(pattern: string): boolean {
       return isLast ? segmentSource : `${segmentSource}/`;
     })
     .join('');
-  return new RegExp(`^${regexSource}$`, 'u').test('worker-configuration.d.ts');
+  return new RegExp(`^${regexSource}$`, 'u').test(targetPath);
 }
 
 /**

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -327,9 +327,11 @@ export function consumesGeneratedWorkerTypes(config: Pick<PackageConfig, 'dirPat
     return patternSet.patterns.some((pattern) => {
       if (typeof pattern !== 'string') return false;
       // `${configDir}`-prefixed patterns were expanded to absolute paths at resolve time.
-      if (path.isAbsolute(pattern)) return tsconfigPatternCouldMatchPath(pattern, workerTypesPath);
+      if (path.isAbsolute(pattern)) {
+        return tsconfigPatternCouldMatchPath(pattern, workerTypesPath, patternSet.expandsDirectories);
+      }
       if (relativePath.startsWith('..')) return false;
-      return tsconfigPatternCouldMatchPath(pattern, relativePath);
+      return tsconfigPatternCouldMatchPath(pattern, relativePath, patternSet.expandsDirectories);
     });
   };
   // `files` entries are always part of the program, even when `exclude` matches them.
@@ -343,6 +345,8 @@ export function consumesGeneratedWorkerTypes(config: Pick<PackageConfig, 'dirPat
 interface TsconfigPatternSet {
   /** Directory of the config that declared the patterns; tsc resolves them relative to it. */
   baseDirPath: string;
+  /** include/exclude treat an extensionless non-glob pattern as a directory subtree; `files` does not. */
+  expandsDirectories: boolean;
   patterns: unknown;
 }
 
@@ -374,10 +378,11 @@ function resolveTsconfigFileSet(
   if (!tsconfig) return undefined;
   const dirPath = path.dirname(filePath);
   // `${configDir}` resolves to the directory of the ROOT (consuming) config, wherever it appears.
-  const toPatternSet = (patterns: unknown): TsconfigPatternSet | undefined =>
+  const toPatternSet = (patterns: unknown, expandsDirectories: boolean): TsconfigPatternSet | undefined =>
     Array.isArray(patterns)
       ? {
           baseDirPath: dirPath,
+          expandsDirectories,
           patterns: patterns.map((pattern) =>
             typeof pattern === 'string' && pattern.startsWith('${configDir}')
               ? path.join(consumerDirPath, pattern.slice('${configDir}'.length))
@@ -386,9 +391,9 @@ function resolveTsconfigFileSet(
         }
       : undefined;
   const fileSet: TsconfigFileSet = {
-    exclude: toPatternSet(tsconfig.exclude),
-    files: toPatternSet(tsconfig.files),
-    include: toPatternSet(tsconfig.include),
+    exclude: toPatternSet(tsconfig.exclude, true),
+    files: toPatternSet(tsconfig.files, false),
+    include: toPatternSet(tsconfig.include, true),
   };
   const parents =
     typeof tsconfig.extends === 'string' ? [tsconfig.extends] : Array.isArray(tsconfig.extends) ? tsconfig.extends : [];
@@ -409,10 +414,13 @@ function resolveTsconfigFileSet(
   return fileSet;
 }
 
-function tsconfigPatternCouldMatchPath(pattern: string, targetPath: string): boolean {
+function tsconfigPatternCouldMatchPath(pattern: string, targetPath: string, expandsDirectories: boolean): boolean {
   const normalized = pattern.replace(/^\.\//u, '');
   // A bare `.` include covers everything under the config's directory.
   if (normalized === '' || normalized === '.') return true;
+  // Absolute patterns (expanded `${configDir}`) are matched against the absolute target; drop the
+  // leading slashes from both so the segment-built regex anchors identically.
+  targetPath = targetPath.replace(/^\/+/u, '');
   const segments = normalized.split('/').filter((segment) => segment !== '');
   const regexSource = segments
     .map((segment, index) => {
@@ -425,7 +433,11 @@ function tsconfigPatternCouldMatchPath(pattern: string, targetPath: string): boo
       return isLast ? segmentSource : `${segmentSource}/`;
     })
     .join('');
-  return new RegExp(`^${regexSource}$`, 'u').test(targetPath);
+  // tsc treats an extensionless non-glob include/exclude entry as a directory whose subtree is included.
+  const lastSegment = segments.at(-1) ?? '';
+  const directorySuffix =
+    expandsDirectories && !/[*?]/u.test(lastSegment) && !lastSegment.includes('.') ? String.raw`(?:/.*)?` : '';
+  return new RegExp(`^${regexSource}${directorySuffix}$`, 'u').test(targetPath);
 }
 
 /**

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -290,8 +290,53 @@ export function generatesWorkerTypes(config: PackageConfig): boolean {
     // fallback generator over the same file, and several distinct flagged generators leave no deterministic
     // choice, so such packages stay unmanaged.
     !selectProjectWranglerTypesGenerator(packageJson?.scripts ?? {}).conflicting &&
+    consumesGeneratedWorkerTypes(config) &&
     hasReproducibleWorkerTypesInference(config)
   );
+}
+
+/**
+ * A package whose tsconfig cannot include worker-configuration.d.ts (e.g. one on a hand-maintained minimal `Env`
+ * with `types: ["bun"]`, the standard escape when the ambient wrangler globals conflict with the `@types/bun`
+ * globals its tests need) gains nothing from regenerating the ~500KB file on every install, so wbfy leaves such
+ * packages unmanaged instead of re-adding the generation step. Only an explicit `include`/`files` set that cannot
+ * match the file opts out; a missing or unparseable tsconfig (or TypeScript's default `**` inclusion) keeps the
+ * current managed behavior.
+ */
+export function consumesGeneratedWorkerTypes(config: Pick<PackageConfig, 'dirPath'>): boolean {
+  let content: string;
+  try {
+    content = fs.readFileSync(path.resolve(config.dirPath, 'tsconfig.json'), 'utf8');
+  } catch {
+    return true;
+  }
+  const tsconfig = jsoncUtil.parseObjectIgnoringError<{ files?: unknown; include?: unknown }>(content);
+  if (!tsconfig) return true;
+  const declaredPatterns = [tsconfig.include, tsconfig.files].filter((value) => Array.isArray(value));
+  if (declaredPatterns.length === 0) return true;
+  return declaredPatterns
+    .flat()
+    .some((pattern) => typeof pattern === 'string' && tsconfigPatternCouldMatchWorkerTypes(pattern));
+}
+
+function tsconfigPatternCouldMatchWorkerTypes(pattern: string): boolean {
+  const normalized = pattern.replace(/^\.\//u, '');
+  // A bare `.` include covers everything under the package root, where worker-configuration.d.ts lives;
+  // a plain directory segment (e.g. `src`) cannot contain the root-level file.
+  if (normalized === '' || normalized === '.') return true;
+  const segments = normalized.split('/').filter((segment) => segment !== '');
+  const regexSource = segments
+    .map((segment, index) => {
+      const isLast = index === segments.length - 1;
+      if (segment === '**') return isLast ? '.*' : String.raw`(?:[^/]+/)*`;
+      const segmentSource = segment
+        .replaceAll(/[.+^${}()|[\]\\]/gu, String.raw`\$&`)
+        .replaceAll('*', String.raw`[^/]*`)
+        .replaceAll('?', String.raw`[^/]`);
+      return isLast ? segmentSource : `${segmentSource}/`;
+    })
+    .join('');
+  return new RegExp(`^${regexSource}$`, 'u').test('worker-configuration.d.ts');
 }
 
 /**

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -299,24 +299,63 @@ export function generatesWorkerTypes(config: PackageConfig): boolean {
  * A package whose tsconfig cannot include worker-configuration.d.ts (e.g. one on a hand-maintained minimal `Env`
  * with `types: ["bun"]`, the standard escape when the ambient wrangler globals conflict with the `@types/bun`
  * globals its tests need) gains nothing from regenerating the ~500KB file on every install, so wbfy leaves such
- * packages unmanaged instead of re-adding the generation step. Only an explicit `include`/`files` set that cannot
- * match the file opts out; a missing or unparseable tsconfig (or TypeScript's default `**` inclusion) keeps the
- * current managed behavior.
+ * packages unmanaged instead of re-adding the generation step. The `files`/`include`/`exclude` set is resolved
+ * through relative `extends` chains (child keys override parent keys, matching tsc; package-name extends such as
+ * `@tsconfig/bun` define no file set, so they contribute nothing); whenever the effective set cannot be
+ * determined (missing or unparseable tsconfig, or TypeScript's default `**` inclusion), the current managed
+ * behavior is kept.
  */
 export function consumesGeneratedWorkerTypes(config: Pick<PackageConfig, 'dirPath'>): boolean {
+  const fileSet = resolveTsconfigFileSet(path.resolve(config.dirPath, 'tsconfig.json'), 5);
+  if (!fileSet) return true;
+  const matches = (patterns: unknown): boolean =>
+    Array.isArray(patterns) &&
+    patterns.some((pattern) => typeof pattern === 'string' && tsconfigPatternCouldMatchWorkerTypes(pattern));
+  // `files` entries are always part of the program, even when `exclude` matches them.
+  if (matches(fileSet.files)) return true;
+  if (matches(fileSet.exclude)) return false;
+  // Neither include nor files declared: TypeScript's default `**` inclusion covers the file.
+  if (!Array.isArray(fileSet.include) && !Array.isArray(fileSet.files)) return true;
+  return matches(fileSet.include);
+}
+
+/** Resolves files/include/exclude through relative `extends` chains; undefined when unreadable. */
+function resolveTsconfigFileSet(
+  filePath: string,
+  remainingDepth: number
+): { exclude?: unknown; files?: unknown; include?: unknown } | undefined {
+  if (remainingDepth <= 0) return undefined;
   let content: string;
   try {
-    content = fs.readFileSync(path.resolve(config.dirPath, 'tsconfig.json'), 'utf8');
+    content = fs.readFileSync(filePath, 'utf8');
   } catch {
-    return true;
+    return undefined;
   }
-  const tsconfig = jsoncUtil.parseObjectIgnoringError<{ files?: unknown; include?: unknown }>(content);
-  if (!tsconfig) return true;
-  const declaredPatterns = [tsconfig.include, tsconfig.files].filter((value) => Array.isArray(value));
-  if (declaredPatterns.length === 0) return true;
-  return declaredPatterns
-    .flat()
-    .some((pattern) => typeof pattern === 'string' && tsconfigPatternCouldMatchWorkerTypes(pattern));
+  const tsconfig = jsoncUtil.parseObjectIgnoringError<{
+    exclude?: unknown;
+    extends?: unknown;
+    files?: unknown;
+    include?: unknown;
+  }>(content);
+  if (!tsconfig) return undefined;
+  const fileSet = { exclude: tsconfig.exclude, files: tsconfig.files, include: tsconfig.include };
+  const parents =
+    typeof tsconfig.extends === 'string' ? [tsconfig.extends] : Array.isArray(tsconfig.extends) ? tsconfig.extends : [];
+  // With an `extends` array, later entries override earlier ones, and the child overrides all —
+  // so fill each still-missing key from the last parent that defines it.
+  for (const parent of parents.toReversed()) {
+    if (fileSet.exclude !== undefined && fileSet.files !== undefined && fileSet.include !== undefined) break;
+    // Package-name extends (e.g. `@tsconfig/bun`) are compilerOptions presets without file sets.
+    if (typeof parent !== 'string' || !parent.startsWith('.')) continue;
+    let parentPath = path.resolve(path.dirname(filePath), parent);
+    if (!fs.existsSync(parentPath) && fs.existsSync(`${parentPath}.json`)) parentPath += '.json';
+    const parentFileSet = resolveTsconfigFileSet(parentPath, remainingDepth - 1);
+    if (!parentFileSet) continue;
+    fileSet.exclude ??= parentFileSet.exclude;
+    fileSet.files ??= parentFileSet.files;
+    fileSet.include ??= parentFileSet.include;
+  }
+  return fileSet;
 }
 
 function tsconfigPatternCouldMatchWorkerTypes(pattern: string): boolean {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -308,7 +308,14 @@ export function generatesWorkerTypes(config: PackageConfig): boolean {
  */
 export function consumesGeneratedWorkerTypes(config: Pick<PackageConfig, 'dirPath'>): boolean {
   // `git grep` searches tracked files only, so the gitignored generated file itself never matches.
-  const grepResult = spawnSyncAndReturnStdout('git', ['grep', '-l', 'worker-configuration', '--', '.'], config.dirPath);
+  // wbfy's own managed artifacts are excluded: the `.gitignore` rule (`/worker-configuration.d.ts`)
+  // wbfy committed while it managed the package must not count as consumption, or a once-managed
+  // package could never opt out.
+  const grepResult = spawnSyncAndReturnStdout(
+    'git',
+    ['grep', '-l', 'worker-configuration', '--', '.', ':(exclude).gitignore', ':(exclude).gitattributes'],
+    config.dirPath
+  );
   if (grepResult.trim()) return true;
 
   const workerTypesPath = path.resolve(config.dirPath, 'worker-configuration.d.ts');

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -313,7 +313,18 @@ export function consumesGeneratedWorkerTypes(config: Pick<PackageConfig, 'dirPat
   // package could never opt out.
   const grepResult = spawnSyncAndReturnStdout(
     'git',
-    ['grep', '-l', 'worker-configuration', '--', '.', ':(exclude).gitignore', ':(exclude).gitattributes'],
+    // tsconfig files are classified by the resolved files/include/exclude logic below — a textual
+    // hit there (e.g. an `exclude` entry) must not count as consumption.
+    [
+      'grep',
+      '-l',
+      'worker-configuration',
+      '--',
+      '.',
+      ':(exclude).gitignore',
+      ':(exclude).gitattributes',
+      String.raw`:(glob,exclude)**/tsconfig*.json`,
+    ],
     config.dirPath
   );
   if (grepResult.trim()) return true;

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { expect, test } from 'vitest';
+import type { PackageJson } from 'type-fest';
 
 import { generatePackageJson } from '../src/generators/packageJson.js';
 import { createConfig } from './testConfig.js';
@@ -168,7 +169,45 @@ test('keeps wb as a runtime dependency when postinstall uses it', async () => {
 
   expect(packageJson.dependencies?.['@willbooster/wb']).toMatch(/^\d+\.\d+\.\d+/u);
   expect(packageJson.dependencies?.['@willbooster/wb']).not.toBe(oldWbVersion);
-  expect(packageJson.devDependencies?.['@willbooster/wb']).toBeUndefined();
+});
+
+test('preserves workspace: dependency specifiers in public packages', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      devDependencies: {
+        '@willbooster/wb': 'workspace:^14.0.0',
+      },
+      workspaces: ['packages/*'],
+    },
+    { isRoot: true },
+    {
+      files: {
+        'packages/wb/package.json': JSON.stringify({ name: '@willbooster/wb' }),
+      },
+    }
+  );
+
+  expect(packageJson.devDependencies?.['@willbooster/wb']).toBe('workspace:^14.0.0');
+});
+
+test('updates non-workspace dependency specifiers in public packages', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      devDependencies: {
+        '@willbooster/wb': '0.0.1',
+      },
+      workspaces: ['packages/*'],
+    },
+    { isRoot: true },
+    {
+      files: {
+        'packages/wb/package.json': JSON.stringify({ name: '@willbooster/wb' }),
+      },
+    }
+  );
+
+  expect(packageJson.devDependencies?.['@willbooster/wb']).toMatch(/^\d+\.\d+\.\d+$/u);
+  expect(packageJson.devDependencies?.['@willbooster/wb']).not.toBe('0.0.1');
 });
 
 test('uses stable age-gated versions for generated dependencies when skipping installs', async () => {
@@ -1608,7 +1647,7 @@ async function generatePackageJsonFrom(
   configOverrides: Parameters<typeof createConfig>[0] = {},
   options: { createI18nDir?: boolean; files?: Record<string, string> } = {}
 ): Promise<GeneratedPackageJson> {
-  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-'));
+  const dirPath = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-package-json-')));
   const packageJsonPath = path.join(dirPath, 'package.json');
 
   try {
@@ -1623,6 +1662,7 @@ async function generatePackageJsonFrom(
     await fs.writeFile(packageJsonPath, JSON.stringify(initialPackageJson));
 
     const config = createConfig({
+      packageJson: initialPackageJson as PackageJson,
       ...configOverrides,
       dirPath,
     });

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -53,7 +53,15 @@ test('merges settings from a tsconfig containing JSONC comments instead of repla
     },
   }
 }`);
-  expect(compilerOptions.paths).toEqual({ 'undici-types': ['./node_modules/undici-types'] });
+  // The legacy package-directory mapping is normalized to the concrete index.d.ts file.
+  expect(compilerOptions.paths).toEqual({ 'undici-types': ['./node_modules/undici-types/index.d.ts'] });
+});
+
+test('keeps a deliberate repo-local undici-types mapping untouched', async () => {
+  const compilerOptions = await generateCompilerOptionsFromContent(
+    JSON.stringify({ compilerOptions: { paths: { 'undici-types': ['./patched-types/undici-types/index.d.ts'] } } })
+  );
+  expect(compilerOptions.paths).toEqual({ 'undici-types': ['./patched-types/undici-types/index.d.ts'] });
 });
 
 test('leaves an unparseable tsconfig untouched', async () => {
@@ -122,7 +130,7 @@ test('merges settings from a tsconfig with a UTF-8 BOM instead of skipping it', 
   const compilerOptions = await generateCompilerOptionsFromContent(
     '\uFEFF' + JSON.stringify({ compilerOptions: { paths: { 'undici-types': ['./node_modules/undici-types'] } } })
   );
-  expect(compilerOptions.paths).toEqual({ 'undici-types': ['./node_modules/undici-types'] });
+  expect(compilerOptions.paths).toEqual({ 'undici-types': ['./node_modules/undici-types/index.d.ts'] });
 });
 
 test('keeps a commented Next tsconfig byte-identical when no cleanup is needed', async () => {

--- a/packages/wbfy/test/workerTypesConsumption.test.ts
+++ b/packages/wbfy/test/workerTypesConsumption.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { consumesGeneratedWorkerTypes } from '../src/packageConfig.js';
+
+async function consumesWithTsconfig(tsconfigContent: string | undefined): Promise<boolean> {
+  const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wbfy-worker-types-'));
+  try {
+    if (tsconfigContent !== undefined) {
+      await fs.promises.writeFile(path.join(dirPath, 'tsconfig.json'), tsconfigContent);
+    }
+    return consumesGeneratedWorkerTypes({ dirPath });
+  } finally {
+    await fs.promises.rm(dirPath, { force: true, recursive: true });
+  }
+}
+
+test('treats a missing, unparseable, or unrestricted tsconfig as consuming worker types', async () => {
+  expect(await consumesWithTsconfig(undefined)).toBe(true);
+  expect(await consumesWithTsconfig('{ broken')).toBe(true);
+  // No include/files: TypeScript's default `**` inclusion covers the root-level file.
+  expect(await consumesWithTsconfig('{ "compilerOptions": { "strict": true } }')).toBe(true);
+});
+
+test('detects include/files entries that can match the root-level worker-configuration.d.ts', async () => {
+  expect(await consumesWithTsconfig('{ "include": ["worker-configuration.d.ts", "src/**/*"] }')).toBe(true);
+  expect(await consumesWithTsconfig('{ "include": ["./worker-configuration.d.ts"] }')).toBe(true);
+  expect(await consumesWithTsconfig('{ "include": ["**/*"] }')).toBe(true);
+  expect(await consumesWithTsconfig('{ "include": ["**"] }')).toBe(true);
+  expect(await consumesWithTsconfig('{ "include": ["*.ts"] }')).toBe(true);
+  expect(await consumesWithTsconfig('{ "include": ["."] }')).toBe(true);
+  expect(await consumesWithTsconfig('{ "files": ["worker-configuration.d.ts"] }')).toBe(true);
+});
+
+test('opts out when the explicit include/files set cannot match the generated file', async () => {
+  // The llm-proxy/cheerlings shape: hand-maintained Env with `types: ["bun"]` and source-only includes.
+  expect(await consumesWithTsconfig('{ "include": ["*.config.ts", "scripts/**/*", "src/**/*", "test/**/*"] }')).toBe(
+    false
+  );
+  expect(await consumesWithTsconfig('{ "include": ["src"] }')).toBe(false);
+  expect(await consumesWithTsconfig('{ "files": ["src/index.ts"] }')).toBe(false);
+  expect(await consumesWithTsconfig('{ "include": [] }')).toBe(false);
+});

--- a/packages/wbfy/test/workerTypesConsumption.test.ts
+++ b/packages/wbfy/test/workerTypesConsumption.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -69,6 +70,32 @@ test('honors exclude and relative extends chains when resolving the effective fi
     // ...while a base config covering only a sibling directory does not.
     await fs.promises.writeFile(path.join(dirPath, 'tsconfig.base.json'), '{ "include": ["other/**/*"] }');
     expect(consumesGeneratedWorkerTypes({ dirPath: packageDirPath })).toBe(false);
+  } finally {
+    await fs.promises.rm(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('counts tracked source mentions as consumption but ignores the managed .gitignore rule', async () => {
+  const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wbfy-worker-types-git-'));
+  const git = (...args: string[]): Buffer =>
+    execFileSync('git', args, { cwd: dirPath, env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null' } });
+  try {
+    git('init', '--initial-branch=main');
+    // wbfy's own committed artifacts must not count as consumption, or a once-managed package
+    // could never opt out.
+    await fs.promises.writeFile(path.join(dirPath, '.gitignore'), '/worker-configuration.d.ts\n');
+    await fs.promises.writeFile(path.join(dirPath, 'tsconfig.json'), '{ "include": ["src/**/*"] }');
+    git('add', '-A');
+    expect(consumesGeneratedWorkerTypes({ dirPath })).toBe(false);
+
+    // A genuine reference in a tracked source file DOES count.
+    await fs.promises.mkdir(path.join(dirPath, 'src'));
+    await fs.promises.writeFile(
+      path.join(dirPath, 'src', 'index.ts'),
+      '/// <reference path="../worker-configuration.d.ts" />\n'
+    );
+    git('add', '-A');
+    expect(consumesGeneratedWorkerTypes({ dirPath })).toBe(true);
   } finally {
     await fs.promises.rm(dirPath, { force: true, recursive: true });
   }

--- a/packages/wbfy/test/workerTypesConsumption.test.ts
+++ b/packages/wbfy/test/workerTypesConsumption.test.ts
@@ -95,6 +95,17 @@ test('counts tracked source mentions as consumption but ignores the managed .git
     git('add', '-A');
     expect(consumesGeneratedWorkerTypes({ dirPath })).toBe(false);
 
+    // A tracked tsconfig mentioning the file (here: an exclude entry) is classified by the
+    // resolved file-set logic, not the grep — the exclusion must win.
+    await fs.promises.writeFile(
+      path.join(dirPath, 'tsconfig.json'),
+      '{ "include": ["**/*"], "exclude": ["worker-configuration.d.ts"] }'
+    );
+    git('add', '-A');
+    expect(consumesGeneratedWorkerTypes({ dirPath })).toBe(false);
+    await fs.promises.writeFile(path.join(dirPath, 'tsconfig.json'), '{ "include": ["src/**/*"] }');
+    git('add', '-A');
+
     // A genuine reference in a tracked source file DOES count.
     await fs.promises.mkdir(path.join(dirPath, 'src'));
     await fs.promises.writeFile(

--- a/packages/wbfy/test/workerTypesConsumption.test.ts
+++ b/packages/wbfy/test/workerTypesConsumption.test.ts
@@ -35,6 +35,34 @@ test('detects include/files entries that can match the root-level worker-configu
   expect(await consumesWithTsconfig('{ "files": ["worker-configuration.d.ts"] }')).toBe(true);
 });
 
+test('honors exclude and relative extends chains when resolving the effective file set', async () => {
+  // `exclude` removes the file from a wildcard include...
+  expect(await consumesWithTsconfig('{ "include": ["**/*"], "exclude": ["worker-configuration.d.ts"] }')).toBe(false);
+  // ...but `files` entries are always part of the program, even when excluded.
+  expect(
+    await consumesWithTsconfig(
+      '{ "files": ["worker-configuration.d.ts"], "include": [], "exclude": ["worker-configuration.d.ts"] }'
+    )
+  ).toBe(true);
+
+  const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wbfy-worker-types-extends-'));
+  try {
+    await fs.promises.writeFile(path.join(dirPath, 'tsconfig.base.json'), '{ "include": ["src/**/*"] }');
+    await fs.promises.writeFile(
+      path.join(dirPath, 'tsconfig.json'),
+      '{ "extends": "./tsconfig.base.json", "compilerOptions": {} }'
+    );
+    // The source-only include inherited from the base config cannot match the root-level file.
+    expect(consumesGeneratedWorkerTypes({ dirPath })).toBe(false);
+
+    // A package-name extends contributes no file set, so the default `**` inclusion applies.
+    await fs.promises.writeFile(path.join(dirPath, 'tsconfig.json'), '{ "extends": "@tsconfig/bun/tsconfig.json" }');
+    expect(consumesGeneratedWorkerTypes({ dirPath })).toBe(true);
+  } finally {
+    await fs.promises.rm(dirPath, { force: true, recursive: true });
+  }
+});
+
 test('opts out when the explicit include/files set cannot match the generated file', async () => {
   // The llm-proxy/cheerlings shape: hand-maintained Env with `types: ["bun"]` and source-only includes.
   expect(await consumesWithTsconfig('{ "include": ["*.config.ts", "scripts/**/*", "src/**/*", "test/**/*"] }')).toBe(

--- a/packages/wbfy/test/workerTypesConsumption.test.ts
+++ b/packages/wbfy/test/workerTypesConsumption.test.ts
@@ -67,6 +67,13 @@ test('honors exclude and relative extends chains when resolving the effective fi
     await fs.promises.writeFile(path.join(dirPath, 'tsconfig.base.json'), '{ "include": ["pkg/**/*"] }');
     await fs.promises.writeFile(path.join(packageDirPath, 'tsconfig.json'), '{ "extends": "../tsconfig.base.json" }');
     expect(consumesGeneratedWorkerTypes({ dirPath: packageDirPath })).toBe(true);
+    // `${configDir}` resolves to the consuming package's directory, wherever declared.
+    await fs.promises.writeFile(path.join(packageDirPath, 'tsconfig.json'), '{ "include": ["${configDir}/**/*"] }');
+    expect(consumesGeneratedWorkerTypes({ dirPath: packageDirPath })).toBe(true);
+    // A directory include (extensionless, no glob) covers its whole subtree, like tsc.
+    await fs.promises.writeFile(path.join(dirPath, 'tsconfig.base.json'), '{ "include": ["pkg"] }');
+    await fs.promises.writeFile(path.join(packageDirPath, 'tsconfig.json'), '{ "extends": "../tsconfig.base.json" }');
+    expect(consumesGeneratedWorkerTypes({ dirPath: packageDirPath })).toBe(true);
     // ...while a base config covering only a sibling directory does not.
     await fs.promises.writeFile(path.join(dirPath, 'tsconfig.base.json'), '{ "include": ["other/**/*"] }');
     expect(consumesGeneratedWorkerTypes({ dirPath: packageDirPath })).toBe(false);

--- a/packages/wbfy/test/workerTypesConsumption.test.ts
+++ b/packages/wbfy/test/workerTypesConsumption.test.ts
@@ -58,6 +58,17 @@ test('honors exclude and relative extends chains when resolving the effective fi
     // A package-name extends contributes no file set, so the default `**` inclusion applies.
     await fs.promises.writeFile(path.join(dirPath, 'tsconfig.json'), '{ "extends": "@tsconfig/bun/tsconfig.json" }');
     expect(consumesGeneratedWorkerTypes({ dirPath })).toBe(true);
+
+    // Inherited patterns stay relative to the config that declared them (tsc semantics): a base
+    // config one level up whose include covers the package DOES reach the package's root file.
+    const packageDirPath = path.join(dirPath, 'pkg');
+    await fs.promises.mkdir(packageDirPath);
+    await fs.promises.writeFile(path.join(dirPath, 'tsconfig.base.json'), '{ "include": ["pkg/**/*"] }');
+    await fs.promises.writeFile(path.join(packageDirPath, 'tsconfig.json'), '{ "extends": "../tsconfig.base.json" }');
+    expect(consumesGeneratedWorkerTypes({ dirPath: packageDirPath })).toBe(true);
+    // ...while a base config covering only a sibling directory does not.
+    await fs.promises.writeFile(path.join(dirPath, 'tsconfig.base.json'), '{ "include": ["other/**/*"] }');
+    expect(consumesGeneratedWorkerTypes({ dirPath: packageDirPath })).toBe(false);
   } finally {
     await fs.promises.rm(dirPath, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Summary

Org-wide audit of bun-isolated-install / fnox / Cloudflare best practices surfaced repository-config gaps that wbfy can fix automatically, plus generator defects found by a 6-round multi-agent review. wbfy now:

- **Injects a job-level `permissions: contents: read`** on each caller job of the reusable `deploy.yml@main` that declares no permissions (job-level so inline/pinned sibling jobs are unaffected; run-script callers excluded because arbitrary scripts may push commits).
- **Preserves `workspace:` dependency specifiers everywhere**: a declared `workspace:` value is never overwritten by a registry install — including monorepo-subdirectory runs and every managed dependency (fixes the broken bot PR #967 behavior).
- **Normalizes the legacy `undici-types` paths mapping** to the concrete `index.d.ts` form.
- **Recognizes worker-types opt-outs**: `generatesWorkerTypes` resolves the tsconfig `files`/`include`/`exclude` set through relative `extends` chains (patterns kept relative to the declaring config, `${configDir}` expanded, directory includes expanded, files-beats-exclude precedence) plus a `git grep` for genuine source references (excluding `.gitignore`/`.gitattributes`/tsconfigs). On a genuine opt-out it also strips the wbfy-managed generating postinstall segments and deletes an untracked leftover `worker-configuration.d.ts`.
- **Deduplicates `.gitignore` HEAD-section lines** that verbatim-match managed/template patterns (head-only: tail rules may re-assert patterns over negations; CRLF-tolerant), and exempts `.gitignore` from git text normalization (`.gitattributes` `-text`) so the macOS `Icon\r\r` rule stops degrading one CR per checkin.
- **Skips deploy badges for never-run workflows** (GitHub's badge endpoint 404s), removing stale broken badges first; 404 is conclusive only for public repos (private 404s can mean an under-scoped token, so the badge is kept).

## Verification

- `bun verify` passes; wbfy suite: 125 tests incl. new git-backed worker-types tests and tsconfig-resolution tests.
- The improved wbfy was run against ai-game-builder, llm-proxy, cheerlings, agentic-workflows, and this repo itself; diffs reviewed, each repo's `bun verify` green, and reruns are idempotent (companion PRs all merged).
- Multi-agent review (Claude Code / Codex / Antigravity) over 6 rounds; final round reports no concerns; Gemini threads addressed.

Supersedes #967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
