### PR TITLE
fix: restore the legacy-peer-deps .npmrc that releases depend on

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# npm is used only by semantic-release's npm plugin (npm version / npm publish); its strict peer
+# resolution crashes on this workspace tree ("Cannot read properties of null (reading 'matches')"),
+# so keep the legacy resolver. #978 removed this file and every release failed until it was
+# restored (see #986). Bun ignores this setting.
+legacy-peer-deps=true


### PR DESCRIPTION
#978 deleted the committed `.npmrc` (`legacy-peer-deps=true`), and every release since 2026-07-16 19:16 failed: npm — invoked by semantic-release's npm plugin as `npm version` — crashes during strict peer resolution on this workspace tree with `Cannot read properties of null (reading 'matches')`.

Verified in a worktree of current main: `npm version 14.1.0 --no-git-tag-version` crashes without the file and exits 0 with it restored (even with the `workspace:` protocol present). The release-time `scripts/stripWorkspaceProtocol.mjs` from #986 stays as defense-in-depth for npm's `workspace:` parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)