### PR TITLE
feat(wb): add `wb release` and fix env/build/deploy/private-package issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ __generated__/
 .tokensave/
 .wb/
 @willbooster/
+@willbooster-private/
 */mount/*.hash
 CLAUDE.local.md
 dist/

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -222,7 +222,7 @@ export function readFnoxEnvironmentVariables(
 ): [Record<string, string>, string[]] {
   if (!hasProjectFnoxConfig(cwd)) return [{}, []];
 
-  const secrets = runFnoxExport(cwd, cascade, false);
+  const secrets = runFnoxExport(cwd, cascade, { quiet: false });
   if (!secrets) return [{}, []];
   // `[profiles.<cascade>.secrets]` is the fnox analogue of `.env.<cascade>`: when the caller
   // forces a mode off CI, profile-specific values must override inherited shell variables just
@@ -233,7 +233,7 @@ export function readFnoxEnvironmentVariables(
   // subprocess (including age decryption) to every forced-mode invocation for nothing.
   let cachedBaseSecrets: Record<string, unknown> | undefined | false = false;
   const getBaseSecrets = (): Record<string, unknown> | undefined => {
-    if (cachedBaseSecrets === false) cachedBaseSecrets = runFnoxExport(cwd, undefined, true);
+    if (cachedBaseSecrets === false) cachedBaseSecrets = runFnoxExport(cwd, undefined, { quiet: true });
     return cachedBaseSecrets;
   };
 
@@ -256,23 +256,33 @@ export function readFnoxEnvironmentVariables(
   return [envVars, keys];
 }
 
-function runFnoxExport(cwd: string, cascade: string | undefined, quiet: boolean): Record<string, unknown> | undefined {
+function runFnoxExport(
+  cwd: string,
+  cascade: string | undefined,
+  options: { quiet: boolean }
+): Record<string, unknown> | undefined {
   // `--if-missing error`: fnox otherwise exits 0 and silently omits secrets it fails to resolve
   // (e.g. a missing age key), which would be indistinguishable from undeclared secrets.
   // `--non-interactive`: prompts or browser auth flows would hang forever because stdin is ignored.
   const args = ['export', '--format', 'json', '--no-color', '--if-missing', 'error', '--non-interactive'];
+  const env = { ...process.env };
   if (cascade) {
     args.push('--profile', cascade);
+  } else {
+    // Without `--profile`, fnox falls back to FNOX_PROFILE; the base export must read the BASE
+    // secrets (it adjudicates profile-specificity), so an inherited profile selection is cleared.
+    delete env.FNOX_PROFILE;
   }
   const result = childProcess.spawnSync('fnox', args, {
     cwd,
+    env,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   if (result.error || result.status !== 0 || !result.stdout?.trim()) {
     // The repository declares fnox-managed secrets (fnox.toml exists), so a failing export must be
     // surfaced: swallowing it would make declared secrets indistinguishable from undeclared ones.
-    if (!quiet) {
+    if (!options.quiet) {
       console.warn(
         `Failed to read fnox secrets: ${result.error?.message || result.stderr?.trim() || `fnox exited with status ${result.status}`}`
       );

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -113,21 +113,28 @@ export function readEnvironmentVariables(
     (argv.cascadeNodeEnv ? runtimeEnv.NODE_ENV || 'development' : argv.autoCascadeEnv ? runtimeEnv.WB_ENV : undefined)
   );
   const modeFileOverridesProcessEnv = modeIsForced && !isCIEnvironment(runtimeEnv.CI);
+  // Override eligibility is decided per KEY, not per file: `.env.local` outranks `.env.<mode>`
+  // in the cascade, so once the mode defines a key, the value winning the normal file precedence
+  // (which may come from `.env.local`) must be the one overriding the shell.
+  const modeSpecificEnvKeys = new Set<string>();
+  if (modeFileOverridesProcessEnv && typeof cascade === 'string' && cascade.length > 0) {
+    for (const envPath of envPaths) {
+      if (envPath.endsWith(`.${cascade}`) || envPath.endsWith(`.${cascade}.local`)) {
+        for (const key of Object.keys(readEnvFile(path.join(cwd, envPath)))) modeSpecificEnvKeys.add(key);
+      }
+    }
+  }
 
   const envPathAndLoadedEnvVarNames: [string, string[]][] = [];
   const envVars: Record<string, string> = {};
   for (const envPath of envPaths) {
-    const isModeSpecificEnvFile =
-      typeof cascade === 'string' &&
-      cascade.length > 0 &&
-      (envPath.endsWith(`.${cascade}`) || envPath.endsWith(`.${cascade}.local`));
     const keys: string[] = [];
     for (const [key, value] of Object.entries(readEnvFile(path.join(cwd, envPath)))) {
       if (key in envVars) continue;
 
       const inheritedValue = process.env[key];
       const shadowedByProcessEnv = !options?.ignoreProcessEnv && key in process.env;
-      if (shadowedByProcessEnv && !(isModeSpecificEnvFile && modeFileOverridesProcessEnv)) {
+      if (shadowedByProcessEnv && !(modeFileOverridesProcessEnv && modeSpecificEnvKeys.has(key))) {
         continue;
       }
       if (shadowedByProcessEnv && inheritedValue !== value && !shouldSuppressOutput) {
@@ -221,19 +228,28 @@ export function readFnoxEnvironmentVariables(
   // forces a mode off CI, profile-specific values must override inherited shell variables just
   // like `.env.<mode>` values do, while base `[secrets]` values keep losing to process.env. A key
   // is profile-specific when the profile export's value differs from the base export's; when the
-  // base export fails, no override is applied (conservative).
-  const baseSecrets = options?.modeFileOverridesProcessEnv && cascade ? runFnoxExport(cwd, undefined, true) : undefined;
+  // base export fails, no override is applied (conservative). The base export runs LAZILY, only
+  // when a process.env collision actually needs adjudicating — it would otherwise add a
+  // subprocess (including age decryption) to every forced-mode invocation for nothing.
+  let cachedBaseSecrets: Record<string, unknown> | undefined | false = false;
+  const getBaseSecrets = (): Record<string, unknown> | undefined => {
+    if (cachedBaseSecrets === false) cachedBaseSecrets = runFnoxExport(cwd, undefined, true);
+    return cachedBaseSecrets;
+  };
 
   const envVars: Record<string, string> = {};
   const keys: string[] = [];
   for (const [key, value] of Object.entries(secrets)) {
     if (typeof value !== 'string' || key in currentEnvVars) continue;
-    const overridesProcessEnv = baseSecrets !== undefined && baseSecrets[key] !== value;
     // Explicitly exported environment variables win over fnox base values, mirroring the .env rule.
     // (The mise reader below intentionally uses a value-equality check instead: `mise env` echoes
     // back variables the ambient mise activation already exported, and a differing value means the
     // requested cascade profile should win over the stale activation.)
-    if (!options?.ignoreProcessEnv && key in process.env && !overridesProcessEnv) continue;
+    if (!options?.ignoreProcessEnv && key in process.env) {
+      const baseSecrets = options?.modeFileOverridesProcessEnv && cascade ? getBaseSecrets() : undefined;
+      const overridesProcessEnv = baseSecrets !== undefined && baseSecrets[key] !== value;
+      if (!overridesProcessEnv) continue;
+    }
     envVars[key] = value;
     keys.push(key);
   }

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -102,12 +102,16 @@ export function readEnvironmentVariables(
     console.info('Reading env files:', envPaths.join(', '));
   }
 
-  // When the caller explicitly forces a mode (--cascade-env / an exported WB_ENV), values that the
-  // mode's own env files define must win over variables inherited from the parent shell: a stale
-  // `export DATABASE_URL=...` from a development shell must not leak into `wb test`'s test mode
-  // (cf. https://github.com/WillBooster/shared/issues/930). On CI the inherited variables keep
-  // winning — workflows deliberately inject env vars that override the committed files.
-  const modeIsForced = Boolean(argv.cascadeEnv ?? (argv.autoCascadeEnv ? runtimeEnv.WB_ENV : undefined));
+  // When the caller explicitly forces a mode (--cascade-env / --cascade-node-env / an exported
+  // WB_ENV), values that the mode's own env files define must win over variables inherited from
+  // the parent shell: a stale `export DATABASE_URL=...` from a development shell must not leak
+  // into `wb test`'s test mode (cf. https://github.com/WillBooster/shared/issues/930). On CI the
+  // inherited variables keep winning — workflows deliberately inject env vars that override the
+  // committed files — and that shadowing is the designed behavior, so no warning is emitted.
+  const modeIsForced = Boolean(
+    argv.cascadeEnv ??
+    (argv.cascadeNodeEnv ? runtimeEnv.NODE_ENV || 'development' : argv.autoCascadeEnv ? runtimeEnv.WB_ENV : undefined)
+  );
   const modeFileOverridesProcessEnv = modeIsForced && !isCIEnvironment(runtimeEnv.CI);
 
   const envPathAndLoadedEnvVarNames: [string, string[]][] = [];
@@ -124,9 +128,6 @@ export function readEnvironmentVariables(
       const inheritedValue = process.env[key];
       const shadowedByProcessEnv = !options?.ignoreProcessEnv && key in process.env;
       if (shadowedByProcessEnv && !(isModeSpecificEnvFile && modeFileOverridesProcessEnv)) {
-        if (isModeSpecificEnvFile && modeIsForced && inheritedValue !== value && !shouldSuppressOutput) {
-          console.warn(`Warning: the inherited environment variable ${key} shadows the value defined in ${envPath}.`);
-        }
         continue;
       }
       if (shadowedByProcessEnv && inheritedValue !== value && !shouldSuppressOutput) {
@@ -142,9 +143,15 @@ export function readEnvironmentVariables(
       console.info(`Read ${keys.length} environment variables from ${envPath}`);
     }
   }
-  const [fnoxEnvVars, fnoxEnvVarNames] = readFnoxEnvironmentVariables(cwd, cascade, envVars, options);
+  const [fnoxEnvVars, fnoxEnvVarNames] = readFnoxEnvironmentVariables(cwd, cascade, envVars, {
+    ...options,
+    modeFileOverridesProcessEnv,
+  });
   Object.assign(envVars, fnoxEnvVars);
-  if (fnoxEnvVarNames.length > 0) {
+  // Report the fnox source whenever fnox.toml exists — even when it yields no keys (all shadowed,
+  // empty profile, or a failing export): consumers such as wb's required-environment validation
+  // must see that a declared env source exists rather than silently failing open.
+  if (fnoxEnvVarNames.length > 0 || hasProjectFnoxConfig(cwd)) {
     envPathAndLoadedEnvVarNames.push([fnoxEnvironmentSourceName(cascade), fnoxEnvVarNames]);
     if (argv.verbose && !shouldSuppressOutput) {
       console.info(`Read ${fnoxEnvVarNames.length} environment variables from ${fnoxEnvironmentSourceName(cascade)}`);
@@ -204,10 +211,36 @@ export function readFnoxEnvironmentVariables(
   cwd: string,
   cascade: string | undefined,
   currentEnvVars: Record<string, string>,
-  options?: { ignoreProcessEnv?: boolean }
+  options?: { ignoreProcessEnv?: boolean; modeFileOverridesProcessEnv?: boolean }
 ): [Record<string, string>, string[]] {
   if (!hasProjectFnoxConfig(cwd)) return [{}, []];
 
+  const secrets = runFnoxExport(cwd, cascade, false);
+  if (!secrets) return [{}, []];
+  // `[profiles.<cascade>.secrets]` is the fnox analogue of `.env.<cascade>`: when the caller
+  // forces a mode off CI, profile-specific values must override inherited shell variables just
+  // like `.env.<mode>` values do, while base `[secrets]` values keep losing to process.env. A key
+  // is profile-specific when the profile export's value differs from the base export's; when the
+  // base export fails, no override is applied (conservative).
+  const baseSecrets = options?.modeFileOverridesProcessEnv && cascade ? runFnoxExport(cwd, undefined, true) : undefined;
+
+  const envVars: Record<string, string> = {};
+  const keys: string[] = [];
+  for (const [key, value] of Object.entries(secrets)) {
+    if (typeof value !== 'string' || key in currentEnvVars) continue;
+    const overridesProcessEnv = baseSecrets !== undefined && baseSecrets[key] !== value;
+    // Explicitly exported environment variables win over fnox base values, mirroring the .env rule.
+    // (The mise reader below intentionally uses a value-equality check instead: `mise env` echoes
+    // back variables the ambient mise activation already exported, and a differing value means the
+    // requested cascade profile should win over the stale activation.)
+    if (!options?.ignoreProcessEnv && key in process.env && !overridesProcessEnv) continue;
+    envVars[key] = value;
+    keys.push(key);
+  }
+  return [envVars, keys];
+}
+
+function runFnoxExport(cwd: string, cascade: string | undefined, quiet: boolean): Record<string, unknown> | undefined {
   // `--if-missing error`: fnox otherwise exits 0 and silently omits secrets it fails to resolve
   // (e.g. a missing age key), which would be indistinguishable from undeclared secrets.
   // `--non-interactive`: prompts or browser auth flows would hang forever because stdin is ignored.
@@ -223,34 +256,23 @@ export function readFnoxEnvironmentVariables(
   if (result.error || result.status !== 0 || !result.stdout?.trim()) {
     // The repository declares fnox-managed secrets (fnox.toml exists), so a failing export must be
     // surfaced: swallowing it would make declared secrets indistinguishable from undeclared ones.
-    console.warn(
-      `Failed to read fnox secrets: ${result.error?.message || result.stderr?.trim() || `fnox exited with status ${result.status}`}`
-    );
-    return [{}, []];
+    if (!quiet) {
+      console.warn(
+        `Failed to read fnox secrets: ${result.error?.message || result.stderr?.trim() || `fnox exited with status ${result.status}`}`
+      );
+    }
+    return;
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(result.stdout);
   } catch {
-    return [{}, []];
+    return;
   }
   const secrets = (parsed as { secrets?: unknown } | undefined)?.secrets;
-  if (!secrets || typeof secrets !== 'object' || Array.isArray(secrets)) return [{}, []];
-
-  const envVars: Record<string, string> = {};
-  const keys: string[] = [];
-  for (const [key, value] of Object.entries(secrets)) {
-    if (typeof value !== 'string' || key in currentEnvVars) continue;
-    // Explicitly exported environment variables win over fnox values, mirroring the .env rule.
-    // (The mise reader below intentionally uses a value-equality check instead: `mise env` echoes
-    // back variables the ambient mise activation already exported, and a differing value means the
-    // requested cascade profile should win over the stale activation.)
-    if (!options?.ignoreProcessEnv && key in process.env) continue;
-    envVars[key] = value;
-    keys.push(key);
-  }
-  return [envVars, keys];
+  if (!secrets || typeof secrets !== 'object' || Array.isArray(secrets)) return;
+  return secrets as Record<string, unknown>;
 }
 
 export function hasProjectFnoxConfig(cwd: string): boolean {

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -102,15 +102,40 @@ export function readEnvironmentVariables(
     console.info('Reading env files:', envPaths.join(', '));
   }
 
+  // When the caller explicitly forces a mode (--cascade-env / an exported WB_ENV), values that the
+  // mode's own env files define must win over variables inherited from the parent shell: a stale
+  // `export DATABASE_URL=...` from a development shell must not leak into `wb test`'s test mode
+  // (cf. https://github.com/WillBooster/shared/issues/930). On CI the inherited variables keep
+  // winning — workflows deliberately inject env vars that override the committed files.
+  const modeIsForced = Boolean(argv.cascadeEnv ?? (argv.autoCascadeEnv ? runtimeEnv.WB_ENV : undefined));
+  const modeFileOverridesProcessEnv = modeIsForced && !isCIEnvironment(runtimeEnv.CI);
+
   const envPathAndLoadedEnvVarNames: [string, string[]][] = [];
   const envVars: Record<string, string> = {};
   for (const envPath of envPaths) {
+    const isModeSpecificEnvFile =
+      typeof cascade === 'string' &&
+      cascade.length > 0 &&
+      (envPath.endsWith(`.${cascade}`) || envPath.endsWith(`.${cascade}.local`));
     const keys: string[] = [];
     for (const [key, value] of Object.entries(readEnvFile(path.join(cwd, envPath)))) {
-      if (!(key in envVars) && (options?.ignoreProcessEnv || !(key in process.env))) {
-        envVars[key] = value;
-        keys.push(key);
+      if (key in envVars) continue;
+
+      const inheritedValue = process.env[key];
+      const shadowedByProcessEnv = !options?.ignoreProcessEnv && key in process.env;
+      if (shadowedByProcessEnv && !(isModeSpecificEnvFile && modeFileOverridesProcessEnv)) {
+        if (isModeSpecificEnvFile && modeIsForced && inheritedValue !== value && !shouldSuppressOutput) {
+          console.warn(`Warning: the inherited environment variable ${key} shadows the value defined in ${envPath}.`);
+        }
+        continue;
       }
+      if (shadowedByProcessEnv && inheritedValue !== value && !shouldSuppressOutput) {
+        console.warn(
+          `Warning: ${key} in ${envPath} overrides the value inherited from the parent environment because the ${cascade} environment is explicitly forced.`
+        );
+      }
+      envVars[key] = value;
+      keys.push(key);
     }
     envPathAndLoadedEnvVarNames.push([envPath, keys]);
     if (argv.verbose && !shouldSuppressOutput && keys.length > 0) {
@@ -299,6 +324,10 @@ function miseEnvironmentSourceName(cascade: string | undefined): string {
   return cascade ? `mise env --env ${cascade}` : 'mise env';
 }
 
+function isCIEnvironment(ciEnv: string | undefined): boolean {
+  return !!ciEnv && ciEnv !== '0' && ciEnv !== 'false';
+}
+
 export function shouldSuppressEnvironmentOutput(argv: EnvReaderOptions): boolean {
   const outputOptions = argv as EnvReaderOptions & { quietEnv?: boolean; silent?: boolean };
   return outputOptions.quietEnv === true || (outputOptions.quietEnv !== false && outputOptions.silent === true);
@@ -313,6 +342,9 @@ export function readAndApplyEnvironmentVariables(
 ): Record<string, string | undefined> {
   const [envVars] = readEnvironmentVariables(argv, cwd);
   for (const [key, value] of Object.entries(envVars)) {
+    // Existing process.env keys are kept: envVars may deliberately contain differing values that
+    // must win only in the returned record (mise cascade-profile values, forced-mode overrides
+    // consumed via `project.env`), never clobber the caller's own process environment.
     if (!(key in process.env)) {
       process.env[key] = value;
     }

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -233,7 +233,9 @@ export function readFnoxEnvironmentVariables(
   // subprocess (including age decryption) to every forced-mode invocation for nothing.
   let cachedBaseSecrets: Record<string, unknown> | undefined | false = false;
   const getBaseSecrets = (): Record<string, unknown> | undefined => {
-    if (cachedBaseSecrets === false) cachedBaseSecrets = runFnoxExport(cwd, undefined, { quiet: true });
+    if (cachedBaseSecrets === false) {
+      cachedBaseSecrets = runFnoxExport(cwd, undefined, { quiet: true, ignoreProfileEnvVar: true });
+    }
     return cachedBaseSecrets;
   };
 
@@ -259,7 +261,7 @@ export function readFnoxEnvironmentVariables(
 function runFnoxExport(
   cwd: string,
   cascade: string | undefined,
-  options: { quiet: boolean }
+  options: { quiet: boolean; ignoreProfileEnvVar?: boolean }
 ): Record<string, unknown> | undefined {
   // `--if-missing error`: fnox otherwise exits 0 and silently omits secrets it fails to resolve
   // (e.g. a missing age key), which would be indistinguishable from undeclared secrets.
@@ -268,9 +270,12 @@ function runFnoxExport(
   const env = { ...process.env };
   if (cascade) {
     args.push('--profile', cascade);
-  } else {
-    // Without `--profile`, fnox falls back to FNOX_PROFILE; the base export must read the BASE
-    // secrets (it adjudicates profile-specificity), so an inherited profile selection is cleared.
+  }
+  if (options.ignoreProfileEnvVar) {
+    // Without `--profile`, fnox falls back to FNOX_PROFILE; the base-adjudication export must
+    // read the BASE secrets, so the inherited profile selection is cleared for it — and only for
+    // it: a profile-less PRIMARY export (e.g. `wb dotenv` without WB_ENV) keeps honoring
+    // FNOX_PROFILE.
     delete env.FNOX_PROFILE;
   }
   const result = childProcess.spawnSync('fnox', args, {

--- a/packages/shared-lib-node/test/env.test.ts
+++ b/packages/shared-lib-node/test/env.test.ts
@@ -108,6 +108,24 @@ describe('readAndApplyEnvironmentVariables()', () => {
     expect(process.env.PORT).toBe('9999');
   });
 
+  it.runIf(isFnoxAvailable())(
+    'should let fnox profile values override inherited process.env when the mode is forced (non-CI)',
+    () => {
+      delete process.env.CI;
+      process.env.WB_ENV = 'test';
+      process.env.PORT = '9999';
+      process.env.FNOX_ONLY = 'shell';
+      const envVars = readAndApplyEnvironmentVariables({ autoCascadeEnv: true }, 'test/fixtures/app-fnox');
+      // The test profile defines PORT=6002 (differing from the base 6001), so the forced test
+      // mode must win over the inherited shell value; FNOX_ONLY exists only in the base secrets
+      // and must keep losing to process.env.
+      expect(envVars.PORT).toBe('6002');
+      expect(envVars.FNOX_ONLY).toBeUndefined();
+      expect(process.env.PORT).toBe('9999');
+      delete process.env.FNOX_ONLY;
+    }
+  );
+
   it.runIf(isFnoxAvailable())('should load env vars from a fnox profile with --cascade-env=test', () => {
     const envVars = readAndApplyEnvironmentVariables({ cascadeEnv: 'test' }, 'test/fixtures/app-fnox');
     expect(envVars).toMatchObject({

--- a/packages/shared-lib-node/test/env.test.ts
+++ b/packages/shared-lib-node/test/env.test.ts
@@ -137,6 +137,34 @@ describe('readEnvironmentVariables()', () => {
     expect(process.env.NAME).toBe('override');
   });
 
+  it('should let mode-specific env file values override inherited process.env when the mode is forced (non-CI)', () => {
+    delete process.env.CI;
+    process.env.WB_ENV = 'test';
+    process.env.PORT = '9999';
+    const [envVars] = readEnvironmentVariables({ autoCascadeEnv: true }, 'test/fixtures/app1');
+    // .env.test defines PORT=3002; the forced test mode must win over the inherited shell value.
+    expect(envVars.PORT).toBe('3002');
+    expect(envVars.ENV).toBe('test1');
+  });
+
+  it('should keep inherited process.env values on CI even when the mode is forced', () => {
+    process.env.CI = 'true';
+    process.env.WB_ENV = 'test';
+    process.env.PORT = '9999';
+    const [envVars] = readEnvironmentVariables({ autoCascadeEnv: true }, 'test/fixtures/app1');
+    expect(envVars.PORT).toBeUndefined();
+    expect(process.env.PORT).toBe('9999');
+  });
+
+  it('should not override inherited process.env values that only the base .env defines even when the mode is forced', () => {
+    delete process.env.CI;
+    process.env.WB_ENV = 'test';
+    process.env.NAME = 'override';
+    const [envVars] = readEnvironmentVariables({ autoCascadeEnv: true }, 'test/fixtures/app1');
+    expect(envVars.NAME).toBeUndefined();
+    expect(process.env.NAME).toBe('override');
+  });
+
   it('should expand references to exported variables literally', () => {
     // Values referencing exported keys must resolve to the effective value without the
     // exported content being recursively re-expanded (pa$word must stay pa$word).

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -86,12 +86,18 @@ function readAndApplyEnvironmentVariables(cwd) {
   // fnox.toml is the committed, encrypted equivalent of .env files; local .env files still win over it.
   const fnoxVars = readFnoxEnvironmentVariables(cwd, mode, dotenvVars, modeFileOverridesProcessEnv);
   const parsed = { ...fnoxVars, ...dotenvVars };
-  // Expand ${...} references against exported variables NOT loaded from files, so a reference to
-  // a shell-only variable resolves to its effective value instead of an empty string.
+  // Expand ${...} references against exported variables whose FILE value loses to the shell
+  // (mirroring readEnvironmentVariables' effective-value semantics): a reference must resolve to
+  // the value the child will actually see, so a shell-shadowed key expands to the shell value
+  // while a winning file/override value expands to the file value.
+  const fileValueWins = (key) =>
+    !(key in process.env) || (modeFileOverridesProcessEnv && (key in modeVars || key in fnoxVars));
   const referenceEnv = {};
   for (const [key, value] of Object.entries(process.env)) {
     // Escape dollar signs so exported values substitute literally (pa$word stays pa$word).
-    if (value !== undefined && !(key in parsed)) referenceEnv[key] = value.replaceAll('$', String.raw`\$`);
+    if (value !== undefined && !(key in parsed && fileValueWins(key))) {
+      referenceEnv[key] = value.replaceAll('$', String.raw`\$`);
+    }
   }
   const envVars = expand({ parsed, processEnv: referenceEnv }).parsed ?? parsed;
   for (const [key, value] of Object.entries(envVars)) {
@@ -117,14 +123,16 @@ function readAndApplyEnvironmentVariables(cwd) {
 function readFnoxEnvironmentVariables(cwd, cascade, currentEnvVars, modeFileOverridesProcessEnv) {
   if (!hasProjectFnoxConfig(cwd)) return {};
 
-  const secrets = runFnoxExport(cwd, cascade, false);
+  const secrets = runFnoxExport(cwd, cascade, { quiet: false });
   if (!secrets) return {};
   // A key is profile-specific (and may override process.env off CI) when the profile export's
   // value differs from the base export's; when the base export fails, no override is applied.
   // The base export runs lazily, only when a process.env collision needs adjudicating.
   let cachedBaseSecrets = false;
   const getBaseSecrets = () => {
-    if (cachedBaseSecrets === false) cachedBaseSecrets = runFnoxExport(cwd, undefined, true);
+    if (cachedBaseSecrets === false) {
+      cachedBaseSecrets = runFnoxExport(cwd, undefined, { quiet: true, ignoreProfileEnvVar: true });
+    }
     return cachedBaseSecrets;
   };
 
@@ -141,16 +149,19 @@ function readFnoxEnvironmentVariables(cwd, cascade, currentEnvVars, modeFileOver
   return envVars;
 }
 
-function runFnoxExport(cwd, cascade, quiet) {
+function runFnoxExport(cwd, cascade, options) {
   // `--if-missing error`: fnox otherwise exits 0 and silently omits secrets it fails to resolve.
   // `--non-interactive`: prompts or browser auth flows would hang forever because stdin is ignored.
   const args = ['export', '--format', 'json', '--no-color', '--if-missing', 'error', '--non-interactive'];
   const env = { ...process.env };
   if (cascade) {
     args.push('--profile', cascade);
-  } else {
-    // Without `--profile`, fnox falls back to FNOX_PROFILE; the base export must read the BASE
-    // secrets (it adjudicates profile-specificity), so an inherited profile selection is cleared.
+  }
+  if (options.ignoreProfileEnvVar) {
+    // Without `--profile`, fnox falls back to FNOX_PROFILE; the base-adjudication export must
+    // read the BASE secrets, so the inherited profile selection is cleared for it — and only for
+    // it: a profile-less PRIMARY export (e.g. `wb dotenv` without WB_ENV) keeps honoring
+    // FNOX_PROFILE.
     delete env.FNOX_PROFILE;
   }
   const result = childProcess.spawnSync('fnox', args, {
@@ -160,7 +171,7 @@ function runFnoxExport(cwd, cascade, quiet) {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   if (result.error || result.status !== 0 || !result.stdout?.trim()) {
-    if (!quiet) {
+    if (!options.quiet) {
       console.warn(
         `Failed to read fnox secrets: ${result.error?.message || result.stderr?.trim() || `fnox exited with status ${result.status}`}`
       );

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -67,26 +67,76 @@ export function runDotenvCommand(args) {
   });
 }
 
+// Mirrors src/commands/dotenv.ts (readAndApplyEnvironmentVariables) for this startup fast path.
 function readAndApplyEnvironmentVariables(cwd) {
+  const mode = process.env.WB_ENV;
+  // Mode-specific sources drive the forced-mode override below.
+  const modeVars = mode
+    ? { ...readEnvFile(path.join(cwd, `.env.${mode}`)), ...readEnvFile(path.join(cwd, `.env.${mode}.local`)) }
+    : {};
+  // Mirror the shared cascade's precedence: .env.<mode>.local > .env.local > .env.<mode> > .env.
   const dotenvVars = {
     ...readEnvFile(path.join(cwd, '.env')),
-    ...(process.env.WB_ENV ? readEnvFile(path.join(cwd, `.env.${process.env.WB_ENV}`)) : {}),
+    ...(mode ? readEnvFile(path.join(cwd, `.env.${mode}`)) : {}),
+    ...readEnvFile(path.join(cwd, '.env.local')),
+    ...(mode ? readEnvFile(path.join(cwd, `.env.${mode}.local`)) : {}),
   };
-  // fnox.toml is the committed, encrypted equivalent of .env files; local .env files still win
-  // over it. Mirrors src/commands/dotenv.ts for this startup fast path.
-  const parsed = { ...readFnoxEnvironmentVariables(cwd, process.env.WB_ENV, dotenvVars), ...dotenvVars };
-  const envVars = expand({ parsed, processEnv: {} }).parsed ?? parsed;
+  // WB_ENV in process.env means the mode is explicitly forced, so values from the mode's own
+  // sources (.env.<mode>[.local] and the fnox profile) win over variables inherited from the
+  // parent shell — except on CI, where injected env vars must keep overriding committed files
+  // (see https://github.com/WillBooster/shared/issues/930).
+  const modeFileOverridesProcessEnv = !!mode && !isCI(process.env.CI);
+  // fnox.toml is the committed, encrypted equivalent of .env files; local .env files still win over it.
+  const fnoxVars = readFnoxEnvironmentVariables(cwd, mode, dotenvVars, modeFileOverridesProcessEnv);
+  const parsed = { ...fnoxVars, ...dotenvVars };
+  // Expand ${...} references against exported variables NOT loaded from files, so a reference to
+  // a shell-only variable resolves to its effective value instead of an empty string.
+  const referenceEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    // Escape dollar signs so exported values substitute literally (pa$word stays pa$word).
+    if (value !== undefined && !(key in parsed)) referenceEnv[key] = value.replaceAll('$', String.raw`\$`);
+  }
+  const envVars = expand({ parsed, processEnv: referenceEnv }).parsed ?? parsed;
   for (const [key, value] of Object.entries(envVars)) {
     if (!(key in process.env)) {
       process.env[key] = value;
+      continue;
     }
+    // readFnoxEnvironmentVariables returns a process.env-shadowed key only when the forced
+    // profile overrides it, so fnox-provided keys count as mode-specific here.
+    if (!(key in modeVars || key in fnoxVars) || process.env[key] === value) continue;
+
+    if (modeFileOverridesProcessEnv) {
+      console.warn(
+        `Warning: ${key} in the "${mode}" mode's env sources overrides the value inherited from the parent environment because WB_ENV is explicitly set.`
+      );
+      process.env[key] = value;
+    }
+    // On CI, inherited variables intentionally win; no warning is emitted.
   }
 }
 
 // Mirrors readFnoxEnvironmentVariables in @willbooster/shared-lib-node for this startup fast path.
-function readFnoxEnvironmentVariables(cwd, cascade, currentEnvVars) {
+function readFnoxEnvironmentVariables(cwd, cascade, currentEnvVars, modeFileOverridesProcessEnv) {
   if (!hasProjectFnoxConfig(cwd)) return {};
 
+  const secrets = runFnoxExport(cwd, cascade, false);
+  if (!secrets) return {};
+  // A key is profile-specific (and may override process.env off CI) when the profile export's
+  // value differs from the base export's; when the base export fails, no override is applied.
+  const baseSecrets = modeFileOverridesProcessEnv && cascade ? runFnoxExport(cwd, undefined, true) : undefined;
+
+  const envVars = {};
+  for (const [key, value] of Object.entries(secrets)) {
+    if (typeof value !== 'string' || key in currentEnvVars) continue;
+    const overridesProcessEnv = baseSecrets !== undefined && baseSecrets[key] !== value;
+    if (key in process.env && !overridesProcessEnv) continue;
+    envVars[key] = value;
+  }
+  return envVars;
+}
+
+function runFnoxExport(cwd, cascade, quiet) {
   // `--if-missing error`: fnox otherwise exits 0 and silently omits secrets it fails to resolve.
   // `--non-interactive`: prompts or browser auth flows would hang forever because stdin is ignored.
   const args = ['export', '--format', 'json', '--no-color', '--if-missing', 'error', '--non-interactive'];
@@ -99,27 +149,28 @@ function readFnoxEnvironmentVariables(cwd, cascade, currentEnvVars) {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   if (result.error || result.status !== 0 || !result.stdout?.trim()) {
-    console.warn(
-      `Failed to read fnox secrets: ${result.error?.message || result.stderr?.trim() || `fnox exited with status ${result.status}`}`
-    );
-    return {};
+    if (!quiet) {
+      console.warn(
+        `Failed to read fnox secrets: ${result.error?.message || result.stderr?.trim() || `fnox exited with status ${result.status}`}`
+      );
+    }
+    return;
   }
 
   let parsed;
   try {
     parsed = JSON.parse(result.stdout);
   } catch {
-    return {};
+    return;
   }
   const secrets = parsed?.secrets;
-  if (!secrets || typeof secrets !== 'object' || Array.isArray(secrets)) return {};
+  if (!secrets || typeof secrets !== 'object' || Array.isArray(secrets)) return;
+  return secrets;
+}
 
-  const envVars = {};
-  for (const [key, value] of Object.entries(secrets)) {
-    if (typeof value !== 'string' || key in currentEnvVars || key in process.env) continue;
-    envVars[key] = value;
-  }
-  return envVars;
+// Mirrors src/utils/ci.ts for this startup fast path.
+function isCI(ciEnv) {
+  return !!ciEnv && ciEnv !== '0' && ciEnv !== 'false';
 }
 
 function hasProjectFnoxConfig(cwd) {

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -124,13 +124,21 @@ function readFnoxEnvironmentVariables(cwd, cascade, currentEnvVars, modeFileOver
   if (!secrets) return {};
   // A key is profile-specific (and may override process.env off CI) when the profile export's
   // value differs from the base export's; when the base export fails, no override is applied.
-  const baseSecrets = modeFileOverridesProcessEnv && cascade ? runFnoxExport(cwd, undefined, true) : undefined;
+  // The base export runs lazily, only when a process.env collision needs adjudicating.
+  let cachedBaseSecrets = false;
+  const getBaseSecrets = () => {
+    if (cachedBaseSecrets === false) cachedBaseSecrets = runFnoxExport(cwd, undefined, true);
+    return cachedBaseSecrets;
+  };
 
   const envVars = {};
   for (const [key, value] of Object.entries(secrets)) {
     if (typeof value !== 'string' || key in currentEnvVars) continue;
-    const overridesProcessEnv = baseSecrets !== undefined && baseSecrets[key] !== value;
-    if (key in process.env && !overridesProcessEnv) continue;
+    if (key in process.env) {
+      const baseSecrets = modeFileOverridesProcessEnv && cascade ? getBaseSecrets() : undefined;
+      const overridesProcessEnv = baseSecrets !== undefined && baseSecrets[key] !== value;
+      if (!overridesProcessEnv) continue;
+    }
     envVars[key] = value;
   }
   return envVars;

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -145,11 +145,17 @@ function runFnoxExport(cwd, cascade, quiet) {
   // `--if-missing error`: fnox otherwise exits 0 and silently omits secrets it fails to resolve.
   // `--non-interactive`: prompts or browser auth flows would hang forever because stdin is ignored.
   const args = ['export', '--format', 'json', '--no-color', '--if-missing', 'error', '--non-interactive'];
+  const env = { ...process.env };
   if (cascade) {
     args.push('--profile', cascade);
+  } else {
+    // Without `--profile`, fnox falls back to FNOX_PROFILE; the base export must read the BASE
+    // secrets (it adjudicates profile-specificity), so an inherited profile selection is cleared.
+    delete env.FNOX_PROFILE;
   }
   const result = childProcess.spawnSync('fnox', args, {
     cwd,
+    env,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
   });

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -39,14 +39,12 @@ export function runDotenvCommand(args) {
     stdio: 'inherit',
   });
   const signalHandlers = new Map();
-  let forwardedShutdownSignal;
   child.on('error', (error) => {
     console.error(error);
     process.exit(1);
   });
   for (const signal of shutdownSignals) {
     const signalHandler = () => {
-      forwardedShutdownSignal = signal;
       child.kill(signal);
     };
     signalHandlers.set(signal, signalHandler);
@@ -56,10 +54,9 @@ export function runDotenvCommand(args) {
     for (const [shutdownSignal, signalHandler] of signalHandlers) {
       process.off(shutdownSignal, signalHandler);
     }
-    if (signal && signal === forwardedShutdownSignal) {
-      process.exit(0);
-    }
     if (signal) {
+      // Re-raise even for forwarded shutdown signals so callers observe the conventional
+      // signal exit status (e.g. 130 for SIGINT) instead of a misleading success.
       process.kill(process.pid, signal);
       return;
     }

--- a/packages/wb/src/commands/buildIfNeeded.ts
+++ b/packages/wb/src/commands/buildIfNeeded.ts
@@ -190,7 +190,9 @@ function parseBuildCache(cachedContent: string | undefined): { hash: string; out
   }
 }
 
-const includePatterns = ['src/', 'public/'];
+// Matched as complete path SEGMENTS (not substrings): `src/contest/` must not be excluded by
+// `test`, and `mysrc/` must not be included by `src`.
+const includeDirNames = new Set(['src', 'public']);
 const includeSuffix = [
   '.js',
   '.cjs',
@@ -208,7 +210,7 @@ const includeSuffix = [
   'bun.lock',
   'bun.lockb',
 ];
-const excludePatterns = ['test/', 'tests/', '__tests__/', 'test-fixtures/', 'test/fixtures/'];
+const excludeDirNames = new Set(['test', 'tests', '__tests__', 'test-fixtures']);
 
 async function updateHashWithDiffResult(
   project: Project,
@@ -252,14 +254,16 @@ async function updateHashWithDiffResult(
     const outputPaths = (getExplicitOutputPaths(argv) ?? defaultOutputCandidates).map((outputPath) =>
       path.join(projectRelativeDirPath, outputPath)
     );
-    const filteredEntries = normalizedEntries.filter(
-      ({ filePath, hashPath }) =>
-        (includePatterns.some((pattern) => hashPath.includes(pattern)) ||
+    const filteredEntries = normalizedEntries.filter(({ filePath, hashPath }) => {
+      const directorySegments = hashPath.split('/').slice(0, -1);
+      return (
+        (directorySegments.some((segment) => includeDirNames.has(segment)) ||
           includeSuffix.some((suffix) => hashPath.endsWith(suffix))) &&
-        !excludePatterns.some((pattern) => hashPath.includes(pattern)) &&
+        !directorySegments.some((segment) => excludeDirNames.has(segment)) &&
         // An `--output` value may name a file, so exclude the exact path as well as descendants.
         !outputPaths.some((outputPath) => filePath === outputPath || filePath.startsWith(`${outputPath}/`))
-    );
+      );
+    });
     if (argv.verbose) {
       console.info(`Changed files: ${filteredEntries.map((entry) => entry.hashPath).join(', ')}`);
     }

--- a/packages/wb/src/commands/buildIfNeeded.ts
+++ b/packages/wb/src/commands/buildIfNeeded.ts
@@ -18,6 +18,12 @@ const builder = {
     type: 'string',
     alias: 'c',
   },
+  output: {
+    description:
+      'Build output paths (relative to the project directory) that must exist for the cache to be valid (default: auto-detected common output directories)',
+    type: 'array',
+    alias: 'o',
+  },
 } as const;
 
 export const buildIfNeededCommand: CommandModule<unknown, InferredOptionTypes<typeof builder>> = {
@@ -62,9 +68,24 @@ export async function buildIfNeeded(
   if (!build(project, argv)) return;
 
   if (!argv.dryRun) {
-    await fs.promises.writeFile(cacheFilePath, contentHash, 'utf8');
+    const outputPaths = getExplicitOutputPaths(argv) ?? detectExistingDefaultOutputPaths(project);
+    await fs.promises.writeFile(cacheFilePath, JSON.stringify({ hash: contentHash, outputPaths }), 'utf8');
   }
   return true;
+}
+
+// Common build output directories used across org projects (vinext/build-ts emit dist,
+// Next.js emits .next, CRA-style apps emit build, `next export` emits out).
+const defaultOutputCandidates = ['dist', 'build', '.next', 'out'];
+
+function getExplicitOutputPaths(
+  argv: Partial<ArgumentsCamelCase<InferredOptionTypes<typeof builder>>>
+): string[] | undefined {
+  return argv.output?.length ? argv.output.map(String) : undefined;
+}
+
+function detectExistingDefaultOutputPaths(project: Project): string[] {
+  return defaultOutputCandidates.filter((outputPath) => fs.existsSync(path.join(project.dirPath, outputPath)));
 }
 
 function build(project: Project, argv: Partial<ArgumentsCamelCase<InferredOptionTypes<typeof builder>>>): boolean {
@@ -109,8 +130,37 @@ export async function canSkipBuild(
   await updateHashWithDiffResult(project, argv, hash);
   const contentHash = hash.digest('hex');
 
-  const cachedContentHash = await ignoreEnoentAsync(() => fs.promises.readFile(cacheFilePath, 'utf8'));
-  return [cachedContentHash === contentHash, cacheFilePath, contentHash];
+  const cachedContent = await ignoreEnoentAsync(() => fs.promises.readFile(cacheFilePath, 'utf8'));
+  const cache = parseBuildCache(cachedContent);
+  if (cache?.hash !== contentHash) return [false, cacheFilePath, contentHash];
+
+  // The cache is valid only while the recorded (or explicitly requested) build outputs still
+  // exist: a deleted output directory (e.g. `rm -rf dist`) must trigger a rebuild even when the
+  // inputs are unchanged (https://github.com/WillBooster/shared/issues/981).
+  const requiredOutputPaths = getExplicitOutputPaths(argv) ?? cache.outputPaths;
+  const missingOutputPaths = requiredOutputPaths.filter(
+    (outputPath) => !fs.existsSync(path.resolve(project.dirPath, outputPath))
+  );
+  if (missingOutputPaths.length > 0) {
+    console.info(chalk.yellow(`Rebuilding because build outputs are missing: ${missingOutputPaths.join(', ')}`));
+    return [false, cacheFilePath, contentHash];
+  }
+  return [true, cacheFilePath, contentHash];
+}
+
+function parseBuildCache(cachedContent: string | undefined): { hash: string; outputPaths: string[] } | undefined {
+  if (!cachedContent) return;
+  try {
+    const parsed = JSON.parse(cachedContent) as { hash?: unknown; outputPaths?: unknown };
+    if (typeof parsed?.hash !== 'string') return;
+    const outputPaths = Array.isArray(parsed.outputPaths)
+      ? parsed.outputPaths.filter((p) => typeof p === 'string')
+      : [];
+    return { hash: parsed.hash, outputPaths };
+  } catch {
+    // A legacy cache file contains the raw content hash without output records.
+    return { hash: cachedContent, outputPaths: [] };
+  }
 }
 
 const includePatterns = ['src/', 'public/'];

--- a/packages/wb/src/commands/buildIfNeeded.ts
+++ b/packages/wb/src/commands/buildIfNeeded.ts
@@ -100,6 +100,11 @@ function detectExistingDefaultOutputPaths(project: Project): string[] {
   return defaultOutputCandidates.filter((outputPath) => fs.existsSync(path.join(project.dirPath, outputPath)));
 }
 
+/** An `--output` value may name a file, so match the exact path as well as descendants. */
+function matchesOutputPath(outputPaths: string[], filePath: string): boolean {
+  return outputPaths.some((outputPath) => filePath === outputPath || filePath.startsWith(`${outputPath}/`));
+}
+
 function hasGitCommit(project: Project): boolean {
   return (
     child_process.spawnSync('git', ['rev-parse', '--verify', 'HEAD'], {
@@ -251,21 +256,21 @@ async function updateHashWithDiffResult(
     // Build OUTPUTS must never count as build inputs: hashing e.g. an untracked dist/ file would
     // change the hash on every build and disable the cache permanently.
     const projectRelativeDirPath = path.relative(project.rootDirPath, project.dirPath);
-    // The UNION of defaults and explicit paths: an `--output` naming a single file must not stop
-    // sibling artifacts in dist/build/.next/out from being excluded, or every build would change
-    // the hash and permanently disable the cache. (The cache-validity existence check in
-    // canSkipBuild deliberately narrows to the explicit paths instead.)
-    const outputPaths = [...new Set([...defaultOutputCandidates, ...(getExplicitOutputPaths(argv) ?? [])])].map(
-      (outputPath) => path.join(projectRelativeDirPath, outputPath)
-    );
-    const filteredEntries = normalizedEntries.filter(({ filePath, hashPath }) => {
+    const toProjectPath = (outputPath: string): string => path.join(projectRelativeDirPath, outputPath);
+    const explicitOutputPaths = (getExplicitOutputPaths(argv) ?? []).map(toProjectPath);
+    const defaultOutputPaths = defaultOutputCandidates.map(toProjectPath);
+    const filteredEntries = normalizedEntries.filter(({ filePath, hashPath, untracked }) => {
       const directorySegments = hashPath.split('/').slice(0, -1);
       return (
         (directorySegments.some((segment) => includeDirNames.has(segment)) ||
           includeSuffix.some((suffix) => hashPath.endsWith(suffix))) &&
         !directorySegments.some((segment) => excludeDirNames.has(segment)) &&
-        // An `--output` value may name a file, so exclude the exact path as well as descendants.
-        !outputPaths.some((outputPath) => filePath === outputPath || filePath.startsWith(`${outputPath}/`))
+        // Explicitly declared outputs are never inputs. The default candidates exclude only
+        // UNTRACKED entries: real build artifacts are untracked (usually gitignored), so
+        // hashing them would change the hash on every build and disable the cache — while a
+        // TRACKED file under e.g. build/ is source (build scripts/config) and must invalidate.
+        !matchesOutputPath(explicitOutputPaths, filePath) &&
+        !(untracked && matchesOutputPath(defaultOutputPaths, filePath))
       );
     });
     if (argv.verbose) {

--- a/packages/wb/src/commands/buildIfNeeded.ts
+++ b/packages/wb/src/commands/buildIfNeeded.ts
@@ -256,21 +256,21 @@ async function updateHashWithDiffResult(
     // Build OUTPUTS must never count as build inputs: hashing e.g. an untracked dist/ file would
     // change the hash on every build and disable the cache permanently.
     const projectRelativeDirPath = path.relative(project.rootDirPath, project.dirPath);
-    const toProjectPath = (outputPath: string): string => path.join(projectRelativeDirPath, outputPath);
-    const explicitOutputPaths = (getExplicitOutputPaths(argv) ?? []).map(toProjectPath);
-    const defaultOutputPaths = defaultOutputCandidates.map(toProjectPath);
-    const filteredEntries = normalizedEntries.filter(({ filePath, hashPath, untracked }) => {
+    const explicitOutputPaths = (getExplicitOutputPaths(argv) ?? []).map((outputPath) =>
+      path.join(projectRelativeDirPath, outputPath)
+    );
+    const filteredEntries = normalizedEntries.filter(({ filePath, hashPath }) => {
       const directorySegments = hashPath.split('/').slice(0, -1);
       return (
         (directorySegments.some((segment) => includeDirNames.has(segment)) ||
           includeSuffix.some((suffix) => hashPath.endsWith(suffix))) &&
         !directorySegments.some((segment) => excludeDirNames.has(segment)) &&
-        // Explicitly declared outputs are never inputs. The default candidates exclude only
-        // UNTRACKED entries: real build artifacts are untracked (usually gitignored), so
-        // hashing them would change the hash on every build and disable the cache — while a
-        // TRACKED file under e.g. build/ is source (build scripts/config) and must invalidate.
-        !matchesOutputPath(explicitOutputPaths, filePath) &&
-        !(untracked && matchesOutputPath(defaultOutputPaths, filePath))
+        // Only EXPLICITLY declared outputs are excluded from the input hash. Default candidates
+        // (dist/build/.next/out) are NOT: gitignored artifacts never appear in `git status`
+        // anyway, and a non-ignored file there may be genuine source (e.g. build/ scripts), whose
+        // changes must invalidate the cache — correctness over cache hits. Projects keeping
+        // non-ignored artifacts in those directories should gitignore them or pass --output.
+        !matchesOutputPath(explicitOutputPaths, filePath)
       );
     });
     if (argv.verbose) {

--- a/packages/wb/src/commands/buildIfNeeded.ts
+++ b/packages/wb/src/commands/buildIfNeeded.ts
@@ -69,6 +69,13 @@ export async function buildIfNeeded(
 
   if (!argv.dryRun) {
     const outputPaths = getExplicitOutputPaths(argv) ?? detectExistingDefaultOutputPaths(project);
+    if (outputPaths.length === 0) {
+      // With no recorded outputs, a deleted build directory can never invalidate the cache; make
+      // the inactive protection visible instead of failing silently (cf. issue #981).
+      console.info(
+        chalk.yellow('No build output directory detected; pass --output to enable missing-output cache invalidation.')
+      );
+    }
     await fs.promises.writeFile(cacheFilePath, JSON.stringify({ hash: contentHash, outputPaths }), 'utf8');
   }
   return true;
@@ -120,6 +127,10 @@ export async function canSkipBuild(
   const commitHash = child_process.execSync('git rev-parse HEAD', { cwd: project.dirPath }).toString().trim();
   hash.update(commitHash);
 
+  // The invoked build command is part of the cache identity: `-c commandB` must not reuse a
+  // cache recorded for commandA with otherwise unchanged inputs.
+  hash.update(argv.command ?? '');
+
   const environmentJson = JSON.stringify(
     Object.entries(project.env)
       .filter(([key]) => !ignoringEnvVarNames.has(key))
@@ -151,15 +162,17 @@ export async function canSkipBuild(
 function parseBuildCache(cachedContent: string | undefined): { hash: string; outputPaths: string[] } | undefined {
   if (!cachedContent) return;
   try {
-    const parsed = JSON.parse(cachedContent) as { hash?: unknown; outputPaths?: unknown };
+    const parsed = JSON.parse(cachedContent) as { hash?: unknown; outputPaths?: unknown } | undefined;
     if (typeof parsed?.hash !== 'string') return;
     const outputPaths = Array.isArray(parsed.outputPaths)
       ? parsed.outputPaths.filter((p) => typeof p === 'string')
       : [];
     return { hash: parsed.hash, outputPaths };
   } catch {
-    // A legacy cache file contains the raw content hash without output records.
-    return { hash: cachedContent, outputPaths: [] };
+    // A legacy cache file contains a raw content hash without output records. Treat it as a miss:
+    // honoring it would let a matching hash skip a build whose outputs were deleted, and one
+    // rebuild upgrades the record to the JSON format.
+    return;
   }
 }
 
@@ -187,33 +200,63 @@ async function updateHashWithDiffResult(
   hash: Hash
 ): Promise<void> {
   return new Promise((resolve) => {
-    const ret = child_process.spawnSync('git', ['status', '--porcelain'], {
+    // `-uall` lists untracked files individually (not just their directory), so new files in a
+    // brand-new source directory participate in the hash below.
+    const ret = child_process.spawnSync('git', ['status', '--porcelain', '-uall'], {
       cwd: project.dirPath,
       env: project.env,
       stdio: 'pipe',
       encoding: 'utf8',
     });
-    const lines = ret.stdout
+    const statusEntries = ret.stdout
       .trim()
       .split('\n')
-      .filter((line) => line.length > 0);
-    const filePaths = lines
-      .map((line) => line.slice(2).trim())
-      .map((filePath) =>
-        project.env.WB_ENV === 'test' ? filePath.replace(/packages\/wb\/test\/fixtures\/[^/]+\//, '') : filePath
-      );
-    const filteredFilePaths = filePaths.filter(
-      (filePath) =>
-        (includePatterns.some((pattern) => filePath.includes(pattern)) ||
-          includeSuffix.some((suffix) => filePath.endsWith(suffix))) &&
-        !excludePatterns.some((pattern) => filePath.includes(pattern))
+      .filter((line) => line.length > 0)
+      .map((line) => {
+        const rawPath = line.slice(2).trim();
+        return {
+          untracked: line.startsWith('??'),
+          // Renames are reported as `old -> new`; only the new path exists in the worktree.
+          filePath: rawPath.includes(' -> ') ? (rawPath.split(' -> ').at(-1) ?? rawPath) : rawPath,
+        };
+      })
+      .map((entry) => ({
+        ...entry,
+        hashPath:
+          project.env.WB_ENV === 'test'
+            ? entry.filePath.replace(/packages\/wb\/test\/fixtures\/[^/]+\//, '')
+            : entry.filePath,
+      }));
+    const filteredEntries = statusEntries.filter(
+      ({ hashPath }) =>
+        (includePatterns.some((pattern) => hashPath.includes(pattern)) ||
+          includeSuffix.some((suffix) => hashPath.endsWith(suffix))) &&
+        !excludePatterns.some((pattern) => hashPath.includes(pattern))
     );
     if (argv.verbose) {
-      console.info(`Changed files: ${filteredFilePaths.join(', ')}`);
+      console.info(`Changed files: ${filteredEntries.map((entry) => entry.hashPath).join(', ')}`);
     }
 
-    // 'git diff --' works only on rootDirPath
-    const proc = child_process.spawn('git', ['diff', '--', ...filteredFilePaths], { cwd: project.rootDirPath });
+    // Untracked files never appear in `git diff`, so hash their contents directly.
+    for (const entry of filteredEntries.filter((entry) => entry.untracked)) {
+      try {
+        hash.update(entry.hashPath);
+        hash.update(fs.readFileSync(path.join(project.rootDirPath, entry.filePath)));
+      } catch {
+        // The file may vanish concurrently; the tracked-state diff below is unaffected.
+      }
+    }
+
+    const trackedPaths = filteredEntries.filter((entry) => !entry.untracked).map((entry) => entry.hashPath);
+    if (trackedPaths.length === 0) {
+      // `git diff HEAD --` with no pathspec would diff EVERY file, letting excluded changes
+      // (docs, tests) invalidate the cache.
+      resolve();
+      return;
+    }
+    // `git diff HEAD` (not plain `git diff`) so staged-only changes invalidate the cache too;
+    // 'git diff --' works only on rootDirPath.
+    const proc = child_process.spawn('git', ['diff', 'HEAD', '--', ...trackedPaths], { cwd: project.rootDirPath });
     proc.stdout.on('data', (data: BinaryLike) => {
       hash.update(data);
       if (argv.verbose) {

--- a/packages/wb/src/commands/buildIfNeeded.ts
+++ b/packages/wb/src/commands/buildIfNeeded.ts
@@ -57,7 +57,9 @@ export async function buildIfNeeded(
   // The cache requires the git repository root to BE rootDirPath: porcelain paths and diff
   // pathspecs below are joined/executed against rootDirPath. When the repo root is elsewhere
   // (e.g. a subproject of a larger repository), always build instead of mis-resolving paths.
-  if (!fs.existsSync(path.join(project.rootDirPath, '.git'))) {
+  // A freshly initialized repo without commits (unborn HEAD) likewise builds without caching:
+  // `git rev-parse HEAD` would throw.
+  if (!fs.existsSync(path.join(project.rootDirPath, '.git')) || !hasGitCommit(project)) {
     build(project, argv);
     return true;
   }
@@ -96,6 +98,15 @@ function getExplicitOutputPaths(
 
 function detectExistingDefaultOutputPaths(project: Project): string[] {
   return defaultOutputCandidates.filter((outputPath) => fs.existsSync(path.join(project.dirPath, outputPath)));
+}
+
+function hasGitCommit(project: Project): boolean {
+  return (
+    child_process.spawnSync('git', ['rev-parse', '--verify', 'HEAD'], {
+      cwd: project.dirPath,
+      stdio: 'ignore',
+    }).status === 0
+  );
 }
 
 function build(project: Project, argv: Partial<ArgumentsCamelCase<InferredOptionTypes<typeof builder>>>): boolean {
@@ -238,15 +249,16 @@ async function updateHashWithDiffResult(
     // Build OUTPUTS must never count as build inputs: hashing e.g. an untracked dist/ file would
     // change the hash on every build and disable the cache permanently.
     const projectRelativeDirPath = path.relative(project.rootDirPath, project.dirPath);
-    const outputPathPrefixes = (getExplicitOutputPaths(argv) ?? defaultOutputCandidates).map(
-      (outputPath) => `${path.join(projectRelativeDirPath, outputPath)}/`
+    const outputPaths = (getExplicitOutputPaths(argv) ?? defaultOutputCandidates).map((outputPath) =>
+      path.join(projectRelativeDirPath, outputPath)
     );
     const filteredEntries = normalizedEntries.filter(
       ({ filePath, hashPath }) =>
         (includePatterns.some((pattern) => hashPath.includes(pattern)) ||
           includeSuffix.some((suffix) => hashPath.endsWith(suffix))) &&
         !excludePatterns.some((pattern) => hashPath.includes(pattern)) &&
-        !outputPathPrefixes.some((prefix) => filePath.startsWith(prefix))
+        // An `--output` value may name a file, so exclude the exact path as well as descendants.
+        !outputPaths.some((outputPath) => filePath === outputPath || filePath.startsWith(`${outputPath}/`))
     );
     if (argv.verbose) {
       console.info(`Changed files: ${filteredEntries.map((entry) => entry.hashPath).join(', ')}`);

--- a/packages/wb/src/commands/buildIfNeeded.ts
+++ b/packages/wb/src/commands/buildIfNeeded.ts
@@ -251,8 +251,12 @@ async function updateHashWithDiffResult(
     // Build OUTPUTS must never count as build inputs: hashing e.g. an untracked dist/ file would
     // change the hash on every build and disable the cache permanently.
     const projectRelativeDirPath = path.relative(project.rootDirPath, project.dirPath);
-    const outputPaths = (getExplicitOutputPaths(argv) ?? defaultOutputCandidates).map((outputPath) =>
-      path.join(projectRelativeDirPath, outputPath)
+    // The UNION of defaults and explicit paths: an `--output` naming a single file must not stop
+    // sibling artifacts in dist/build/.next/out from being excluded, or every build would change
+    // the hash and permanently disable the cache. (The cache-validity existence check in
+    // canSkipBuild deliberately narrows to the explicit paths instead.)
+    const outputPaths = [...new Set([...defaultOutputCandidates, ...(getExplicitOutputPaths(argv) ?? [])])].map(
+      (outputPath) => path.join(projectRelativeDirPath, outputPath)
     );
     const filteredEntries = normalizedEntries.filter(({ filePath, hashPath }) => {
       const directorySegments = hashPath.split('/').slice(0, -1);

--- a/packages/wb/src/commands/buildIfNeeded.ts
+++ b/packages/wb/src/commands/buildIfNeeded.ts
@@ -54,6 +54,9 @@ export async function buildIfNeeded(
   }
   argv = { ...argv, command: buildCommand };
 
+  // The cache requires the git repository root to BE rootDirPath: porcelain paths and diff
+  // pathspecs below are joined/executed against rootDirPath. When the repo root is elsewhere
+  // (e.g. a subproject of a larger repository), always build instead of mis-resolving paths.
   if (!fs.existsSync(path.join(project.rootDirPath, '.git'))) {
     build(project, argv);
     return true;
@@ -191,6 +194,8 @@ const includeSuffix = [
   // Because some build commands affected by changes in `package.json`
   'package.json',
   'yarn.lock',
+  'bun.lock',
+  'bun.lockb',
 ];
 const excludePatterns = ['test/', 'tests/', '__tests__/', 'test-fixtures/', 'test/fixtures/'];
 
@@ -201,37 +206,47 @@ async function updateHashWithDiffResult(
 ): Promise<void> {
   return new Promise((resolve) => {
     // `-uall` lists untracked files individually (not just their directory), so new files in a
-    // brand-new source directory participate in the hash below.
-    const ret = child_process.spawnSync('git', ['status', '--porcelain', '-uall'], {
+    // brand-new source directory participate in the hash below. `-z` yields NUL-delimited,
+    // UNQUOTED records: without it git C-quotes non-ASCII paths, which would silently drop those
+    // files from both the untracked hashing and the `git diff` pathspecs.
+    const ret = child_process.spawnSync('git', ['status', '--porcelain', '-uall', '-z'], {
       cwd: project.dirPath,
       env: project.env,
       stdio: 'pipe',
       encoding: 'utf8',
     });
-    const statusEntries = ret.stdout
-      .trim()
-      .split('\n')
-      .filter((line) => line.length > 0)
-      .map((line) => {
-        const rawPath = line.slice(2).trim();
-        return {
-          untracked: line.startsWith('??'),
-          // Renames are reported as `old -> new`; only the new path exists in the worktree.
-          filePath: rawPath.includes(' -> ') ? (rawPath.split(' -> ').at(-1) ?? rawPath) : rawPath,
-        };
-      })
-      .map((entry) => ({
-        ...entry,
-        hashPath:
-          project.env.WB_ENV === 'test'
-            ? entry.filePath.replace(/packages\/wb\/test\/fixtures\/[^/]+\//, '')
-            : entry.filePath,
-      }));
-    const filteredEntries = statusEntries.filter(
-      ({ hashPath }) =>
+    const tokens = ret.stdout.split('\0').filter((token) => token.length > 0);
+    const statusEntries: { untracked: boolean; filePath: string }[] = [];
+    for (let index = 0; index < tokens.length; index++) {
+      const token = tokens[index]!;
+      const status = token.slice(0, 2);
+      statusEntries.push({ untracked: status === '??', filePath: token.slice(3) });
+      // Rename/copy records carry the ORIGINAL path as an extra NUL-delimited field; include it
+      // so a file renamed out of the build inputs still invalidates the cache.
+      if (status.includes('R') || status.includes('C')) {
+        const originalPath = tokens[++index];
+        if (originalPath) statusEntries.push({ untracked: false, filePath: originalPath });
+      }
+    }
+    const normalizedEntries = statusEntries.map((entry) => ({
+      ...entry,
+      hashPath:
+        project.env.WB_ENV === 'test'
+          ? entry.filePath.replace(/packages\/wb\/test\/fixtures\/[^/]+\//, '')
+          : entry.filePath,
+    }));
+    // Build OUTPUTS must never count as build inputs: hashing e.g. an untracked dist/ file would
+    // change the hash on every build and disable the cache permanently.
+    const projectRelativeDirPath = path.relative(project.rootDirPath, project.dirPath);
+    const outputPathPrefixes = (getExplicitOutputPaths(argv) ?? defaultOutputCandidates).map(
+      (outputPath) => `${path.join(projectRelativeDirPath, outputPath)}/`
+    );
+    const filteredEntries = normalizedEntries.filter(
+      ({ filePath, hashPath }) =>
         (includePatterns.some((pattern) => hashPath.includes(pattern)) ||
           includeSuffix.some((suffix) => hashPath.endsWith(suffix))) &&
-        !excludePatterns.some((pattern) => hashPath.includes(pattern))
+        !excludePatterns.some((pattern) => hashPath.includes(pattern)) &&
+        !outputPathPrefixes.some((prefix) => filePath.startsWith(prefix))
     );
     if (argv.verbose) {
       console.info(`Changed files: ${filteredEntries.map((entry) => entry.hashPath).join(', ')}`);

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -10,7 +10,7 @@ import type { ArgumentsCamelCase, Argv, CommandModule, InferredOptionTypes } fro
 
 import type { Project } from '../project.js';
 import { findSelfProject } from '../project.js';
-import { buildDrizzleKitCommand } from '../scripts/drizzleScripts.js';
+import { buildDrizzleKitCommand, usesDrizzleKitForD1 } from '../scripts/drizzleScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { isCI } from '../utils/ci.js';
@@ -136,13 +136,17 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
     }
     const accountId = resolvedConfig.accountId ?? project.env.CLOUDFLARE_ACCOUNT_ID;
     // Prefer wrangler-native migrations whenever the resolved environment's D1 bindings have an
-    // existing migrations directory: a drizzle-orm dependency alone does not imply the project
-    // migrates D1 with drizzle-kit's d1-http driver (some drizzle apps use wrangler-native).
+    // existing migrations directory. A drizzle-orm dependency alone does not imply the project
+    // migrates D1 with drizzle-kit's d1-http driver: the explicit marker is a drizzle config
+    // whose dialect/driver targets sqlite / d1-http / durable-sqlite (see usesDrizzleKitForD1;
+    // https://github.com/WillBooster/shared/issues/942). A drizzle config targeting another
+    // database (e.g. PostgreSQL via Hyperdrive) leaves the D1 bindings unmanaged by wb deploy.
     const wranglerNativeD1Databases = resolvedConfig.d1Databases.filter((database) =>
       usesWranglerNativeMigrations(project, database)
     );
+    const drizzleKitManagesD1 = usesDrizzleKitForD1(project);
     if (
-      project.hasDrizzle &&
+      drizzleKitManagesD1 &&
       wranglerNativeD1Databases.length > 0 &&
       wranglerNativeD1Databases.length < resolvedConfig.d1Databases.length
     ) {
@@ -154,8 +158,8 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       process.exit(1);
     }
     const drizzleD1Database =
-      wranglerNativeD1Databases.length === 0 && project.hasDrizzle ? resolvedConfig.d1Databases[0] : undefined;
-    if (wranglerNativeD1Databases.length === 0 && project.hasDrizzle && resolvedConfig.d1Databases.length > 1) {
+      wranglerNativeD1Databases.length === 0 && drizzleKitManagesD1 ? resolvedConfig.d1Databases[0] : undefined;
+    if (wranglerNativeD1Databases.length === 0 && drizzleKitManagesD1 && resolvedConfig.d1Databases.length > 1) {
       console.error(
         chalk.red('wb deploy supports drizzle-kit migrations only for a single D1 binding; found multiple.')
       );
@@ -163,10 +167,23 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
     }
     // Dry runs execute nothing authenticated, so they skip the credential preflight entirely.
     if (!argv.dryRun) {
-      if (drizzleD1Database && !project.env.CLOUDFLARE_API_TOKEN) {
+      // Whenever a deploy/post hook exists and wb will export CLOUDFLARE_D1_DATABASE_ID to it
+      // (exactly one D1 binding — see step 5), the hook's drizzle config typically selects its
+      // d1-http branch, which needs CLOUDFLARE_API_TOKEN even for local, wrangler-OAuth deploys.
+      // Failing here keeps the fail-fast ordering: a missing token must abort before the deploy
+      // goes live, not during deploy/post (https://github.com/WillBooster/shared/issues/956).
+      const postHookReceivesD1DatabaseId =
+        !!project.packageJson.scripts?.['deploy/post'] && resolvedConfig.d1Databases.length === 1;
+      if ((drizzleD1Database || postHookReceivesD1DatabaseId) && !project.env.CLOUDFLARE_API_TOKEN) {
         // drizzle-kit's d1-http driver requires this specific token even for local runs; a
         // local wrangler OAuth login covers only the wrangler-native path.
-        console.error(chalk.red('CLOUDFLARE_API_TOKEN is required for remote drizzle-kit migrations.'));
+        console.error(
+          chalk.red(
+            drizzleD1Database
+              ? 'CLOUDFLARE_API_TOKEN is required for remote drizzle-kit migrations.'
+              : 'CLOUDFLARE_API_TOKEN is required because deploy/post will receive CLOUDFLARE_D1_DATABASE_ID.'
+          )
+        );
         process.exit(1);
       }
       const hasWranglerAuthentication =
@@ -367,8 +384,9 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
     }
 
     // 3. Apply D1 migrations to the remote database with the project's single migration
-    //    mechanism (wrangler-native when a migrations directory exists, else drizzle-kit for
-    //    drizzle-orm apps). Migrations must be backward compatible: the old Worker serves
+    //    mechanism (wrangler-native when a migrations directory exists, else drizzle-kit when
+    //    the drizzle config targets sqlite/d1-http/durable-sqlite). Migrations must be backward
+    //    compatible: the old Worker serves
     //    traffic until the deploy below.
     const envOption = resolvedConfig.usesEnvSection ? ` --env ${shellEscapeArgument(envName)}` : '';
     for (const database of wranglerNativeD1Databases) {

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -184,32 +184,15 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
     }
     // Dry runs execute nothing authenticated, so they skip the credential preflight entirely.
     if (!argv.dryRun) {
-      // Whenever a deploy/post hook exists, drizzle-kit manages a D1 database, and wb will export
-      // CLOUDFLARE_D1_DATABASE_ID to the hook (exactly one D1 binding WITH a database_id — see
-      // step 5), the hook's drizzle config selects its d1-http branch, which needs
-      // CLOUDFLARE_API_TOKEN even for local, wrangler-OAuth deploys. Failing here keeps the
-      // fail-fast ordering: a missing token must abort before the deploy goes live, not during
-      // deploy/post (https://github.com/WillBooster/shared/issues/956). Hooks unrelated to
-      // drizzle-managed D1 (e.g. cache purges on a wrangler-native project) must not require the
-      // token: a local wrangler OAuth login suffices for them.
-      const postHookReceivesD1DatabaseId =
-        !!project.packageJson.scripts?.['deploy/post'] &&
-        drizzleKitManagesD1 &&
-        // When wrangler-native migrations are the selected mechanism, a wrangler OAuth login
-        // suffices; only a drizzle-selected D1 database routes the hook through d1-http.
-        wranglerNativeD1Databases.length === 0 &&
-        resolvedConfig.d1Databases.length === 1 &&
-        !!resolvedConfig.d1Databases[0]?.database_id;
-      if ((drizzleD1Database || postHookReceivesD1DatabaseId) && !project.env.CLOUDFLARE_API_TOKEN) {
-        // drizzle-kit's d1-http driver requires this specific token even for local runs; a
-        // local wrangler OAuth login covers only the wrangler-native path.
-        console.error(
-          chalk.red(
-            drizzleD1Database
-              ? 'CLOUDFLARE_API_TOKEN is required for remote drizzle-kit migrations.'
-              : 'CLOUDFLARE_API_TOKEN is required because deploy/post will receive CLOUDFLARE_D1_DATABASE_ID.'
-          )
-        );
+      // A drizzle-selected D1 database routes both the migration in step 3 and any deploy/post
+      // hook through drizzle-kit's d1-http driver, which needs CLOUDFLARE_API_TOKEN even for
+      // local, wrangler-OAuth deploys. Failing here keeps the fail-fast ordering: a missing token
+      // must abort before the deploy goes live, not during migration or deploy/post
+      // (https://github.com/WillBooster/shared/issues/956). Wrangler-native projects (with or
+      // without hooks) must not require the token: a local wrangler OAuth login suffices there,
+      // even though step 5 still exports CLOUDFLARE_D1_DATABASE_ID to their hooks.
+      if (drizzleD1Database && !project.env.CLOUDFLARE_API_TOKEN) {
+        console.error(chalk.red('CLOUDFLARE_API_TOKEN is required for remote drizzle-kit migrations.'));
         process.exit(1);
       }
       const hasWranglerAuthentication =

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -165,15 +165,34 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       );
       process.exit(1);
     }
+    if (resolvedConfig.d1Databases.length > 0 && wranglerNativeD1Databases.length === 0 && !drizzleKitManagesD1) {
+      // Say so out loud instead of silently deploying code against unmigrated databases: the
+      // drizzle marker detection is heuristic (text scan of drizzle.config.*), so a project that
+      // genuinely migrates D1 must be able to notice when no mechanism was selected.
+      console.warn(
+        chalk.yellow(
+          `No D1 migration mechanism detected for ${resolvedConfig.d1Databases
+            .map((database) => database.binding ?? database.database_name ?? 'unnamed binding')
+            .join(', ')} ` +
+            '(no wrangler migrations directory and no drizzle config targeting sqlite/d1-http/durable-sqlite); wb deploy will not run D1 migrations.'
+        )
+      );
+    }
     // Dry runs execute nothing authenticated, so they skip the credential preflight entirely.
     if (!argv.dryRun) {
-      // Whenever a deploy/post hook exists and wb will export CLOUDFLARE_D1_DATABASE_ID to it
-      // (exactly one D1 binding — see step 5), the hook's drizzle config typically selects its
-      // d1-http branch, which needs CLOUDFLARE_API_TOKEN even for local, wrangler-OAuth deploys.
-      // Failing here keeps the fail-fast ordering: a missing token must abort before the deploy
-      // goes live, not during deploy/post (https://github.com/WillBooster/shared/issues/956).
+      // Whenever a deploy/post hook exists, drizzle-kit manages a D1 database, and wb will export
+      // CLOUDFLARE_D1_DATABASE_ID to the hook (exactly one D1 binding WITH a database_id — see
+      // step 5), the hook's drizzle config selects its d1-http branch, which needs
+      // CLOUDFLARE_API_TOKEN even for local, wrangler-OAuth deploys. Failing here keeps the
+      // fail-fast ordering: a missing token must abort before the deploy goes live, not during
+      // deploy/post (https://github.com/WillBooster/shared/issues/956). Hooks unrelated to
+      // drizzle-managed D1 (e.g. cache purges on a wrangler-native project) must not require the
+      // token: a local wrangler OAuth login suffices for them.
       const postHookReceivesD1DatabaseId =
-        !!project.packageJson.scripts?.['deploy/post'] && resolvedConfig.d1Databases.length === 1;
+        !!project.packageJson.scripts?.['deploy/post'] &&
+        drizzleKitManagesD1 &&
+        resolvedConfig.d1Databases.length === 1 &&
+        !!resolvedConfig.d1Databases[0]?.database_id;
       if ((drizzleD1Database || postHookReceivesD1DatabaseId) && !project.env.CLOUDFLARE_API_TOKEN) {
         // drizzle-kit's d1-http driver requires this specific token even for local runs; a
         // local wrangler OAuth login covers only the wrangler-native path.

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -165,16 +165,20 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       );
       process.exit(1);
     }
-    if (resolvedConfig.d1Databases.length > 0 && wranglerNativeD1Databases.length === 0 && !drizzleKitManagesD1) {
+    const managedD1Databases = new Set(wranglerNativeD1Databases);
+    if (drizzleD1Database) managedD1Databases.add(drizzleD1Database);
+    const unmanagedD1Databases = resolvedConfig.d1Databases.filter((database) => !managedD1Databases.has(database));
+    if (unmanagedD1Databases.length > 0) {
       // Say so out loud instead of silently deploying code against unmigrated databases: the
       // drizzle marker detection is heuristic (text scan of drizzle.config.*), so a project that
-      // genuinely migrates D1 must be able to notice when no mechanism was selected.
+      // genuinely migrates D1 must be able to notice when no mechanism was selected. This also
+      // covers partial layouts (some bindings wrangler-native, others unmanaged).
       console.warn(
         chalk.yellow(
-          `No D1 migration mechanism detected for ${resolvedConfig.d1Databases
+          `No D1 migration mechanism detected for ${unmanagedD1Databases
             .map((database) => database.binding ?? database.database_name ?? 'unnamed binding')
             .join(', ')} ` +
-            '(no wrangler migrations directory and no drizzle config targeting sqlite/d1-http/durable-sqlite); wb deploy will not run D1 migrations.'
+            '(no wrangler migrations directory and no drizzle config targeting sqlite/d1-http/durable-sqlite); wb deploy will not run D1 migrations for them.'
         )
       );
     }
@@ -191,6 +195,9 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       const postHookReceivesD1DatabaseId =
         !!project.packageJson.scripts?.['deploy/post'] &&
         drizzleKitManagesD1 &&
+        // When wrangler-native migrations are the selected mechanism, a wrangler OAuth login
+        // suffices; only a drizzle-selected D1 database routes the hook through d1-http.
+        wranglerNativeD1Databases.length === 0 &&
         resolvedConfig.d1Databases.length === 1 &&
         !!resolvedConfig.d1Databases[0]?.database_id;
       if ((drizzleD1Database || postHookReceivesD1DatabaseId) && !project.env.CLOUDFLARE_API_TOKEN) {

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -58,14 +58,12 @@ async function runParsedDotenvCommand({ command }: ParsedDotenvArgs): Promise<vo
     stdio: 'inherit',
   });
   const signalHandlers = new Map<NodeJS.Signals, () => void>();
-  let forwardedShutdownSignal: NodeJS.Signals | undefined;
   child.on('error', (error) => {
     console.error(error);
     process.exit(1);
   });
   for (const signal of shutdownSignals) {
     const signalHandler = (): void => {
-      forwardedShutdownSignal = signal;
       child.kill(signal);
     };
     signalHandlers.set(signal, signalHandler);
@@ -75,10 +73,9 @@ async function runParsedDotenvCommand({ command }: ParsedDotenvArgs): Promise<vo
     for (const [shutdownSignal, signalHandler] of signalHandlers) {
       process.off(shutdownSignal, signalHandler);
     }
-    if (signal && signal === forwardedShutdownSignal) {
-      process.exit(0);
-    }
     if (signal) {
+      // Re-raise even for forwarded shutdown signals so callers observe the conventional
+      // signal exit status (e.g. 130 for SIGINT) instead of a misleading success.
       process.kill(process.pid, signal);
       return;
     }

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -100,38 +100,56 @@ function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
   return { command: separatorIndex === -1 ? args : args.slice(separatorIndex + 1) };
 }
 
+// NOTE: `wb dotenv` deliberately skips Project.env's WB_ENV/NEXT_PUBLIC_WB_ENV validation: it is
+// a generic runner also used before env sources exist (bootstrap) and must not fail fast for
+// repositories that have not adopted the org env standard.
 function readAndApplyEnvironmentVariables(cwd: string): void {
-  const modeVars = process.env.WB_ENV
-    ? (config({ path: path.join(cwd, `.env.${process.env.WB_ENV}`), processEnv: {}, quiet: true }).parsed ?? {})
-    : {};
+  const mode = process.env.WB_ENV;
+  const readEnvFile = (fileName: string): Record<string, string> =>
+    config({ path: path.join(cwd, fileName), processEnv: {}, quiet: true }).parsed ?? {};
+  // Mode-specific sources drive the forced-mode override below.
+  const modeVars = mode ? { ...readEnvFile(`.env.${mode}`), ...readEnvFile(`.env.${mode}.local`) } : {};
+  // Mirror the shared cascade's precedence: .env.<mode>.local > .env.local > .env.<mode> > .env.
   const dotenvVars = {
-    ...config({ path: path.join(cwd, '.env'), processEnv: {}, quiet: true }).parsed,
-    ...modeVars,
+    ...readEnvFile('.env'),
+    ...(mode ? readEnvFile(`.env.${mode}`) : {}),
+    ...readEnvFile('.env.local'),
+    ...(mode ? readEnvFile(`.env.${mode}.local`) : {}),
   };
+  // WB_ENV in process.env means the mode is explicitly forced, so values from the mode's own
+  // sources (.env.<mode>[.local] and the fnox profile) win over variables inherited from the
+  // parent shell — except on CI, where injected env vars must keep overriding committed files
+  // (see https://github.com/WillBooster/shared/issues/930).
+  const modeFileOverridesProcessEnv = !!mode && !isCI(process.env.CI);
   // fnox.toml is the committed, encrypted equivalent of .env files; local .env files still win over it.
-  const [fnoxVars] = readFnoxEnvironmentVariables(cwd, process.env.WB_ENV, dotenvVars);
+  const [fnoxVars] = readFnoxEnvironmentVariables(cwd, mode, dotenvVars, { modeFileOverridesProcessEnv });
   const parsed = { ...fnoxVars, ...dotenvVars };
-  const envVars = expand({ parsed, processEnv: {} }).parsed ?? parsed;
-  // WB_ENV in process.env means the mode is explicitly forced, so the mode file's own values win
-  // over variables inherited from the parent shell — except on CI, where injected env vars must
-  // keep overriding committed files (see https://github.com/WillBooster/shared/issues/930).
-  const modeFileOverridesProcessEnv = !isCI(process.env.CI);
+  // Expand ${...} references against exported variables NOT loaded from files (mirroring
+  // readEnvironmentVariables): with an empty processEnv a reference to a shell-only variable
+  // would expand to '', and the forced-mode override below would then replace a correct
+  // inherited value with a broken one.
+  const referenceEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    // Escape dollar signs so exported values substitute literally (pa$word stays pa$word).
+    if (value !== undefined && !(key in parsed)) referenceEnv[key] = value.replaceAll('$', String.raw`\$`);
+  }
+  const envVars = expand({ parsed, processEnv: referenceEnv }).parsed ?? parsed;
   for (const [key, value] of Object.entries(envVars)) {
     if (!(key in process.env)) {
       process.env[key] = value;
       continue;
     }
-    if (!(key in modeVars) || process.env[key] === value) continue;
+    // readFnoxEnvironmentVariables returns a process.env-shadowed key only when the forced
+    // profile overrides it, so fnox-provided keys count as mode-specific here.
+    if (!(key in modeVars || key in fnoxVars) || process.env[key] === value) continue;
 
     if (modeFileOverridesProcessEnv) {
       console.warn(
-        `Warning: ${key} in .env.${process.env.WB_ENV} overrides the value inherited from the parent environment because WB_ENV is explicitly set.`
+        `Warning: ${key} in the "${mode}" mode's env sources overrides the value inherited from the parent environment because WB_ENV is explicitly set.`
       );
       process.env[key] = value;
-    } else {
-      console.warn(
-        `Warning: the inherited environment variable ${key} shadows the value defined in .env.${process.env.WB_ENV}.`
-      );
     }
+    // On CI, inherited variables intentionally win (workflows deliberately inject env vars that
+    // override the committed files); this is the designed behavior, so no warning is emitted.
   }
 }

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -121,14 +121,18 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
   // fnox.toml is the committed, encrypted equivalent of .env files; local .env files still win over it.
   const [fnoxVars] = readFnoxEnvironmentVariables(cwd, mode, dotenvVars, { modeFileOverridesProcessEnv });
   const parsed = { ...fnoxVars, ...dotenvVars };
-  // Expand ${...} references against exported variables NOT loaded from files (mirroring
-  // readEnvironmentVariables): with an empty processEnv a reference to a shell-only variable
-  // would expand to '', and the forced-mode override below would then replace a correct
-  // inherited value with a broken one.
+  // Expand ${...} references against exported variables whose FILE value loses to the shell
+  // (mirroring readEnvironmentVariables' effective-value semantics): a reference must resolve to
+  // the value the child will actually see, so a shell-shadowed key expands to the shell value
+  // while a winning file/override value expands to the file value.
+  const fileValueWins = (key: string): boolean =>
+    !(key in process.env) || (modeFileOverridesProcessEnv && (key in modeVars || key in fnoxVars));
   const referenceEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
     // Escape dollar signs so exported values substitute literally (pa$word stays pa$word).
-    if (value !== undefined && !(key in parsed)) referenceEnv[key] = value.replaceAll('$', String.raw`\$`);
+    if (value !== undefined && !(key in parsed && fileValueWins(key))) {
+      referenceEnv[key] = value.replaceAll('$', String.raw`\$`);
+    }
   }
   const envVars = expand({ parsed, processEnv: referenceEnv }).parsed ?? parsed;
   for (const [key, value] of Object.entries(envVars)) {

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -7,6 +7,7 @@ import { expand } from 'dotenv-expand';
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
 
 import { prependNodeModulesBinToPath } from '../utils/binPath.js';
+import { isCI } from '../utils/ci.js';
 
 interface ParsedDotenvArgs {
   command: string[];
@@ -100,19 +101,37 @@ function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
 }
 
 function readAndApplyEnvironmentVariables(cwd: string): void {
+  const modeVars = process.env.WB_ENV
+    ? (config({ path: path.join(cwd, `.env.${process.env.WB_ENV}`), processEnv: {}, quiet: true }).parsed ?? {})
+    : {};
   const dotenvVars = {
     ...config({ path: path.join(cwd, '.env'), processEnv: {}, quiet: true }).parsed,
-    ...(process.env.WB_ENV
-      ? (config({ path: path.join(cwd, `.env.${process.env.WB_ENV}`), processEnv: {}, quiet: true }).parsed ?? {})
-      : {}),
+    ...modeVars,
   };
   // fnox.toml is the committed, encrypted equivalent of .env files; local .env files still win over it.
   const [fnoxVars] = readFnoxEnvironmentVariables(cwd, process.env.WB_ENV, dotenvVars);
   const parsed = { ...fnoxVars, ...dotenvVars };
   const envVars = expand({ parsed, processEnv: {} }).parsed ?? parsed;
+  // WB_ENV in process.env means the mode is explicitly forced, so the mode file's own values win
+  // over variables inherited from the parent shell — except on CI, where injected env vars must
+  // keep overriding committed files (see https://github.com/WillBooster/shared/issues/930).
+  const modeFileOverridesProcessEnv = !isCI(process.env.CI);
   for (const [key, value] of Object.entries(envVars)) {
     if (!(key in process.env)) {
       process.env[key] = value;
+      continue;
+    }
+    if (!(key in modeVars) || process.env[key] === value) continue;
+
+    if (modeFileOverridesProcessEnv) {
+      console.warn(
+        `Warning: ${key} in .env.${process.env.WB_ENV} overrides the value inherited from the parent environment because WB_ENV is explicitly set.`
+      );
+      process.env[key] = value;
+    } else {
+      console.warn(
+        `Warning: the inherited environment variable ${key} shadows the value defined in .env.${process.env.WB_ENV}.`
+      );
     }
   }
 }

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -19,6 +19,8 @@ import {
   PRIVATE_REGISTRY_SCOPE,
   isPrivateGitDependency,
   isPrivateRegistryDependency,
+  rangeAdmits,
+  toBaseVersion,
 } from '../utils/privateRegistry.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
@@ -133,11 +135,17 @@ function rewritePrivateGitHubDependenciesForDir(
           );
           continue;
         }
-        // `wb setup-private-packages` degrades ^/~ ranges to their base version, so equality
-        // against the stripped specifier is exact for pinned versions and simple ranges;
-        // dist-tag specifiers (non-numeric) skip the staleness check.
-        const requestedVersion = value.replace(/^[\^~]/, '');
-        if (/^\d/.test(requestedVersion) && materializedVersion !== requestedVersion) {
+        // The materialized version is stale when it neither equals the specifier's degraded base
+        // (`wb setup-private-packages` degrades ^/~ to the base version) nor is admitted by the
+        // ^/~ range — setup may legitimately materialize a NEWER admitted version selected by an
+        // exact pin elsewhere in the manifest. Dist-tag specifiers (no x.y.z base, e.g.
+        // `2026-stable`) skip the staleness check.
+        const requestedBaseVersion = toBaseVersion(value);
+        if (
+          requestedBaseVersion !== undefined &&
+          materializedVersion !== requestedBaseVersion &&
+          !rangeAdmits(value, materializedVersion)
+        ) {
           console.error(
             chalk.red(
               `Materialized ${name} is ${materializedVersion} but package.json requires ${value}; rerun \`wb setup-private-packages\`.`

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -114,10 +114,18 @@ function rewritePrivateGitHubDependenciesForDir(
         // The Dockerfile copies those workspace packages into the image instead.
         deps[name] = getPrivatePackageDockerSpecifier(rootDirPath, packageDirPath, '@willbooster', name);
         rewrittenDependencies.push(`${key}.${name}`);
-      } else if (
-        isPrivateRegistryDependency(name, value) &&
-        fs.existsSync(path.join(rootDirPath, PRIVATE_REGISTRY_SCOPE, toUnscopedPackageName(name), 'package.json'))
-      ) {
+      } else if (isPrivateRegistryDependency(name, value)) {
+        const materializedVersion = readMaterializedPackageVersion(rootDirPath, name);
+        if (materializedVersion === undefined) continue;
+        // `wb setup-private-packages` degrades ^/~ ranges to their base version, so equality
+        // against the stripped specifier is exact for pinned versions and simple ranges;
+        // dist-tag specifiers (non-numeric) skip the staleness check.
+        const requestedVersion = value.replace(/^[\^~]/, '');
+        if (/^\d/.test(requestedVersion) && materializedVersion !== requestedVersion) {
+          throw new Error(
+            `Materialized ${name} is ${materializedVersion} but package.json requires ${value}; rerun \`wb setup-private-packages\`.`
+          );
+        }
         // Registry packages that `wb setup-private-packages` materialized on the host are used as
         // local paths so image builds need no Verdaccio credentials; the COMMITTED package.json
         // keeps the registry specifier — only the generated (dist/)package.json is rewritten
@@ -144,6 +152,21 @@ function getPrivatePackageDockerSpecifier(
 
 function toUnscopedPackageName(packageName: string): string {
   return packageName.replace(/^@willbooster(?:-private)?\//, '');
+}
+
+/** Undefined when the package is not materialized (or its manifest is unreadable/versionless). */
+function readMaterializedPackageVersion(rootDirPath: string, packageName: string): string | undefined {
+  const packageJsonPath = path.join(
+    rootDirPath,
+    PRIVATE_REGISTRY_SCOPE,
+    toUnscopedPackageName(packageName),
+    'package.json'
+  );
+  try {
+    return (JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageJson).version;
+  } catch {
+    return undefined;
+  }
 }
 
 async function writeDockerShellScripts(dirPath: string): Promise<void> {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -15,7 +15,11 @@ import {
   type Project,
 } from '../project.js';
 
-import { PRIVATE_REGISTRY_SCOPE, isPrivateRegistryDependency } from '../utils/privateRegistry.js';
+import {
+  PRIVATE_REGISTRY_SCOPE,
+  isPrivateGitDependency,
+  isPrivateRegistryDependency,
+} from '../utils/privateRegistry.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
 
@@ -109,9 +113,12 @@ function rewritePrivateGitHubDependenciesForDir(
   for (const key of dependencySectionKeys) {
     const deps = packageJson[key] ?? {};
     for (const [name, value] of Object.entries(deps)) {
-      if (value?.startsWith('git@github.com:')) {
+      if (isPrivateGitDependency(value)) {
         // Docker builds cannot access private SSH URLs unless credentials are forwarded.
-        // The Dockerfile copies those workspace packages into the image instead.
+        // The Dockerfile copies those workspace packages into the image instead. Only the org's
+        // own git dependencies are rewritten — the shared predicate matches exactly what
+        // `wb setup-private-packages` materializes, so other SSH URLs are left unchanged instead
+        // of being pointed at never-materialized local paths.
         deps[name] = getPrivatePackageDockerSpecifier(rootDirPath, packageDirPath, '@willbooster', name);
         rewrittenDependencies.push(`${key}.${name}`);
       } else if (isPrivateRegistryDependency(name, value)) {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -15,6 +15,8 @@ import {
   type Project,
 } from '../project.js';
 
+import { PRIVATE_REGISTRY_SCOPE, isPrivateRegistryDependency } from '../utils/privateRegistry.js';
+
 import { prepareForRunningCommand } from './commandUtils.js';
 
 const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
@@ -110,23 +112,38 @@ function rewritePrivateGitHubDependenciesForDir(
       if (value?.startsWith('git@github.com:')) {
         // Docker builds cannot access private SSH URLs unless credentials are forwarded.
         // The Dockerfile copies those workspace packages into the image instead.
-        deps[name] = getPrivatePackageDockerSpecifier(rootDirPath, packageDirPath, name);
+        deps[name] = getPrivatePackageDockerSpecifier(rootDirPath, packageDirPath, '@willbooster', name);
+        rewrittenDependencies.push(`${key}.${name}`);
+      } else if (
+        isPrivateRegistryDependency(name, value) &&
+        fs.existsSync(path.join(rootDirPath, PRIVATE_REGISTRY_SCOPE, toUnscopedPackageName(name), 'package.json'))
+      ) {
+        // Registry packages that `wb setup-private-packages` materialized on the host are used as
+        // local paths so image builds need no Verdaccio credentials; the COMMITTED package.json
+        // keeps the registry specifier — only the generated (dist/)package.json is rewritten
+        // (https://github.com/WillBooster/shared/issues/964).
+        deps[name] = getPrivatePackageDockerSpecifier(rootDirPath, packageDirPath, PRIVATE_REGISTRY_SCOPE, name);
         rewrittenDependencies.push(`${key}.${name}`);
       }
     }
   }
-  console.info('Rewrote private GitHub dependencies:', rewrittenDependencies.join(', ') || 'none');
+  console.info('Rewrote private dependencies:', rewrittenDependencies.join(', ') || 'none');
   return rewrittenDependencies;
 }
 
-function getPrivatePackageDockerSpecifier(rootDirPath: string, packageDirPath: string, packageName: string): string {
-  const privatePackageDirPath = path.join(rootDirPath, '@willbooster', toUnscopedPackageName(packageName));
+function getPrivatePackageDockerSpecifier(
+  rootDirPath: string,
+  packageDirPath: string,
+  scopeDirName: string,
+  packageName: string
+): string {
+  const privatePackageDirPath = path.join(rootDirPath, scopeDirName, toUnscopedPackageName(packageName));
   const relativePath = path.relative(packageDirPath, privatePackageDirPath);
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
 }
 
 function toUnscopedPackageName(packageName: string): string {
-  return packageName.replace(/^@willbooster\//, '');
+  return packageName.replace(/^@willbooster(?:-private)?\//, '');
 }
 
 async function writeDockerShellScripts(dirPath: string): Promise<void> {

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -123,15 +123,27 @@ function rewritePrivateGitHubDependenciesForDir(
         rewrittenDependencies.push(`${key}.${name}`);
       } else if (isPrivateRegistryDependency(name, value)) {
         const materializedVersion = readMaterializedPackageVersion(rootDirPath, name);
-        if (materializedVersion === undefined) continue;
+        if (materializedVersion === undefined) {
+          // Leaving the registry specifier means the in-image install needs Verdaccio
+          // credentials — the failure this feature exists to avoid — so say so out loud.
+          console.warn(
+            chalk.yellow(
+              `${name} is not materialized under ${PRIVATE_REGISTRY_SCOPE}/; run \`wb setup-private-packages\` so the Docker build does not need registry credentials.`
+            )
+          );
+          continue;
+        }
         // `wb setup-private-packages` degrades ^/~ ranges to their base version, so equality
         // against the stripped specifier is exact for pinned versions and simple ranges;
         // dist-tag specifiers (non-numeric) skip the staleness check.
         const requestedVersion = value.replace(/^[\^~]/, '');
         if (/^\d/.test(requestedVersion) && materializedVersion !== requestedVersion) {
-          throw new Error(
-            `Materialized ${name} is ${materializedVersion} but package.json requires ${value}; rerun \`wb setup-private-packages\`.`
+          console.error(
+            chalk.red(
+              `Materialized ${name} is ${materializedVersion} but package.json requires ${value}; rerun \`wb setup-private-packages\`.`
+            )
           );
+          process.exit(1);
         }
         // Registry packages that `wb setup-private-packages` materialized on the host are used as
         // local paths so image builds need no Verdaccio credentials; the COMMITTED package.json

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -76,20 +76,26 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
     // On failure or interruption, restore byte-for-byte: semantic-release may have left PARTIAL
     // edits (e.g. a version bump without a publish), which must not survive. The semantic
     // workspace-range restore is reserved for a successful release.
+    const restoredFilePaths: string[] = [];
     for (const [filePath, content] of modifiedFiles) {
-      restoreModifiedFile(filePath, content, releaseRanSuccessfully);
+      if (restoreModifiedFile(filePath, content, releaseRanSuccessfully)) restoredFilePaths.push(filePath);
     }
-    if (modifiedFiles.size > 0) {
+    if (restoredFilePaths.length > 0) {
       console.info(
-        chalk.cyan(`Restored ${[...modifiedFiles.keys()].map((p) => path.relative(project.dirPath, p)).join(', ')}.`)
+        chalk.cyan(`Restored ${restoredFilePaths.map((p) => path.relative(project.dirPath, p)).join(', ')}.`)
       );
-      if (!isCI(project.env.CI)) {
-        console.info(
-          chalk.yellow(
-            'node_modules now uses the hoisted layout; run a clean reinstall (`rm -rf node_modules packages/*/node_modules && bun install`) to restore the isolated layout.'
-          )
-        );
-      }
+    }
+    // The hint applies only when the hoisted reinstall actually ran; bunfig.toml is snapshotted
+    // exactly in that branch.
+    const reinstalledWithHoistedLinker = [...modifiedFiles.keys()].some(
+      (filePath) => path.basename(filePath) === 'bunfig.toml'
+    );
+    if (reinstalledWithHoistedLinker && !isCI(project.env.CI)) {
+      console.info(
+        chalk.yellow(
+          'node_modules now uses the hoisted layout; run a clean reinstall (`rm -rf node_modules packages/*/node_modules && bun install`) to restore the isolated layout.'
+        )
+      );
     }
     for (const signal of guardedSignals) process.off(signal, signalHandler);
   }
@@ -180,22 +186,33 @@ async function prepareNpmCompatibleLayout(
  * revert that bump — so when the file changed during the release, only the `workspace:`
  * specifiers are written back into the CURRENT content.
  */
-function restoreModifiedFile(filePath: string, originalContent: Buffer | undefined, releaseSucceeded: boolean): void {
+/** Returns whether the on-disk content actually changed (drives the "Restored ..." message). */
+function restoreModifiedFile(
+  filePath: string,
+  originalContent: Buffer | undefined,
+  releaseSucceeded: boolean
+): boolean {
   if (originalContent === undefined) {
+    const existed = fs.existsSync(filePath);
     fs.rmSync(filePath, { force: true });
-    return;
+    return existed;
   }
   if (releaseSucceeded && path.basename(filePath) === 'package.json' && fs.existsSync(filePath)) {
     const currentContent = fs.readFileSync(filePath, 'utf8');
     const originalText = originalContent.toString('utf8');
     if (currentContent !== rewriteWorkspaceRanges(originalText)) {
-      fs.writeFileSync(filePath, restoreWorkspaceRanges(currentContent, originalText), 'utf8');
-      return;
+      const restoredContent = restoreWorkspaceRanges(currentContent, originalText);
+      if (restoredContent === currentContent) return false;
+      fs.writeFileSync(filePath, restoredContent, 'utf8');
+      return true;
     }
   }
+  const currentBuffer = fs.existsSync(filePath) ? fs.readFileSync(filePath) : undefined;
+  if (currentBuffer?.equals(originalContent)) return false;
   // Write the snapshot bytes verbatim: bun.lockb is binary, so any text decode/encode round trip
   // would corrupt it.
   fs.writeFileSync(filePath, originalContent);
+  return true;
 }
 
 export function buildHoistedBunfig(bunfig: string): string {

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -7,6 +7,8 @@ import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
 import type { ArgumentsCamelCase, Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
+import { treeKill } from '@willbooster/shared-lib-node/src';
+
 import type { Project } from '../project.js';
 import { findRootAndSelfProjects } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
@@ -54,7 +56,9 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
   const activeChild: ActiveChildRef = { current: undefined };
   const signalHandler = (signal: NodeJS.Signals): void => {
     receivedSignal = signal;
-    activeChild.current?.kill(signal);
+    // treeKill (not child.kill): semantic-release and bun install spawn their own subprocesses
+    // (npm publish, git push, ...), which must not keep publishing after wb reports cancellation.
+    if (activeChild.current?.pid) treeKill(activeChild.current.pid, signal);
   };
   const guardedSignals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
   for (const signal of guardedSignals) process.on(signal, signalHandler);

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -1,0 +1,171 @@
+import child_process from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import chalk from 'chalk';
+import { globby } from 'globby';
+import type { ArgumentsCamelCase, Argv, CommandModule, InferredOptionTypes } from 'yargs';
+
+import type { Project } from '../project.js';
+import { findRootAndSelfProjects } from '../project.js';
+import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { prependNodeModulesBinToPath } from '../utils/binPath.js';
+import { isCI } from '../utils/ci.js';
+
+type ReleaseArgv = Partial<ArgumentsCamelCase<InferredOptionTypes<typeof sharedOptionsBuilder>>> & {
+  args?: unknown[];
+  '--'?: unknown[];
+};
+
+export const releaseCommand: CommandModule = {
+  command: 'release [args..]',
+  describe:
+    'Run semantic-release (or multi-semantic-release) so that repositories using Bun isolated installs can publish to npm: ' +
+    "reinstall with the hoisted linker (npm cannot walk Bun's isolated node_modules layout), " +
+    'rewrite `workspace:` ranges npm cannot parse, run the release, then restore the modified files. ' +
+    'Extra arguments (e.g. `--debug`, after `--`) are forwarded to the release command.',
+  builder: (yargs: Argv<unknown>) => yargs.parserConfiguration({ 'populate--': true }),
+  async handler(argv) {
+    await release(argv as ReleaseArgv);
+  },
+};
+
+export async function release(argv: ReleaseArgv, projectPathForTesting?: string): Promise<void> {
+  const projects = findRootAndSelfProjects(argv, false, projectPathForTesting);
+  if (!projects) {
+    console.error(chalk.red('No project found.'));
+    process.exit(1);
+  }
+  // semantic-release must run at the repository root: it reads the git repo and, for monorepos,
+  // multi-semantic-release walks the workspaces itself.
+  const project = projects.root;
+
+  const modifiedFiles = new Map<string, string>();
+  let exitCode = 0;
+  try {
+    await prepareNpmCompatibleLayout(project, argv, modifiedFiles);
+    exitCode = runSemanticRelease(project, argv);
+  } finally {
+    for (const [filePath, content] of modifiedFiles) {
+      fs.writeFileSync(filePath, content, 'utf8');
+    }
+    if (modifiedFiles.size > 0) {
+      console.info(
+        chalk.cyan(`Restored ${[...modifiedFiles.keys()].map((p) => path.relative(project.dirPath, p)).join(', ')}.`)
+      );
+      if (!isCI(process.env.CI)) {
+        console.info(
+          chalk.yellow(
+            'node_modules now uses the hoisted layout; run a clean reinstall (`rm -rf node_modules packages/*/node_modules && bun install`) to restore the isolated layout.'
+          )
+        );
+      }
+    }
+  }
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+}
+
+/**
+ * Make the checkout digestible for npm, which semantic-release's npm plugin shells out to for
+ * `npm version` / `npm publish`:
+ * 1. npm's arborist cannot walk Bun's ISOLATED node_modules layout (the `.bun` symlink farm), so
+ *    clean-reinstall with the hoisted linker first. A non-clean linker switch would leave stale
+ *    global-store symlinks behind (packages then resolve from ~/.bun/install/cache/links where
+ *    phantom dependencies are unreachable), so every node_modules directory is wiped first.
+ * 2. npm cannot parse `workspace:` specifiers, while Bun REQUIRES the protocol so a cold install
+ *    links the workspace — so rewrite the ranges to `*` AFTER the reinstall (Bun must still see
+ *    the protocol while installing; npm only needs the manifest TEXT to be parseable). The
+ *    affected manifests are private/unpublished or rewritten by the npm plugin on publish.
+ * All mutations are restored by the caller after the release.
+ */
+async function prepareNpmCompatibleLayout(
+  project: Project,
+  argv: ReleaseArgv,
+  modifiedFiles: Map<string, string>
+): Promise<void> {
+  const bunfigPath = path.join(project.dirPath, 'bunfig.toml');
+  const bunfig = fs.existsSync(bunfigPath) ? fs.readFileSync(bunfigPath, 'utf8') : undefined;
+  const hoistedBunfig = bunfig === undefined ? undefined : buildHoistedBunfig(bunfig);
+  if (bunfig !== undefined && hoistedBunfig !== bunfig) {
+    console.info(chalk.cyan('Clean-reinstalling with the hoisted linker so npm can walk node_modules...'));
+    if (!argv.dryRun) {
+      modifiedFiles.set(bunfigPath, bunfig);
+      fs.writeFileSync(bunfigPath, hoistedBunfig ?? '', 'utf8');
+      for (const packageDirPath of [project.dirPath, ...(await findWorkspacePackageDirs(project))]) {
+        fs.rmSync(path.join(packageDirPath, 'node_modules'), { force: true, recursive: true });
+      }
+      const ret = child_process.spawnSync('bun', ['install'], { cwd: project.dirPath, stdio: 'inherit' });
+      if (ret.status !== 0) {
+        console.error(chalk.red('bun install failed while preparing the release.'));
+        process.exit(ret.status ?? 1);
+      }
+    }
+  }
+
+  const workspacePackageDirs = await findWorkspacePackageDirs(project);
+  for (const packageJsonPath of [
+    project.packageJsonPath,
+    ...workspacePackageDirs.map((dirPath) => path.join(dirPath, 'package.json')),
+  ]) {
+    if (!fs.existsSync(packageJsonPath)) continue;
+
+    const original = fs.readFileSync(packageJsonPath, 'utf8');
+    const rewritten = rewriteWorkspaceRanges(original);
+    if (rewritten === original) continue;
+
+    console.info(chalk.cyan(`Rewriting workspace: ranges in ${path.relative(project.dirPath, packageJsonPath)}...`));
+    if (!argv.dryRun) {
+      modifiedFiles.set(packageJsonPath, original);
+      fs.writeFileSync(packageJsonPath, rewritten, 'utf8');
+    }
+  }
+}
+
+export function buildHoistedBunfig(bunfig: string): string {
+  return bunfig
+    .replace(/^(\s*linker\s*=\s*)["']isolated["']/mu, '$1"hoisted"')
+    .replace(/^\s*globalStore\s*=\s*true[^\n]*\n?/mu, '');
+}
+
+export function rewriteWorkspaceRanges(packageJsonContent: string): string {
+  return packageJsonContent.replaceAll(/"workspace:[^"]*"/gu, '"*"');
+}
+
+function runSemanticRelease(project: Project, argv: ReleaseArgv): number {
+  const forwardedArgs = [...(argv.args ?? []), ...(argv['--'] ?? [])].map(String);
+  const releaseBin =
+    project.packageJson.devDependencies?.['@anolilab/multi-semantic-release'] ||
+    project.packageJson.devDependencies?.['multi-semantic-release'] ||
+    project.packageJson.devDependencies?.['@qiwi/multi-semantic-release']
+      ? 'multi-semantic-release'
+      : 'semantic-release';
+
+  const env = { ...process.env };
+  prependNodeModulesBinToPath(project.dirPath, env);
+  const hasLocalBin = fs.existsSync(path.join(project.dirPath, 'node_modules', '.bin', releaseBin));
+  const command = hasLocalBin
+    ? [releaseBin, ...forwardedArgs]
+    : project.packageManagerCommand === 'bun'
+      ? ['bunx', releaseBin, ...forwardedArgs]
+      : ['yarn', 'dlx', releaseBin, ...forwardedArgs];
+  console.info(chalk.cyan(`Running: ${command.join(' ')}`));
+  if (argv.dryRun) return 0;
+
+  const ret = child_process.spawnSync(command[0]!, command.slice(1), {
+    cwd: project.dirPath,
+    env,
+    stdio: 'inherit',
+  });
+  return ret.status ?? 1;
+}
+
+async function findWorkspacePackageDirs(project: Project): Promise<string[]> {
+  const workspaces = project.packageJson.workspaces;
+  const patterns = Array.isArray(workspaces) ? workspaces : (workspaces?.packages ?? []);
+  if (patterns.length === 0) return [];
+
+  const dirPaths = await globby(patterns, { cwd: project.dirPath, onlyDirectories: true });
+  return dirPaths.map((dirPath) => path.join(project.dirPath, dirPath));
+}

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -58,7 +58,15 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
     receivedSignal = signal;
     // treeKill (not child.kill): semantic-release and bun install spawn their own subprocesses
     // (npm publish, git push, ...), which must not keep publishing after wb reports cancellation.
-    if (activeChild.current?.pid) treeKill(activeChild.current.pid, signal);
+    // treeKill THROWS (missing/timing-out `ps`, EPERM), and an exception escaping a signal
+    // listener would terminate the process and skip the restoring finally — so degrade to
+    // killing the direct child instead.
+    try {
+      if (activeChild.current?.pid) treeKill(activeChild.current.pid, signal);
+    } catch (error) {
+      console.error(chalk.red(`Failed to terminate the release child process tree: ${String(error)}`));
+      activeChild.current?.kill(signal);
+    }
   };
   const guardedSignals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
   for (const signal of guardedSignals) process.on(signal, signalHandler);
@@ -117,19 +125,6 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
   }
 }
 
-/**
- * Make the checkout digestible for npm, which semantic-release's npm plugin shells out to for
- * `npm version` / `npm publish`:
- * 1. npm's arborist cannot walk Bun's ISOLATED node_modules layout (the `.bun` symlink farm), so
- *    clean-reinstall with the hoisted linker first. A non-clean linker switch would leave stale
- *    global-store symlinks behind (packages then resolve from ~/.bun/install/cache/links where
- *    phantom dependencies are unreachable), so every node_modules directory is wiped first.
- * 2. npm cannot parse `workspace:` specifiers, while Bun REQUIRES the protocol so a cold install
- *    links the workspace — so rewrite the ranges to `*` AFTER the reinstall (Bun must still see
- *    the protocol while installing; npm only needs the manifest TEXT to be parseable). The
- *    affected manifests are private/unpublished or rewritten by the npm plugin on publish.
- * All mutations are restored by the caller after the release.
- */
 interface ActiveChildRef {
   current: child_process.ChildProcess | undefined;
 }
@@ -159,6 +154,19 @@ async function spawnAndWait(
   });
 }
 
+/**
+ * Make the checkout digestible for npm, which semantic-release's npm plugin shells out to for
+ * `npm version` / `npm publish`:
+ * 1. npm's arborist cannot walk Bun's ISOLATED node_modules layout (the `.bun` symlink farm), so
+ *    clean-reinstall with the hoisted linker first. A non-clean linker switch would leave stale
+ *    global-store symlinks behind (packages then resolve from ~/.bun/install/cache/links where
+ *    phantom dependencies are unreachable), so every node_modules directory is wiped first.
+ * 2. npm cannot parse `workspace:` specifiers, while Bun REQUIRES the protocol so a cold install
+ *    links the workspace — so rewrite the ranges to `*` AFTER the reinstall (Bun must still see
+ *    the protocol while installing; npm only needs the manifest TEXT to be parseable). The
+ *    affected manifests are private/unpublished or rewritten by the npm plugin on publish.
+ * All mutations are restored by the caller after the release.
+ */
 async function prepareNpmCompatibleLayout(
   project: Project,
   argv: ReleaseArgv,

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -158,12 +158,16 @@ async function prepareNpmCompatibleLayout(
     if (!fs.existsSync(packageJsonPath)) continue;
 
     const original = fs.readFileSync(packageJsonPath, 'utf8');
+    // Snapshot EVERY manifest (not only rewritten ones): semantic-release also edits manifests
+    // without workspace: ranges (version bumps), and a failed release must restore those too.
+    if (!argv.dryRun) {
+      modifiedFiles.set(packageJsonPath, Buffer.from(original, 'utf8'));
+    }
     const rewritten = rewriteWorkspaceRanges(original);
     if (rewritten === original) continue;
 
     console.info(chalk.cyan(`Rewriting workspace: ranges in ${path.relative(project.dirPath, packageJsonPath)}...`));
     if (!argv.dryRun) {
-      modifiedFiles.set(packageJsonPath, Buffer.from(original, 'utf8'));
       fs.writeFileSync(packageJsonPath, rewritten, 'utf8');
     }
   }

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import chalk from 'chalk';
 import { globby } from 'globby';
+import type { PackageJson } from 'type-fest';
 import type { ArgumentsCamelCase, Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
 import type { Project } from '../project.js';
@@ -40,20 +41,27 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
   // multi-semantic-release walks the workspaces itself.
   const project = projects.root;
 
-  const modifiedFiles = new Map<string, string>();
+  // Maps a mutated file to its pre-release content; `undefined` marks a file that did not exist
+  // and must be deleted on restore (e.g. a lockfile `bun install` created).
+  const modifiedFiles = new Map<string, string | undefined>();
   let exitCode = 0;
   try {
     await prepareNpmCompatibleLayout(project, argv, modifiedFiles);
     exitCode = runSemanticRelease(project, argv);
+  } catch (error) {
+    // Errors must unwind through this try (never `process.exit` inside it): the restore below is
+    // the only thing that undoes the bunfig/package.json mutations.
+    console.error(chalk.red(String(error instanceof Error ? error.message : error)));
+    exitCode = 1;
   } finally {
     for (const [filePath, content] of modifiedFiles) {
-      fs.writeFileSync(filePath, content, 'utf8');
+      restoreModifiedFile(filePath, content);
     }
     if (modifiedFiles.size > 0) {
       console.info(
         chalk.cyan(`Restored ${[...modifiedFiles.keys()].map((p) => path.relative(project.dirPath, p)).join(', ')}.`)
       );
-      if (!isCI(process.env.CI)) {
+      if (!isCI(project.env.CI)) {
         console.info(
           chalk.yellow(
             'node_modules now uses the hoisted layout; run a clean reinstall (`rm -rf node_modules packages/*/node_modules && bun install`) to restore the isolated layout.'
@@ -83,7 +91,7 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
 async function prepareNpmCompatibleLayout(
   project: Project,
   argv: ReleaseArgv,
-  modifiedFiles: Map<string, string>
+  modifiedFiles: Map<string, string | undefined>
 ): Promise<void> {
   const bunfigPath = path.join(project.dirPath, 'bunfig.toml');
   const bunfig = fs.existsSync(bunfigPath) ? fs.readFileSync(bunfigPath, 'utf8') : undefined;
@@ -92,14 +100,24 @@ async function prepareNpmCompatibleLayout(
     console.info(chalk.cyan('Clean-reinstalling with the hoisted linker so npm can walk node_modules...'));
     if (!argv.dryRun) {
       modifiedFiles.set(bunfigPath, bunfig);
+      // The hoisted reinstall may rewrite (or create) the lockfile; snapshot it so a successful
+      // release leaves no tracked or untracked lockfile changes behind.
+      for (const lockFileName of ['bun.lock', 'bun.lockb']) {
+        const lockFilePath = path.join(project.dirPath, lockFileName);
+        modifiedFiles.set(
+          lockFilePath,
+          fs.existsSync(lockFilePath) ? fs.readFileSync(lockFilePath, 'utf8') : undefined
+        );
+      }
       fs.writeFileSync(bunfigPath, hoistedBunfig ?? '', 'utf8');
       for (const packageDirPath of [project.dirPath, ...(await findWorkspacePackageDirs(project))]) {
         fs.rmSync(path.join(packageDirPath, 'node_modules'), { force: true, recursive: true });
       }
       const ret = child_process.spawnSync('bun', ['install'], { cwd: project.dirPath, stdio: 'inherit' });
       if (ret.status !== 0) {
-        console.error(chalk.red('bun install failed while preparing the release.'));
-        process.exit(ret.status ?? 1);
+        // Throwing (instead of process.exit, which would skip the caller's finally) lets the
+        // restore run before the process terminates.
+        throw new Error('bun install failed while preparing the release.');
       }
     }
   }
@@ -123,6 +141,28 @@ async function prepareNpmCompatibleLayout(
   }
 }
 
+/**
+ * Undo the temporary release-time mutations of one file. `package.json` files are restored
+ * semantically instead of byte-for-byte: semantic-release's npm plugin writes the released
+ * version into manifests while they hold the rewritten ranges, and a byte restore would silently
+ * revert that bump — so when the file changed during the release, only the `workspace:`
+ * specifiers are written back into the CURRENT content.
+ */
+function restoreModifiedFile(filePath: string, originalContent: string | undefined): void {
+  if (originalContent === undefined) {
+    fs.rmSync(filePath, { force: true });
+    return;
+  }
+  if (path.basename(filePath) === 'package.json' && fs.existsSync(filePath)) {
+    const currentContent = fs.readFileSync(filePath, 'utf8');
+    if (currentContent !== rewriteWorkspaceRanges(originalContent)) {
+      fs.writeFileSync(filePath, restoreWorkspaceRanges(currentContent, originalContent), 'utf8');
+      return;
+    }
+  }
+  fs.writeFileSync(filePath, originalContent, 'utf8');
+}
+
 export function buildHoistedBunfig(bunfig: string): string {
   return bunfig
     .replace(/^(\s*linker\s*=\s*)["']isolated["']/mu, '$1"hoisted"')
@@ -130,7 +170,47 @@ export function buildHoistedBunfig(bunfig: string): string {
 }
 
 export function rewriteWorkspaceRanges(packageJsonContent: string): string {
-  return packageJsonContent.replaceAll(/"workspace:[^"]*"/gu, '"*"');
+  // Rewrite only dependency entries collected from the parsed manifest: a blanket
+  // `"workspace:..."` replacement would also corrupt unrelated string values (e.g. a
+  // description starting with `workspace:`) in the manifest npm publishes.
+  let content = packageJsonContent;
+  for (const { name } of collectWorkspaceDependencies(packageJsonContent)) {
+    content = content.replaceAll(new RegExp(`("${escapeRegExp(name)}"\\s*:\\s*)"workspace:[^"]*"`, 'gu'), '$1"*"');
+  }
+  return content;
+}
+
+export function restoreWorkspaceRanges(currentContent: string, originalContent: string): string {
+  let content = currentContent;
+  for (const { name, specifier } of collectWorkspaceDependencies(originalContent)) {
+    content = content.replaceAll(
+      new RegExp(`("${escapeRegExp(name)}"\\s*:\\s*)"\\*"`, 'gu'),
+      `$1${JSON.stringify(specifier)}`
+    );
+  }
+  return content;
+}
+
+function collectWorkspaceDependencies(packageJsonContent: string): { name: string; specifier: string }[] {
+  let packageJson: PackageJson;
+  try {
+    packageJson = JSON.parse(packageJsonContent) as PackageJson;
+  } catch {
+    return [];
+  }
+  const dependenciesByName = new Map<string, string>();
+  for (const key of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const) {
+    for (const [name, value] of Object.entries(packageJson[key] ?? {})) {
+      if (typeof value === 'string' && value.startsWith('workspace:')) {
+        dependenciesByName.set(name, value);
+      }
+    }
+  }
+  return [...dependenciesByName].map(([name, specifier]) => ({ name, specifier }));
+}
+
+function escapeRegExp(text: string): string {
+  return text.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
 }
 
 function runSemanticRelease(project: Project, argv: ReleaseArgv): number {

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -44,6 +44,16 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
   // Maps a mutated file to its pre-release content (raw bytes — bun.lockb is binary); `undefined`
   // marks a file that did not exist and must be deleted on restore (e.g. a created lockfile).
   const modifiedFiles = new Map<string, Buffer | undefined>();
+  // With a handler installed, SIGINT/SIGTERM no longer terminate this process while a child runs
+  // (the child in the same terminal group still receives the signal and exits, making spawnSync
+  // return), so the finally-restore always executes; the signal is re-raised afterwards.
+  let receivedSignal: NodeJS.Signals | undefined;
+  const signalHandler = (signal: NodeJS.Signals): void => {
+    receivedSignal = signal;
+  };
+  const guardedSignals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
+  for (const signal of guardedSignals) process.on(signal, signalHandler);
+
   let exitCode = 0;
   try {
     await prepareNpmCompatibleLayout(project, argv, modifiedFiles);
@@ -54,8 +64,12 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
     console.error(chalk.red(String(error instanceof Error ? error.message : error)));
     exitCode = 1;
   } finally {
+    // On failure or interruption, restore byte-for-byte: semantic-release may have left PARTIAL
+    // edits (e.g. a version bump without a publish), which must not survive. The semantic
+    // workspace-range restore is reserved for a successful release.
+    const releaseSucceeded = exitCode === 0 && receivedSignal === undefined;
     for (const [filePath, content] of modifiedFiles) {
-      restoreModifiedFile(filePath, content);
+      restoreModifiedFile(filePath, content, releaseSucceeded);
     }
     if (modifiedFiles.size > 0) {
       console.info(
@@ -69,6 +83,11 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
         );
       }
     }
+    for (const signal of guardedSignals) process.off(signal, signalHandler);
+  }
+  if (receivedSignal) {
+    process.kill(process.pid, receivedSignal);
+    return;
   }
   if (exitCode !== 0) {
     process.exit(exitCode);
@@ -149,12 +168,12 @@ async function prepareNpmCompatibleLayout(
  * revert that bump — so when the file changed during the release, only the `workspace:`
  * specifiers are written back into the CURRENT content.
  */
-function restoreModifiedFile(filePath: string, originalContent: Buffer | undefined): void {
+function restoreModifiedFile(filePath: string, originalContent: Buffer | undefined, releaseSucceeded: boolean): void {
   if (originalContent === undefined) {
     fs.rmSync(filePath, { force: true });
     return;
   }
-  if (path.basename(filePath) === 'package.json' && fs.existsSync(filePath)) {
+  if (releaseSucceeded && path.basename(filePath) === 'package.json' && fs.existsSync(filePath)) {
     const currentContent = fs.readFileSync(filePath, 'utf8');
     const originalText = originalContent.toString('utf8');
     if (currentContent !== rewriteWorkspaceRanges(originalText)) {
@@ -247,12 +266,13 @@ function escapeRegExp(text: string): string {
 
 function runSemanticRelease(project: Project, argv: ReleaseArgv): number {
   const forwardedArgs = [...(argv.args ?? []), ...(argv['--'] ?? [])].map(String);
-  const releaseBin =
-    project.packageJson.devDependencies?.['@anolilab/multi-semantic-release'] ||
-    project.packageJson.devDependencies?.['multi-semantic-release'] ||
-    project.packageJson.devDependencies?.['@qiwi/multi-semantic-release']
-      ? 'multi-semantic-release'
-      : 'semantic-release';
+  // The PACKAGE name (for `bunx`/`yarn dlx`, which fetch a package) and the BIN name (for the
+  // local node_modules/.bin lookup) differ for the scoped forks: `bunx multi-semantic-release`
+  // would fetch the unrelated unscoped npm package instead of e.g. @anolilab's fork.
+  const releasePackageName = (
+    ['@anolilab/multi-semantic-release', 'multi-semantic-release', '@qiwi/multi-semantic-release'] as const
+  ).find((packageName) => project.packageJson.devDependencies?.[packageName]);
+  const releaseBin = releasePackageName ? 'multi-semantic-release' : 'semantic-release';
 
   // The project is loaded with loadEnv: false (semantic-release runs with the ambient/CI
   // environment by design), so project.env aliases process.env here; using it keeps the
@@ -260,11 +280,12 @@ function runSemanticRelease(project: Project, argv: ReleaseArgv): number {
   const env = { ...project.env };
   prependNodeModulesBinToPath(project.dirPath, env);
   const hasLocalBin = fs.existsSync(path.join(project.dirPath, 'node_modules', '.bin', releaseBin));
+  const fallbackPackageName = releasePackageName ?? 'semantic-release';
   const command = hasLocalBin
     ? [releaseBin, ...forwardedArgs]
     : project.packageManagerCommand === 'bun'
-      ? ['bunx', releaseBin, ...forwardedArgs]
-      : ['yarn', 'dlx', releaseBin, ...forwardedArgs];
+      ? ['bunx', fallbackPackageName, ...forwardedArgs]
+      : ['yarn', 'dlx', fallbackPackageName, ...forwardedArgs];
   console.info(chalk.cyan(`Running: ${command.join(' ')}`));
   if (argv.dryRun) return 0;
 

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -191,9 +191,13 @@ export function rewriteWorkspaceRanges(packageJsonContent: string): string {
  */
 export function restoreWorkspaceRanges(currentContent: string, originalContent: string): string {
   const workspaceDependencies = collectWorkspaceDependencies(originalContent);
-  return replaceInDependencySections(currentContent, (section) => {
+  // Restore per (section, name): a same-named dependency in another section may legitimately
+  // hold a non-workspace range (e.g. a peerDependencies `>=1.0.0` next to a devDependencies
+  // `workspace:*`) or a different workspace range, and must keep its own value.
+  return replaceInDependencySections(currentContent, (section, sectionKey) => {
     let result = section;
-    for (const { name, specifier } of workspaceDependencies) {
+    for (const { section: dependencySection, name, specifier } of workspaceDependencies) {
+      if (dependencySection !== sectionKey) continue;
       result = result.replaceAll(
         new RegExp(`("${escapeRegExp(name)}"\\s*:\\s*)"[^"]*"`, 'gu'),
         // A replacer function, not a replacement string: specifiers containing `$` must be
@@ -206,29 +210,35 @@ export function restoreWorkspaceRanges(currentContent: string, originalContent: 
 }
 
 /** Dependency sections contain only `"name": "specifier"` string pairs, so `[^{}]*` spans them. */
-function replaceInDependencySections(content: string, replaceSection: (section: string) => string): string {
+function replaceInDependencySections(
+  content: string,
+  replaceSection: (section: string, sectionKey: string) => string
+): string {
   return content.replaceAll(
-    /("(?:dependencies|devDependencies|optionalDependencies|peerDependencies)"\s*:\s*\{)([^{}]*)(\})/gu,
-    (_match, prefix: string, body: string, suffix: string) => `${prefix}${replaceSection(body)}${suffix}`
+    /("(dependencies|devDependencies|optionalDependencies|peerDependencies)"\s*:\s*\{)([^{}]*)(\})/gu,
+    (_match, prefix: string, sectionKey: string, body: string, suffix: string) =>
+      `${prefix}${replaceSection(body, sectionKey)}${suffix}`
   );
 }
 
-function collectWorkspaceDependencies(packageJsonContent: string): { name: string; specifier: string }[] {
+function collectWorkspaceDependencies(
+  packageJsonContent: string
+): { section: string; name: string; specifier: string }[] {
   let packageJson: PackageJson;
   try {
     packageJson = JSON.parse(packageJsonContent) as PackageJson;
   } catch {
     return [];
   }
-  const dependenciesByName = new Map<string, string>();
+  const dependencies: { section: string; name: string; specifier: string }[] = [];
   for (const key of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const) {
     for (const [name, value] of Object.entries(packageJson[key] ?? {})) {
       if (typeof value === 'string' && value.startsWith('workspace:')) {
-        dependenciesByName.set(name, value);
+        dependencies.push({ section: key, name, specifier: value });
       }
     }
   }
-  return [...dependenciesByName].map(([name, specifier]) => ({ name, specifier }));
+  return dependencies;
 }
 
 function escapeRegExp(text: string): string {

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -44,12 +44,17 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
   // Maps a mutated file to its pre-release content (raw bytes — bun.lockb is binary); `undefined`
   // marks a file that did not exist and must be deleted on restore (e.g. a created lockfile).
   const modifiedFiles = new Map<string, Buffer | undefined>();
-  // With a handler installed, SIGINT/SIGTERM no longer terminate this process while a child runs
-  // (the child in the same terminal group still receives the signal and exits, making spawnSync
-  // return), so the finally-restore always executes; the signal is re-raised afterwards.
+  // With a handler installed, SIGINT/SIGTERM no longer terminate this process, so the
+  // finally-restore always executes and the signal is re-raised afterwards. The handler also
+  // FORWARDS the signal to the running child: children are spawned asynchronously (never
+  // spawnSync, which would block the event loop and defer the handler until after the child —
+  // and a publish — completed), so a signal targeted at this process alone still cancels the
+  // child promptly.
   let receivedSignal: NodeJS.Signals | undefined;
+  const activeChild: ActiveChildRef = { current: undefined };
   const signalHandler = (signal: NodeJS.Signals): void => {
     receivedSignal = signal;
+    activeChild.current?.kill(signal);
   };
   const guardedSignals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
   for (const signal of guardedSignals) process.on(signal, signalHandler);
@@ -57,13 +62,13 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
   let exitCode = 0;
   let releaseRanSuccessfully = false;
   try {
-    await prepareNpmCompatibleLayout(project, argv, modifiedFiles);
-    // A signal targeted at this process alone (not the terminal group) leaves the prepare
-    // children untouched, so it must be checked explicitly before anything publishes.
+    await prepareNpmCompatibleLayout(project, argv, modifiedFiles, activeChild);
+    // A signal may have arrived between children (nothing to forward to at that instant), so it
+    // must be checked explicitly before anything publishes.
     if (receivedSignal) {
       throw new Error(`Aborted by ${receivedSignal} before running the release.`);
     }
-    exitCode = runSemanticRelease(project, argv);
+    exitCode = await runSemanticRelease(project, argv, activeChild);
     // Recorded separately from receivedSignal: a signal arriving AFTER a successful publish must
     // not demote the restore to byte-for-byte (that would revert the published version bumps).
     releaseRanSuccessfully = exitCode === 0;
@@ -121,10 +126,40 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
  *    affected manifests are private/unpublished or rewritten by the npm plugin on publish.
  * All mutations are restored by the caller after the release.
  */
+interface ActiveChildRef {
+  current: child_process.ChildProcess | undefined;
+}
+
+/**
+ * Spawn asynchronously and await the exit status. The event loop stays free, so parent-only
+ * signals are handled promptly and forwarded to the child by release()'s signal handler.
+ */
+async function spawnAndWait(
+  activeChild: ActiveChildRef,
+  command: string,
+  args: string[],
+  options: child_process.SpawnOptions
+): Promise<number> {
+  return await new Promise<number>((resolve) => {
+    const child = child_process.spawn(command, args, options);
+    activeChild.current = child;
+    child.on('error', (error) => {
+      activeChild.current = undefined;
+      console.error(chalk.red(String(error)));
+      resolve(1);
+    });
+    child.on('exit', (code) => {
+      activeChild.current = undefined;
+      resolve(code ?? 1);
+    });
+  });
+}
+
 async function prepareNpmCompatibleLayout(
   project: Project,
   argv: ReleaseArgv,
-  modifiedFiles: Map<string, Buffer | undefined>
+  modifiedFiles: Map<string, Buffer | undefined>,
+  activeChild: ActiveChildRef
 ): Promise<void> {
   const bunfigPath = path.join(project.dirPath, 'bunfig.toml');
   const bunfig = fs.existsSync(bunfigPath) ? fs.readFileSync(bunfigPath, 'utf8') : undefined;
@@ -143,12 +178,12 @@ async function prepareNpmCompatibleLayout(
       for (const packageDirPath of [project.dirPath, ...(await findWorkspacePackageDirs(project))]) {
         fs.rmSync(path.join(packageDirPath, 'node_modules'), { force: true, recursive: true });
       }
-      const ret = child_process.spawnSync('bun', ['install'], {
+      const installStatus = await spawnAndWait(activeChild, 'bun', ['install'], {
         cwd: project.dirPath,
         env: project.env,
         stdio: 'inherit',
       });
-      if (ret.status !== 0) {
+      if (installStatus !== 0) {
         // Throwing (instead of process.exit, which would skip the caller's finally) lets the
         // restore run before the process terminates.
         throw new Error('bun install failed while preparing the release.');
@@ -293,7 +328,7 @@ function escapeRegExp(text: string): string {
   return text.replaceAll(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
 }
 
-function runSemanticRelease(project: Project, argv: ReleaseArgv): number {
+async function runSemanticRelease(project: Project, argv: ReleaseArgv, activeChild: ActiveChildRef): Promise<number> {
   const forwardedArgs = [...(argv.args ?? []), ...(argv['--'] ?? [])].map(String);
   // The PACKAGE name (for `bunx`/`yarn dlx`, which fetch a package) and the BIN name (for the
   // local node_modules/.bin lookup) differ for the scoped forks: `bunx multi-semantic-release`
@@ -318,12 +353,11 @@ function runSemanticRelease(project: Project, argv: ReleaseArgv): number {
   console.info(chalk.cyan(`Running: ${command.join(' ')}`));
   if (argv.dryRun) return 0;
 
-  const ret = child_process.spawnSync(command[0]!, command.slice(1), {
+  return await spawnAndWait(activeChild, command[0]!, command.slice(1), {
     cwd: project.dirPath,
     env,
     stdio: 'inherit',
   });
-  return ret.status ?? 1;
 }
 
 async function findWorkspacePackageDirs(project: Project): Promise<string[]> {

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -55,9 +55,18 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
   for (const signal of guardedSignals) process.on(signal, signalHandler);
 
   let exitCode = 0;
+  let releaseRanSuccessfully = false;
   try {
     await prepareNpmCompatibleLayout(project, argv, modifiedFiles);
+    // A signal targeted at this process alone (not the terminal group) leaves the prepare
+    // children untouched, so it must be checked explicitly before anything publishes.
+    if (receivedSignal) {
+      throw new Error(`Aborted by ${receivedSignal} before running the release.`);
+    }
     exitCode = runSemanticRelease(project, argv);
+    // Recorded separately from receivedSignal: a signal arriving AFTER a successful publish must
+    // not demote the restore to byte-for-byte (that would revert the published version bumps).
+    releaseRanSuccessfully = exitCode === 0;
   } catch (error) {
     // Errors must unwind through this try (never `process.exit` inside it): the restore below is
     // the only thing that undoes the bunfig/package.json mutations.
@@ -67,9 +76,8 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
     // On failure or interruption, restore byte-for-byte: semantic-release may have left PARTIAL
     // edits (e.g. a version bump without a publish), which must not survive. The semantic
     // workspace-range restore is reserved for a successful release.
-    const releaseSucceeded = exitCode === 0 && receivedSignal === undefined;
     for (const [filePath, content] of modifiedFiles) {
-      restoreModifiedFile(filePath, content, releaseSucceeded);
+      restoreModifiedFile(filePath, content, releaseRanSuccessfully);
     }
     if (modifiedFiles.size > 0) {
       console.info(

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -41,9 +41,9 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
   // multi-semantic-release walks the workspaces itself.
   const project = projects.root;
 
-  // Maps a mutated file to its pre-release content; `undefined` marks a file that did not exist
-  // and must be deleted on restore (e.g. a lockfile `bun install` created).
-  const modifiedFiles = new Map<string, string | undefined>();
+  // Maps a mutated file to its pre-release content (raw bytes — bun.lockb is binary); `undefined`
+  // marks a file that did not exist and must be deleted on restore (e.g. a created lockfile).
+  const modifiedFiles = new Map<string, Buffer | undefined>();
   let exitCode = 0;
   try {
     await prepareNpmCompatibleLayout(project, argv, modifiedFiles);
@@ -91,7 +91,7 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
 async function prepareNpmCompatibleLayout(
   project: Project,
   argv: ReleaseArgv,
-  modifiedFiles: Map<string, string | undefined>
+  modifiedFiles: Map<string, Buffer | undefined>
 ): Promise<void> {
   const bunfigPath = path.join(project.dirPath, 'bunfig.toml');
   const bunfig = fs.existsSync(bunfigPath) ? fs.readFileSync(bunfigPath, 'utf8') : undefined;
@@ -99,21 +99,22 @@ async function prepareNpmCompatibleLayout(
   if (bunfig !== undefined && hoistedBunfig !== bunfig) {
     console.info(chalk.cyan('Clean-reinstalling with the hoisted linker so npm can walk node_modules...'));
     if (!argv.dryRun) {
-      modifiedFiles.set(bunfigPath, bunfig);
-      // The hoisted reinstall may rewrite (or create) the lockfile; snapshot it so a successful
-      // release leaves no tracked or untracked lockfile changes behind.
+      modifiedFiles.set(bunfigPath, Buffer.from(bunfig, 'utf8'));
+      // The hoisted reinstall may rewrite (or create) the lockfile; snapshot the raw bytes so a
+      // successful release leaves no tracked or untracked lockfile changes behind.
       for (const lockFileName of ['bun.lock', 'bun.lockb']) {
         const lockFilePath = path.join(project.dirPath, lockFileName);
-        modifiedFiles.set(
-          lockFilePath,
-          fs.existsSync(lockFilePath) ? fs.readFileSync(lockFilePath, 'utf8') : undefined
-        );
+        modifiedFiles.set(lockFilePath, fs.existsSync(lockFilePath) ? fs.readFileSync(lockFilePath) : undefined);
       }
       fs.writeFileSync(bunfigPath, hoistedBunfig ?? '', 'utf8');
       for (const packageDirPath of [project.dirPath, ...(await findWorkspacePackageDirs(project))]) {
         fs.rmSync(path.join(packageDirPath, 'node_modules'), { force: true, recursive: true });
       }
-      const ret = child_process.spawnSync('bun', ['install'], { cwd: project.dirPath, stdio: 'inherit' });
+      const ret = child_process.spawnSync('bun', ['install'], {
+        cwd: project.dirPath,
+        env: project.env,
+        stdio: 'inherit',
+      });
       if (ret.status !== 0) {
         // Throwing (instead of process.exit, which would skip the caller's finally) lets the
         // restore run before the process terminates.
@@ -135,7 +136,7 @@ async function prepareNpmCompatibleLayout(
 
     console.info(chalk.cyan(`Rewriting workspace: ranges in ${path.relative(project.dirPath, packageJsonPath)}...`));
     if (!argv.dryRun) {
-      modifiedFiles.set(packageJsonPath, original);
+      modifiedFiles.set(packageJsonPath, Buffer.from(original, 'utf8'));
       fs.writeFileSync(packageJsonPath, rewritten, 'utf8');
     }
   }
@@ -148,19 +149,22 @@ async function prepareNpmCompatibleLayout(
  * revert that bump — so when the file changed during the release, only the `workspace:`
  * specifiers are written back into the CURRENT content.
  */
-function restoreModifiedFile(filePath: string, originalContent: string | undefined): void {
+function restoreModifiedFile(filePath: string, originalContent: Buffer | undefined): void {
   if (originalContent === undefined) {
     fs.rmSync(filePath, { force: true });
     return;
   }
   if (path.basename(filePath) === 'package.json' && fs.existsSync(filePath)) {
     const currentContent = fs.readFileSync(filePath, 'utf8');
-    if (currentContent !== rewriteWorkspaceRanges(originalContent)) {
-      fs.writeFileSync(filePath, restoreWorkspaceRanges(currentContent, originalContent), 'utf8');
+    const originalText = originalContent.toString('utf8');
+    if (currentContent !== rewriteWorkspaceRanges(originalText)) {
+      fs.writeFileSync(filePath, restoreWorkspaceRanges(currentContent, originalText), 'utf8');
       return;
     }
   }
-  fs.writeFileSync(filePath, originalContent, 'utf8');
+  // Write the snapshot bytes verbatim: bun.lockb is binary, so any text decode/encode round trip
+  // would corrupt it.
+  fs.writeFileSync(filePath, originalContent);
 }
 
 export function buildHoistedBunfig(bunfig: string): string {
@@ -170,25 +174,43 @@ export function buildHoistedBunfig(bunfig: string): string {
 }
 
 export function rewriteWorkspaceRanges(packageJsonContent: string): string {
-  // Rewrite only dependency entries collected from the parsed manifest: a blanket
-  // `"workspace:..."` replacement would also corrupt unrelated string values (e.g. a
-  // description starting with `workspace:`) in the manifest npm publishes.
-  let content = packageJsonContent;
-  for (const { name } of collectWorkspaceDependencies(packageJsonContent)) {
-    content = content.replaceAll(new RegExp(`("${escapeRegExp(name)}"\\s*:\\s*)"workspace:[^"]*"`, 'gu'), '$1"*"');
-  }
-  return content;
+  // Operate only inside the dependency sections: a blanket `"workspace:..."` replacement would
+  // also corrupt unrelated string values (e.g. a description starting with `workspace:`), and a
+  // name-keyed global replacement would touch same-named keys in other sections (e.g. overrides).
+  return replaceInDependencySections(packageJsonContent, (section) =>
+    section.replaceAll(/("[^"\n]+"\s*:\s*)"workspace:[^"]*"/gu, '$1"*"')
+  );
 }
 
+/**
+ * Re-apply the original `workspace:` specifiers to the CURRENT manifest content. Matching keys
+ * off the dependency NAME (not the `"*"` placeholder) is deliberate: multi-semantic-release's
+ * prepare step overwrites local dependency specifiers with concrete released versions, and the
+ * committed manifest must get its `workspace:` protocol back regardless — Bun requires the
+ * protocol so a cold install links the workspace instead of resolving a registry copy.
+ */
 export function restoreWorkspaceRanges(currentContent: string, originalContent: string): string {
-  let content = currentContent;
-  for (const { name, specifier } of collectWorkspaceDependencies(originalContent)) {
-    content = content.replaceAll(
-      new RegExp(`("${escapeRegExp(name)}"\\s*:\\s*)"\\*"`, 'gu'),
-      `$1${JSON.stringify(specifier)}`
-    );
-  }
-  return content;
+  const workspaceDependencies = collectWorkspaceDependencies(originalContent);
+  return replaceInDependencySections(currentContent, (section) => {
+    let result = section;
+    for (const { name, specifier } of workspaceDependencies) {
+      result = result.replaceAll(
+        new RegExp(`("${escapeRegExp(name)}"\\s*:\\s*)"[^"]*"`, 'gu'),
+        // A replacer function, not a replacement string: specifiers containing `$` must be
+        // inserted literally instead of being interpreted as substitution patterns.
+        (_match, prefix: string) => `${prefix}${JSON.stringify(specifier)}`
+      );
+    }
+    return result;
+  });
+}
+
+/** Dependency sections contain only `"name": "specifier"` string pairs, so `[^{}]*` spans them. */
+function replaceInDependencySections(content: string, replaceSection: (section: string) => string): string {
+  return content.replaceAll(
+    /("(?:dependencies|devDependencies|optionalDependencies|peerDependencies)"\s*:\s*\{)([^{}]*)(\})/gu,
+    (_match, prefix: string, body: string, suffix: string) => `${prefix}${replaceSection(body)}${suffix}`
+  );
 }
 
 function collectWorkspaceDependencies(packageJsonContent: string): { name: string; specifier: string }[] {
@@ -222,7 +244,10 @@ function runSemanticRelease(project: Project, argv: ReleaseArgv): number {
       ? 'multi-semantic-release'
       : 'semantic-release';
 
-  const env = { ...process.env };
+  // The project is loaded with loadEnv: false (semantic-release runs with the ambient/CI
+  // environment by design), so project.env aliases process.env here; using it keeps the
+  // project.env convention and picks up env loading if that design ever changes.
+  const env = { ...project.env };
   prependNodeModulesBinToPath(project.dirPath, env);
   const hasLocalBin = fs.existsSync(path.join(project.dirPath, 'node_modules', '.bin', releaseBin));
   const command = hasLocalBin

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -204,44 +204,46 @@ async function collectNestedPrivatePackages(
     extractedPackage.kind === 'registry'
       ? toStagedPath(extractedPackage.targetDirPath)
       : extractedPackage.targetDirPath;
-  const packageJsonPath = path.join(extractedDirPath, 'package.json');
-  if (!fs.existsSync(packageJsonPath)) return;
-
-  for (const nested of findPrivateDependencies(
-    await readPackageJson(packageJsonPath),
-    outDirPath,
-    registryOutDirPath
-  )) {
-    const existing = privatePackages.get(nested.name);
-    if (existing) {
-      // Collapsing different requested versions into one materialization would silently violate
-      // the dependent's requirement, so conflicts must fail loudly.
-      assertNoVersionConflict(existing, nested, extractedPackage.name);
-      continue;
-    }
-
-    if (nested.kind === 'git') {
-      nested.sourceDirPath = findInstalledPackageDir(rootDirPath, nested.name);
-      await copyGitPackage(rootDirPath, nested);
-    } else {
-      await downloadAndExtractRegistryPackage(
-        auth,
-        nested.name,
-        nested.versionSpecifier ?? 'latest',
-        toStagedPath(nested.targetDirPath)
-      );
-      console.info(`Downloaded ${nested.name} (nested dependency) to ${nested.targetDirPath}`);
-    }
-    privatePackages.set(nested.name, nested);
-    await collectNestedPrivatePackages(
-      rootDirPath,
-      auth,
-      nested,
-      privatePackages,
+  // Scan EVERY manifest of the materialized package (org git dependencies are whole monorepo
+  // checkouts with packages/*/package.json), mirroring collectPrivatePackages' deep scan — the
+  // dependency-rewrite step walks the same set, so anything declared there must be materialized.
+  for (const packageJsonPath of await findPackageJsonPaths(extractedDirPath)) {
+    for (const nested of findPrivateDependencies(
+      await readPackageJson(packageJsonPath),
       outDirPath,
-      registryOutDirPath,
-      toStagedPath
-    );
+      registryOutDirPath
+    )) {
+      const existing = privatePackages.get(nested.name);
+      if (existing) {
+        // Collapsing different requested versions into one materialization would silently violate
+        // the dependent's requirement, so conflicts must fail loudly.
+        assertNoVersionConflict(existing, nested, extractedPackage.name);
+        continue;
+      }
+
+      if (nested.kind === 'git') {
+        nested.sourceDirPath = findInstalledPackageDir(rootDirPath, nested.name);
+        await copyGitPackage(rootDirPath, nested);
+      } else {
+        await downloadAndExtractRegistryPackage(
+          auth,
+          nested.name,
+          nested.versionSpecifier ?? 'latest',
+          toStagedPath(nested.targetDirPath)
+        );
+        console.info(`Downloaded ${nested.name} (nested dependency) to ${nested.targetDirPath}`);
+      }
+      privatePackages.set(nested.name, nested);
+      await collectNestedPrivatePackages(
+        rootDirPath,
+        auth,
+        nested,
+        privatePackages,
+        outDirPath,
+        registryOutDirPath,
+        toStagedPath
+      );
+    }
   }
 }
 
@@ -311,17 +313,27 @@ function findInstalledPackageDir(rootDirPath: string, packageName: string): stri
     return fs.realpathSync(directDirPath);
   }
   // Bun's isolated linker keeps transitive-only dependencies out of the root node_modules;
-  // search the .bun store for the package before giving up.
+  // search the .bun store for the package before giving up. The store may legitimately hold
+  // MULTIPLE resolutions of one package (different versions/revisions), and picking an arbitrary
+  // one could silently materialize the wrong content — so ambiguity fails loudly.
   const bunStoreDirPath = path.join(rootDirPath, 'node_modules', '.bun');
+  const candidateDirPaths = new Set<string>();
   try {
     for (const dirent of fs.readdirSync(bunStoreDirPath, { withFileTypes: true })) {
       const candidateDirPath = path.join(bunStoreDirPath, dirent.name, 'node_modules', '@willbooster', unscopedName);
       if (fs.existsSync(path.join(candidateDirPath, 'package.json'))) {
-        return fs.realpathSync(candidateDirPath);
+        candidateDirPaths.add(fs.realpathSync(candidateDirPath));
       }
     }
   } catch {
     // No .bun store (hoisted install); fall through to the error below.
+  }
+  if (candidateDirPaths.size === 1) return [...candidateDirPaths][0]!;
+  if (candidateDirPaths.size > 1) {
+    throw new Error(
+      `Multiple installed resolutions found for ${packageName}: ${[...candidateDirPaths].join(', ')}. ` +
+        'Deduplicate the dependency so a single resolution remains.'
+    );
   }
   throw new Error(`Private package is not installed: ${packageName} (${directDirPath})`);
 }

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -10,9 +10,12 @@ import type { PrivateRegistryAuth } from '../utils/privateRegistry.js';
 import {
   PRIVATE_REGISTRY_SCOPE,
   downloadAndExtractRegistryPackage,
+  isExactVersion,
   isPrivateGitDependency,
   isPrivateRegistryDependency,
+  rangeAdmits,
   resolvePrivateRegistryAuth,
+  toBaseVersion,
 } from '../utils/privateRegistry.js';
 
 interface PrivatePackage {
@@ -51,10 +54,11 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     // Registry packages always materialize at the repository root: `wb optimizeForDockerBuild`
     // resolves them from `<root>/@willbooster-private` regardless of `--out-dir`.
     const registryOutDirPath = path.join(projects.root.dirPath, PRIVATE_REGISTRY_SCOPE);
-    if (outDirPath === registryOutDirPath) {
-      // e.g. `--out-dir @willbooster-private`: the registry download step would delete the git
-      // packages copied into the aliased directory moments earlier.
-      console.error(chalk.red(`--out-dir must not be the ${PRIVATE_REGISTRY_SCOPE} registry output directory itself.`));
+    if (pathsOverlap(outDirPath, registryOutDirPath)) {
+      // e.g. `--out-dir @willbooster-private` or `--out-dir @willbooster-private/sub`: the
+      // registry step recursively deletes registryOutDirPath, which would destroy the git
+      // packages copied into an equal or NESTED directory moments earlier.
+      console.error(chalk.red(`--out-dir must not overlap the ${PRIVATE_REGISTRY_SCOPE} registry output directory.`));
       process.exit(1);
     }
     if (path.relative(projects.root.dirPath, outDirPath) !== '@willbooster') {
@@ -280,39 +284,14 @@ function assertNoVersionConflict(existing: PrivatePackage, requested: PrivatePac
   );
 }
 
-/** The version the specifier resolves to under the degrade-ranges rule, or undefined for tags/git. */
-function toBaseVersion(specifier: string | undefined): string | undefined {
-  if (!specifier) return;
-  const base = specifier.replace(/^[\^~]/, '');
-  return /^\d+\.\d+\.\d+/.test(base) ? base : undefined;
+/** Whether the two paths are equal or one contains the other. */
+function pathsOverlap(a: string, b: string): boolean {
+  return isEqualOrAncestorPath(a, b) || isEqualOrAncestorPath(b, a);
 }
 
-/** Simplified semver: `^` admits same-major >= base, `~` admits same-major.minor >= base. */
-function rangeAdmits(range: string, version: string): boolean {
-  const baseVersion = parseVersion(range.replace(/^[\^~]/, ''));
-  const candidate = parseVersion(version);
-  if (!baseVersion || !candidate) return false;
-  if (range.startsWith('^')) {
-    return candidate[0] === baseVersion[0] && compareVersions(candidate, baseVersion) >= 0;
-  }
-  if (range.startsWith('~')) {
-    return (
-      candidate[0] === baseVersion[0] && candidate[1] === baseVersion[1] && compareVersions(candidate, baseVersion) >= 0
-    );
-  }
-  return false;
-}
-
-function parseVersion(version: string): [number, number, number] | undefined {
-  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
-  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : undefined;
-}
-
-function compareVersions(a: [number, number, number], b: [number, number, number]): number {
-  for (let index = 0; index < 3; index++) {
-    if (a[index]! !== b[index]!) return a[index]! - b[index]!;
-  }
-  return 0;
+function isEqualOrAncestorPath(ancestorPath: string, descendantPath: string): boolean {
+  const relativePath = path.relative(ancestorPath, descendantPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
 }
 
 function assertSubdirectory(rootDirPath: string, outDirPath: string): void {
@@ -388,11 +367,6 @@ function findPrivateDependencies(
 
 /**
  * A manifest may legitimately request one package from several dependency sections (e.g. an exact
- * devDependencies pin alongside a peerDependencies range): prefer the exact pin, and fail loudly
- * only when the requirements genuinely diverge.
- */
-/**
- * A manifest may legitimately request one package from several dependency sections (e.g. an exact
  * devDependencies pin alongside a peerDependencies range). Prefer the exact pin when the other
  * side is a range admitting it (that pin becomes the materialized version); fail loudly when the
  * requirements genuinely diverge.
@@ -418,10 +392,6 @@ function mergeSameManifestRequirement(existing: PrivatePackage, requested: Priva
     `Conflicting requirements for ${existing.name} within one manifest: ` +
       `${existing.versionSpecifier ?? existing.kind} vs ${requested.versionSpecifier ?? requested.kind}.`
   );
-}
-
-function isExactVersion(specifier: string | undefined): boolean {
-  return !!specifier && /^\d/.test(specifier);
 }
 
 async function replacePrivateDependencies(

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -6,11 +6,20 @@ import type { PackageJson } from 'type-fest';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
 import { findRootAndSelfProjects } from '../project.js';
+import {
+  PRIVATE_REGISTRY_SCOPE,
+  downloadAndExtractRegistryPackage,
+  isPrivateRegistryDependency,
+  resolvePrivateRegistryAuth,
+} from '../utils/privateRegistry.js';
 
 interface PrivatePackage {
   name: string;
-  sourceDirPath: string;
+  kind: 'git' | 'registry';
+  /** Undefined for registry packages, which are downloaded instead of copied. */
+  sourceDirPath: string | undefined;
   targetDirPath: string;
+  versionSpecifier: string | undefined;
 }
 
 const dependencyKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
@@ -26,7 +35,8 @@ const builder = {
 
 export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, InferredOptionTypes<typeof builder>> = {
   command: 'setup-private-packages',
-  describe: 'Copy private git dependencies for Docker builds',
+  describe:
+    'Materialize private dependencies for Docker builds: copy git dependencies and download @willbooster-private/* registry packages (auth via .npmrc / ~/.npmrc locally, or VERDACCIO_TOKEN on CI)',
   builder,
   async handler(argv) {
     const projects = findRootAndSelfProjects(argv, false);
@@ -37,21 +47,32 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
 
     const outDirPath = path.resolve(projects.root.dirPath, argv.outDir);
     assertSubdirectory(projects.root.dirPath, outDirPath);
-    const copiedPackages = await collectPrivatePackages(projects.root.dirPath, projects.root.packageJson, outDirPath);
+    const registryOutDirPath = path.join(path.dirname(outDirPath), PRIVATE_REGISTRY_SCOPE);
+    assertSubdirectory(projects.root.dirPath, registryOutDirPath);
+    const privatePackages = await collectPrivatePackages(
+      projects.root.dirPath,
+      projects.root.packageJson,
+      outDirPath,
+      registryOutDirPath
+    );
 
     if (argv.dryRun) {
-      printDryRunResult(outDirPath, copiedPackages);
+      printDryRunResult(outDirPath, privatePackages);
       return;
     }
 
+    const copiedPackages = [...privatePackages.values()].filter((p) => p.kind === 'git');
+    const registryPackages = [...privatePackages.values()].filter((p) => p.kind === 'registry');
     await fs.promises.rm(outDirPath, { recursive: true, force: true });
-    await fs.promises.mkdir(outDirPath, { recursive: true });
-    for (const privatePackage of copiedPackages.values()) {
-      await fs.promises.cp(privatePackage.sourceDirPath, privatePackage.targetDirPath, {
+    if (copiedPackages.length > 0) {
+      await fs.promises.mkdir(outDirPath, { recursive: true });
+    }
+    for (const privatePackage of copiedPackages) {
+      await fs.promises.cp(privatePackage.sourceDirPath!, privatePackage.targetDirPath, {
         recursive: true,
         force: true,
         filter: (src) => {
-          const segments = path.relative(privatePackage.sourceDirPath, src).split(path.sep);
+          const segments = path.relative(privatePackage.sourceDirPath!, src).split(path.sep);
           return !segments.includes('node_modules') && !segments.includes('.git');
         },
       });
@@ -60,40 +81,101 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       );
     }
 
-    await replacePrivateGitDependencies(outDirPath, copiedPackages);
+    await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
+    if (registryPackages.length > 0) {
+      const auth = resolvePrivateRegistryAuth(projects.root.dirPath);
+      if (!auth) {
+        console.error(
+          chalk.red(
+            `No registry configured for the ${PRIVATE_REGISTRY_SCOPE} scope; add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc.`
+          )
+        );
+        process.exit(1);
+      }
+      for (const privatePackage of registryPackages) {
+        await downloadAndExtractRegistryPackage(
+          auth,
+          privatePackage.name,
+          privatePackage.versionSpecifier ?? 'latest',
+          privatePackage.targetDirPath
+        );
+        console.info(
+          `Downloaded ${privatePackage.name} to ${path.relative(projects.root.dirPath, privatePackage.targetDirPath)}`
+        );
+        // A downloaded package may itself depend on private packages that were not visible before
+        // extraction; materialize them too.
+        await collectNestedPrivatePackages(privatePackage, privatePackages, outDirPath, registryOutDirPath);
+      }
+    }
+
+    await replacePrivateDependencies(projects.root.dirPath, privatePackages);
   },
 };
 
 async function collectPrivatePackages(
   rootDirPath: string,
   rootPackageJson: PackageJson,
-  outDirPath: string
+  outDirPath: string,
+  registryOutDirPath: string
 ): Promise<Map<string, PrivatePackage>> {
-  const copiedPackages = new Map<string, PrivatePackage>();
+  const privatePackages = new Map<string, PrivatePackage>();
   // Start from the root package.json by design; workspace package dependencies are outside this command's target.
-  const packageNamesToCopy = findPrivateGitDependencyNames(rootPackageJson);
-  const queuedPackageNames = new Set(packageNamesToCopy);
+  const packagesToProcess = findPrivateDependencies(rootPackageJson, outDirPath, registryOutDirPath);
+  const queuedPackageNames = new Set(packagesToProcess.map((p) => p.name));
 
-  for (let index = 0; index < packageNamesToCopy.length; index++) {
-    const packageName = packageNamesToCopy[index];
-    if (!packageName) continue;
-    if (copiedPackages.has(packageName)) continue;
+  for (let index = 0; index < packagesToProcess.length; index++) {
+    const privatePackage = packagesToProcess[index];
+    if (!privatePackage) continue;
+    if (privatePackages.has(privatePackage.name)) continue;
 
-    const privatePackage = buildPrivatePackage(rootDirPath, outDirPath, packageName);
-    copiedPackages.set(packageName, privatePackage);
-
-    for (const packageJsonPath of await findPackageJsonPaths(privatePackage.sourceDirPath)) {
-      const packageJson = await readPackageJson(packageJsonPath);
-      for (const nestedPackageName of findPrivateGitDependencyNames(packageJson)) {
-        if (!queuedPackageNames.has(nestedPackageName)) {
-          queuedPackageNames.add(nestedPackageName);
-          packageNamesToCopy.push(nestedPackageName);
+    if (privatePackage.kind === 'git') {
+      privatePackage.sourceDirPath = findInstalledPackageDir(rootDirPath, privatePackage.name);
+      // Nested private dependencies of an installed git package are discoverable right away;
+      // registry packages are inspected after download instead (collectNestedPrivatePackages).
+      for (const packageJsonPath of await findPackageJsonPaths(privatePackage.sourceDirPath)) {
+        const packageJson = await readPackageJson(packageJsonPath);
+        for (const nested of findPrivateDependencies(packageJson, outDirPath, registryOutDirPath)) {
+          if (!queuedPackageNames.has(nested.name)) {
+            queuedPackageNames.add(nested.name);
+            packagesToProcess.push(nested);
+          }
         }
       }
     }
+    privatePackages.set(privatePackage.name, privatePackage);
   }
 
-  return copiedPackages;
+  return privatePackages;
+}
+
+async function collectNestedPrivatePackages(
+  extractedPackage: PrivatePackage,
+  privatePackages: Map<string, PrivatePackage>,
+  outDirPath: string,
+  registryOutDirPath: string
+): Promise<void> {
+  const packageJsonPath = path.join(extractedPackage.targetDirPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) return;
+
+  for (const nested of findPrivateDependencies(
+    await readPackageJson(packageJsonPath),
+    outDirPath,
+    registryOutDirPath
+  )) {
+    if (privatePackages.has(nested.name) || nested.kind !== 'registry') continue;
+
+    const auth = resolvePrivateRegistryAuth(path.dirname(registryOutDirPath));
+    if (!auth) continue;
+    await downloadAndExtractRegistryPackage(
+      auth,
+      nested.name,
+      nested.versionSpecifier ?? 'latest',
+      nested.targetDirPath
+    );
+    console.info(`Downloaded ${nested.name} (nested dependency) to ${nested.targetDirPath}`);
+    privatePackages.set(nested.name, nested);
+    await collectNestedPrivatePackages(nested, privatePackages, outDirPath, registryOutDirPath);
+  }
 }
 
 function assertSubdirectory(rootDirPath: string, outDirPath: string): void {
@@ -104,49 +186,61 @@ function assertSubdirectory(rootDirPath: string, outDirPath: string): void {
   process.exit(1);
 }
 
-function buildPrivatePackage(rootDirPath: string, outDirPath: string, packageName: string): PrivatePackage {
-  const unscopedPackageName = toUnscopedPackageName(packageName);
-  const sourceDirPath = path.join(rootDirPath, 'node_modules', '@willbooster', unscopedPackageName);
+function findInstalledPackageDir(rootDirPath: string, packageName: string): string {
+  const sourceDirPath = path.join(rootDirPath, 'node_modules', '@willbooster', toUnscopedPackageName(packageName));
   if (!fs.existsSync(path.join(sourceDirPath, 'package.json'))) {
     throw new Error(`Private package is not installed: ${packageName} (${sourceDirPath})`);
   }
-
-  return {
-    name: packageName,
-    sourceDirPath,
-    targetDirPath: path.join(outDirPath, unscopedPackageName),
-  };
+  return sourceDirPath;
 }
 
-function findPrivateGitDependencyNames(packageJson: PackageJson): string[] {
-  const packageNames: string[] = [];
+function findPrivateDependencies(
+  packageJson: PackageJson,
+  outDirPath: string,
+  registryOutDirPath: string
+): PrivatePackage[] {
+  const privatePackages = new Map<string, PrivatePackage>();
   for (const key of dependencyKeys) {
     const dependencies = packageJson[key];
     if (!dependencies) continue;
 
     for (const [name, value] of Object.entries(dependencies)) {
-      if (!isPrivateGitDependency(value)) continue;
-
-      if (!name.startsWith('@willbooster/')) {
-        throw new Error(`Private git dependency must be an @willbooster package: ${name}`);
+      if (isPrivateGitDependency(value)) {
+        if (!name.startsWith('@willbooster/')) {
+          throw new Error(`Private git dependency must be an @willbooster package: ${name}`);
+        }
+        privatePackages.set(name, {
+          name,
+          kind: 'git',
+          sourceDirPath: undefined,
+          targetDirPath: path.join(outDirPath, toUnscopedPackageName(name)),
+          versionSpecifier: undefined,
+        });
+      } else if (isPrivateRegistryDependency(name, value)) {
+        privatePackages.set(name, {
+          name,
+          kind: 'registry',
+          sourceDirPath: undefined,
+          targetDirPath: path.join(registryOutDirPath, toUnscopedPackageName(name)),
+          versionSpecifier: value,
+        });
       }
-      packageNames.push(name);
     }
   }
-  return [...new Set(packageNames)];
+  return [...privatePackages.values()];
 }
 
-async function replacePrivateGitDependencies(
-  outDirPath: string,
-  copiedPackages: Map<string, PrivatePackage>
+async function replacePrivateDependencies(
+  rootDirPath: string,
+  privatePackages: Map<string, PrivatePackage>
 ): Promise<void> {
-  for (const privatePackage of copiedPackages.values()) {
+  for (const privatePackage of privatePackages.values()) {
     for (const packageJsonPath of await findPackageJsonPaths(privatePackage.targetDirPath)) {
       const packageJson = await readPackageJson(packageJsonPath);
-      if (!replacePackageJsonDependencies(packageJsonPath, packageJson, copiedPackages)) continue;
+      if (!replacePackageJsonDependencies(packageJsonPath, packageJson, privatePackages)) continue;
 
       await fs.promises.writeFile(packageJsonPath, `${JSON.stringify(packageJson, undefined, 2)}\n`, 'utf8');
-      console.info(`Rewrote private dependencies in ${path.relative(outDirPath, packageJsonPath)}`);
+      console.info(`Rewrote private dependencies in ${path.relative(rootDirPath, packageJsonPath)}`);
     }
   }
 }
@@ -154,7 +248,7 @@ async function replacePrivateGitDependencies(
 function replacePackageJsonDependencies(
   packageJsonPath: string,
   packageJson: PackageJson,
-  copiedPackages: Map<string, PrivatePackage>
+  privatePackages: Map<string, PrivatePackage>
 ): boolean {
   let changed = false;
   for (const key of dependencyKeys) {
@@ -162,8 +256,8 @@ function replacePackageJsonDependencies(
     if (!dependencies) continue;
 
     for (const [name, value] of Object.entries(dependencies)) {
-      if (!isPrivateGitDependency(value)) continue;
-      const targetPackage = copiedPackages.get(name);
+      if (!isPrivateGitDependency(value) && !isPrivateRegistryDependency(name, value)) continue;
+      const targetPackage = privatePackages.get(name);
       if (!targetPackage) continue;
 
       dependencies[name] = `file:${path.relative(path.dirname(packageJsonPath), targetPackage.targetDirPath)}`;
@@ -174,6 +268,8 @@ function replacePackageJsonDependencies(
 }
 
 async function findPackageJsonPaths(dirPath: string): Promise<string[]> {
+  if (!fs.existsSync(dirPath)) return [];
+
   const packageJsonPaths: string[] = [];
   for (const dirent of await fs.promises.readdir(dirPath, { withFileTypes: true })) {
     if (dirent.name === 'node_modules' || dirent.name === '.git') continue;
@@ -199,13 +295,17 @@ function isPrivateGitDependency(value: unknown): value is string {
 }
 
 function toUnscopedPackageName(packageName: string): string {
-  return packageName.replace(/^@willbooster\//, '');
+  return packageName.replace(/^@willbooster(?:-private)?\//, '');
 }
 
-function printDryRunResult(outDirPath: string, copiedPackages: Map<string, PrivatePackage>): void {
+function printDryRunResult(outDirPath: string, privatePackages: Map<string, PrivatePackage>): void {
   console.info(`[dry-run] Would recreate ${outDirPath}`);
-  for (const privatePackage of copiedPackages.values()) {
-    console.info(`[dry-run] Would copy ${privatePackage.name}: ${privatePackage.sourceDirPath}`);
+  for (const privatePackage of privatePackages.values()) {
+    console.info(
+      privatePackage.kind === 'git'
+        ? `[dry-run] Would copy ${privatePackage.name}: ${privatePackage.sourceDirPath ?? '(installed under node_modules)'}`
+        : `[dry-run] Would download ${privatePackage.name}@${privatePackage.versionSpecifier} to ${privatePackage.targetDirPath}`
+    );
   }
-  console.info(`[dry-run] Would rewrite copied private git dependencies to file:../<name>`);
+  console.info(`[dry-run] Would rewrite copied private dependencies to file:../<name>`);
 }

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -6,6 +6,7 @@ import type { PackageJson } from 'type-fest';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
 import { findRootAndSelfProjects } from '../project.js';
+import type { PrivateRegistryAuth } from '../utils/privateRegistry.js';
 import {
   PRIVATE_REGISTRY_SCOPE,
   downloadAndExtractRegistryPackage,
@@ -49,6 +50,12 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     assertSubdirectory(projects.root.dirPath, outDirPath);
     const registryOutDirPath = path.join(path.dirname(outDirPath), PRIVATE_REGISTRY_SCOPE);
     assertSubdirectory(projects.root.dirPath, registryOutDirPath);
+    if (outDirPath === registryOutDirPath) {
+      // e.g. `--out-dir @willbooster-private`: the registry download step would delete the git
+      // packages copied into the aliased directory moments earlier.
+      console.error(chalk.red(`--out-dir must not be the ${PRIVATE_REGISTRY_SCOPE} registry output directory itself.`));
+      process.exit(1);
+    }
     const privatePackages = await collectPrivatePackages(
       projects.root.dirPath,
       projects.root.packageJson,
@@ -63,35 +70,28 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
 
     const copiedPackages = [...privatePackages.values()].filter((p) => p.kind === 'git');
     const registryPackages = [...privatePackages.values()].filter((p) => p.kind === 'registry');
+    // Resolve required configuration BEFORE deleting the existing materializations, so a missing
+    // registry configuration cannot destroy a previously usable output tree.
+    const auth = registryPackages.length > 0 ? resolvePrivateRegistryAuth(projects.root.dirPath) : undefined;
+    if (registryPackages.length > 0 && !auth) {
+      console.error(
+        chalk.red(
+          `No registry configured for the ${PRIVATE_REGISTRY_SCOPE} scope; add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc.`
+        )
+      );
+      process.exit(1);
+    }
+
     await fs.promises.rm(outDirPath, { recursive: true, force: true });
     if (copiedPackages.length > 0) {
       await fs.promises.mkdir(outDirPath, { recursive: true });
     }
     for (const privatePackage of copiedPackages) {
-      await fs.promises.cp(privatePackage.sourceDirPath!, privatePackage.targetDirPath, {
-        recursive: true,
-        force: true,
-        filter: (src) => {
-          const segments = path.relative(privatePackage.sourceDirPath!, src).split(path.sep);
-          return !segments.includes('node_modules') && !segments.includes('.git');
-        },
-      });
-      console.info(
-        `Copied ${privatePackage.name} to ${path.relative(projects.root.dirPath, privatePackage.targetDirPath)}`
-      );
+      await copyGitPackage(projects.root.dirPath, privatePackage);
     }
 
     await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
-    if (registryPackages.length > 0) {
-      const auth = resolvePrivateRegistryAuth(projects.root.dirPath);
-      if (!auth) {
-        console.error(
-          chalk.red(
-            `No registry configured for the ${PRIVATE_REGISTRY_SCOPE} scope; add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc.`
-          )
-        );
-        process.exit(1);
-      }
+    if (auth) {
       for (const privatePackage of registryPackages) {
         await downloadAndExtractRegistryPackage(
           auth,
@@ -104,7 +104,14 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
         );
         // A downloaded package may itself depend on private packages that were not visible before
         // extraction; materialize them too.
-        await collectNestedPrivatePackages(privatePackage, privatePackages, outDirPath, registryOutDirPath);
+        await collectNestedPrivatePackages(
+          projects.root.dirPath,
+          auth,
+          privatePackage,
+          privatePackages,
+          outDirPath,
+          registryOutDirPath
+        );
       }
     }
 
@@ -121,7 +128,7 @@ async function collectPrivatePackages(
   const privatePackages = new Map<string, PrivatePackage>();
   // Start from the root package.json by design; workspace package dependencies are outside this command's target.
   const packagesToProcess = findPrivateDependencies(rootPackageJson, outDirPath, registryOutDirPath);
-  const queuedPackageNames = new Set(packagesToProcess.map((p) => p.name));
+  const queuedPackages = new Map(packagesToProcess.map((p) => [p.name, p]));
 
   for (let index = 0; index < packagesToProcess.length; index++) {
     const privatePackage = packagesToProcess[index];
@@ -135,8 +142,11 @@ async function collectPrivatePackages(
       for (const packageJsonPath of await findPackageJsonPaths(privatePackage.sourceDirPath)) {
         const packageJson = await readPackageJson(packageJsonPath);
         for (const nested of findPrivateDependencies(packageJson, outDirPath, registryOutDirPath)) {
-          if (!queuedPackageNames.has(nested.name)) {
-            queuedPackageNames.add(nested.name);
+          const queued = queuedPackages.get(nested.name);
+          if (queued) {
+            assertNoVersionConflict(queued, nested, privatePackage.name);
+          } else {
+            queuedPackages.set(nested.name, nested);
             packagesToProcess.push(nested);
           }
         }
@@ -149,6 +159,8 @@ async function collectPrivatePackages(
 }
 
 async function collectNestedPrivatePackages(
+  rootDirPath: string,
+  auth: PrivateRegistryAuth,
   extractedPackage: PrivatePackage,
   privatePackages: Map<string, PrivatePackage>,
   outDirPath: string,
@@ -162,20 +174,51 @@ async function collectNestedPrivatePackages(
     outDirPath,
     registryOutDirPath
   )) {
-    if (privatePackages.has(nested.name) || nested.kind !== 'registry') continue;
+    const existing = privatePackages.get(nested.name);
+    if (existing) {
+      // Collapsing different requested versions into one materialization would silently violate
+      // the dependent's requirement, so conflicts must fail loudly.
+      assertNoVersionConflict(existing, nested, extractedPackage.name);
+      continue;
+    }
 
-    const auth = resolvePrivateRegistryAuth(path.dirname(registryOutDirPath));
-    if (!auth) continue;
-    await downloadAndExtractRegistryPackage(
-      auth,
-      nested.name,
-      nested.versionSpecifier ?? 'latest',
-      nested.targetDirPath
-    );
-    console.info(`Downloaded ${nested.name} (nested dependency) to ${nested.targetDirPath}`);
+    if (nested.kind === 'git') {
+      nested.sourceDirPath = findInstalledPackageDir(rootDirPath, nested.name);
+      await copyGitPackage(rootDirPath, nested);
+    } else {
+      await downloadAndExtractRegistryPackage(
+        auth,
+        nested.name,
+        nested.versionSpecifier ?? 'latest',
+        nested.targetDirPath
+      );
+      console.info(`Downloaded ${nested.name} (nested dependency) to ${nested.targetDirPath}`);
+    }
     privatePackages.set(nested.name, nested);
-    await collectNestedPrivatePackages(nested, privatePackages, outDirPath, registryOutDirPath);
+    await collectNestedPrivatePackages(rootDirPath, auth, nested, privatePackages, outDirPath, registryOutDirPath);
   }
+}
+
+async function copyGitPackage(rootDirPath: string, privatePackage: PrivatePackage): Promise<void> {
+  await fs.promises.cp(privatePackage.sourceDirPath!, privatePackage.targetDirPath, {
+    recursive: true,
+    force: true,
+    filter: (src) => {
+      const segments = path.relative(privatePackage.sourceDirPath!, src).split(path.sep);
+      return !segments.includes('node_modules') && !segments.includes('.git');
+    },
+  });
+  console.info(`Copied ${privatePackage.name} to ${path.relative(rootDirPath, privatePackage.targetDirPath)}`);
+}
+
+function assertNoVersionConflict(existing: PrivatePackage, requested: PrivatePackage, dependentName: string): void {
+  if (existing.kind === requested.kind && existing.versionSpecifier === requested.versionSpecifier) return;
+
+  throw new Error(
+    `Conflicting requirements for ${existing.name}: ` +
+      `${existing.versionSpecifier ?? existing.kind} is already selected, but ${dependentName} requires ` +
+      `${requested.versionSpecifier ?? requested.kind}. Only a single version per private package is supported.`
+  );
 }
 
 function assertSubdirectory(rootDirPath: string, outDirPath: string): void {
@@ -205,26 +248,25 @@ function findPrivateDependencies(
     if (!dependencies) continue;
 
     for (const [name, value] of Object.entries(dependencies)) {
-      if (isPrivateGitDependency(value)) {
-        if (!name.startsWith('@willbooster/')) {
-          throw new Error(`Private git dependency must be an @willbooster package: ${name}`);
-        }
-        privatePackages.set(name, {
-          name,
-          kind: 'git',
-          sourceDirPath: undefined,
-          targetDirPath: path.join(outDirPath, toUnscopedPackageName(name)),
-          versionSpecifier: undefined,
-        });
-      } else if (isPrivateRegistryDependency(name, value)) {
-        privatePackages.set(name, {
-          name,
-          kind: 'registry',
-          sourceDirPath: undefined,
-          targetDirPath: path.join(registryOutDirPath, toUnscopedPackageName(name)),
-          versionSpecifier: value,
-        });
+      const isGit = isPrivateGitDependency(value);
+      if (!isGit && !isPrivateRegistryDependency(name, value)) continue;
+      if (isGit && !name.startsWith('@willbooster/')) {
+        throw new Error(`Private git dependency must be an @willbooster package: ${name}`);
       }
+      const unscopedName = toUnscopedPackageName(name);
+      // Dependency names become external data once nested manifests come from downloaded
+      // tarballs; reject anything (path separators, `..`, hidden-file prefixes) that could
+      // escape the output directory the name is joined into before it is recursively deleted.
+      if (!/^[\w.-]+$/.test(unscopedName) || unscopedName.startsWith('.')) {
+        throw new Error(`Invalid private package name: ${name}`);
+      }
+      privatePackages.set(name, {
+        name,
+        kind: isGit ? 'git' : 'registry',
+        sourceDirPath: undefined,
+        targetDirPath: path.join(isGit ? outDirPath : registryOutDirPath, unscopedName),
+        versionSpecifier: isGit ? undefined : (value as string),
+      });
     }
   }
   return [...privatePackages.values()];

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -10,6 +10,7 @@ import type { PrivateRegistryAuth } from '../utils/privateRegistry.js';
 import {
   PRIVATE_REGISTRY_SCOPE,
   downloadAndExtractRegistryPackage,
+  isPrivateGitDependency,
   isPrivateRegistryDependency,
   resolvePrivateRegistryAuth,
 } from '../utils/privateRegistry.js';
@@ -24,7 +25,6 @@ interface PrivatePackage {
 }
 
 const dependencyKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
-const privateGitDependencyPattern = /^git@github\.com:(?:WillBooster|WillBoosterLab)\/[^/#]+(?:\.git)?(?:#.*)?$/;
 
 const builder = {
   'out-dir': {
@@ -48,8 +48,9 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
 
     const outDirPath = path.resolve(projects.root.dirPath, argv.outDir);
     assertSubdirectory(projects.root.dirPath, outDirPath);
-    const registryOutDirPath = path.join(path.dirname(outDirPath), PRIVATE_REGISTRY_SCOPE);
-    assertSubdirectory(projects.root.dirPath, registryOutDirPath);
+    // Registry packages always materialize at the repository root: `wb optimizeForDockerBuild`
+    // resolves them from `<root>/@willbooster-private` regardless of `--out-dir`.
+    const registryOutDirPath = path.join(projects.root.dirPath, PRIVATE_REGISTRY_SCOPE);
     if (outDirPath === registryOutDirPath) {
       // e.g. `--out-dir @willbooster-private`: the registry download step would delete the git
       // packages copied into the aliased directory moments earlier.
@@ -83,36 +84,53 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     }
 
     await fs.promises.rm(outDirPath, { recursive: true, force: true });
-    if (copiedPackages.length > 0) {
-      await fs.promises.mkdir(outDirPath, { recursive: true });
-    }
+    // Both output directories always exist afterwards: Dockerfiles COPY them unconditionally,
+    // and a missing source path fails the build.
+    await fs.promises.mkdir(outDirPath, { recursive: true });
     for (const privatePackage of copiedPackages) {
       await copyGitPackage(projects.root.dirPath, privatePackage);
     }
 
-    await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
     if (auth) {
-      for (const privatePackage of registryPackages) {
-        await downloadAndExtractRegistryPackage(
-          auth,
-          privatePackage.name,
-          privatePackage.versionSpecifier ?? 'latest',
-          privatePackage.targetDirPath
-        );
-        console.info(
-          `Downloaded ${privatePackage.name} to ${path.relative(projects.root.dirPath, privatePackage.targetDirPath)}`
-        );
-        // A downloaded package may itself depend on private packages that were not visible before
-        // extraction; materialize them too.
-        await collectNestedPrivatePackages(
-          projects.root.dirPath,
-          auth,
-          privatePackage,
-          privatePackages,
-          outDirPath,
-          registryOutDirPath
-        );
+      // Download into a staging directory and swap it in only after every download succeeded, so
+      // a failing registry/token/extraction cannot destroy the last usable materialization.
+      const stagingDirPath = path.join(projects.root.dirPath, '.tmp', 'wb-private-registry-staging');
+      const toStagedPath = (targetDirPath: string): string =>
+        path.join(stagingDirPath, path.relative(registryOutDirPath, targetDirPath));
+      await fs.promises.rm(stagingDirPath, { recursive: true, force: true });
+      await fs.promises.mkdir(stagingDirPath, { recursive: true });
+      try {
+        for (const privatePackage of registryPackages) {
+          await downloadAndExtractRegistryPackage(
+            auth,
+            privatePackage.name,
+            privatePackage.versionSpecifier ?? 'latest',
+            toStagedPath(privatePackage.targetDirPath)
+          );
+          console.info(
+            `Downloaded ${privatePackage.name} to ${path.relative(projects.root.dirPath, privatePackage.targetDirPath)}`
+          );
+          // A downloaded package may itself depend on private packages that were not visible
+          // before extraction; materialize them too.
+          await collectNestedPrivatePackages(
+            projects.root.dirPath,
+            auth,
+            privatePackage,
+            privatePackages,
+            outDirPath,
+            registryOutDirPath,
+            toStagedPath
+          );
+        }
+        await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
+        await fs.promises.rename(stagingDirPath, registryOutDirPath);
+      } catch (error) {
+        await fs.promises.rm(stagingDirPath, { recursive: true, force: true });
+        throw error;
       }
+    } else {
+      await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
+      await fs.promises.mkdir(registryOutDirPath, { recursive: true });
     }
 
     await replacePrivateDependencies(projects.root.dirPath, privatePackages);
@@ -164,9 +182,12 @@ async function collectNestedPrivatePackages(
   extractedPackage: PrivatePackage,
   privatePackages: Map<string, PrivatePackage>,
   outDirPath: string,
-  registryOutDirPath: string
+  registryOutDirPath: string,
+  toStagedPath: (targetDirPath: string) => string
 ): Promise<void> {
-  const packageJsonPath = path.join(extractedPackage.targetDirPath, 'package.json');
+  // Registry packages still live in the staging directory at this point (they are swapped into
+  // place only after every download succeeded).
+  const packageJsonPath = path.join(toStagedPath(extractedPackage.targetDirPath), 'package.json');
   if (!fs.existsSync(packageJsonPath)) return;
 
   for (const nested of findPrivateDependencies(
@@ -190,12 +211,20 @@ async function collectNestedPrivatePackages(
         auth,
         nested.name,
         nested.versionSpecifier ?? 'latest',
-        nested.targetDirPath
+        toStagedPath(nested.targetDirPath)
       );
       console.info(`Downloaded ${nested.name} (nested dependency) to ${nested.targetDirPath}`);
     }
     privatePackages.set(nested.name, nested);
-    await collectNestedPrivatePackages(rootDirPath, auth, nested, privatePackages, outDirPath, registryOutDirPath);
+    await collectNestedPrivatePackages(
+      rootDirPath,
+      auth,
+      nested,
+      privatePackages,
+      outDirPath,
+      registryOutDirPath,
+      toStagedPath
+    );
   }
 }
 
@@ -203,6 +232,10 @@ async function copyGitPackage(rootDirPath: string, privatePackage: PrivatePackag
   await fs.promises.cp(privatePackage.sourceDirPath!, privatePackage.targetDirPath, {
     recursive: true,
     force: true,
+    // Bun's isolated linker exposes installed packages through symlinks; the materialized tree
+    // must contain real files (a copied absolute symlink would dangle inside the Docker image,
+    // and later dependency rewriting would write through it into the shared store).
+    dereference: true,
     filter: (src) => {
       const segments = path.relative(privatePackage.sourceDirPath!, src).split(path.sep);
       return !segments.includes('node_modules') && !segments.includes('.git');
@@ -230,11 +263,27 @@ function assertSubdirectory(rootDirPath: string, outDirPath: string): void {
 }
 
 function findInstalledPackageDir(rootDirPath: string, packageName: string): string {
-  const sourceDirPath = path.join(rootDirPath, 'node_modules', '@willbooster', toUnscopedPackageName(packageName));
-  if (!fs.existsSync(path.join(sourceDirPath, 'package.json'))) {
-    throw new Error(`Private package is not installed: ${packageName} (${sourceDirPath})`);
+  const unscopedName = toUnscopedPackageName(packageName);
+  // realpathSync resolves the isolated linker's symlink so copies read (and the copy filter
+  // computes relative paths against) the actual package directory.
+  const directDirPath = path.join(rootDirPath, 'node_modules', '@willbooster', unscopedName);
+  if (fs.existsSync(path.join(directDirPath, 'package.json'))) {
+    return fs.realpathSync(directDirPath);
   }
-  return sourceDirPath;
+  // Bun's isolated linker keeps transitive-only dependencies out of the root node_modules;
+  // search the .bun store for the package before giving up.
+  const bunStoreDirPath = path.join(rootDirPath, 'node_modules', '.bun');
+  try {
+    for (const dirent of fs.readdirSync(bunStoreDirPath, { withFileTypes: true })) {
+      const candidateDirPath = path.join(bunStoreDirPath, dirent.name, 'node_modules', '@willbooster', unscopedName);
+      if (fs.existsSync(path.join(candidateDirPath, 'package.json'))) {
+        return fs.realpathSync(candidateDirPath);
+      }
+    }
+  } catch {
+    // No .bun store (hoisted install); fall through to the error below.
+  }
+  throw new Error(`Private package is not installed: ${packageName} (${directDirPath})`);
 }
 
 function findPrivateDependencies(
@@ -260,16 +309,40 @@ function findPrivateDependencies(
       if (!/^[\w.-]+$/.test(unscopedName) || unscopedName.startsWith('.')) {
         throw new Error(`Invalid private package name: ${name}`);
       }
-      privatePackages.set(name, {
+      const requested: PrivatePackage = {
         name,
         kind: isGit ? 'git' : 'registry',
         sourceDirPath: undefined,
         targetDirPath: path.join(isGit ? outDirPath : registryOutDirPath, unscopedName),
         versionSpecifier: isGit ? undefined : (value as string),
-      });
+      };
+      const existing = privatePackages.get(name);
+      privatePackages.set(name, existing ? mergeSameManifestRequirement(existing, requested) : requested);
     }
   }
   return [...privatePackages.values()];
+}
+
+/**
+ * A manifest may legitimately request one package from several dependency sections (e.g. an exact
+ * devDependencies pin alongside a peerDependencies range): prefer the exact pin, and fail loudly
+ * only when the requirements genuinely diverge.
+ */
+function mergeSameManifestRequirement(existing: PrivatePackage, requested: PrivatePackage): PrivatePackage {
+  if (existing.kind === requested.kind && existing.versionSpecifier === requested.versionSpecifier) return existing;
+
+  if (existing.kind === requested.kind) {
+    if (isExactVersion(existing.versionSpecifier) && !isExactVersion(requested.versionSpecifier)) return existing;
+    if (!isExactVersion(existing.versionSpecifier) && isExactVersion(requested.versionSpecifier)) return requested;
+  }
+  throw new Error(
+    `Conflicting requirements for ${existing.name} within one manifest: ` +
+      `${existing.versionSpecifier ?? existing.kind} vs ${requested.versionSpecifier ?? requested.kind}.`
+  );
+}
+
+function isExactVersion(specifier: string | undefined): boolean {
+  return !!specifier && /^\d/.test(specifier);
 }
 
 async function replacePrivateDependencies(
@@ -330,10 +403,6 @@ async function findPackageJsonPaths(dirPath: string): Promise<string[]> {
 
 async function readPackageJson(packageJsonPath: string): Promise<PackageJson> {
   return JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf8')) as PackageJson;
-}
-
-function isPrivateGitDependency(value: unknown): value is string {
-  return typeof value === 'string' && privateGitDependencyPattern.test(value);
 }
 
 function toUnscopedPackageName(packageName: string): string {

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -57,6 +57,14 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       console.error(chalk.red(`--out-dir must not be the ${PRIVATE_REGISTRY_SCOPE} registry output directory itself.`));
       process.exit(1);
     }
+    if (path.relative(projects.root.dirPath, outDirPath) !== '@willbooster') {
+      // Pre-existing limitation of the option: the Docker manifest rewrite has no access to it.
+      console.warn(
+        chalk.yellow(
+          'Note: wb optimizeForDockerBuild rewrites git dependencies to <root>/@willbooster; a custom --out-dir requires a matching Dockerfile layout.'
+        )
+      );
+    }
     const privatePackages = await collectPrivatePackages(
       projects.root.dirPath,
       projects.root.packageJson,
@@ -186,8 +194,13 @@ async function collectNestedPrivatePackages(
   toStagedPath: (targetDirPath: string) => string
 ): Promise<void> {
   // Registry packages still live in the staging directory at this point (they are swapped into
-  // place only after every download succeeded).
-  const packageJsonPath = path.join(toStagedPath(extractedPackage.targetDirPath), 'package.json');
+  // place only after every download succeeded); git packages are copied straight to their final
+  // location, so their manifest must be read there.
+  const extractedDirPath =
+    extractedPackage.kind === 'registry'
+      ? toStagedPath(extractedPackage.targetDirPath)
+      : extractedPackage.targetDirPath;
+  const packageJsonPath = path.join(extractedDirPath, 'package.json');
   if (!fs.existsSync(packageJsonPath)) return;
 
   for (const nested of findPrivateDependencies(
@@ -244,14 +257,62 @@ async function copyGitPackage(rootDirPath: string, privatePackage: PrivatePackag
   console.info(`Copied ${privatePackage.name} to ${path.relative(rootDirPath, privatePackage.targetDirPath)}`);
 }
 
+/**
+ * The materialization for `existing` is already selected (its `^`/`~` range degraded to the base
+ * version — see downloadAndExtractRegistryPackage), so accept `requested` only when that selected
+ * version satisfies it: an exact request must equal it, a `^`/`~` request must admit it, and
+ * non-numeric specifiers (dist-tags, git URLs/revisions) must match exactly.
+ */
 function assertNoVersionConflict(existing: PrivatePackage, requested: PrivatePackage, dependentName: string): void {
-  if (existing.kind === requested.kind && existing.versionSpecifier === requested.versionSpecifier) return;
+  if (existing.kind === requested.kind) {
+    if (existing.versionSpecifier === requested.versionSpecifier) return;
+    const selectedVersion = toBaseVersion(existing.versionSpecifier);
+    if (selectedVersion !== undefined && requested.versionSpecifier !== undefined) {
+      if (isExactVersion(requested.versionSpecifier) && requested.versionSpecifier === selectedVersion) return;
+      if (rangeAdmits(requested.versionSpecifier, selectedVersion)) return;
+    }
+  }
 
   throw new Error(
     `Conflicting requirements for ${existing.name}: ` +
       `${existing.versionSpecifier ?? existing.kind} is already selected, but ${dependentName} requires ` +
       `${requested.versionSpecifier ?? requested.kind}. Only a single version per private package is supported.`
   );
+}
+
+/** The version the specifier resolves to under the degrade-ranges rule, or undefined for tags/git. */
+function toBaseVersion(specifier: string | undefined): string | undefined {
+  if (!specifier) return;
+  const base = specifier.replace(/^[\^~]/, '');
+  return /^\d+\.\d+\.\d+/.test(base) ? base : undefined;
+}
+
+/** Simplified semver: `^` admits same-major >= base, `~` admits same-major.minor >= base. */
+function rangeAdmits(range: string, version: string): boolean {
+  const baseVersion = parseVersion(range.replace(/^[\^~]/, ''));
+  const candidate = parseVersion(version);
+  if (!baseVersion || !candidate) return false;
+  if (range.startsWith('^')) {
+    return candidate[0] === baseVersion[0] && compareVersions(candidate, baseVersion) >= 0;
+  }
+  if (range.startsWith('~')) {
+    return (
+      candidate[0] === baseVersion[0] && candidate[1] === baseVersion[1] && compareVersions(candidate, baseVersion) >= 0
+    );
+  }
+  return false;
+}
+
+function parseVersion(version: string): [number, number, number] | undefined {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : undefined;
+}
+
+function compareVersions(a: [number, number, number], b: [number, number, number]): number {
+  for (let index = 0; index < 3; index++) {
+    if (a[index]! !== b[index]!) return a[index]! - b[index]!;
+  }
+  return 0;
 }
 
 function assertSubdirectory(rootDirPath: string, outDirPath: string): void {
@@ -314,7 +375,9 @@ function findPrivateDependencies(
         kind: isGit ? 'git' : 'registry',
         sourceDirPath: undefined,
         targetDirPath: path.join(isGit ? outDirPath : registryOutDirPath, unscopedName),
-        versionSpecifier: isGit ? undefined : (value as string),
+        // The full git specifier is preserved so divergent URLs/revisions (#abc vs #def) are
+        // detected as conflicts instead of silently collapsing into one copied package.
+        versionSpecifier: value as string,
       };
       const existing = privatePackages.get(name);
       privatePackages.set(name, existing ? mergeSameManifestRequirement(existing, requested) : requested);
@@ -328,12 +391,28 @@ function findPrivateDependencies(
  * devDependencies pin alongside a peerDependencies range): prefer the exact pin, and fail loudly
  * only when the requirements genuinely diverge.
  */
+/**
+ * A manifest may legitimately request one package from several dependency sections (e.g. an exact
+ * devDependencies pin alongside a peerDependencies range). Prefer the exact pin when the other
+ * side is a range admitting it (that pin becomes the materialized version); fail loudly when the
+ * requirements genuinely diverge.
+ */
 function mergeSameManifestRequirement(existing: PrivatePackage, requested: PrivatePackage): PrivatePackage {
-  if (existing.kind === requested.kind && existing.versionSpecifier === requested.versionSpecifier) return existing;
-
   if (existing.kind === requested.kind) {
-    if (isExactVersion(existing.versionSpecifier) && !isExactVersion(requested.versionSpecifier)) return existing;
-    if (!isExactVersion(existing.versionSpecifier) && isExactVersion(requested.versionSpecifier)) return requested;
+    if (existing.versionSpecifier === requested.versionSpecifier) return existing;
+    const [exact, other] = isExactVersion(existing.versionSpecifier) ? [existing, requested] : [requested, existing];
+    if (
+      isExactVersion(exact.versionSpecifier) &&
+      other.versionSpecifier !== undefined &&
+      (other.versionSpecifier === exact.versionSpecifier ||
+        rangeAdmits(other.versionSpecifier, exact.versionSpecifier!) ||
+        toBaseVersion(other.versionSpecifier) === exact.versionSpecifier)
+    ) {
+      return exact;
+    }
+    // Two ranges degrading to the same base version select the same materialization.
+    const baseVersion = toBaseVersion(existing.versionSpecifier);
+    if (baseVersion !== undefined && baseVersion === toBaseVersion(requested.versionSpecifier)) return existing;
   }
   throw new Error(
     `Conflicting requirements for ${existing.name} within one manifest: ` +

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -16,6 +16,7 @@ import { lintCommand } from './commands/lint.js';
 import { maintenanceCommand } from './commands/maintenance.js';
 import { optimizeForDockerBuildCommand } from './commands/optimizeForDockerBuild.js';
 import { prismaCommand } from './commands/prisma.js';
+import { releaseCommand } from './commands/release.js';
 import { retryCommand } from './commands/retry.js';
 import { setupCommand } from './commands/setup.js';
 import { setupPrivatePackagesCommand } from './commands/setupPrivatePackages.js';
@@ -60,6 +61,7 @@ await yargs(hideBin(process.argv))
   .command(maintenanceCommand)
   .command(optimizeForDockerBuildCommand)
   .command(prismaCommand)
+  .command(releaseCommand)
   .command(retryCommand)
   .command(setupCommand)
   .command(setupPrivatePackagesCommand)

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import type { EnvReaderOptions } from '@willbooster/shared-lib-node/src';
 import { readEnvironmentVariables, shouldSuppressEnvironmentOutput } from '@willbooster/shared-lib-node/src';
 import { memoizeOne } from 'at-decorators';
+import chalk from 'chalk';
 import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
 
@@ -142,11 +143,54 @@ export class Project {
       }
     }
     // Spreading envVars last is safe for exported-variable precedence: readEnvironmentVariables
-    // already excludes keys present in process.env from .env/fnox sources. Mise values that
+    // already excludes keys present in process.env from .env/fnox sources (returning a key that
+    // exists in process.env only for deliberate forced-mode overrides). Mise values that
     // differ from the ambient activation are deliberately kept so the requested cascade profile
     // (e.g. `--cascade-env=test`) wins over a stale `mise activate` environment.
     this.envCache = { ...process.env, ...envVars };
+    // `mise env` is excluded: it reports tool-activation output (e.g. PATH) even in repos that
+    // declare no environment variables at all, which must not force the WB_ENV requirement.
+    this.validateRequiredEnvironmentVariables(
+      envPathAndLoadedEnvVarCountPairs.some(([source]) => !source.startsWith('mise env'))
+    );
     return this.envCache;
+  }
+
+  /**
+   * Fail fast when the resolved environment violates the org standard: every mode
+   * (development/test/staging/production) must define `WB_ENV`, and Next.js/vinext apps must also
+   * define `NEXT_PUBLIC_WB_ENV` (see the guidelines-for-mise-fnox skill). Skipped while no env
+   * sources exist yet (e.g. during `wb setup` bootstrap before env files/fnox.toml are created)
+   * and when `WB_SKIP_ENV_CHECK=1` is set.
+   */
+  private validateRequiredEnvironmentVariables(hasEnvironmentSources: boolean): void {
+    const env = this.envCache;
+    if (!env || !hasEnvironmentSources) return;
+    if (env.WB_SKIP_ENV_CHECK === '1' || env.WB_SKIP_ENV_CHECK === 'true') return;
+
+    const missingKeys: string[] = [];
+    if (!env.WB_ENV) missingKeys.push('WB_ENV');
+    if (this.requiresNextPublicWbEnv && !env.NEXT_PUBLIC_WB_ENV) missingKeys.push('NEXT_PUBLIC_WB_ENV');
+    if (missingKeys.length === 0) return;
+
+    const mode =
+      this.argv.cascadeEnv ??
+      (this.argv.cascadeNodeEnv
+        ? process.env.NODE_ENV || 'development'
+        : (process.env.WB_ENV ?? process.env.NODE_ENV ?? 'development'));
+    console.error(
+      chalk.red(
+        `${missingKeys.join(' and ')} ${missingKeys.length === 1 ? 'is' : 'are'} not defined for the "${mode}" environment. ` +
+          `Define ${missingKeys.join(' and ')} in the mode's env source (e.g. .env.${mode} or the fnox "${mode}" profile; see guidelines-for-mise-fnox), ` +
+          'or set WB_SKIP_ENV_CHECK=1 to skip this check.'
+      )
+    );
+    process.exit(1);
+  }
+
+  @memoizeOne
+  private get requiresNextPublicWbEnv(): boolean {
+    return this.hasDependency('next') || this.hasDependency('vinext');
   }
 
   @memoizeOne

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -136,10 +136,10 @@ export class Project {
       return this.envCache;
     }
 
-    const [envVars, envPathAndLoadedEnvVarCountPairs] = readEnvironmentVariables(this.argv, this.dirPath);
+    const [envVars, envPathAndLoadedEnvVarNamePairs] = readEnvironmentVariables(this.argv, this.dirPath);
     if (!shouldSuppressEnvironmentOutput(this.argv)) {
-      for (const [envPath, count] of envPathAndLoadedEnvVarCountPairs) {
-        console.info(`Loaded ${count} environment variables from ${envPath}`);
+      for (const [envPath, names] of envPathAndLoadedEnvVarNamePairs) {
+        console.info(`Loaded ${names.length} environment variables from ${envPath}`);
       }
     }
     // Spreading envVars last is safe for exported-variable precedence: readEnvironmentVariables
@@ -151,7 +151,7 @@ export class Project {
     // `mise env` is excluded: it reports tool-activation output (e.g. PATH) even in repos that
     // declare no environment variables at all, which must not force the WB_ENV requirement.
     this.validateRequiredEnvironmentVariables(
-      envPathAndLoadedEnvVarCountPairs.some(([source]) => !source.startsWith('mise env'))
+      envPathAndLoadedEnvVarNamePairs.some(([source]) => !source.startsWith('mise env'))
     );
     return this.envCache;
   }

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -173,11 +173,11 @@ export class Project {
     if (this.requiresNextPublicWbEnv && !env.NEXT_PUBLIC_WB_ENV) missingKeys.push('NEXT_PUBLIC_WB_ENV');
     if (missingKeys.length === 0) return;
 
+    // Resolve the mode label from the loaded environment (not process.env): a WB_ENV/NODE_ENV
+    // supplied only by env files or fnox must still name the correct mode in the error message.
     const mode =
       this.argv.cascadeEnv ??
-      (this.argv.cascadeNodeEnv
-        ? process.env.NODE_ENV || 'development'
-        : (process.env.WB_ENV ?? process.env.NODE_ENV ?? 'development'));
+      (this.argv.cascadeNodeEnv ? env.NODE_ENV || 'development' : (env.WB_ENV ?? env.NODE_ENV ?? 'development'));
     console.error(
       chalk.red(
         `${missingKeys.join(' and ')} ${missingKeys.length === 1 ? 'is' : 'are'} not defined for the "${mode}" environment. ` +

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -190,7 +190,9 @@ export class Project {
 
   @memoizeOne
   private get requiresNextPublicWbEnv(): boolean {
-    return this.hasDependency('next') || this.hasDependency('vinext');
+    // OWN dependencies only: a root-level next/vinext devDependency in a mixed monorepo must not
+    // force NEXT_PUBLIC_WB_ENV onto every non-Next workspace package.
+    return !!this.getOwnDependencyVersion('next') || !!this.getOwnDependencyVersion('vinext');
   }
 
   @memoizeOne

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -156,7 +156,10 @@ function extractExportedConfigObject(content: string, exportedContent: string): 
   const identifierMatch = /^([A-Za-z_$][\w$]*)\s*(?:;|\n|$)/.exec(exportedExpression);
   if (!identifierMatch) return extractFirstBalancedObject(exportedContent);
 
-  const declarationMatch = new RegExp(String.raw`(?:const|let|var)\s+${identifierMatch[1]}\b`).exec(content);
+  // `$` is legal in identifiers but a regex anchor, so it must be escaped before interpolation;
+  // `(?![\w$])` (not `\b`) ends the match because `\b` never fires after a trailing `$`.
+  const escapedIdentifier = identifierMatch[1]!.replaceAll('$', String.raw`\$`);
+  const declarationMatch = new RegExp(String.raw`(?:const|let|var)\s+${escapedIdentifier}(?![\w$])`).exec(content);
   if (!declarationMatch) return;
   const assignmentIndex = content.indexOf('=', declarationMatch.index);
   if (assignmentIndex === -1) return;

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -162,8 +162,13 @@ function extractExportedConfigObject(content: string, exportedContent: string): 
 
   // `$` is legal in identifiers but a regex anchor, so it must be escaped before interpolation;
   // `(?![\w$])` (not `\b`) ends the match because `\b` never fires after a trailing `$`.
+  // Anchored to the line start (module scope): a same-named declaration inside a function body is
+  // indented and must not shadow the top-level binding the export actually references.
   const escapedIdentifier = identifierMatch[1]!.replaceAll('$', String.raw`\$`);
-  const declarationMatch = new RegExp(String.raw`(?:const|let|var)\s+${escapedIdentifier}(?![\w$])`).exec(content);
+  const declarationMatch = new RegExp(
+    String.raw`^(?:export\s+)?(?:const|let|var)\s+${escapedIdentifier}(?![\w$])`,
+    'm'
+  ).exec(content);
   if (!declarationMatch) return;
   const assignmentIndex = content.indexOf('=', declarationMatch.index);
   if (assignmentIndex === -1) return;

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -137,14 +137,30 @@ export function usesDrizzleKitForD1(project: Project): boolean {
       .map((marker) => content.indexOf(marker))
       .filter((index) => index !== -1);
     const exportedContent = exportIndices.length > 0 ? content.slice(Math.min(...exportIndices)) : content;
-    // When the export references an identifier (`const config = {...}; export default config;`),
-    // no object literal follows the marker; scan the WHOLE file then, so such configs are still
-    // detected (the string-aware property scanner keeps string noise from matching).
-    const objectSpan = extractFirstBalancedObject(exportedContent);
-    return declaresSqliteTarget(objectSpan ?? content);
+    const objectSpan = extractExportedConfigObject(content, exportedContent);
+    return objectSpan !== undefined && declaresSqliteTarget(objectSpan);
   } catch {
     return false;
   }
+}
+
+/**
+ * The object literal the export actually evaluates to: for `export default {...}` or
+ * `export default defineConfig({...})` the first balanced object after the marker, and for
+ * `export default config;` the initializer of that identifier's declaration — never the whole
+ * file, since an unrelated object (e.g. an unused sqlite-shaped constant) must not be selected.
+ * Undefined when the expression cannot be resolved; wb deploy's unmanaged-D1 warning covers that.
+ */
+function extractExportedConfigObject(content: string, exportedContent: string): string | undefined {
+  const exportedExpression = exportedContent.replace(/^(?:export\s+default|module\.exports\s*=)\s*/, '');
+  const identifierMatch = /^([A-Za-z_$][\w$]*)\s*(?:;|\n|$)/.exec(exportedExpression);
+  if (!identifierMatch) return extractFirstBalancedObject(exportedContent);
+
+  const declarationMatch = new RegExp(String.raw`(?:const|let|var)\s+${identifierMatch[1]}\b`).exec(content);
+  if (!declarationMatch) return;
+  const assignmentIndex = content.indexOf('=', declarationMatch.index);
+  if (assignmentIndex === -1) return;
+  return extractFirstBalancedObject(content.slice(assignmentIndex));
 }
 
 /**

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -132,10 +132,21 @@ export function usesDrizzleKitForD1(project: Project): boolean {
   if (!config) return false;
 
   try {
-    return drizzleSqliteConfigPattern.test(fs.readFileSync(path.join(config.dirPath, config.fileName), 'utf8'));
+    return drizzleSqliteConfigPattern.test(
+      stripJsComments(fs.readFileSync(path.join(config.dirPath, config.fileName), 'utf8'))
+    );
   } catch {
     return false;
   }
+}
+
+/**
+ * Remove block and line comments so commented-out markers (e.g. `// dialect: 'sqlite'` in a
+ * PostgreSQL config) cannot misclassify the config. `//` preceded by `:`, quotes, or a backslash
+ * is kept so URLs such as `https://...` in connection strings survive.
+ */
+function stripJsComments(content: string): string {
+  return content.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/(^|[^:"'`\\])\/\/.*$/gm, '$1');
 }
 
 export function findDrizzleConfig(project: Project): { dirPath: string; fileName: string } | undefined {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -134,19 +134,40 @@ export function usesDrizzleKitForD1(project: Project): boolean {
 
   try {
     const content = stripJsComments(fs.readFileSync(path.join(config.dirPath, config.fileName), 'utf8'));
-    // Scan only from the exported config onward: drizzle-kit consumes the default export, and
-    // matching earlier text (e.g. an unused sqlite-shaped constant above a PostgreSQL config)
-    // would select the wrong migration mechanism. Configs whose export references earlier
-    // objects fall outside the heuristic; wb deploy warns when no mechanism is detected.
+    // Scan only the exported config's object literal: drizzle-kit consumes the default export,
+    // and matching other text (an unused sqlite-shaped constant above the export, or marker-like
+    // string content in statements after it) would select the wrong migration mechanism. Configs
+    // whose export references an earlier object fall back to scanning from the export marker;
+    // wb deploy warns when no mechanism is detected.
     const exportIndices = ['export default', 'module.exports']
       .map((marker) => content.indexOf(marker))
       .filter((index) => index !== -1);
-    return drizzleSqliteConfigPattern.test(
-      exportIndices.length > 0 ? content.slice(Math.min(...exportIndices)) : content
-    );
+    const exportedContent = exportIndices.length > 0 ? content.slice(Math.min(...exportIndices)) : content;
+    return drizzleSqliteConfigPattern.test(extractFirstBalancedObject(exportedContent) ?? exportedContent);
   } catch {
     return false;
   }
+}
+
+/** The first `{ ... }` span (string-aware brace matching), or undefined when none exists. */
+function extractFirstBalancedObject(content: string): string | undefined {
+  const startIndex = content.indexOf('{');
+  if (startIndex === -1) return;
+
+  let depth = 0;
+  let stringDelimiter: string | undefined;
+  for (let index = startIndex; index < content.length; index++) {
+    const char = content[index]!;
+    if (stringDelimiter) {
+      if (char === '\\') index++;
+      else if (char === stringDelimiter || (stringDelimiter !== '`' && char === '\n')) stringDelimiter = undefined;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') stringDelimiter = char;
+    else if (char === '{') depth++;
+    else if (char === '}' && --depth === 0) return content.slice(startIndex, index + 1);
+  }
+  return;
 }
 
 /**

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -172,21 +172,37 @@ function extractExportedConfigObject(
 
   // `$` is legal in identifiers but a regex anchor, so it must be escaped before interpolation;
   // `(?![\w$])` (not `\b`) ends the match because `\b` never fires after a trailing `$`.
-  // Anchored to the line start (module scope): a same-named declaration inside a function body is
-  // indented and must not shadow the top-level binding the export actually references.
   const escapedIdentifier = identifierMatch[1]!.replaceAll('$', String.raw`\$`);
-  const declarationMatch = new RegExp(
-    String.raw`^(?:export\s+)?(?:const|let|var)\s+${escapedIdentifier}(?![\w$])`,
-    'm'
-  ).exec(maskedContent);
-  if (!declarationMatch) return;
+  const declarationEndIndex = findModuleScopeDeclarationEnd(maskedContent, escapedIdentifier);
+  if (declarationEndIndex === undefined) return;
   // The initializer must belong to THIS declaration (a type annotation may precede the `=`); an
   // uninitialized `let config;` stays unresolved instead of grabbing a later statement's `=`.
-  const afterDeclaration = maskedContent.slice(declarationMatch.index + declarationMatch[0].length);
-  const assignmentMatch = /^\s*(?::[^=;\n]*)?=/.exec(afterDeclaration);
+  const assignmentMatch = /^\s*(?::[^=;\n]*)?=/.exec(maskedContent.slice(declarationEndIndex));
   if (!assignmentMatch) return;
-  const assignmentIndex = declarationMatch.index + declarationMatch[0].length + assignmentMatch[0].length;
-  return extractFirstBalancedObject(content.slice(assignmentIndex));
+  return extractFirstBalancedObject(content.slice(declarationEndIndex + assignmentMatch[0].length));
+}
+
+/**
+ * The end index of the identifier's declaration at brace depth ZERO (module scope): a same-named
+ * declaration inside a function body must not shadow the binding the export references, and
+ * indentation is no scope signal — depth over the string-masked content is.
+ */
+function findModuleScopeDeclarationEnd(maskedContent: string, escapedIdentifier: string): number | undefined {
+  const declarationRegex = new RegExp(
+    String.raw`(?<![\w$])(?:export\s+)?(?:const|let|var)\s+${escapedIdentifier}(?![\w$])`,
+    'g'
+  );
+  let depth = 0;
+  let scanIndex = 0;
+  for (let match = declarationRegex.exec(maskedContent); match; match = declarationRegex.exec(maskedContent)) {
+    for (; scanIndex < match.index; scanIndex++) {
+      const char = maskedContent[scanIndex];
+      if (char === '{') depth++;
+      else if (char === '}') depth--;
+    }
+    if (depth === 0) return match.index + match[0].length;
+  }
+  return;
 }
 
 /**

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -130,14 +130,15 @@ export function usesDrizzleKitForD1(project: Project): boolean {
     const content = stripJsComments(fs.readFileSync(path.join(config.dirPath, config.fileName), 'utf8'));
     // Scan only the exported config's object literal: drizzle-kit consumes the default export,
     // and matching other text (an unused sqlite-shaped constant above the export, or marker-like
-    // string content in statements after it) would select the wrong migration mechanism. Configs
-    // whose export references an earlier object fall back to scanning from the export marker;
-    // wb deploy warns when no mechanism is detected.
+    // string content in statements after it) would select the wrong migration mechanism.
+    // POSITIONS (export markers, declarations) are located on a string-masked view of the same
+    // length, so `export default` inside a string literal cannot mislead the search.
+    const maskedContent = maskStringContents(content);
     const exportIndices = ['export default', 'module.exports']
-      .map((marker) => content.indexOf(marker))
+      .map((marker) => maskedContent.indexOf(marker))
       .filter((index) => index !== -1);
-    const exportedContent = exportIndices.length > 0 ? content.slice(Math.min(...exportIndices)) : content;
-    const objectSpan = extractExportedConfigObject(content, exportedContent);
+    const exportStartIndex = exportIndices.length > 0 ? Math.min(...exportIndices) : 0;
+    const objectSpan = extractExportedConfigObject(content, maskedContent, exportStartIndex);
     return objectSpan !== undefined && declaresSqliteTarget(objectSpan);
   } catch {
     return false;
@@ -151,14 +152,23 @@ export function usesDrizzleKitForD1(project: Project): boolean {
  * file, since an unrelated object (e.g. an unused sqlite-shaped constant) must not be selected.
  * Undefined when the expression cannot be resolved; wb deploy's unmanaged-D1 warning covers that.
  */
-function extractExportedConfigObject(content: string, exportedContent: string): string | undefined {
-  const exportedExpression = exportedContent
+function extractExportedConfigObject(
+  content: string,
+  maskedContent: string,
+  exportStartIndex: number
+): string | undefined {
+  const exportedExpression = maskedContent
+    .slice(exportStartIndex)
     .replace(/^(?:export\s+default|module\.exports\s*=)\s*/, '')
     // Drop a TypeScript type postfix (`config satisfies Config;` / `config as Config;`) so the
     // identifier branch below still recognizes the export.
     .replace(/^([A-Za-z_$][\w$]*)\s+(?:satisfies|as)\b[^;\n{]*/, '$1');
   const identifierMatch = /^([A-Za-z_$][\w$]*)\s*(?:;|\n|$)/.exec(exportedExpression);
-  if (!identifierMatch) return extractFirstBalancedObject(exportedContent);
+  if (!identifierMatch) {
+    const braceOffset = maskedContent.slice(exportStartIndex).indexOf('{');
+    if (braceOffset === -1) return;
+    return extractFirstBalancedObject(content.slice(exportStartIndex + braceOffset));
+  }
 
   // `$` is legal in identifiers but a regex anchor, so it must be escaped before interpolation;
   // `(?![\w$])` (not `\b`) ends the match because `\b` never fires after a trailing `$`.
@@ -168,11 +178,45 @@ function extractExportedConfigObject(content: string, exportedContent: string): 
   const declarationMatch = new RegExp(
     String.raw`^(?:export\s+)?(?:const|let|var)\s+${escapedIdentifier}(?![\w$])`,
     'm'
-  ).exec(content);
+  ).exec(maskedContent);
   if (!declarationMatch) return;
-  const assignmentIndex = content.indexOf('=', declarationMatch.index);
-  if (assignmentIndex === -1) return;
+  // The initializer must belong to THIS declaration (a type annotation may precede the `=`); an
+  // uninitialized `let config;` stays unresolved instead of grabbing a later statement's `=`.
+  const afterDeclaration = maskedContent.slice(declarationMatch.index + declarationMatch[0].length);
+  const assignmentMatch = /^\s*(?::[^=;\n]*)?=/.exec(afterDeclaration);
+  if (!assignmentMatch) return;
+  const assignmentIndex = declarationMatch.index + declarationMatch[0].length + assignmentMatch[0].length;
   return extractFirstBalancedObject(content.slice(assignmentIndex));
+}
+
+/**
+ * Replace the CONTENTS of string literals with spaces (same length, newlines kept), so position
+ * searches over the result cannot match text inside strings while all indexes still map 1:1 to
+ * the original content.
+ */
+function maskStringContents(content: string): string {
+  let result = '';
+  let stringDelimiter: string | undefined;
+  for (let index = 0; index < content.length; index++) {
+    const char = content[index]!;
+    if (stringDelimiter) {
+      if (char === '\\') {
+        result += '  ';
+        index++;
+        continue;
+      }
+      if (char === stringDelimiter || (stringDelimiter !== '`' && char === '\n')) {
+        stringDelimiter = undefined;
+        result += char;
+        continue;
+      }
+      result += char === '\n' ? '\n' : ' ';
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') stringDelimiter = char;
+    result += char;
+  }
+  return result;
 }
 
 /**

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -115,7 +115,8 @@ export function wrapWithDrizzleConfigDir(project: Project, command: string): str
 // Markers indicating the drizzle config manages a (Cloudflare D1 compatible) SQLite database:
 // `dialect: 'sqlite'` covers d1-http and plain SQLite configs, `driver: 'd1-http'` and
 // `driver: 'durable-sqlite'` are the explicit D1/Durable Object drivers.
-const drizzleSqliteConfigPattern = /dialect\s*:\s*['"`]sqlite['"`]|driver\s*:\s*['"`](?:d1-http|durable-sqlite)['"`]/;
+const drizzleSqliteConfigPattern =
+  /['"`]?dialect['"`]?\s*:\s*['"`]sqlite['"`]|['"`]?driver['"`]?\s*:\s*['"`](?:d1-http|durable-sqlite)['"`]/;
 
 /**
  * Whether drizzle-kit is the project's D1 migration mechanism. A drizzle-orm dependency alone is
@@ -142,11 +143,47 @@ export function usesDrizzleKitForD1(project: Project): boolean {
 
 /**
  * Remove block and line comments so commented-out markers (e.g. `// dialect: 'sqlite'` in a
- * PostgreSQL config) cannot misclassify the config. `//` preceded by `:`, quotes, or a backslash
- * is kept so URLs such as `https://...` in connection strings survive.
+ * PostgreSQL config) cannot misclassify the config. The scanner tracks string state, so `//`
+ * inside string literals (URLs such as `https://...` in connection strings) survives while
+ * comments directly after a string literal are still removed.
  */
 function stripJsComments(content: string): string {
-  return content.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/(^|[^:"'`\\])\/\/.*$/gm, '$1');
+  let result = '';
+  let stringDelimiter: string | undefined;
+  for (let index = 0; index < content.length; index++) {
+    const char = content[index]!;
+    const nextChar = content[index + 1];
+    if (stringDelimiter) {
+      if (char === '\\') {
+        result += char + (nextChar ?? '');
+        index++;
+        continue;
+      }
+      if (char === stringDelimiter || (stringDelimiter !== '`' && char === '\n')) {
+        stringDelimiter = undefined;
+      }
+      result += char;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      stringDelimiter = char;
+      result += char;
+      continue;
+    }
+    if (char === '/' && nextChar === '/') {
+      while (index < content.length && content[index] !== '\n') index++;
+      result += '\n';
+      continue;
+    }
+    if (char === '/' && nextChar === '*') {
+      index += 2;
+      while (index < content.length && !(content[index] === '*' && content[index + 1] === '/')) index++;
+      index++;
+      continue;
+    }
+    result += char;
+  }
+  return result;
 }
 
 export function findDrizzleConfig(project: Project): { dirPath: string; fileName: string } | undefined {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -137,7 +137,11 @@ export function usesDrizzleKitForD1(project: Project): boolean {
       .map((marker) => content.indexOf(marker))
       .filter((index) => index !== -1);
     const exportedContent = exportIndices.length > 0 ? content.slice(Math.min(...exportIndices)) : content;
-    return declaresSqliteTarget(extractFirstBalancedObject(exportedContent) ?? exportedContent);
+    // When the export references an identifier (`const config = {...}; export default config;`),
+    // no object literal follows the marker; scan the WHOLE file then, so such configs are still
+    // detected (the string-aware property scanner keeps string noise from matching).
+    const objectSpan = extractFirstBalancedObject(exportedContent);
+    return declaresSqliteTarget(objectSpan ?? content);
   } catch {
     return false;
   }

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -152,7 +152,11 @@ export function usesDrizzleKitForD1(project: Project): boolean {
  * Undefined when the expression cannot be resolved; wb deploy's unmanaged-D1 warning covers that.
  */
 function extractExportedConfigObject(content: string, exportedContent: string): string | undefined {
-  const exportedExpression = exportedContent.replace(/^(?:export\s+default|module\.exports\s*=)\s*/, '');
+  const exportedExpression = exportedContent
+    .replace(/^(?:export\s+default|module\.exports\s*=)\s*/, '')
+    // Drop a TypeScript type postfix (`config satisfies Config;` / `config as Config;`) so the
+    // identifier branch below still recognizes the export.
+    .replace(/^([A-Za-z_$][\w$]*)\s+(?:satisfies|as)\b[^;\n{]*/, '$1');
   const identifierMatch = /^([A-Za-z_$][\w$]*)\s*(?:;|\n|$)/.exec(exportedExpression);
   if (!identifierMatch) return extractFirstBalancedObject(exportedContent);
 

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -159,11 +159,11 @@ function extractExportedConfigObject(
 ): string | undefined {
   const exportedExpression = maskedContent
     .slice(exportStartIndex)
-    .replace(/^(?:export\s+default|module\.exports\s*=)\s*/, '')
-    // Drop a TypeScript type postfix (`config satisfies Config;` / `config as Config;`) so the
-    // identifier branch below still recognizes the export.
-    .replace(/^([A-Za-z_$][\w$]*)\s+(?:satisfies|as)\b[^;\n{]*/, '$1');
-  const identifierMatch = /^([A-Za-z_$][\w$]*)\s*(?:;|\n|$)/.exec(exportedExpression);
+    .replace(/^(?:export\s+default|module\.exports\s*=)\s*/, '');
+  // An identifier export may carry a TypeScript type postfix (`config satisfies Config;` /
+  // `config as Config;`); the identifier is recognized FIRST so a postfix containing a TYPE
+  // literal (`satisfies { dialect: 'sqlite' | ... }`) is never mistaken for the runtime config.
+  const identifierMatch = /^([A-Za-z_$][\w$]*)\s*(?:satisfies\b|as\b|;|\n|$)/.exec(exportedExpression);
   if (!identifierMatch) {
     const braceOffset = maskedContent.slice(exportStartIndex).indexOf('{');
     if (braceOffset === -1) return;

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -112,12 +112,6 @@ export function wrapWithDrizzleConfigDir(project: Project, command: string): str
     : command;
 }
 
-// Markers indicating the drizzle config manages a (Cloudflare D1 compatible) SQLite database:
-// `dialect: 'sqlite'` covers d1-http and plain SQLite configs, `driver: 'd1-http'` and
-// `driver: 'durable-sqlite'` are the explicit D1/Durable Object drivers.
-const drizzleSqliteConfigPattern =
-  /['"`]?dialect['"`]?\s*:\s*['"`]sqlite['"`]|['"`]?driver['"`]?\s*:\s*['"`](?:d1-http|durable-sqlite)['"`]/;
-
 /**
  * Whether drizzle-kit is the project's D1 migration mechanism. A drizzle-orm dependency alone is
  * not a reliable marker: a Worker may use D1 only for caching while its drizzle config targets an
@@ -143,10 +137,78 @@ export function usesDrizzleKitForD1(project: Project): boolean {
       .map((marker) => content.indexOf(marker))
       .filter((index) => index !== -1);
     const exportedContent = exportIndices.length > 0 ? content.slice(Math.min(...exportIndices)) : content;
-    return drizzleSqliteConfigPattern.test(extractFirstBalancedObject(exportedContent) ?? exportedContent);
+    return declaresSqliteTarget(extractFirstBalancedObject(exportedContent) ?? exportedContent);
   } catch {
     return false;
   }
+}
+
+/**
+ * String-aware scan for the markers indicating the config manages a (Cloudflare D1 compatible)
+ * SQLite database — a `dialect: 'sqlite'`, `driver: 'd1-http'`, or `driver: 'durable-sqlite'`
+ * PROPERTY (plain or quoted key). Keys are only recognized in code position, so marker-like text
+ * embedded in unrelated string values (e.g. a schema path) cannot match.
+ */
+function declaresSqliteTarget(content: string): boolean {
+  const tokens = tokenizeStrings(content);
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index]!;
+    let key: string | undefined;
+    let valueTokenIndex: number | undefined;
+    if (token.type === 'code') {
+      const match = /(?:^|[\s{,(])(dialect|driver)\s*:\s*$/.exec(token.value);
+      if (match) {
+        key = match[1];
+        valueTokenIndex = index + 1;
+      }
+    } else if (token.value === 'dialect' || token.value === 'driver') {
+      // A quoted key: the surrounding code tokens must form a property position (`{`/`,` before,
+      // `:` after).
+      const previousToken = tokens[index - 1];
+      const nextToken = tokens[index + 1];
+      if (
+        previousToken?.type === 'code' &&
+        /[{,(]\s*$/.test(previousToken.value) &&
+        nextToken?.type === 'code' &&
+        /^\s*:\s*$/.test(nextToken.value)
+      ) {
+        key = token.value;
+        valueTokenIndex = index + 2;
+      }
+    }
+    if (key === undefined || valueTokenIndex === undefined) continue;
+
+    const valueToken = tokens[valueTokenIndex];
+    if (valueToken?.type !== 'string') continue;
+    if (key === 'dialect' && valueToken.value === 'sqlite') return true;
+    if (key === 'driver' && (valueToken.value === 'd1-http' || valueToken.value === 'durable-sqlite')) return true;
+  }
+  return false;
+}
+
+/** Split into alternating code and string-literal-content tokens (quotes excluded). */
+function tokenizeStrings(content: string): { type: 'code' | 'string'; value: string }[] {
+  const tokens: { type: 'code' | 'string'; value: string }[] = [];
+  let code = '';
+  for (let index = 0; index < content.length; index++) {
+    const char = content[index]!;
+    if (char === "'" || char === '"' || char === '`') {
+      tokens.push({ type: 'code', value: code });
+      code = '';
+      let value = '';
+      index++;
+      while (index < content.length && content[index] !== char) {
+        if (content[index] === '\\') index++;
+        value += content[index] ?? '';
+        index++;
+      }
+      tokens.push({ type: 'string', value });
+      continue;
+    }
+    code += char;
+  }
+  tokens.push({ type: 'code', value: code });
+  return tokens;
 }
 
 /** The first `{ ... }` span (string-aware brace matching), or undefined when none exists. */

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -213,7 +213,12 @@ function declaresSqliteTarget(content: string): boolean {
   return false;
 }
 
-/** Split into alternating code and string-literal-content tokens (quotes excluded). */
+/**
+ * Split into alternating code and string-literal-content tokens (quotes excluded). The input is
+ * already comment-free — usesDrizzleKitForD1 runs stripJsComments before any scanning — so
+ * comment delimiters need no handling here (a commented-out `// dialect: 'sqlite'` can never
+ * reach this tokenizer).
+ */
 function tokenizeStrings(content: string): { type: 'code' | 'string'; value: string }[] {
   const tokens: { type: 'code' | 'string'; value: string }[] = [];
   let code = '';

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -112,6 +112,32 @@ export function wrapWithDrizzleConfigDir(project: Project, command: string): str
     : command;
 }
 
+// Markers indicating the drizzle config manages a (Cloudflare D1 compatible) SQLite database:
+// `dialect: 'sqlite'` covers d1-http and plain SQLite configs, `driver: 'd1-http'` and
+// `driver: 'durable-sqlite'` are the explicit D1/Durable Object drivers.
+const drizzleSqliteConfigPattern = /dialect\s*:\s*['"`]sqlite['"`]|driver\s*:\s*['"`](?:d1-http|durable-sqlite)['"`]/;
+
+/**
+ * Whether drizzle-kit is the project's D1 migration mechanism. A drizzle-orm dependency alone is
+ * not a reliable marker: a Worker may use D1 only for caching while its drizzle config targets an
+ * unrelated database (e.g. PostgreSQL via Hyperdrive), and running `drizzle-kit migrate` against
+ * that database during a D1 deploy would be wrong (https://github.com/WillBooster/shared/issues/942).
+ * So require an explicit marker: a drizzle config whose dialect/driver targets sqlite, d1-http, or
+ * durable-sqlite.
+ */
+export function usesDrizzleKitForD1(project: Project): boolean {
+  if (!project.hasDrizzle) return false;
+
+  const config = findDrizzleConfig(project);
+  if (!config) return false;
+
+  try {
+    return drizzleSqliteConfigPattern.test(fs.readFileSync(path.join(config.dirPath, config.fileName), 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
 export function findDrizzleConfig(project: Project): { dirPath: string; fileName: string } | undefined {
   const candidates = ['drizzle.config.ts', 'drizzle.config.mts', 'drizzle.config.js', 'drizzle.config.mjs'];
   for (const dirPath of [project.dirPath, project.rootDirPath]) {

--- a/packages/wb/src/scripts/drizzleScripts.ts
+++ b/packages/wb/src/scripts/drizzleScripts.ts
@@ -133,8 +133,16 @@ export function usesDrizzleKitForD1(project: Project): boolean {
   if (!config) return false;
 
   try {
+    const content = stripJsComments(fs.readFileSync(path.join(config.dirPath, config.fileName), 'utf8'));
+    // Scan only from the exported config onward: drizzle-kit consumes the default export, and
+    // matching earlier text (e.g. an unused sqlite-shaped constant above a PostgreSQL config)
+    // would select the wrong migration mechanism. Configs whose export references earlier
+    // objects fall outside the heuristic; wb deploy warns when no mechanism is detected.
+    const exportIndices = ['export default', 'module.exports']
+      .map((marker) => content.indexOf(marker))
+      .filter((index) => index !== -1);
     return drizzleSqliteConfigPattern.test(
-      stripJsComments(fs.readFileSync(path.join(config.dirPath, config.fileName), 'utf8'))
+      exportIndices.length > 0 ? content.slice(Math.min(...exportIndices)) : content
     );
   } catch {
     return false;

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -208,9 +208,11 @@ function encodePackageName(packageName: string): string {
   return packageName.replace('/', '%2F');
 }
 
-// Anchored: numeric-looking dist-tags such as `1.2.3latest` must NOT count as versions
-// (resolveVersion treats them as tags), only complete SemVer with optional prerelease/build.
-const exactSemverPattern = /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/;
+// The official SemVer 2.0.0 grammar (semver.org), anchored: numeric-looking dist-tags such as
+// `1.2.3latest`, leading-zero versions (`01.2.3`), and underscore identifiers are NOT versions —
+// resolveVersion treats them as tags, matching node-semver's classification.
+const exactSemverPattern =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$/;
 
 /** Whether the specifier is an exact SemVer version (not a range, tag, or git URL). */
 export function isExactVersion(specifier: string | undefined): boolean {

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -230,10 +230,13 @@ export function toBaseVersion(specifier: string | undefined): string | undefined
  * return false, so only an exact string match (checked separately by the callers) is accepted.
  */
 export function rangeAdmits(range: string, version: string): boolean {
-  const rangeBase = range.replace(/^[\^~]/, '');
-  if (rangeBase.includes('-') || version.includes('-')) return false;
+  // SemVer build metadata (`+build-1`) is ignored for ordering and may itself contain hyphens,
+  // so strip it BEFORE the prerelease (`-`) check.
+  const rangeBase = range.replace(/^[\^~]/, '').split('+')[0]!;
+  const candidateVersion = version.split('+')[0]!;
+  if (rangeBase.includes('-') || candidateVersion.includes('-')) return false;
   const baseVersion = parseVersion(rangeBase);
-  const candidate = parseVersion(version);
+  const candidate = parseVersion(candidateVersion);
   if (!baseVersion || !candidate) return false;
   if (range.startsWith('^')) {
     if (baseVersion[0] === 0) {

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -211,16 +211,20 @@ function encodePackageName(packageName: string): string {
   return packageName.replace('/', '%2F');
 }
 
-/** Whether the specifier is an exact version-like string (not a range, tag, or git URL). */
+// Anchored: numeric-looking dist-tags such as `1.2.3latest` must NOT count as versions
+// (resolveVersion treats them as tags), only complete SemVer with optional prerelease/build.
+const exactSemverPattern = /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/;
+
+/** Whether the specifier is an exact SemVer version (not a range, tag, or git URL). */
 export function isExactVersion(specifier: string | undefined): boolean {
-  return !!specifier && /^\d+\.\d+\.\d+/.test(specifier);
+  return !!specifier && exactSemverPattern.test(specifier);
 }
 
 /** The version the specifier resolves to under the degrade-ranges rule, or undefined for tags/git. */
 export function toBaseVersion(specifier: string | undefined): string | undefined {
   if (!specifier) return;
   const base = specifier.replace(/^[\^~]/, '');
-  return /^\d+\.\d+\.\d+/.test(base) ? base : undefined;
+  return exactSemverPattern.test(base) ? base : undefined;
 }
 
 /**
@@ -254,7 +258,9 @@ export function rangeAdmits(range: string, version: string): boolean {
 }
 
 function parseVersion(version: string): [number, number, number] | undefined {
-  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  // Anchored: callers strip build metadata and reject prereleases beforehand, so anything beyond
+  // x.y.z marks a non-version (e.g. a numeric-looking dist-tag).
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
   return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : undefined;
 }
 

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -11,7 +11,20 @@ import path from 'node:path';
  */
 export const PRIVATE_REGISTRY_SCOPE = '@willbooster-private';
 
-const nonRegistrySpecifierPrefixes = ['git', 'file:', 'link:', 'workspace:', 'http:', 'https:', 'portal:', 'patch:'];
+// `git:`/`git+`/`git@` (not the bare word `git`): npm allows arbitrary dist-tags, so a tag named
+// `git` or `git-next` must still be treated as a registry specifier.
+const nonRegistrySpecifierPrefixes = [
+  'git:',
+  'git+',
+  'git@',
+  'file:',
+  'link:',
+  'workspace:',
+  'http:',
+  'https:',
+  'portal:',
+  'patch:',
+];
 
 // The single source of truth for which git specifiers the private-package tooling supports:
 // `wb setup-private-packages` materializes exactly these, and `wb optimizeForDockerBuild` must
@@ -144,9 +157,10 @@ async function resolveVersion(
   packageName: string,
   versionSpecifier: string
 ): Promise<string> {
-  const exactVersion = /^\d+\.\d+\.\d+(?:-[\w.-]+)?$/.test(versionSpecifier)
+  // Prerelease and `+build` metadata are both part of valid exact SemVer versions.
+  const exactVersion = /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/.test(versionSpecifier)
     ? versionSpecifier
-    : /^[\^~]\d+\.\d+\.\d+(?:-[\w.-]+)?$/.test(versionSpecifier)
+    : /^[\^~]\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/.test(versionSpecifier)
       ? // Without a semver resolver, degrade a simple range to its base version (org repos pin
         // exact versions, so this path is a best-effort fallback).
         versionSpecifier.slice(1)

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -210,3 +210,54 @@ function isSameOrigin(url: string, registryUrl: string): boolean {
 function encodePackageName(packageName: string): string {
   return packageName.replace('/', '%2F');
 }
+
+/** Whether the specifier is an exact version-like string (not a range, tag, or git URL). */
+export function isExactVersion(specifier: string | undefined): boolean {
+  return !!specifier && /^\d+\.\d+\.\d+/.test(specifier);
+}
+
+/** The version the specifier resolves to under the degrade-ranges rule, or undefined for tags/git. */
+export function toBaseVersion(specifier: string | undefined): string | undefined {
+  if (!specifier) return;
+  const base = specifier.replace(/^[\^~]/, '');
+  return /^\d+\.\d+\.\d+/.test(base) ? base : undefined;
+}
+
+/**
+ * Simplified node-semver rules: `^` admits versions not changing the left-most non-zero component
+ * (so `^0.1.0` rejects `0.2.0` and `^0.0.3` admits only `0.0.3`), `~` admits same-major.minor
+ * >= base. Prerelease identifiers are handled conservatively: any `-` on either side makes this
+ * return false, so only an exact string match (checked separately by the callers) is accepted.
+ */
+export function rangeAdmits(range: string, version: string): boolean {
+  const rangeBase = range.replace(/^[\^~]/, '');
+  if (rangeBase.includes('-') || version.includes('-')) return false;
+  const baseVersion = parseVersion(rangeBase);
+  const candidate = parseVersion(version);
+  if (!baseVersion || !candidate) return false;
+  if (range.startsWith('^')) {
+    if (baseVersion[0] === 0) {
+      if (baseVersion[1] === 0) return compareVersions(candidate, baseVersion) === 0;
+      return candidate[0] === 0 && candidate[1] === baseVersion[1] && compareVersions(candidate, baseVersion) >= 0;
+    }
+    return candidate[0] === baseVersion[0] && compareVersions(candidate, baseVersion) >= 0;
+  }
+  if (range.startsWith('~')) {
+    return (
+      candidate[0] === baseVersion[0] && candidate[1] === baseVersion[1] && compareVersions(candidate, baseVersion) >= 0
+    );
+  }
+  return false;
+}
+
+function parseVersion(version: string): [number, number, number] | undefined {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : undefined;
+}
+
+function compareVersions(a: [number, number, number], b: [number, number, number]): number {
+  for (let index = 0; index < 3; index++) {
+    if (a[index]! !== b[index]!) return a[index]! - b[index]!;
+  }
+  return 0;
+}

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -13,6 +13,17 @@ export const PRIVATE_REGISTRY_SCOPE = '@willbooster-private';
 
 const nonRegistrySpecifierPrefixes = ['git', 'file:', 'link:', 'workspace:', 'http:', 'https:', 'portal:', 'patch:'];
 
+// The single source of truth for which git specifiers the private-package tooling supports:
+// `wb setup-private-packages` materializes exactly these, and `wb optimizeForDockerBuild` must
+// rewrite exactly these (rewriting other orgs' SSH URLs would point at never-materialized paths).
+const privateGitDependencyPattern = /^git@github\.com:(?:WillBooster|WillBoosterLab)\/[^/#]+(?:\.git)?(?:#.*)?$/;
+
+// Returns boolean (not a `value is string` predicate): a predicate would narrow the negative
+// branch to `undefined` and break `else if` chains over `string | undefined` dependency values.
+export function isPrivateGitDependency(value: unknown): boolean {
+  return typeof value === 'string' && privateGitDependencyPattern.test(value);
+}
+
 export function isPrivateRegistryDependency(name: string, value: unknown): value is string {
   return (
     name.startsWith(`${PRIVATE_REGISTRY_SCOPE}/`) &&
@@ -52,7 +63,9 @@ export function resolvePrivateRegistryAuth(rootDirPath: string): PrivateRegistry
   let matchedToken: string | undefined;
   let matchedPrefixLength = -1;
   for (const [key, value] of Object.entries(entries)) {
-    if (!key.endsWith(':_authToken')) continue;
+    // Skip empty tokens (an unset `${VAR}` expands to ''): an empty match must not defeat the
+    // VERDACCIO_TOKEN fallback below.
+    if (!key.endsWith(':_authToken') || !value) continue;
     const prefix = `${key.slice(0, -':_authToken'.length).replace(/\/+$/, '')}/`;
     if (normalizedRegistryUrl.startsWith(prefix) && prefix.length > matchedPrefixLength) {
       matchedPrefixLength = prefix.length;

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -45,13 +45,23 @@ export function resolvePrivateRegistryAuth(rootDirPath: string): PrivateRegistry
   const registryUrl = entries[`${PRIVATE_REGISTRY_SCOPE}:registry`]?.replace(/\/+$/, '');
   if (!registryUrl) return;
 
-  const registryUrlWithoutProtocol = registryUrl.replace(/^https?:/, '');
-  const authToken =
-    Object.entries(entries).find(
-      ([key]) =>
-        key.endsWith(':_authToken') &&
-        registryUrlWithoutProtocol.startsWith(key.slice(0, -':_authToken'.length).replace(/\/+$/, ''))
-    )?.[1] ?? process.env.VERDACCIO_TOKEN;
+  // npm-style URI matching: normalize both sides to a trailing slash so a token for
+  // `//verdaccio.example.com/` can never match `//verdaccio.example.com-other.org/`, and pick the
+  // MOST SPECIFIC (longest) matching prefix so `//host/private/` beats `//host/`.
+  const normalizedRegistryUrl = `${registryUrl.replace(/^https?:/, '').replace(/\/+$/, '')}/`;
+  let matchedToken: string | undefined;
+  let matchedPrefixLength = -1;
+  for (const [key, value] of Object.entries(entries)) {
+    if (!key.endsWith(':_authToken')) continue;
+    const prefix = `${key.slice(0, -':_authToken'.length).replace(/\/+$/, '')}/`;
+    if (normalizedRegistryUrl.startsWith(prefix) && prefix.length > matchedPrefixLength) {
+      matchedPrefixLength = prefix.length;
+      matchedToken = value;
+    }
+  }
+  // No Project instance exists at this layer, so process.env is the only source for the
+  // CI-injected fallback token.
+  const authToken = matchedToken ?? process.env.VERDACCIO_TOKEN;
   return { registryUrl, authToken };
 }
 
@@ -149,13 +159,25 @@ async function fetchRegistryJson<T>(auth: PrivateRegistryAuth, url: string): Pro
 }
 
 async function fetchFromRegistry(auth: PrivateRegistryAuth, url: string): Promise<Response> {
+  // Tarball URLs come from registry-controlled metadata; attach the token only to the configured
+  // registry's own origin so a malicious or misconfigured registry cannot redirect the credential
+  // to a third-party host.
+  const sendAuthToken = !!auth.authToken && isSameOrigin(url, auth.registryUrl);
   const response = await fetch(url, {
-    headers: auth.authToken ? { authorization: `Bearer ${auth.authToken}` } : {},
+    headers: sendAuthToken ? { authorization: `Bearer ${auth.authToken}` } : {},
   });
   if (!response.ok) {
     throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
   }
   return response;
+}
+
+function isSameOrigin(url: string, registryUrl: string): boolean {
+  try {
+    return new URL(url).origin === new URL(registryUrl).origin;
+  } catch {
+    return false;
+  }
 }
 
 function encodePackageName(packageName: string): string {

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -158,13 +158,10 @@ async function resolveVersion(
   versionSpecifier: string
 ): Promise<string> {
   // Prerelease and `+build` metadata are both part of valid exact SemVer versions.
-  const exactVersion = /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/.test(versionSpecifier)
-    ? versionSpecifier
-    : /^[\^~]\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/.test(versionSpecifier)
-      ? // Without a semver resolver, degrade a simple range to its base version (org repos pin
-        // exact versions, so this path is a best-effort fallback).
-        versionSpecifier.slice(1)
-      : undefined;
+  // toBaseVersion applies the shared anchored SemVer classification: an exact version resolves to
+  // itself and a simple `^`/`~` range degrades to its base version (org repos pin exact versions,
+  // so the range path is a best-effort fallback); anything else resolves as a dist-tag below.
+  const exactVersion = toBaseVersion(versionSpecifier);
   if (exactVersion) return exactVersion;
 
   const packument = await fetchRegistryJson<{ 'dist-tags'?: Record<string, string> }>(

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -1,0 +1,163 @@
+import child_process from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Materialization of `@willbooster-private/*` registry (Verdaccio) dependencies for Docker builds:
+ * the packages are downloaded on the host (auth via .npmrc / ~/.npmrc locally, or VERDACCIO_TOKEN
+ * on CI) and extracted next to the repository so image builds need no registry credentials
+ * (https://github.com/WillBooster/shared/issues/964).
+ */
+export const PRIVATE_REGISTRY_SCOPE = '@willbooster-private';
+
+const nonRegistrySpecifierPrefixes = ['git', 'file:', 'link:', 'workspace:', 'http:', 'https:', 'portal:', 'patch:'];
+
+export function isPrivateRegistryDependency(name: string, value: unknown): value is string {
+  return (
+    name.startsWith(`${PRIVATE_REGISTRY_SCOPE}/`) &&
+    typeof value === 'string' &&
+    !nonRegistrySpecifierPrefixes.some((prefix) => value.startsWith(prefix))
+  );
+}
+
+export interface PrivateRegistryAuth {
+  registryUrl: string;
+  authToken: string | undefined;
+}
+
+/**
+ * Resolve the registry URL and auth token for the private scope from the project's .npmrc and
+ * ~/.npmrc (nearer file wins), expanding `${VAR}` references from the environment. On CI the
+ * VERDACCIO_TOKEN environment variable serves as the fallback token.
+ */
+export function resolvePrivateRegistryAuth(rootDirPath: string): PrivateRegistryAuth | undefined {
+  const entries: Record<string, string> = {};
+  // Reverse order so nearer files overwrite the home-directory defaults.
+  for (const npmrcPath of [path.join(os.homedir(), '.npmrc'), path.join(rootDirPath, '.npmrc')]) {
+    try {
+      Object.assign(entries, parseNpmrc(fs.readFileSync(npmrcPath, 'utf8')));
+    } catch {
+      // Missing npmrc files are fine; the other file or VERDACCIO_TOKEN may still provide auth.
+    }
+  }
+
+  const registryUrl = entries[`${PRIVATE_REGISTRY_SCOPE}:registry`]?.replace(/\/+$/, '');
+  if (!registryUrl) return;
+
+  const registryUrlWithoutProtocol = registryUrl.replace(/^https?:/, '');
+  const authToken =
+    Object.entries(entries).find(
+      ([key]) =>
+        key.endsWith(':_authToken') &&
+        registryUrlWithoutProtocol.startsWith(key.slice(0, -':_authToken'.length).replace(/\/+$/, ''))
+    )?.[1] ?? process.env.VERDACCIO_TOKEN;
+  return { registryUrl, authToken };
+}
+
+export function parseNpmrc(content: string): Record<string, string> {
+  const entries: Record<string, string> = {};
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#') || line.startsWith(';')) continue;
+
+    const separatorIndex = line.indexOf('=');
+    if (separatorIndex <= 0) continue;
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line
+      .slice(separatorIndex + 1)
+      .trim()
+      .replaceAll(/\$\{([^}]+)\}/g, (_, variableName: string) => process.env[variableName] ?? '');
+    entries[key] = value;
+  }
+  return entries;
+}
+
+/**
+ * Download and extract one registry package into `targetDirPath`. The version must be an exact
+ * semver (the org pins exact versions via bunfig `exact = true`); `latest` and simple `^`/`~`
+ * ranges degrade to the range's base version or the registry's latest dist-tag.
+ */
+export async function downloadAndExtractRegistryPackage(
+  auth: PrivateRegistryAuth,
+  packageName: string,
+  versionSpecifier: string,
+  targetDirPath: string
+): Promise<void> {
+  const version = await resolveVersion(auth, packageName, versionSpecifier);
+  const metadata = await fetchRegistryJson<{ dist?: { tarball?: string } }>(
+    auth,
+    `${auth.registryUrl}/${encodePackageName(packageName)}/${version}`
+  );
+  const tarballUrl = metadata.dist?.tarball;
+  if (!tarballUrl) {
+    throw new Error(`No tarball URL for ${packageName}@${version} in ${auth.registryUrl}.`);
+  }
+
+  const response = await fetchFromRegistry(auth, tarballUrl);
+  const tarballPath = path.join(
+    await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-private-package-')),
+    'package.tgz'
+  );
+  try {
+    await fs.promises.writeFile(tarballPath, Buffer.from(await response.arrayBuffer()));
+    await fs.promises.rm(targetDirPath, { force: true, recursive: true });
+    await fs.promises.mkdir(targetDirPath, { recursive: true });
+    // npm tarballs place the content under a top-level `package/` directory.
+    const ret = child_process.spawnSync('tar', ['-xzf', tarballPath, '-C', targetDirPath, '--strip-components=1'], {
+      stdio: 'inherit',
+    });
+    if (ret.status !== 0) {
+      throw new Error(`Failed to extract ${packageName}@${version} (${tarballUrl}).`);
+    }
+  } finally {
+    await fs.promises.rm(path.dirname(tarballPath), { force: true, recursive: true });
+  }
+}
+
+async function resolveVersion(
+  auth: PrivateRegistryAuth,
+  packageName: string,
+  versionSpecifier: string
+): Promise<string> {
+  const exactVersion = /^\d+\.\d+\.\d+(?:-[\w.-]+)?$/.test(versionSpecifier)
+    ? versionSpecifier
+    : /^[\^~]\d+\.\d+\.\d+(?:-[\w.-]+)?$/.test(versionSpecifier)
+      ? // Without a semver resolver, degrade a simple range to its base version (org repos pin
+        // exact versions, so this path is a best-effort fallback).
+        versionSpecifier.slice(1)
+      : undefined;
+  if (exactVersion) return exactVersion;
+
+  const packument = await fetchRegistryJson<{ 'dist-tags'?: Record<string, string> }>(
+    auth,
+    `${auth.registryUrl}/${encodePackageName(packageName)}`
+  );
+  const distTag = packument['dist-tags']?.[versionSpecifier === '*' ? 'latest' : versionSpecifier];
+  if (!distTag) {
+    throw new Error(
+      `Cannot resolve ${packageName}@${versionSpecifier}; use an exact version, a ^/~ range, or a dist-tag.`
+    );
+  }
+  return distTag;
+}
+
+async function fetchRegistryJson<T>(auth: PrivateRegistryAuth, url: string): Promise<T> {
+  const response = await fetchFromRegistry(auth, url);
+  return (await response.json()) as T;
+}
+
+async function fetchFromRegistry(auth: PrivateRegistryAuth, url: string): Promise<Response> {
+  const response = await fetch(url, {
+    headers: auth.authToken ? { authorization: `Bearer ${auth.authToken}` } : {},
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+  return response;
+}
+
+function encodePackageName(packageName: string): string {
+  return packageName.replace('/', '%2F');
+}

--- a/packages/wb/test/buildIfNeeded.test.ts
+++ b/packages/wb/test/buildIfNeeded.test.ts
@@ -43,4 +43,25 @@ describe('buildIfNeeded', () => {
     );
     expect(await buildIfNeeded({ command }, dirPath)).toBe(true);
   });
+
+  it('rebuilds when a recorded build output directory is missing', async () => {
+    const dirPath = path.join(tempDir, 'outputs', 'app');
+    await fs.promises.rm(path.join(tempDir, 'outputs'), { recursive: true, force: true });
+    await fs.promises.mkdir(path.join(tempDir, 'outputs'), { recursive: true });
+    await initializeProjectDirectory(dirPath);
+
+    child_process.execSync('git init', { cwd: dirPath, stdio: 'inherit' });
+    child_process.execSync('git config user.email "bot@willbooster.com"', { cwd: dirPath, stdio: 'inherit' });
+    child_process.execSync('git config user.name "WillBooster Inc."', { cwd: dirPath, stdio: 'inherit' });
+    child_process.execSync('git add -A', { cwd: dirPath, stdio: 'inherit' });
+    child_process.execSync('git commit -m .', { cwd: dirPath, stdio: 'inherit' });
+
+    const command = 'mkdir -p dist && echo built > dist/index.txt';
+    expect(await buildIfNeeded({ command }, dirPath)).toBe(true);
+    expect(await buildIfNeeded({ command }, dirPath)).toBe(false);
+
+    await fs.promises.rm(path.join(dirPath, 'dist'), { recursive: true, force: true });
+    expect(await buildIfNeeded({ command }, dirPath)).toBe(true);
+    expect(await buildIfNeeded({ command }, dirPath)).toBe(false);
+  });
 }, 30_000);

--- a/packages/wb/test/fixtures/blitz/.env
+++ b/packages/wb/test/fixtures/blitz/.env
@@ -1,1 +1,3 @@
 PORT=3000
+WB_ENV=development
+NEXT_PUBLIC_WB_ENV=development

--- a/packages/wb/test/privateRegistry.test.ts
+++ b/packages/wb/test/privateRegistry.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isPrivateRegistryDependency, parseNpmrc } from '../src/utils/privateRegistry.js';
+
+describe('isPrivateRegistryDependency', () => {
+  it('accepts registry ranges for the private scope only', () => {
+    expect(isPrivateRegistryDependency('@willbooster-private/agentic-workflows', '1.2.3')).toBe(true);
+    expect(isPrivateRegistryDependency('@willbooster-private/llm-proxy', '^1.2.3')).toBe(true);
+    expect(isPrivateRegistryDependency('@willbooster/wb', '1.2.3')).toBe(false);
+    expect(
+      isPrivateRegistryDependency('@willbooster-private/agentic-workflows', 'git@github.com:WillBooster/x.git')
+    ).toBe(false);
+    expect(isPrivateRegistryDependency('@willbooster-private/agentic-workflows', 'workspace:*')).toBe(false);
+    expect(isPrivateRegistryDependency('@willbooster-private/agentic-workflows', 'file:../x')).toBe(false);
+  });
+});
+
+describe('parseNpmrc', () => {
+  afterEach(() => {
+    delete process.env.TEST_VERDACCIO_TOKEN;
+  });
+
+  it('parses entries and expands environment variable references', () => {
+    process.env.TEST_VERDACCIO_TOKEN = 'secret-token';
+    const entries = parseNpmrc(`# comment
+@willbooster-private:registry=https://verdaccio.example.com/
+//verdaccio.example.com/:_authToken=\${TEST_VERDACCIO_TOKEN}
+legacy-peer-deps=true
+`);
+    expect(entries).toEqual({
+      '@willbooster-private:registry': 'https://verdaccio.example.com/',
+      '//verdaccio.example.com/:_authToken': 'secret-token',
+      'legacy-peer-deps': 'true',
+    });
+  });
+});

--- a/packages/wb/test/release.test.ts
+++ b/packages/wb/test/release.test.ts
@@ -62,4 +62,36 @@ describe('restoreWorkspaceRanges', () => {
   "dependencies": { "@willbooster/shared-lib": "workspace:^1.0.0" }
 }`);
   });
+
+  it('restores specifiers multi-semantic-release overwrote with concrete versions', () => {
+    // multi-semantic-release's prepare step overwrites local dependency specifiers (e.g. the
+    // temporary "*" becomes "^1.1.0"); the committed manifest must still get workspace: back.
+    const original = `{
+  "version": "1.0.0",
+  "dependencies": { "@willbooster/shared-lib": "workspace:^1.0.0" }
+}`;
+    const currentAfterRelease = `{
+  "version": "1.1.0",
+  "dependencies": { "@willbooster/shared-lib": "^1.1.0" }
+}`;
+    expect(restoreWorkspaceRanges(currentAfterRelease, original)).toBe(`{
+  "version": "1.1.0",
+  "dependencies": { "@willbooster/shared-lib": "workspace:^1.0.0" }
+}`);
+  });
+
+  it('leaves same-named keys outside dependency sections untouched', () => {
+    const original = `{
+  "dependencies": { "foo": "workspace:*" },
+  "overrides": { "foo": "*" }
+}`;
+    const currentAfterRelease = `{
+  "dependencies": { "foo": "*" },
+  "overrides": { "foo": "*" }
+}`;
+    expect(restoreWorkspaceRanges(currentAfterRelease, original)).toBe(`{
+  "dependencies": { "foo": "workspace:*" },
+  "overrides": { "foo": "*" }
+}`);
+  });
 });

--- a/packages/wb/test/release.test.ts
+++ b/packages/wb/test/release.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildHoistedBunfig, rewriteWorkspaceRanges } from '../src/commands/release.js';
+
+describe('buildHoistedBunfig', () => {
+  it('switches the isolated linker to hoisted and drops globalStore', () => {
+    const bunfig = `[install]
+exact = true
+globalStore = true
+linker = "isolated"
+publicHoistPattern = ["tsx"]
+`;
+    expect(buildHoistedBunfig(bunfig)).toBe(`[install]
+exact = true
+linker = "hoisted"
+publicHoistPattern = ["tsx"]
+`);
+  });
+
+  it('keeps a hoisted bunfig unchanged', () => {
+    const bunfig = `[install]\nlinker = "hoisted"\n`;
+    expect(buildHoistedBunfig(bunfig)).toBe(bunfig);
+  });
+});
+
+describe('rewriteWorkspaceRanges', () => {
+  it('rewrites workspace: specifiers to *', () => {
+    const packageJson = `{
+  "dependencies": { "@willbooster/shared-lib": "workspace:*", "chalk": "5.6.2" },
+  "devDependencies": { "@willbooster/wb": "workspace:^1.0.0" }
+}`;
+    expect(rewriteWorkspaceRanges(packageJson)).toBe(`{
+  "dependencies": { "@willbooster/shared-lib": "*", "chalk": "5.6.2" },
+  "devDependencies": { "@willbooster/wb": "*" }
+}`);
+  });
+});

--- a/packages/wb/test/release.test.ts
+++ b/packages/wb/test/release.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildHoistedBunfig, rewriteWorkspaceRanges } from '../src/commands/release.js';
+import { buildHoistedBunfig, restoreWorkspaceRanges, rewriteWorkspaceRanges } from '../src/commands/release.js';
 
 describe('buildHoistedBunfig', () => {
   it('switches the isolated linker to hoisted and drops globalStore', () => {
@@ -32,6 +32,34 @@ describe('rewriteWorkspaceRanges', () => {
     expect(rewriteWorkspaceRanges(packageJson)).toBe(`{
   "dependencies": { "@willbooster/shared-lib": "*", "chalk": "5.6.2" },
   "devDependencies": { "@willbooster/wb": "*" }
+}`);
+  });
+
+  it('leaves non-dependency strings starting with workspace: untouched', () => {
+    const packageJson = `{
+  "description": "workspace: utilities",
+  "dependencies": { "@willbooster/shared-lib": "workspace:*" }
+}`;
+    expect(rewriteWorkspaceRanges(packageJson)).toBe(`{
+  "description": "workspace: utilities",
+  "dependencies": { "@willbooster/shared-lib": "*" }
+}`);
+  });
+});
+
+describe('restoreWorkspaceRanges', () => {
+  it('restores workspace: specifiers into content changed during the release (e.g. a version bump)', () => {
+    const original = `{
+  "version": "1.0.0",
+  "dependencies": { "@willbooster/shared-lib": "workspace:^1.0.0" }
+}`;
+    const currentAfterRelease = `{
+  "version": "1.1.0",
+  "dependencies": { "@willbooster/shared-lib": "*" }
+}`;
+    expect(restoreWorkspaceRanges(currentAfterRelease, original)).toBe(`{
+  "version": "1.1.0",
+  "dependencies": { "@willbooster/shared-lib": "workspace:^1.0.0" }
 }`);
   });
 });

--- a/packages/wb/test/release.test.ts
+++ b/packages/wb/test/release.test.ts
@@ -80,6 +80,25 @@ describe('restoreWorkspaceRanges', () => {
 }`);
   });
 
+  it('restores each section independently for a dependency present in multiple sections', () => {
+    // A peer range next to a workspace devDependency must keep its own value, and two workspace
+    // ranges of the same package must each get their own specifier back.
+    const original = `{
+  "peerDependencies": { "@willbooster/shared-lib": ">=1.0.0" },
+  "devDependencies": { "@willbooster/shared-lib": "workspace:*" }
+}`;
+    const currentAfterRelease = `{
+  "version": "1.1.0",
+  "peerDependencies": { "@willbooster/shared-lib": ">=1.0.0" },
+  "devDependencies": { "@willbooster/shared-lib": "1.1.0" }
+}`;
+    expect(restoreWorkspaceRanges(currentAfterRelease, original)).toBe(`{
+  "version": "1.1.0",
+  "peerDependencies": { "@willbooster/shared-lib": ">=1.0.0" },
+  "devDependencies": { "@willbooster/shared-lib": "workspace:*" }
+}`);
+  });
+
   it('leaves same-named keys outside dependency sections untouched', () => {
     const original = `{
   "dependencies": { "foo": "workspace:*" },


### PR DESCRIPTION
Fixes #981
Fixes #956
Fixes #930
Fixes #942
Fixes #964

## Customer Summary

- Repositories using Bun isolated installs can now publish to npm with a single `"release": "wb release"` script: it temporarily switches to a layout npm understands, runs semantic-release, and restores everything afterwards — even when the release fails or is cancelled.
- `wb buildIfNeeded` no longer reports a successful "skip" when build outputs were deleted or when source files were staged, renamed, newly added (including under `build/`-like directories or with non-ASCII names), or when only the lockfile changed.
- Forcing an environment (e.g. `WB_ENV=test wb test`) now reliably uses that environment's committed values — from `.env.<mode>` files AND fnox profiles — instead of stale variables leaking from the developer's shell; CI-injected variables keep winning on CI.
- `wb deploy` picks the correct D1 migration mechanism (wrangler-native vs drizzle-kit) from the drizzle config's actual exported configuration, warns loudly when a D1 binding has no migration mechanism, and requires `CLOUDFLARE_API_TOKEN` only when drizzle-kit actually needs it.
- Docker builds of apps with private dependencies need no registry or SSH credentials: `wb setup-private-packages` materializes `@willbooster-private/*` Verdaccio packages (and their nested private deps, git or registry) safely and atomically, and `wb optimizeForDockerBuild` validates the materialized versions before rewriting.
- Every mode must define `WB_ENV` (and `NEXT_PUBLIC_WB_ENV` for Next/vinext apps); wb fails fast with a clear message instead of misbehaving later (`WB_SKIP_ENV_CHECK=1` opts out; bootstrap flows are unaffected).

## Technical Summary

- New `packages/wb/src/commands/release.ts`: hoisted clean-reinstall (bunfig/lockfile snapshotted as raw bytes), dependency-section-scoped `workspace:` rewrite, async child spawning with SIGINT/SIGTERM tree-kill forwarding, per-(section, name) semantic restore on success and byte-for-byte restore on failure/interruption, correct scoped-fork package name for the `bunx`/`yarn dlx` fallback.
- `buildIfNeeded`: cache records output paths and the build command; input hashing covers staged changes (`git diff HEAD`), untracked files (`git status --porcelain -uall -z`, rename-aware, non-ASCII-safe), and bun lockfiles; include/exclude filters match whole path segments; only explicit `--output` paths are excluded from hashing; legacy caches are treated as misses; unborn-HEAD and non-repo-root layouts always build.
- Env loading (`shared-lib-node/src/env.ts`, `wb dotenv` TS + `bin/dotenv.js` fast path): per-key forced-mode override (preserving `.env.local` precedence), fnox profile-specificity via a lazy base `fnox export` (FNOX_PROFILE cleared only for that adjudication), `--cascade-node-env` counts as forced, `${...}` expansion resolves to effective values, fnox sources are reported even when empty so required-env validation cannot fail open, and forwarded shutdown signals re-raise (exit 130).
- `wb deploy`: `usesDrizzleKitForD1` resolves the exported config object via comment stripping, string masking, module-scope identifier resolution, and a string-aware property scanner; unmanaged D1 bindings (including partial layouts) produce a named warning; the token preflight fires exactly when drizzle-kit is the selected mechanism.
- `setup-private-packages` / `optimizeForDockerBuild` / `privateRegistry`: staged atomic registry materialization at `<root>/@willbooster-private`, path-traversal-safe package names, longest-prefix boundary-safe `.npmrc` token matching, auth token sent only to the registry origin, SemVer-2.0.0-grammar version classification shared across download/merge/staleness checks, isolated-linker symlink dereferencing, `.bun`-store fallback with ambiguity errors, and version-conflict detection across manifests.
- `Project`: `NEXT_PUBLIC_WB_ENV` requirement keys off the package's OWN next/vinext dependency; error messages name the correct mode from the loaded env.

## Why

- Publishing from Bun isolated installs previously required a repo-local script (`prepareNpmCompatibleRelease.mjs`); org repos need a reusable, restore-safe command (#987–#990 prior art).
- #981 (false build skips), #930 (stale shell env leaking into forced modes), #942 (wrong-database drizzle migrations), #956 (late token failures), and #964 (credential-requiring Docker builds) were each root-caused and fixed at the mechanism level; three multi-agent review tools (Codex, Claude Code, Antigravity) then hardened the implementation over 16 review rounds until all reported no concern.

## Testing

- `bun verify` (typecheck + lint, all packages) green; packages/wb vitest suite 147 passed / 1 skipped; packages/shared-lib-node suite 40 passed.
- Behavior verified through real entry points: dotenv forced-mode override and `${...}` expansion (TS + bin paths), SIGINT/SIGTERM cancellation of `wb release` (tree-killed grandchildren, restored files, exit 143), buildIfNeeded cache invalidation matrices (outputs, staged, untracked, `src/contest`, `--output` files), 17+ drizzle-config shapes, fnox profile adjudication with `FNOX_PROFILE` set.

## Notes

- #964 version resolution supports exact versions, simple `^`/`~` ranges (degraded to base), and dist-tags — no full semver range resolution. Dockerfiles must COPY `@willbooster-private/` alongside `@willbooster/`.
- `wb release` leaves node_modules hoisted after a local run and prints a clean-reinstall hint; this repo's root `release` script intentionally stays on `prepareNpmCompatibleRelease.mjs` to avoid churning the live pipeline in the same PR.
- The wbfy-generated `.gitignore` still lacks `@willbooster-private/`; tracked in #993 (packages/wbfy is owned by concurrent PR #992). #950 is intentionally NOT closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
