### PR TITLE
feat: enforce WB_ENV conventions in wbfy and fix eight open issues

### DIFF
--- a/packages/wbfy/src/fixers/cloudflareEnv.ts
+++ b/packages/wbfy/src/fixers/cloudflareEnv.ts
@@ -57,6 +57,9 @@ export async function untrackCloudflareEnv(config: PackageConfig): Promise<void>
       console.error(
         `Failed to untrack ${path.resolve(config.dirPath, cloudflareEnvFileName)} (git rm --cached exited with ${rmStatus}); it is STILL TRACKED and holds a CLOUDFLARE_API_TOKEN. Resolve the staged state (e.g. commit or unstage pending changes) and re-run wbfy, then rotate the token.`
       );
+      // Automation must not treat the run as successful while the security remediation is
+      // unapplied; keep processing the batch but fail the process.
+      process.exitCode = 1;
       return;
     }
     console.error(

--- a/packages/wbfy/src/fixers/cloudflareEnv.ts
+++ b/packages/wbfy/src/fixers/cloudflareEnv.ts
@@ -16,9 +16,13 @@ const cloudflareEnvFileName = '.env.cloudflare';
 export async function untrackCloudflareEnv(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('untrackCloudflareEnv', async () => {
     // .gitignore is ignored for already-tracked files, so a committed .env.cloudflare would stay
-    // fully committable despite holding a live CLOUDFLARE_API_TOKEN.
-    const tracked = spawnSyncAndReturnStdout('git', ['ls-files', '--', cloudflareEnvFileName], config.dirPath);
-    if (!tracked) return;
+    // fully committable despite holding a live CLOUDFLARE_API_TOKEN. The managed ignore rule is
+    // unanchored and therefore also covers nested files (e.g. workers/api/.env.cloudflare), so
+    // scan every tracked path, not just the repository root.
+    const trackedPaths = spawnSyncAndReturnStdout('git', ['ls-files'], config.dirPath)
+      .split('\n')
+      .filter((filePath) => filePath === cloudflareEnvFileName || filePath.endsWith(`/${cloudflareEnvFileName}`));
+    if (trackedPaths.length === 0) return;
 
     // Untracking a file the generated .gitignore does not actually cover (e.g. the gitignore.io
     // fetch failed, so the file was never written) would leave it untracked and dirty, so confirm
@@ -35,27 +39,26 @@ export async function untrackCloudflareEnv(config: PackageConfig): Promise<void>
     if (!hasManagedRule) return;
     // --no-index makes git report the rule that would apply, instead of reporting nothing because
     // the file is tracked.
-    const isIgnored =
-      spawnSyncAndReturnStatus(
-        'git',
-        ['check-ignore', '--quiet', '--no-index', '--', cloudflareEnvFileName],
-        config.dirPath
-      ) === 0;
-    if (!isIgnored) return;
+    const ignoredPaths = trackedPaths.filter(
+      (filePath) =>
+        spawnSyncAndReturnStatus('git', ['check-ignore', '--quiet', '--no-index', '--', filePath], config.dirPath) === 0
+    );
+    if (ignoredPaths.length === 0) return;
 
-    // --cached keeps the file on disk: a local `wb deploy` still needs the real token in it.
+    // --cached keeps the files on disk: a local `wb deploy` still needs the real token in them.
     // git refuses the removal (non-zero status) e.g. when the staged content differs from both
     // HEAD and the worktree; claiming success then would leave the token tracked while telling
     // the operator it is untracked, so report the failure instead. `--force` is deliberately not
     // used: overriding git's safety check could discard a staged change the operator intended.
+    const absoluteIgnoredPaths = ignoredPaths.map((filePath) => path.resolve(config.dirPath, filePath));
     const rmStatus = spawnSyncAndReturnStatus(
       'git',
-      ['rm', '--cached', '--quiet', '--', cloudflareEnvFileName],
+      ['rm', '--cached', '--quiet', '--', ...ignoredPaths],
       config.dirPath
     );
     if (rmStatus !== 0) {
       console.error(
-        `Failed to untrack ${path.resolve(config.dirPath, cloudflareEnvFileName)} (git rm --cached exited with ${rmStatus}); it is STILL TRACKED and holds a CLOUDFLARE_API_TOKEN. Resolve the staged state (e.g. commit or unstage pending changes) and re-run wbfy, then rotate the token.`
+        `Failed to untrack ${absoluteIgnoredPaths.join(', ')} (git rm --cached exited with ${rmStatus}); the file(s) are STILL TRACKED and hold a CLOUDFLARE_API_TOKEN. Resolve the staged state (e.g. commit or unstage pending changes) and re-run wbfy, then rotate the token.`
       );
       // Automation must not treat the run as successful while the security remediation is
       // unapplied; keep processing the batch but fail the process.
@@ -65,11 +68,12 @@ export async function untrackCloudflareEnv(config: PackageConfig): Promise<void>
     console.error(
       `
 ********************************************************************************
-*** SECURITY WARNING: ${path.resolve(config.dirPath, cloudflareEnvFileName)}
-*** was tracked by git and has now been untracked (the file stays on disk).
-*** The CLOUDFLARE_API_TOKEN it contains REMAINS IN GIT HISTORY and must be
+*** SECURITY WARNING: the following file(s) were tracked by git and have now
+*** been untracked (they stay on disk):
+${absoluteIgnoredPaths.map((filePath) => `***   ${filePath}`).join('\n')}
+*** The CLOUDFLARE_API_TOKEN they contain REMAINS IN GIT HISTORY and must be
 *** ROTATED immediately (create a new token in the Cloudflare dashboard, update
-*** this file and the CLOUDFLARE_API_TOKEN GitHub secret, then revoke the old
+*** these files and the CLOUDFLARE_API_TOKEN GitHub secret, then revoke the old
 *** token). Commit the index change wbfy just staged.
 ********************************************************************************
 `.trim()

--- a/packages/wbfy/src/fixers/cloudflareEnv.ts
+++ b/packages/wbfy/src/fixers/cloudflareEnv.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
-import { spawnSyncAndReturnStatus, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
+import { spawnSyncAndReturnRawStdout, spawnSyncAndReturnStatus } from '../utils/spawnUtil.js';
 
 const cloudflareEnvFileName = '.env.cloudflare';
 
@@ -20,8 +20,9 @@ export async function untrackCloudflareEnv(config: PackageConfig): Promise<void>
     // unanchored and therefore also covers nested files (e.g. workers/api/.env.cloudflare), so
     // scan every tracked path, not just the repository root.
     // -z + core.quotePath=false: git C-quotes non-ASCII paths by default, which would make the
-    // suffix filter below silently miss e.g. a tracked `アプリ/.env.cloudflare`.
-    const trackedPaths = spawnSyncAndReturnStdout(
+    // suffix filter below silently miss e.g. a tracked `アプリ/.env.cloudflare`. Raw (untrimmed)
+    // stdout, because a leading whitespace byte belongs to the first file name.
+    const trackedPaths = spawnSyncAndReturnRawStdout(
       'git',
       ['-c', 'core.quotePath=false', 'ls-files', '-z', '--', cloudflareEnvFileName, `*/${cloudflareEnvFileName}`],
       config.dirPath

--- a/packages/wbfy/src/fixers/cloudflareEnv.ts
+++ b/packages/wbfy/src/fixers/cloudflareEnv.ts
@@ -19,8 +19,14 @@ export async function untrackCloudflareEnv(config: PackageConfig): Promise<void>
     // fully committable despite holding a live CLOUDFLARE_API_TOKEN. The managed ignore rule is
     // unanchored and therefore also covers nested files (e.g. workers/api/.env.cloudflare), so
     // scan every tracked path, not just the repository root.
-    const trackedPaths = spawnSyncAndReturnStdout('git', ['ls-files'], config.dirPath)
-      .split('\n')
+    // -z + core.quotePath=false: git C-quotes non-ASCII paths by default, which would make the
+    // suffix filter below silently miss e.g. a tracked `アプリ/.env.cloudflare`.
+    const trackedPaths = spawnSyncAndReturnStdout(
+      'git',
+      ['-c', 'core.quotePath=false', 'ls-files', '-z', '--', cloudflareEnvFileName, `*/${cloudflareEnvFileName}`],
+      config.dirPath
+    )
+      .split('\0')
       .filter((filePath) => filePath === cloudflareEnvFileName || filePath.endsWith(`/${cloudflareEnvFileName}`));
     if (trackedPaths.length === 0) return;
 

--- a/packages/wbfy/src/fixers/cloudflareEnv.ts
+++ b/packages/wbfy/src/fixers/cloudflareEnv.ts
@@ -44,7 +44,21 @@ export async function untrackCloudflareEnv(config: PackageConfig): Promise<void>
     if (!isIgnored) return;
 
     // --cached keeps the file on disk: a local `wb deploy` still needs the real token in it.
-    spawnSyncAndReturnStatus('git', ['rm', '--cached', '--quiet', '--', cloudflareEnvFileName], config.dirPath);
+    // git refuses the removal (non-zero status) e.g. when the staged content differs from both
+    // HEAD and the worktree; claiming success then would leave the token tracked while telling
+    // the operator it is untracked, so report the failure instead. `--force` is deliberately not
+    // used: overriding git's safety check could discard a staged change the operator intended.
+    const rmStatus = spawnSyncAndReturnStatus(
+      'git',
+      ['rm', '--cached', '--quiet', '--', cloudflareEnvFileName],
+      config.dirPath
+    );
+    if (rmStatus !== 0) {
+      console.error(
+        `Failed to untrack ${path.resolve(config.dirPath, cloudflareEnvFileName)} (git rm --cached exited with ${rmStatus}); it is STILL TRACKED and holds a CLOUDFLARE_API_TOKEN. Resolve the staged state (e.g. commit or unstage pending changes) and re-run wbfy, then rotate the token.`
+      );
+      return;
+    }
     console.error(
       `
 ********************************************************************************

--- a/packages/wbfy/src/fixers/cloudflareEnv.ts
+++ b/packages/wbfy/src/fixers/cloudflareEnv.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { logger } from '../logger.js';
+import type { PackageConfig } from '../packageConfig.js';
+import { spawnSyncAndReturnStatus, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
+
+const cloudflareEnvFileName = '.env.cloudflare';
+
+/**
+ * Stops tracking .env.cloudflare in Cloudflare projects that committed it before .gitignore
+ * covered it. Unlike worker-configuration.d.ts, nothing regenerates the file, so `--cached` keeps
+ * it on disk — but untracking cannot remediate the leak: the CLOUDFLARE_API_TOKEN it holds
+ * remains in git history and must be rotated, which the prominent warning below demands.
+ */
+export async function untrackCloudflareEnv(config: PackageConfig): Promise<void> {
+  return logger.functionIgnoringException('untrackCloudflareEnv', async () => {
+    // .gitignore is ignored for already-tracked files, so a committed .env.cloudflare would stay
+    // fully committable despite holding a live CLOUDFLARE_API_TOKEN.
+    const tracked = spawnSyncAndReturnStdout('git', ['ls-files', '--', cloudflareEnvFileName], config.dirPath);
+    if (!tracked) return;
+
+    // Untracking a file the generated .gitignore does not actually cover (e.g. the gitignore.io
+    // fetch failed, so the file was never written) would leave it untracked and dirty, so confirm
+    // the managed rule applies first. `git check-ignore` also honors .git/info/exclude and global
+    // excludes, which a fresh clone lacks, so the committed package .gitignore must carry the
+    // managed rule itself.
+    const gitignorePath = path.resolve(config.dirPath, '.gitignore');
+    const hasManagedRule =
+      fs.existsSync(gitignorePath) &&
+      fs
+        .readFileSync(gitignorePath, 'utf8')
+        .split('\n')
+        .some((line) => line.trim() === cloudflareEnvFileName);
+    if (!hasManagedRule) return;
+    // --no-index makes git report the rule that would apply, instead of reporting nothing because
+    // the file is tracked.
+    const isIgnored =
+      spawnSyncAndReturnStatus(
+        'git',
+        ['check-ignore', '--quiet', '--no-index', '--', cloudflareEnvFileName],
+        config.dirPath
+      ) === 0;
+    if (!isIgnored) return;
+
+    // --cached keeps the file on disk: a local `wb deploy` still needs the real token in it.
+    spawnSyncAndReturnStatus('git', ['rm', '--cached', '--quiet', '--', cloudflareEnvFileName], config.dirPath);
+    console.error(
+      `
+********************************************************************************
+*** SECURITY WARNING: ${path.resolve(config.dirPath, cloudflareEnvFileName)}
+*** was tracked by git and has now been untracked (the file stays on disk).
+*** The CLOUDFLARE_API_TOKEN it contains REMAINS IN GIT HISTORY and must be
+*** ROTATED immediately (create a new token in the Cloudflare dashboard, update
+*** this file and the CLOUDFLARE_API_TOKEN GitHub secret, then revoke the old
+*** token). Commit the index change wbfy just staged.
+********************************************************************************
+`.trim()
+    );
+  });
+}

--- a/packages/wbfy/src/generators/gitignore.ts
+++ b/packages/wbfy/src/generators/gitignore.ts
@@ -32,6 +32,7 @@ __generated__/
 .tokensave/
 .wb/
 @willbooster/
+@willbooster-private/
 */mount/*.hash
 CLAUDE.local.md
 dist/

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -314,14 +314,14 @@ function generatePostMergeCommands(config: PackageConfig, allConfigs: PackageCon
   // the separate install-layout hook below.
   // Scan every workspace config (not just the root): in a monorepo the app usually lives in
   // packages/<app> or apps/<app>, and the cache directories are workspace-relative.
-  const rmNextDirectories = collectWorkspaceRelativeDirPaths(
+  const nextCacheDirPaths = collectWorkspaceRelativeDirPaths(
     config,
     allConfigs,
     (workspaceConfig) => workspaceConfig.depending.blitz || workspaceConfig.depending.next,
     '.next'
-  )
-    .map((dirPath) => ` && rm -Rf ${dirPath}`)
-    .join('');
+  );
+  const rmNextDirectories =
+    nextCacheDirPaths.length > 0 ? ` && rm -Rf -- ${nextCacheDirPaths.map(quoteForEvaluatedShell).join(' ')}` : '';
   // bun.lock-only merges (Renovate lockfile maintenance), bunfig.toml / .npmrc changes (linker,
   // registry, hoisting), and patch edits all change the installed tree without touching package.json.
   postMergeCommands.push(
@@ -339,7 +339,7 @@ function generatePostMergeCommands(config: PackageConfig, allConfigs: PackageCon
   );
   if (rmViteCacheDirectories.length > 0) {
     postMergeCommands.push(
-      String.raw`run_if_changed "(bunfig\.toml|\.npmrc)" "rm -Rf ${rmViteCacheDirectories.join(' ')}"`
+      String.raw`run_if_changed "(bunfig\.toml|\.npmrc)" "rm -Rf -- ${rmViteCacheDirectories.map(quoteForEvaluatedShell).join(' ')}"`
     );
   }
   if (config.doesContainPoetryLock) {
@@ -373,6 +373,13 @@ function generatePostMergeCommands(config: PackageConfig, allConfigs: PackageCon
  * workspace whose config matches the predicate. The hook script runs at the repository root, so
  * paths are relative to the root config's directory.
  */
+// The generated command string is eval'd by run_if_changed, so an unquoted path containing
+// spaces or glob characters (e.g. `apps/my app/.next`) would word-split into unrelated rm
+// targets. Single quotes survive the surrounding double-quoted argument and the eval.
+function quoteForEvaluatedShell(filePath: string): string {
+  return `'${filePath.replaceAll("'", String.raw`'\''`)}'`;
+}
+
 function collectWorkspaceRelativeDirPaths(
   rootConfig: PackageConfig,
   allConfigs: PackageConfig[],

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -373,11 +373,14 @@ function generatePostMergeCommands(config: PackageConfig, allConfigs: PackageCon
  * workspace whose config matches the predicate. The hook script runs at the repository root, so
  * paths are relative to the root config's directory.
  */
-// The generated command string is eval'd by run_if_changed, so an unquoted path containing
-// spaces or glob characters (e.g. `apps/my app/.next`) would word-split into unrelated rm
-// targets. Single quotes survive the surrounding double-quoted argument and the eval.
+// The generated command passes through TWO shell parsing stages: the prepare.sh line parses it as
+// a double-quoted argument (processing \, `, $ and " immediately), and run_if_changed then eval's
+// it (word-splitting and globbing). An unquoted path containing spaces (e.g. `apps/my app/.next`)
+// would word-split into unrelated rm targets, and `$`/backtick would expand at the first stage.
+// So: single-quote for the eval stage, then backslash-escape the double-quote-context specials.
 function quoteForEvaluatedShell(filePath: string): string {
-  return `'${filePath.replaceAll("'", String.raw`'\''`)}'`;
+  const evalQuoted = `'${filePath.replaceAll("'", String.raw`'\''`)}'`;
+  return evalQuoted.replaceAll(/[\\`$"]/gu, String.raw`\$&`);
 }
 
 function collectWorkspaceRelativeDirPaths(

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -368,11 +368,6 @@ function generatePostMergeCommands(config: PackageConfig, allConfigs: PackageCon
   return postMergeCommands;
 }
 
-/**
- * The workspace-relative directories (root first, deduplicated, `<subDirName>` appended) of every
- * workspace whose config matches the predicate. The hook script runs at the repository root, so
- * paths are relative to the root config's directory.
- */
 // The generated command passes through TWO shell parsing stages: the prepare.sh line parses it as
 // a double-quoted argument (processing \, `, $ and " immediately), and run_if_changed then eval's
 // it (word-splitting and globbing). An unquoted path containing spaces (e.g. `apps/my app/.next`)
@@ -383,6 +378,11 @@ function quoteForEvaluatedShell(filePath: string): string {
   return evalQuoted.replaceAll(/[\\`$"]/gu, String.raw`\$&`);
 }
 
+/**
+ * The workspace-relative directories (root first, deduplicated, `<subDirName>` appended) of every
+ * workspace whose config matches the predicate. The hook script runs at the repository root, so
+ * paths are relative to the root config's directory.
+ */
 function collectWorkspaceRelativeDirPaths(
   rootConfig: PackageConfig,
   allConfigs: PackageConfig[],

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -98,13 +98,16 @@ run_if_changed() {
 `.trim(),
 };
 
-export async function generateLefthookUpdatingPackageJson(config: PackageConfig): Promise<void> {
+export async function generateLefthookUpdatingPackageJson(
+  config: PackageConfig,
+  allConfigs: PackageConfig[] = [config]
+): Promise<void> {
   return logger.functionIgnoringException('generateLefthookUpdatingPackageJson', async () => {
-    await core(config);
+    await core(config, allConfigs);
   });
 }
 
-async function core(config: PackageConfig): Promise<void> {
+async function core(config: PackageConfig, allConfigs: PackageConfig[]): Promise<void> {
   const dirPath = path.resolve(config.dirPath, '.lefthook');
   const huskyDirPath = path.resolve(config.dirPath, '.husky');
   const hasHuskyDir = fs.existsSync(huskyDirPath);
@@ -146,7 +149,7 @@ async function core(config: PackageConfig): Promise<void> {
       mode: 0o755,
     });
   }
-  const postMergeCommand = `${scripts.postMerge}\n\n${generatePostMergeCommands(config).join('\n')}\n`;
+  const postMergeCommand = `${scripts.postMerge}\n\n${generatePostMergeCommands(config, allConfigs).join('\n')}\n`;
   fs.mkdirSync(path.join(dirPath, 'post-merge'), { recursive: true });
   await fs.promises.writeFile(path.resolve(dirPath, 'post-merge', 'prepare.sh'), postMergeCommand, {
     mode: 0o755,
@@ -297,7 +300,7 @@ function hasLocalWbWorkspace(config: PackageConfig): boolean {
   }
 }
 
-function generatePostMergeCommands(config: PackageConfig): string[] {
+function generatePostMergeCommands(config: PackageConfig, allConfigs: PackageConfig[]): string[] {
   const postMergeCommands: string[] = [];
   // Always emit the mise hook: every managed repository receives mise.toml from generateMiseToml
   // in the same run, and gating on a pre-run hasVersionSettings snapshot would omit the hook on
@@ -307,16 +310,38 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
   const installCommand = 'bun install';
   // Do NOT add `.vinext` here: it holds only vinext's content-hashed font cache and the dev
   // server's lock file (deleting the lock disables the duplicate-dev-server guard for a running
-  // server). vinext's build output goes to `dist/`, and Vite's dependency cache in
-  // `node_modules/.vite` self-invalidates on lockfile / patches / config / NODE_ENV changes
-  // (see Vite's dep pre-bundling docs) - the residual install-layout case (bunfig.toml/.npmrc
-  // changes alone don't touch the lockfile, so Vite's cache survives) is tracked in #983.
-  const rmNextDirectory = config.depending.blitz || config.depending.next ? ' && rm -Rf .next' : '';
+  // server). vinext's build output goes to `dist/`, and Vite's dependency cache is handled by
+  // the separate install-layout hook below.
+  // Scan every workspace config (not just the root): in a monorepo the app usually lives in
+  // packages/<app> or apps/<app>, and the cache directories are workspace-relative.
+  const rmNextDirectories = collectWorkspaceRelativeDirPaths(
+    config,
+    allConfigs,
+    (workspaceConfig) => workspaceConfig.depending.blitz || workspaceConfig.depending.next,
+    '.next'
+  )
+    .map((dirPath) => ` && rm -Rf ${dirPath}`)
+    .join('');
   // bun.lock-only merges (Renovate lockfile maintenance), bunfig.toml / .npmrc changes (linker,
   // registry, hoisting), and patch edits all change the installed tree without touching package.json.
   postMergeCommands.push(
-    String.raw`run_if_changed "(package\.json|bun\.lock|bunfig\.toml|\.npmrc|patches/)" "${installCommand}${rmNextDirectory}"`
+    String.raw`run_if_changed "(package\.json|bun\.lock|bunfig\.toml|\.npmrc|patches/)" "${installCommand}${rmNextDirectories}"`
   );
+  // Vite's dependency cache in node_modules/.vite self-invalidates on lockfile / patches /
+  // config / NODE_ENV changes (see Vite's dep pre-bundling docs), so the residual stale case is
+  // install-layout changes (bunfig.toml linker, .npmrc): they change the installed tree without
+  // touching the lockfile, and they are absent from Vite's cache key.
+  const rmViteCacheDirectories = collectWorkspaceRelativeDirPaths(
+    config,
+    allConfigs,
+    (workspaceConfig) => workspaceConfig.depending.vinext || workspaceConfig.depending.vite,
+    'node_modules/.vite'
+  );
+  if (rmViteCacheDirectories.length > 0) {
+    postMergeCommands.push(
+      String.raw`run_if_changed "(bunfig\.toml|\.npmrc)" "rm -Rf ${rmViteCacheDirectories.join(' ')}"`
+    );
+  }
   if (config.doesContainPoetryLock) {
     postMergeCommands.push(String.raw`run_if_changed "poetry\.lock" "poetry install"`);
   }
@@ -341,6 +366,29 @@ function generatePostMergeCommands(config: PackageConfig): string[] {
     postMergeCommands.push(String.raw`run_if_changed "(^|/)i18n/.*\.json$" "${genI18nTsCommand}"`);
   }
   return postMergeCommands;
+}
+
+/**
+ * The workspace-relative directories (root first, deduplicated, `<subDirName>` appended) of every
+ * workspace whose config matches the predicate. The hook script runs at the repository root, so
+ * paths are relative to the root config's directory.
+ */
+function collectWorkspaceRelativeDirPaths(
+  rootConfig: PackageConfig,
+  allConfigs: PackageConfig[],
+  predicate: (config: PackageConfig) => boolean,
+  subDirName: string
+): string[] {
+  return [
+    ...new Set(
+      allConfigs
+        .filter((config) => predicate(config))
+        .map((config) => {
+          const relativeDirPath = path.relative(rootConfig.dirPath, config.dirPath).replaceAll('\\', '/');
+          return relativeDirPath ? path.posix.join(relativeDirPath, subDirName) : subDirName;
+        })
+    ),
+  ].toSorted();
 }
 
 function hasPythonPackageManager(config: PackageConfig): boolean {

--- a/packages/wbfy/src/generators/miseToml.ts
+++ b/packages/wbfy/src/generators/miseToml.ts
@@ -25,6 +25,17 @@ export const minimumBunVersion = '1.3.14';
 export async function generateMiseToml(config: PackageConfig, currentBunVersion: string): Promise<void> {
   return logger.functionIgnoringException('generateMiseToml', async () => {
     const miseTomlPath = path.resolve(config.dirPath, 'mise.toml');
+    // A migration source that exists but is refused by the confined read (a symlink or a path
+    // resolving outside the repository) must abort generation: proceeding as if it were absent
+    // would silently replace its pins (e.g. a linked .node-version) with freshly resolved versions.
+    for (const sourceName of ['.tool-versions', '.node-version']) {
+      const sourcePath = path.resolve(config.dirPath, sourceName);
+      const sourceStats = await fs.promises.lstat(sourcePath).catch(() => {});
+      if (sourceStats && (await fsUtil.readFileConfinedIfExists(sourcePath)) === undefined) {
+        console.warn(`Skipped generating ${miseTomlPath} because ${sourcePath} exists but cannot be read safely.`);
+        return;
+      }
+    }
     // A parse failure must abort instead of falling back to {}: regenerating from an empty object
     // would silently replace the user's existing (albeit broken) mise.toml.
     const settings = parseMiseToml(miseTomlPath);

--- a/packages/wbfy/src/generators/miseToml.ts
+++ b/packages/wbfy/src/generators/miseToml.ts
@@ -28,7 +28,7 @@ export async function generateMiseToml(config: PackageConfig, currentBunVersion:
     // A parse failure must abort instead of falling back to {}: regenerating from an empty object
     // would silently replace the user's existing (albeit broken) mise.toml.
     const settings = parseMiseToml(miseTomlPath);
-    const toolVersions = readToolVersions(config.dirPath);
+    const toolVersions = await readToolVersions(config.dirPath);
     const tools = { ...settings.tools };
 
     // Migrate every .tool-versions entry, not just Node.js and Bun: mise reads asdf tool names,
@@ -44,7 +44,7 @@ export async function generateMiseToml(config: PackageConfig, currentBunVersion:
     // ordering the lift first avoids resolving `mise latest node@lts` twice for unpinned repos.
     tools.node = pinConcreteToolVersion(
       'node',
-      liftOutdatedNodeVersion(tools.node ?? readNodeVersionFile(config.dirPath), config.dirPath),
+      liftOutdatedNodeVersion(tools.node ?? (await readNodeVersionFile(config.dirPath)), config.dirPath),
       config.dirPath
     );
     tools.bun = liftOutdatedBunVersion(tools.bun ?? 'latest', currentBunVersion);
@@ -56,7 +56,13 @@ export async function generateMiseToml(config: PackageConfig, currentBunVersion:
     // Delete the migration source only after the replacement actually landed; a refused write
     // (e.g. a symlinked mise.toml) must not destroy the only tool configuration.
     if (await fsUtil.generateFile(miseTomlPath, stringify(settings))) {
-      await promisePool.run(() => fs.promises.rm(path.resolve(config.dirPath, '.tool-versions'), { force: true }));
+      const toolVersionsPath = path.resolve(config.dirPath, '.tool-versions');
+      const stats = await fs.promises.lstat(toolVersionsPath).catch(() => {});
+      // Keep a symlinked source: the confined read above rejected it, so its entries were never
+      // migrated and deleting the link would silently drop the only tool pins.
+      if (stats && !stats.isSymbolicLink()) {
+        await promisePool.run(() => fsUtil.removeConfined(toolVersionsPath));
+      }
     }
   });
 }
@@ -144,27 +150,19 @@ function parseMiseToml(miseTomlPath: string): MiseToml {
   return parse(content) as MiseToml;
 }
 
-function readNodeVersionFile(dirPath: string): string | undefined {
-  try {
-    const version = fs.readFileSync(path.resolve(dirPath, '.node-version'), 'utf8').trim().replace(/^v/u, '');
-    return version || undefined;
-  } catch (error) {
-    // An unreadable file must abort instead of being ignored; the file is a migration source.
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
-    throw error;
-  }
+async function readNodeVersionFile(dirPath: string): Promise<string | undefined> {
+  // Confined read: a committed .node-version symlink pointing outside the repository must not
+  // contribute an external file's content to the generated mise.toml.
+  const content = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, '.node-version'));
+  const version = content?.trim().replace(/^v/u, '');
+  return version || undefined;
 }
 
-function readToolVersions(dirPath: string): Map<string, string[]> {
+async function readToolVersions(dirPath: string): Promise<Map<string, string[]>> {
   const versions = new Map<string, string[]>();
-  let content: string | undefined;
-  try {
-    content = fs.readFileSync(path.resolve(dirPath, '.tool-versions'), 'utf8');
-  } catch (error) {
-    // Only a repository without .tool-versions has nothing to migrate; an unreadable file must
-    // abort instead of being silently discarded (it is deleted after mise.toml is written).
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-  }
+  // Confined read: a committed .tool-versions symlink pointing outside the repository must not
+  // get its target's content migrated into the tracked mise.toml (and the link deleted).
+  const content = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, '.tool-versions'));
   for (const line of content?.split('\n') ?? []) {
     const [tool, ...toolVersions] = line.replace(/#.*$/u, '').trim().split(/\s+/u);
     if (tool && toolVersions.length > 0) {

--- a/packages/wbfy/src/generators/miseToml.ts
+++ b/packages/wbfy/src/generators/miseToml.ts
@@ -68,10 +68,10 @@ export async function generateMiseToml(config: PackageConfig, currentBunVersion:
     // (e.g. a symlinked mise.toml) must not destroy the only tool configuration.
     if (await fsUtil.generateFile(miseTomlPath, stringify(settings))) {
       const toolVersionsPath = path.resolve(config.dirPath, '.tool-versions');
-      const stats = await fs.promises.lstat(toolVersionsPath).catch(() => {});
-      // Keep a symlinked source: the confined read above rejected it, so its entries were never
-      // migrated and deleting the link would silently drop the only tool pins.
-      if (stats && !stats.isSymbolicLink()) {
+      // The source-refusal guard at the top guarantees that an existing .tool-versions was
+      // safely read and migrated, so removing it (for a symlink: the link entry only) is safe —
+      // keeping it would leave an active duplicate configuration source that mise still reads.
+      if (await fs.promises.lstat(toolVersionsPath).catch(() => {})) {
         await promisePool.run(() => fsUtil.removeConfined(toolVersionsPath));
       }
     }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -476,7 +476,13 @@ async function applyPackageJsonConventions(
     if (config.doesContainSubPackageJsons) {
       // We don't allow non-array workspaces in monorepo. Yarn v1's object form keeps its
       // declared patterns (workspaces.packages); only extras such as nohoist are dropped.
-      jsonObj.workspaces = merge.all([getDeclaredWorkspacePatterns(jsonObj.workspaces), ['packages/*']], {
+      // Force `packages/*` only when it actually matches a workspace manifest: an apps/*-only
+      // monorepo must not get a never-matching pattern appended to its declaration.
+      const forcedPatterns =
+        fg.globSync('packages/*/package.json', { cwd: config.dirPath, ignore: ['**/node_modules/**'] }).length > 0
+          ? ['packages/*']
+          : [];
+      jsonObj.workspaces = merge.all([getDeclaredWorkspacePatterns(jsonObj.workspaces), forcedPatterns], {
         arrayMerge: combineMerge,
       });
     } else if (Array.isArray(jsonObj.workspaces)) {
@@ -1568,35 +1574,45 @@ function applyDatabaseScripts(
 ): void {
   if (!config.depending.prisma && !config.depending.drizzle) return;
 
-  applyDatabaseScript(scripts, oldScripts, 'db-create-migration', `${wbDbCommand} migrate-dev`);
-  applyDatabaseScript(scripts, oldScripts, 'db-migrate', `${wbDbCommand} migrate --check-idempotency`);
-  applyDatabaseScript(scripts, oldScripts, 'db-view', `${wbDbCommand} studio`);
+  applyDatabaseScript(scripts, oldScripts, 'db-create-migration', `${wbDbCommand} migrate-dev`, /migrate-dev/u);
+  applyDatabaseScript(
+    scripts,
+    oldScripts,
+    'db-migrate',
+    `${wbDbCommand} migrate --check-idempotency`,
+    /migrate(?:\s+--check-idempotency)?/u
+  );
+  applyDatabaseScript(scripts, oldScripts, 'db-view', `${wbDbCommand} studio`, /studio/u);
 }
 
 function applyDatabaseScript(
   scripts: Record<string, string>,
   oldScripts: PackageJson.Scripts,
   name: string,
-  generatedScript: string
+  generatedScript: string,
+  generatedArgsPattern: RegExp
 ): void {
   const oldScript = oldScripts[name];
   // Some repositories wrap migration commands to prepare SQLite directories,
   // fan out over tenants, or perform cleanup that wb cannot infer generically.
-  scripts[name] = oldScript && !isGeneratedDatabaseScript(oldScript) ? oldScript : generatedScript;
+  scripts[name] =
+    oldScript && !isGeneratedDatabaseScript(oldScript, generatedArgsPattern) ? oldScript : generatedScript;
 }
 
 /**
- * Whether a script body is one of the KNOWN generated `wb db`/`wb prisma` invocations (allowing
- * legacy runner prefixes, including the historical `bun --bun`, and the historical argument
- * variants such as `migrate` without `--check-idempotency`). Anchored on the WHOLE body AND on the
- * exact generated argument lists so a custom wrapper that merely contains a wb call
- * (`prepare-sqlite && WB_ENV=… wb db studio`) or carries extra flags (`wb prisma studio
- * --port 5556`) is preserved instead of being replaced wholesale.
+ * Whether a script body is one of the KNOWN generated `wb db`/`wb prisma` invocations FOR THE
+ * GIVEN managed script (allowing legacy runner prefixes, including the historical `bun --bun`,
+ * and that script's historical argument variants such as `migrate` without `--check-idempotency`).
+ * Anchored on the WHOLE body AND on the exact generated argument list so a custom wrapper that
+ * merely contains a wb call (`prepare-sqlite && WB_ENV=… wb db studio`), carries extra flags
+ * (`wb prisma studio --port 5556`), or reuses another managed script's command
+ * (`"db-migrate": "wb db migrate-dev"`) is preserved instead of being replaced wholesale.
  */
-function isGeneratedDatabaseScript(script: string): boolean {
-  return /^(?:(?:bun(?:\s+--bun)?|yarn|npx)\s+)?wb\s+(?:db|prisma)\s+(?:migrate-dev|migrate(?:\s+--check-idempotency)?|studio)$/u.test(
-    script.trim()
-  );
+function isGeneratedDatabaseScript(script: string, generatedArgsPattern: RegExp): boolean {
+  return new RegExp(
+    String.raw`^(?:(?:bun(?:\s+--bun)?|yarn|npx)\s+)?wb\s+(?:db|prisma)\s+(?:${generatedArgsPattern.source})$`,
+    'u'
+  ).test(script.trim());
 }
 
 function getWbDatabaseCommand(config: PackageConfig): 'wb db' | 'wb prisma' {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1586,14 +1586,17 @@ function applyDatabaseScript(
 }
 
 /**
- * Whether a script body is one of the generated `wb db`/`wb prisma` invocations (allowing legacy
- * runner prefixes and extra subcommand/flag tokens). Anchored on the WHOLE body so a custom
- * wrapper that merely CONTAINS a wb call (`prepare-sqlite && WB_ENV=… wb db studio`) is preserved
- * instead of being replaced wholesale; any shell operator or env-assignment prefix marks the
- * script as custom.
+ * Whether a script body is one of the KNOWN generated `wb db`/`wb prisma` invocations (allowing
+ * legacy runner prefixes, including the historical `bun --bun`, and the historical argument
+ * variants such as `migrate` without `--check-idempotency`). Anchored on the WHOLE body AND on the
+ * exact generated argument lists so a custom wrapper that merely contains a wb call
+ * (`prepare-sqlite && WB_ENV=… wb db studio`) or carries extra flags (`wb prisma studio
+ * --port 5556`) is preserved instead of being replaced wholesale.
  */
 function isGeneratedDatabaseScript(script: string): boolean {
-  return /^(?:(?:bun|yarn|npx)\s+)?wb\s+(?:db|prisma)(?:\s+[\w./=@:-]+)*$/u.test(script.trim());
+  return /^(?:(?:bun(?:\s+--bun)?|yarn|npx)\s+)?wb\s+(?:db|prisma)\s+(?:migrate-dev|migrate(?:\s+--check-idempotency)?|studio)$/u.test(
+    script.trim()
+  );
 }
 
 function getWbDatabaseCommand(config: PackageConfig): 'wb db' | 'wb prisma' {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1432,6 +1432,24 @@ function getDeclaredWorkspacePatterns(workspaces: PackageJson['workspaces']): st
 
 const workspacePackageDirsCache = new Map<string, Map<string, string>>();
 
+/** The subset of PackageConfig that workspace discovery needs, so it can run before configs exist. */
+type WorkspaceRootLike = Pick<PackageConfig, 'dirPath' | 'doesContainSubPackageJsons' | 'packageJson'>;
+
+/**
+ * Every declared workspace directory (absolute, deduplicated) of the monorepo root, covering
+ * non-packages/* layouts such as apps/*. Uncached because index.ts calls it before wbfy mutates
+ * the root package.json (the per-name map below caches the post-mutation state).
+ */
+export function getWorkspaceSubDirPaths(rootLike: WorkspaceRootLike): string[] {
+  return [
+    ...new Set(
+      getWorkspacePackageJsonPaths(rootLike).map((packageJsonPath) =>
+        path.resolve(rootLike.dirPath, path.posix.dirname(packageJsonPath))
+      )
+    ),
+  ].toSorted();
+}
+
 /** Map from each workspace package's name to its directory (relative to the monorepo root). */
 export function getWorkspacePackageDirs(rootConfig: PackageConfig): Map<string, string> {
   const cached = workspacePackageDirsCache.get(rootConfig.dirPath);
@@ -1458,7 +1476,7 @@ export function getWorkspacePackageDirs(rootConfig: PackageConfig): Map<string, 
  * Every workspace package.json path (relative to the monorepo root), including manifests without
  * a `name` field — wbfy names those later, so dependency scans must not skip them.
  */
-function getWorkspacePackageJsonPaths(rootConfig: PackageConfig): string[] {
+function getWorkspacePackageJsonPaths(rootConfig: WorkspaceRootLike): string[] {
   // applyPackageJsonConventions forces `packages/*` into every monorepo's workspaces, but it may
   // not have written the root package.json yet, so mirror that normalization here.
   const workspacePatterns = [

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -485,6 +485,11 @@ async function applyPackageJsonConventions(
       jsonObj.workspaces = merge.all([getDeclaredWorkspacePatterns(jsonObj.workspaces), forcedPatterns], {
         arrayMerge: combineMerge,
       });
+      // Both inputs can be empty (e.g. packages/package.json without any packages/*/package.json
+      // and no declared workspaces); do not persist a meaningless `workspaces: []`.
+      if (Array.isArray(jsonObj.workspaces) && jsonObj.workspaces.length === 0) {
+        delete jsonObj.workspaces;
+      }
     } else if (Array.isArray(jsonObj.workspaces)) {
       jsonObj.workspaces = jsonObj.workspaces.filter(
         (workspace) =>
@@ -1580,7 +1585,7 @@ function applyDatabaseScripts(
     oldScripts,
     'db-migrate',
     `${wbDbCommand} migrate --check-idempotency`,
-    /migrate(?:\s+--check-idempotency)?/u
+    /migrate(?:[ \t]+--check-idempotency)?/u
   );
   applyDatabaseScript(scripts, oldScripts, 'db-view', `${wbDbCommand} studio`, /studio/u);
 }
@@ -1609,8 +1614,10 @@ function applyDatabaseScript(
  * (`"db-migrate": "wb db migrate-dev"`) is preserved instead of being replaced wholesale.
  */
 function isGeneratedDatabaseScript(script: string, generatedArgsPattern: RegExp): boolean {
+  // Horizontal whitespace only ([ \t]) — a newline is a shell command separator, so a
+  // newline-containing body is a multi-command wrapper that must be preserved.
   return new RegExp(
-    String.raw`^(?:(?:bun(?:\s+--bun)?|yarn|npx)\s+)?wb\s+(?:db|prisma)\s+(?:${generatedArgsPattern.source})$`,
+    String.raw`^(?:(?:bun(?:[ \t]+--bun)?|yarn|npx)[ \t]+)?wb[ \t]+(?:db|prisma)[ \t]+(?:${generatedArgsPattern.source})$`,
     'u'
   ).test(script.trim());
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1628,8 +1628,15 @@ function applyDatabaseScript(
   scripts[name] = oldScript && !isGeneratedDatabaseScript(oldScript) ? oldScript : generatedScript;
 }
 
+/**
+ * Whether a script body is one of the generated `wb db`/`wb prisma` invocations (allowing legacy
+ * runner prefixes and extra subcommand/flag tokens). Anchored on the WHOLE body so a custom
+ * wrapper that merely CONTAINS a wb call (`prepare-sqlite && WB_ENV=… wb db studio`) is preserved
+ * instead of being replaced wholesale; any shell operator or env-assignment prefix marks the
+ * script as custom.
+ */
 function isGeneratedDatabaseScript(script: string): boolean {
-  return /\bwb\s+(?:db|prisma)\b/u.test(script);
+  return /^(?:(?:bun|yarn|npx)\s+)?wb\s+(?:db|prisma)(?:\s+[\w./=@:-]+)*$/u.test(script.trim());
 }
 
 function getWbDatabaseCommand(config: PackageConfig): 'wb db' | 'wb prisma' {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -32,6 +32,7 @@ import { spawnSync, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
 import { getTsconfigBaseDependencies, managedTsconfigBaseDependencies } from '../utils/tsconfigBase.js';
 import { parseSourceFile } from '../utils/typescriptApi.js';
 import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfigsUtil.js';
+import { getDeclaredWorkspacePatterns, getWorkspacePackageJsonPaths } from '../utils/workspaceUtil.js';
 import { bunMinimumReleaseAgeExcludes, bunMinimumReleaseAgeSeconds } from './bunfig.js';
 
 const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', 'oxfmt', 'oxlint', 'oxlint-tsgolint'];
@@ -1424,31 +1425,7 @@ function doesProductCodeImportMicromatch(dirPath: string): boolean {
   });
 }
 
-/** Workspace patterns from either the array form or Yarn v1's `{ packages: […] }` object form. */
-function getDeclaredWorkspacePatterns(workspaces: PackageJson['workspaces']): string[] {
-  if (Array.isArray(workspaces)) return workspaces;
-  return Array.isArray(workspaces?.packages) ? workspaces.packages : [];
-}
-
 const workspacePackageDirsCache = new Map<string, Map<string, string>>();
-
-/** The subset of PackageConfig that workspace discovery needs, so it can run before configs exist. */
-type WorkspaceRootLike = Pick<PackageConfig, 'dirPath' | 'doesContainSubPackageJsons' | 'packageJson'>;
-
-/**
- * Every declared workspace directory (absolute, deduplicated) of the monorepo root, covering
- * non-packages/* layouts such as apps/*. Uncached because index.ts calls it before wbfy mutates
- * the root package.json (the per-name map below caches the post-mutation state).
- */
-export function getWorkspaceSubDirPaths(rootLike: WorkspaceRootLike): string[] {
-  return [
-    ...new Set(
-      getWorkspacePackageJsonPaths(rootLike).map((packageJsonPath) =>
-        path.resolve(rootLike.dirPath, path.posix.dirname(packageJsonPath))
-      )
-    ),
-  ].toSorted();
-}
 
 /** Map from each workspace package's name to its directory (relative to the monorepo root). */
 export function getWorkspacePackageDirs(rootConfig: PackageConfig): Map<string, string> {
@@ -1470,44 +1447,6 @@ export function getWorkspacePackageDirs(rootConfig: PackageConfig): Map<string, 
   }
   workspacePackageDirsCache.set(rootConfig.dirPath, workspaceDirsByName);
   return workspaceDirsByName;
-}
-
-/**
- * Every workspace package.json path (relative to the monorepo root), including manifests without
- * a `name` field — wbfy names those later, so dependency scans must not skip them.
- */
-function getWorkspacePackageJsonPaths(rootConfig: WorkspaceRootLike): string[] {
-  // applyPackageJsonConventions forces `packages/*` into every monorepo's workspaces, but it may
-  // not have written the root package.json yet, so mirror that normalization here.
-  const workspacePatterns = [
-    ...new Set([
-      ...getDeclaredWorkspacePatterns(rootConfig.packageJson?.workspaces),
-      ...(rootConfig.doesContainSubPackageJsons ? ['packages/*'] : []),
-    ]),
-  ];
-  // Expand all patterns in one glob call so Bun-supported negative patterns (e.g.
-  // `!packages/excluded`) actually exclude their matches. Do not apply globIgnore here: workspace
-  // membership is defined solely by the declared patterns, and source-scanning ignores such as
-  // `build` or `dist` would hide legitimately named workspace directories.
-  const packageJsonGlobs = workspacePatterns
-    // Workspace directories must stay inside the repository: absolute or `..`-traversing patterns
-    // would make consumers such as removeNodeModules operate on another repository's files.
-    .filter((workspacePattern) => {
-      const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
-      return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
-    })
-    .map((workspacePattern) =>
-      workspacePattern.startsWith('!')
-        ? `!${path.posix.join(workspacePattern.slice(1), 'package.json')}`
-        : path.posix.join(workspacePattern, 'package.json')
-    );
-  // followSymbolicLinks: false — a workspace symlink pointing outside the repository must not be
-  // treated as a workspace directory (removeNodeModules would delete through it).
-  return fg.globSync(packageJsonGlobs, {
-    cwd: rootConfig.dirPath,
-    followSymbolicLinks: false,
-    ignore: ['**/node_modules/**'],
-  });
 }
 
 function shouldUpdateExistingManagedDependency(

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -130,10 +130,11 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
     await promisePool.run(() =>
       fsUtil.removeConfined(path.resolve(config.dirPath, '.dependabot'), { recursive: true })
     );
-    // Keep a symlinked legacy config: the confined read above rejected it, so its settings were
-    // never migrated and deleting the link would silently drop them.
+    // Remove the legacy config once its settings were migrated above (for a symlink this deletes
+    // only the link entry). An unread symlinked legacy next to a pre-existing renovate.json is
+    // kept: its settings were never migrated, so deleting the link would silently drop them.
     const legacyStats = await fs.promises.lstat(legacyFilePath).catch(() => {});
-    if (legacyStats && !legacyStats.isSymbolicLink()) {
+    if (legacyStats && (legacyContent !== undefined || !legacyStats.isSymbolicLink())) {
       await promisePool.run(() => fsUtil.removeConfined(legacyFilePath));
     }
   });

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -45,6 +45,16 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
   return logger.functionIgnoringException('generateRenovateJson', async () => {
     let newSettings = structuredClone(jsonObj) as Settings;
     const filePath = path.resolve(config.dirPath, 'renovate.json');
+    // A symlinked renovate.json is never managed: writes through it are refused by the
+    // confinement guards anyway, and when its target happens to already match the generated
+    // settings the semantic no-op below would skip generateFile (and its guard) and proceed to
+    // delete the in-repository fallbacks (.dependabot, .renovaterc.json) — leaving a fresh
+    // checkout with only a possibly-dangling external symlink as Renovate configuration.
+    const managedFileStats = await fs.promises.lstat(filePath).catch(() => {});
+    if (managedFileStats && managedFileStats.isSymbolicLink()) {
+      console.warn(`Skipped generating ${filePath} because it is a symbolic link.`);
+      return;
+    }
     const oldContent = await fsUtil.readFileIfExists(filePath);
     // The shadow checks matter only while renovate.json does not exist: it is FIRST in Renovate's
     // resolution order, so an existing renovate.json already shadows every alternative (including

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -81,6 +81,17 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
     // Confined read: a committed .renovaterc.json symlink pointing outside the repository must not
     // get its target's content copied into the tracked renovate.json.
     const legacyContent = oldContent === undefined ? await fsUtil.readFileConfinedIfExists(legacyFilePath) : undefined;
+    // A legacy config that exists but was refused by the confined read (a symlink or a path
+    // resolving outside the repository) must abort generation: renovate.json resolves before
+    // .renovaterc.json, so generating the bare template would silently shadow the user's settings.
+    if (
+      oldContent === undefined &&
+      legacyContent === undefined &&
+      (await fs.promises.lstat(legacyFilePath).catch(() => {}))
+    ) {
+      console.warn(`Skipped generating ${filePath} because ${legacyFilePath} exists but cannot be read safely.`);
+      return;
+    }
     if (legacyContent !== undefined && !jsoncUtil.isTriviaOnly(legacyContent)) {
       oldSettings = jsoncUtil.parseObjectIgnoringError<Settings>(legacyContent);
       if (!oldSettings) {

--- a/packages/wbfy/src/generators/renovateJson.ts
+++ b/packages/wbfy/src/generators/renovateJson.ts
@@ -78,7 +78,9 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
     // below — but only when renovate.json does not exist yet: renovate.json resolves first, so a
     // .renovaterc.json next to it is dead config whose settings must not be resurrected.
     const legacyFilePath = path.resolve(config.dirPath, '.renovaterc.json');
-    const legacyContent = oldContent === undefined ? await fsUtil.readFileIfExists(legacyFilePath) : undefined;
+    // Confined read: a committed .renovaterc.json symlink pointing outside the repository must not
+    // get its target's content copied into the tracked renovate.json.
+    const legacyContent = oldContent === undefined ? await fsUtil.readFileConfinedIfExists(legacyFilePath) : undefined;
     if (legacyContent !== undefined && !jsoncUtil.isTriviaOnly(legacyContent)) {
       oldSettings = jsoncUtil.parseObjectIgnoringError<Settings>(legacyContent);
       if (!oldSettings) {
@@ -115,9 +117,14 @@ export async function generateRenovateJson(config: PackageConfig): Promise<void>
       if (!(await fsUtil.generateFile(filePath, newContent))) return;
     }
     await promisePool.run(() =>
-      fs.promises.rm(path.resolve(config.dirPath, '.dependabot'), { force: true, recursive: true })
+      fsUtil.removeConfined(path.resolve(config.dirPath, '.dependabot'), { recursive: true })
     );
-    await promisePool.run(() => fs.promises.rm(legacyFilePath, { force: true }));
+    // Keep a symlinked legacy config: the confined read above rejected it, so its settings were
+    // never migrated and deleting the link would silently drop them.
+    const legacyStats = await fs.promises.lstat(legacyFilePath).catch(() => {});
+    if (legacyStats && !legacyStats.isSymbolicLink()) {
+      await promisePool.run(() => fsUtil.removeConfined(legacyFilePath));
+    }
   });
 }
 

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { parse } from 'smol-toml';
+
+import { logger } from '../logger.js';
+import type { PackageConfig } from '../packageConfig.js';
+import { fsUtil } from '../utils/fsUtil.js';
+
+interface FnoxTomlSubtree {
+  secrets?: Record<string, unknown>;
+  profiles?: Record<string, { secrets?: Record<string, unknown> } | undefined>;
+}
+
+// The four standard WB_ENV modes; staging is optional and only completed when the repository
+// already declares it (a staging profile / .env.staging file).
+const wbEnvModes = ['development', 'test', 'staging', 'production'] as const;
+type WbEnvMode = (typeof wbEnvModes)[number];
+
+/**
+ * Ensures the repository defines WB_ENV for every standard mode (and NEXT_PUBLIC_WB_ENV when any
+ * workspace depends on Next.js or vinext): in fnox.toml profiles for fnox-based repositories, and
+ * in the legacy .env mode files otherwise. Existing definitions are always left untouched.
+ */
+export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfigs: PackageConfig[]): Promise<void> {
+  return logger.functionIgnoringException('ensureWbEnvDefinitions', async () => {
+    const needsNextPublic = allConfigs.some((config) => config.depending.next || config.depending.vinext);
+    const fnoxTomlPath = path.resolve(rootConfig.dirPath, 'fnox.toml');
+    if (fs.existsSync(fnoxTomlPath)) {
+      const content = await fsUtil.readFileConfinedIfExists(fnoxTomlPath);
+      if (content === undefined) return;
+      const updatedContent = insertWbEnvIntoFnoxToml(content, needsNextPublic);
+      if (updatedContent !== undefined && updatedContent !== content) {
+        await fsUtil.generateFile(fnoxTomlPath, updatedContent);
+      }
+      return;
+    }
+    for (const mode of wbEnvModes) {
+      const envFilePath = path.resolve(rootConfig.dirPath, mode === 'development' ? '.env' : `.env.${mode}`);
+      const envContent = await fsUtil.readFileConfinedIfExists(envFilePath);
+      // Only existing mode files are completed: creating .env.production (never committed by
+      // convention) or a whole legacy layout from nothing is not wbfy's call.
+      if (envContent === undefined) continue;
+      const updatedEnvContent = insertWbEnvIntoEnvFile(envContent, mode, needsNextPublic);
+      if (updatedEnvContent !== envContent) {
+        await fsUtil.writeFileConfined(envFilePath, updatedEnvContent);
+        console.log(`Generated/Updated ${envFilePath}`);
+      }
+    }
+  });
+}
+
+/**
+ * Inserts missing WB_ENV (and optionally NEXT_PUBLIC_WB_ENV) entries into a fnox.toml: the base
+ * `[secrets]` table carries the development defaults and `[profiles.<mode>.secrets]` overlays
+ * each other mode, matching the org-standard layout. Formatting and comments are preserved (only
+ * missing lines are inserted / missing sections appended). Returns undefined when the content
+ * cannot be safely edited (unparsable before or after the edit).
+ */
+export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolean): string | undefined {
+  let settings: FnoxTomlSubtree;
+  try {
+    settings = parse(content) as FnoxTomlSubtree;
+  } catch {
+    console.warn('Skipped inserting WB_ENV into fnox.toml because it is not parsable as TOML.');
+    return undefined;
+  }
+
+  const keyNames = needsNextPublic ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
+  let updatedContent = content;
+  for (const mode of wbEnvModes) {
+    // The staging mode is optional: complete it only when the repository already declares the profile.
+    if (mode === 'staging' && !settings.profiles?.staging) continue;
+    const definedKeys = mode === 'development' ? settings.secrets : settings.profiles?.[mode]?.secrets;
+    const missingLines = keyNames
+      .filter((keyName) => definedKeys?.[keyName] === undefined)
+      .map((keyName) => `${keyName} = { default = "${mode}" }`);
+    if (missingLines.length === 0) continue;
+    updatedContent = insertIntoFnoxSection(
+      updatedContent,
+      mode === 'development' ? 'secrets' : `profiles.${mode}.secrets`,
+      mode === 'development'
+        ? [
+            '# CI sets WB_ENV as a process env var, which wins over fnox; these defaults only fill it locally.',
+            ...missingLines,
+          ]
+        : missingLines
+    );
+  }
+  if (updatedContent === content) return content;
+
+  // Re-parse before returning: an unusual layout (e.g. dotted keys without a table header) could
+  // make the textual edit produce a duplicate table; fail safely instead of corrupting the file.
+  try {
+    const updatedSettings = parse(updatedContent) as FnoxTomlSubtree;
+    for (const mode of wbEnvModes) {
+      if (mode === 'staging' && !settings.profiles?.staging) continue;
+      const definedKeys = mode === 'development' ? updatedSettings.secrets : updatedSettings.profiles?.[mode]?.secrets;
+      if (keyNames.some((keyName) => definedKeys?.[keyName] === undefined)) {
+        throw new Error(`the inserted ${mode} entries did not take effect`);
+      }
+    }
+  } catch (error) {
+    console.warn(`Skipped inserting WB_ENV into fnox.toml because ${(error as Error).message}.`);
+    return undefined;
+  }
+  return updatedContent;
+}
+
+/**
+ * Inserts lines at the top of a TOML section, right after its `[header]` line so profile-specific
+ * entries stay grouped with their header; the section is appended at the end when it is absent.
+ */
+function insertIntoFnoxSection(content: string, sectionName: string, insertedLines: string[]): string {
+  const headerPattern = new RegExp(
+    String.raw`^\s*\[\s*${sectionName.split('.').join(String.raw`\s*\.\s*`)}\s*\]\s*(?:#.*)?$`,
+    'u'
+  );
+  const lines = content.split('\n');
+  const headerIndex = lines.findIndex((line) => headerPattern.test(line));
+  if (headerIndex === -1) {
+    return `${content.trimEnd()}\n\n[${sectionName}]\n${insertedLines.join('\n')}\n`;
+  }
+  return [...lines.slice(0, headerIndex + 1), ...insertedLines, ...lines.slice(headerIndex + 1)].join('\n');
+}
+
+/**
+ * Appends a missing WB_ENV (and optionally NEXT_PUBLIC_WB_ENV) assignment to a legacy .env mode
+ * file, leaving existing assignments (including `export`-prefixed ones) untouched.
+ */
+export function insertWbEnvIntoEnvFile(content: string, mode: WbEnvMode, needsNextPublic: boolean): string {
+  const keyNames = needsNextPublic ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
+  const missingLines = keyNames
+    .filter((keyName) => !new RegExp(String.raw`^\s*(?:export\s+)?${keyName}\s*=`, 'mu').test(content))
+    .map((keyName) => `${keyName}=${mode}`);
+  if (missingLines.length === 0) return content;
+  const body = content.trimEnd();
+  return `${body ? `${body}\n` : ''}${missingLines.join('\n')}\n`;
+}

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -25,7 +25,7 @@ type WbEnvMode = (typeof wbEnvModes)[number];
  */
 export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfigs: PackageConfig[]): Promise<void> {
   return logger.functionIgnoringException('ensureWbEnvDefinitions', async () => {
-    const needsNextPublic = allConfigs.some((config) => config.depending.next || config.depending.vinext);
+    const needsNextPublic = allConfigs.some((config) => requiresNextPublicWbEnv(config));
     const fnoxTomlPath = path.resolve(rootConfig.dirPath, 'fnox.toml');
     if (fs.existsSync(fnoxTomlPath)) {
       const content = await fsUtil.readFileConfinedIfExists(fnoxTomlPath);
@@ -41,8 +41,7 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
     // e.g. apps/web/.env without WB_ENV. NEXT_PUBLIC_WB_ENV follows each workspace's own
     // framework dependency (the root keeps the repository-wide signal for shared tooling).
     for (const config of allConfigs) {
-      const needsNextPublicHere =
-        config === rootConfig ? needsNextPublic : config.depending.next || config.depending.vinext;
+      const needsNextPublicHere = config === rootConfig ? needsNextPublic : requiresNextPublicWbEnv(config);
       for (const mode of wbEnvModes) {
         const envFilePath = path.resolve(config.dirPath, mode === 'development' ? '.env' : `.env.${mode}`);
         const envContent = await fsUtil.readFileConfinedIfExists(envFilePath);
@@ -57,6 +56,18 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
         }
       }
     }
+  });
+}
+
+/**
+ * Mirrors wb's requiresNextPublicWbEnv contract (packages/wb/src/project.ts): the framework may
+ * be declared in ANY of the four dependency sections (e.g. `next` as a devDependency in a shared
+ * component library), while wbfy's `depending.next` looks only at regular dependencies.
+ */
+function requiresNextPublicWbEnv(config: PackageConfig): boolean {
+  return ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'].some((section) => {
+    const dependencies = config.packageJson?.[section as 'dependencies'];
+    return !!dependencies?.['next'] || !!dependencies?.['vinext'];
   });
 }
 

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -36,17 +36,25 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
       }
       return;
     }
-    for (const mode of wbEnvModes) {
-      const envFilePath = path.resolve(rootConfig.dirPath, mode === 'development' ? '.env' : `.env.${mode}`);
-      const envContent = await fsUtil.readFileConfinedIfExists(envFilePath);
-      // Only existing mode files are completed: creating .env.production (never committed by
-      // convention) or a whole legacy layout from nothing is not wbfy's call.
-      if (envContent === undefined) continue;
-      const updatedEnvContent = insertWbEnvIntoEnvFile(envContent, mode, needsNextPublic);
-      // Log only when the confined write actually happened; writeFileConfined refuses symlinks
-      // and paths resolving outside the repository (with its own warning).
-      if (updatedEnvContent !== envContent && (await fsUtil.writeFileConfined(envFilePath, updatedEnvContent))) {
-        console.log(`Generated/Updated ${envFilePath}`);
+    // Complete the mode files of every workspace, not just the root: Next.js and Vite load .env*
+    // relative to the application's own project directory, so a root-only insertion would leave
+    // e.g. apps/web/.env without WB_ENV. NEXT_PUBLIC_WB_ENV follows each workspace's own
+    // framework dependency (the root keeps the repository-wide signal for shared tooling).
+    for (const config of allConfigs) {
+      const needsNextPublicHere =
+        config === rootConfig ? needsNextPublic : config.depending.next || config.depending.vinext;
+      for (const mode of wbEnvModes) {
+        const envFilePath = path.resolve(config.dirPath, mode === 'development' ? '.env' : `.env.${mode}`);
+        const envContent = await fsUtil.readFileConfinedIfExists(envFilePath);
+        // Only existing mode files are completed: creating .env.production (never committed by
+        // convention) or a whole legacy layout from nothing is not wbfy's call.
+        if (envContent === undefined) continue;
+        const updatedEnvContent = insertWbEnvIntoEnvFile(envContent, mode, needsNextPublicHere);
+        // Log only when the confined write actually happened; writeFileConfined refuses symlinks
+        // and paths resolving outside the repository (with its own warning).
+        if (updatedEnvContent !== envContent && (await fsUtil.writeFileConfined(envFilePath, updatedEnvContent))) {
+          console.log(`Generated/Updated ${envFilePath}`);
+        }
       }
     }
   });

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -27,7 +27,11 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
   return logger.functionIgnoringException('ensureWbEnvDefinitions', async () => {
     const needsNextPublic = allConfigs.some((config) => requiresNextPublicWbEnv(config));
     const fnoxTomlPath = path.resolve(rootConfig.dirPath, 'fnox.toml');
-    if (fs.existsSync(fnoxTomlPath)) {
+    // lstat, not existsSync: existsSync is false for a DANGLING fnox.toml symlink, which would
+    // wrongly select the legacy .env branch and mutate the wrong configuration family while the
+    // fnox synchronization is failing. Any fnox.toml directory entry marks a fnox repository;
+    // a refused/dangling one aborts instead of falling back.
+    if (await fs.promises.lstat(fnoxTomlPath).catch(() => {})) {
       const content = await fsUtil.readFileConfinedIfExists(fnoxTomlPath);
       if (content === undefined) return;
       const updatedContent = insertWbEnvIntoFnoxToml(content, needsNextPublic);

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import dotenv from 'dotenv';
 import { parse } from 'smol-toml';
 
 import { logger } from '../logger.js';
@@ -42,8 +43,9 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
       // convention) or a whole legacy layout from nothing is not wbfy's call.
       if (envContent === undefined) continue;
       const updatedEnvContent = insertWbEnvIntoEnvFile(envContent, mode, needsNextPublic);
-      if (updatedEnvContent !== envContent) {
-        await fsUtil.writeFileConfined(envFilePath, updatedEnvContent);
+      // Log only when the confined write actually happened; writeFileConfined refuses symlinks
+      // and paths resolving outside the repository (with its own warning).
+      if (updatedEnvContent !== envContent && (await fsUtil.writeFileConfined(envFilePath, updatedEnvContent))) {
         console.log(`Generated/Updated ${envFilePath}`);
       }
     }
@@ -66,6 +68,8 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
     return undefined;
   }
 
+  const wbEnvComment =
+    '# CI sets WB_ENV as a process env var, which wins over fnox; these defaults only fill it locally.';
   const keyNames = needsNextPublic ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
   let updatedContent = content;
   for (const mode of wbEnvModes) {
@@ -76,15 +80,13 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
       .filter((keyName) => definedKeys?.[keyName] === undefined)
       .map((keyName) => `${keyName} = { default = "${mode}" }`);
     if (missingLines.length === 0) continue;
+    // Skip the comment when a previous run already wrote it (e.g. WB_ENV exists and only
+    // NEXT_PUBLIC_WB_ENV is inserted now); re-inserting would duplicate it on every such run.
+    const includesComment = mode === 'development' && !updatedContent.includes(wbEnvComment);
     updatedContent = insertIntoFnoxSection(
       updatedContent,
       mode === 'development' ? 'secrets' : `profiles.${mode}.secrets`,
-      mode === 'development'
-        ? [
-            '# CI sets WB_ENV as a process env var, which wins over fnox; these defaults only fill it locally.',
-            ...missingLines,
-          ]
-        : missingLines
+      includesComment ? [wbEnvComment, ...missingLines] : missingLines
     );
   }
   if (updatedContent === content) return content;
@@ -130,8 +132,12 @@ function insertIntoFnoxSection(content: string, sectionName: string, insertedLin
  */
 export function insertWbEnvIntoEnvFile(content: string, mode: WbEnvMode, needsNextPublic: boolean): string {
   const keyNames = needsNextPublic ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
+  // Detect existing keys with dotenv's parser, not a per-line regex: a quoted multiline value may
+  // contain a `WB_ENV=...` LINE without defining the key, which a raw line match would treat as an
+  // existing definition and skip the insertion.
+  const definedKeys = dotenv.parse(content);
   const missingLines = keyNames
-    .filter((keyName) => !new RegExp(String.raw`^\s*(?:export\s+)?${keyName}\s*=`, 'mu').test(content))
+    .filter((keyName) => definedKeys[keyName] === undefined)
     .map((keyName) => `${keyName}=${mode}`);
   if (missingLines.length === 0) return content;
   const body = content.trimEnd();

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -210,16 +210,24 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
     }
 
     const workflowsPath = path.resolve(rootConfig.dirPath, '.github', 'workflows');
+    // With .github or .github/workflows symlinked outside the repository, writeYaml's guards
+    // already refuse the writes, but readdir/rm below would still enumerate and DELETE files
+    // outside the repository — so require the directory to resolve inside it before any
+    // traversal, mkdir, or cleanup.
+    if (!(await fsUtil.isConfinedWritablePath(workflowsPath))) {
+      console.warn(`Skipped generating workflows because ${workflowsPath} resolves outside the repository.`);
+      return;
+    }
     await fs.promises.mkdir(workflowsPath, { recursive: true });
 
     // Remove config of semantic pull request
     const semanticYmlPath = path.resolve(rootConfig.dirPath, '.github', 'semantic.yml');
-    await promisePool.run(() => fs.promises.rm(semanticYmlPath, { force: true, recursive: true }));
+    await promisePool.run(() => fsUtil.removeConfined(semanticYmlPath, { recursive: true }));
 
     const entries = await fs.promises.readdir(workflowsPath, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isFile() || !isObsoleteGenPrWorkflowFileName(entry.name)) continue;
-      await promisePool.run(() => fs.promises.rm(path.join(workflowsPath, entry.name), { force: true }));
+      await promisePool.run(() => fsUtil.removeConfined(path.join(workflowsPath, entry.name)));
     }
     // GitHub accepts both .yml and .yaml workflow files, and a workflow's file name is its public
     // identity (badge URLs, the workflow REST API, same-repository `uses:` references), so .yaml
@@ -297,7 +305,7 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
       // so a separate autofix workflow only duplicates the same process.
       fileNamesByKind.delete('autofix');
       for (const autofixFileName of ['autofix.yml', 'autofix.yaml']) {
-        await promisePool.run(() => fs.promises.rm(path.join(workflowsPath, autofixFileName), { force: true }));
+        await promisePool.run(() => fsUtil.removeConfined(path.join(workflowsPath, autofixFileName)));
       }
     }
 
@@ -432,7 +440,7 @@ async function writeWorkflowYaml(
         newSettings.on.push.branches = config.release.branches;
       } else {
         // Don't use the release workflow if release branch is not specified
-        await fs.promises.rm(filePath, { force: true });
+        await fsUtil.removeConfined(filePath);
         return;
       }
       if (config.isPublicRepo) {
@@ -463,7 +471,7 @@ async function writeWorkflowYaml(
 
   if (kind === 'sync') {
     for (const syncInitFileName of ['sync-init.yml', 'sync-init.yaml']) {
-      await fs.promises.rm(path.join(workflowsPath, syncInitFileName), { force: true });
+      await fsUtil.removeConfined(path.join(workflowsPath, syncInitFileName));
     }
     if (!newSettings.jobs.sync?.with) return;
 

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -27,6 +27,7 @@ interface Workflow {
 interface Concurrency {
   group: string;
   'cancel-in-progress': boolean;
+  queue?: 'single' | 'max';
 }
 
 interface On {
@@ -145,15 +146,17 @@ const workflows = {
         branches: [],
       },
     },
-    // The reusable release workflow's job already declares
-    // `concurrency: { group: release-${{ github.repository }}, cancel-in-progress: false, queue: max }`,
-    // which provides the per-repository serialization and keeps every queued release (#974).
-    // The caller-level group must NOT reuse that name: workflow-level and job-level groups share
-    // one repository-wide namespace, and identical names deadlock the run ("Canceling since a
+    // `queue: max` here too (#974): GitHub's default queue (`single`) cancels an already-PENDING
+    // caller run when another one queues — before its job (and the reusable workflow's own
+    // job-level `queue: max`) ever starts — silently dropping that release trigger.
+    // The caller-level group must NOT reuse the reusable workflow's job-level group name
+    // (`release-${{ github.repository }}`): workflow-level and job-level groups share one
+    // repository-wide namespace, and identical names deadlock the run ("Canceling since a
     // deadlock for concurrency group ... was detected between 'top level workflow' and '<job>'").
     concurrency: {
       group: '${{ github.workflow }}',
       'cancel-in-progress': false,
+      queue: 'max',
     },
     permissions: {
       // https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
@@ -392,6 +395,9 @@ async function writeWorkflowYaml(
   if (kind.startsWith('deploy')) {
     newSettings = {
       ...newSettings,
+      // Unlike the release caller, the default queue (`single`) is intentional here: a pending
+      // deploy that is cancelled and replaced by a newer one loses nothing — the newer deploy
+      // converges the environment to the latest state anyway.
       concurrency: {
         group: '${{ github.workflow }}',
         'cancel-in-progress': false,

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -27,6 +27,7 @@ interface Workflow {
 interface Concurrency {
   group: string;
   'cancel-in-progress': boolean;
+  queue?: 'single' | 'max';
 }
 
 interface On {
@@ -145,9 +146,13 @@ const workflows = {
         branches: [],
       },
     },
+    // Mirror the job-level serialization in the reusable release workflow: GitHub's default
+    // queue (`single`) cancels an already-pending run when another one queues, silently
+    // dropping a release, so keep every queued release with `queue: max`.
     concurrency: {
-      group: '${{ github.workflow }}',
+      group: 'release-${{ github.repository }}',
       'cancel-in-progress': false,
+      queue: 'max',
     },
     permissions: {
       // https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -27,7 +27,6 @@ interface Workflow {
 interface Concurrency {
   group: string;
   'cancel-in-progress': boolean;
-  queue?: 'single' | 'max';
 }
 
 interface On {
@@ -146,13 +145,15 @@ const workflows = {
         branches: [],
       },
     },
-    // Mirror the job-level serialization in the reusable release workflow: GitHub's default
-    // queue (`single`) cancels an already-pending run when another one queues, silently
-    // dropping a release, so keep every queued release with `queue: max`.
+    // The reusable release workflow's job already declares
+    // `concurrency: { group: release-${{ github.repository }}, cancel-in-progress: false, queue: max }`,
+    // which provides the per-repository serialization and keeps every queued release (#974).
+    // The caller-level group must NOT reuse that name: workflow-level and job-level groups share
+    // one repository-wide namespace, and identical names deadlock the run ("Canceling since a
+    // deadlock for concurrency group ... was detected between 'top level workflow' and '<job>'").
     concurrency: {
-      group: 'release-${{ github.repository }}',
+      group: '${{ github.workflow }}',
       'cancel-in-progress': false,
-      queue: 'max',
     },
     permissions: {
       // https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -455,12 +455,15 @@ function readCiAgeSecretKey(): string | undefined {
     );
     return undefined;
   }
-  const keyLine = lines.find((line) => line.trim().startsWith('AGE-SECRET-KEY-'));
-  if (!keyLine) {
+  // Keep EVERY identity line: fnox parses FNOX_AGE_KEY as age identity-file content and tries all
+  // identities, so truncating a multi-identity file (key rotation, multiple recipients) to the
+  // first key would make CI silently skip every secret encrypted to the other identities.
+  const keyLines = lines.map((line) => line.trim()).filter((line) => line.startsWith('AGE-SECRET-KEY-'));
+  if (keyLines.length === 0) {
     console.error(`Failed to upload secrets because ${identityPath} contains no AGE-SECRET-KEY line.`);
     return undefined;
   }
-  return keyLine.trim();
+  return keyLines.join('\n');
 }
 
 // Decrypts ENCRYPTED_VERDACCIO_TOKEN with the CI age identity by running `fnox get` on a minimal

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -445,11 +445,14 @@ function readCiAgeSecretKey(): string | undefined {
   // would let a personal identity copied to this path leak to every repository's CI.
   const ciPublicKey = FNOX_AGE_RECIPIENTS.find((recipient) => recipient.name === 'ci')?.publicKey ?? '';
   // Compare the whole trimmed comment value, not a substring match: a personal identity whose
-  // comment merely mentions the CI key must not pass.
+  // comment merely mentions the CI key must not pass. Check EVERY `# public key:` comment, not
+  // just the first: a legitimate multi-identity file (key rotation) contains one comment per
+  // identity and only one of them matches the single registered CI key, in either order.
   const lines = content.split('\n');
-  const publicKeyLine = lines.find((line) => line.includes('public key:'));
-  const commentedPublicKey = publicKeyLine?.split('public key:')[1]?.trim();
-  if (!ciPublicKey || commentedPublicKey !== ciPublicKey) {
+  const commentedPublicKeys = lines
+    .filter((line) => line.includes('public key:'))
+    .map((line) => line.split('public key:')[1]?.trim());
+  if (!ciPublicKey || !commentedPublicKeys.includes(ciPublicKey)) {
     console.error(
       `Failed to upload secrets because the \`# public key:\` comment in ${identityPath} is missing or differs from the CI age public key (${ciPublicKey}), so the file does not hold the CI-dedicated identity.`
     );
@@ -458,6 +461,9 @@ function readCiAgeSecretKey(): string | undefined {
   // Keep EVERY identity line: fnox parses FNOX_AGE_KEY as age identity-file content and tries all
   // identities, so truncating a multi-identity file (key rotation, multiple recipients) to the
   // first key would make CI silently skip every secret encrypted to the other identities.
+  // Identities beyond the verified CI one are deliberately NOT rejected: during rotation the
+  // outgoing CI key is no longer in FNOX_AGE_RECIPIENTS yet must still decrypt on CI, and this
+  // CI-dedicated path is operator-managed (the personal identity lives in age.txt, not here).
   const keyLines = lines.map((line) => line.trim()).filter((line) => line.startsWith('AGE-SECRET-KEY-'));
   if (keyLines.length === 0) {
     console.error(`Failed to upload secrets because ${identityPath} contains no AGE-SECRET-KEY line.`);

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -268,7 +268,10 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
       setupRepositoryRulesets(rootConfig),
       setupSecrets(rootConfig),
       setupGitHubSettings(rootConfig),
-      generateLefthookUpdatingPackageJson(rootConfig, allPackageConfigs),
+      // Git hooks are repository-level state: when the CLI entry is a child workspace
+      // (`wbfy <repo>/apps/<app>`), installing Lefthook there would delete the child's .husky,
+      // write a child lefthook.yml, and unset the ENCLOSING repository's core.hooksPath.
+      ...(rootConfig.isRoot ? [generateLefthookUpdatingPackageJson(rootConfig, allPackageConfigs)] : []),
       generateLintstagedrc(rootConfig),
     ]);
     await promisePool.promiseAll();

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -27,7 +27,7 @@ import { generateGitignore } from './generators/gitignore.js';
 import { generateIdeaSettings } from './generators/idea.js';
 import { generateLefthookUpdatingPackageJson } from './generators/lefthook.js';
 import { generateLintstagedrc } from './generators/lintstagedrc.js';
-import { generatePackageJson, getWorkspacePackageDirs, getWorkspaceSubDirPaths } from './generators/packageJson.js';
+import { generatePackageJson, getWorkspacePackageDirs } from './generators/packageJson.js';
 import { generateOxfmtConfig } from './generators/oxfmtConfig.js';
 import { generateOxlintConfig } from './generators/oxlintConfig.js';
 import { generatePrettierignore } from './generators/prettierignore.js';
@@ -57,6 +57,7 @@ import { doesContainJsOrTs } from './utils/packageCapabilities.js';
 import { promisePool } from './utils/promisePool.js';
 import { spawnSync, spawnSyncAndReturnStatus, spawnSyncAndReturnStdout } from './utils/spawnUtil.js';
 import { disposeTypeScriptApi } from './utils/typescriptApi.js';
+import { getWorkspaceSubDirPaths } from './utils/workspaceUtil.js';
 
 async function main(): Promise<void> {
   const argv = await yargs(process.argv.slice(2))
@@ -186,7 +187,11 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
 
     await fixTestDirectoriesUpdatingPackageJson([rootDirPath, ...subDirPaths]);
 
-    const rootConfig = await getPackageConfig(rootDirPath, { isRoot: true });
+    // Let getPackageConfig derive isRoot for the entry path: `wbfy <repo>/packages/<app>` is a
+    // supported invocation whose target must keep its child classification, so forcing
+    // `isRoot: true` here would apply root-only processing (lefthook install, root tsconfig,
+    // AGENTS.md, …) to a subpackage.
+    const rootConfig = await getPackageConfig(rootDirPath);
     if (options.isVerbose) {
       console.log('rootConfig:', rootConfig);
     }

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -12,6 +12,7 @@ import { fixTestDirectoriesUpdatingPackageJson } from './fixers/testDirectory.js
 import { fixTypeDefinitions } from './fixers/typeDefinition.js';
 import { fixTypos } from './fixers/typos.js';
 import { fixWbDbCommand } from './fixers/wbDbCommand.js';
+import { untrackCloudflareEnv } from './fixers/cloudflareEnv.js';
 import { untrackWorkerTypes } from './fixers/workerTypes.js';
 import { generateAgentInstructions } from './generators/agents.js';
 import type { BunLinker } from './generators/bunfig.js';
@@ -26,7 +27,7 @@ import { generateGitignore } from './generators/gitignore.js';
 import { generateIdeaSettings } from './generators/idea.js';
 import { generateLefthookUpdatingPackageJson } from './generators/lefthook.js';
 import { generateLintstagedrc } from './generators/lintstagedrc.js';
-import { generatePackageJson, getWorkspacePackageDirs } from './generators/packageJson.js';
+import { generatePackageJson, getWorkspacePackageDirs, getWorkspaceSubDirPaths } from './generators/packageJson.js';
 import { generateOxfmtConfig } from './generators/oxfmtConfig.js';
 import { generateOxlintConfig } from './generators/oxlintConfig.js';
 import { generatePrettierignore } from './generators/prettierignore.js';
@@ -38,6 +39,7 @@ import { generateRenovateJson } from './generators/renovateJson.js';
 import { installAgentSkills } from './generators/skills.js';
 import { generateTsconfig } from './generators/tsconfig.js';
 import { generateVscodeSettings } from './generators/vscodeSettings.js';
+import { ensureWbEnvDefinitions } from './generators/wbEnv.js';
 import { generateWorkflows, isReusableWorkflowsRepo } from './generators/workflow.js';
 import { generateMiseToml, minimumBunVersion } from './generators/miseToml.js';
 import { findUnmigratableYarnSettings, removeYarnFiles } from './generators/removeYarnFiles.js';
@@ -141,7 +143,26 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
 
     const packagesDirPath = path.join(rootDirPath, 'packages');
     const dirents = (await ignoreErrorAsync(() => fs.promises.readdir(packagesDirPath, { withFileTypes: true }))) ?? [];
-    const subDirPaths = dirents.filter((d) => d.isDirectory()).map((d) => path.join(packagesDirPath, d.name));
+    const packagesSubDirPaths = dirents
+      .filter((d) => d.isDirectory())
+      .map((d) => path.resolve(packagesDirPath, d.name));
+    // Also cover workspaces declared outside packages/* (e.g. apps/*): they receive the same
+    // managed configs (tsconfig.json, package.json conventions, …) as packages/* children.
+    const rootPackageJson =
+      ignoreError(
+        () =>
+          JSON.parse(fs.readFileSync(path.resolve(rootDirPath, 'package.json'), 'utf8')) as PackageConfig['packageJson']
+      ) ?? {};
+    const workspaceSubDirPaths = getWorkspaceSubDirPaths({
+      dirPath: rootDirPath,
+      packageJson: rootPackageJson,
+      doesContainSubPackageJsons: packagesSubDirPaths.some((subDirPath) =>
+        fs.existsSync(path.resolve(subDirPath, 'package.json'))
+      ),
+    });
+    const subDirPaths = [...new Set([...packagesSubDirPaths, ...workspaceSubDirPaths])].filter(
+      (subDirPath) => subDirPath !== path.resolve(rootDirPath)
+    );
 
     // Refused writes on core managed files would leave the migration half-applied (e.g. Yarn state
     // removed but bunfig.toml unchanged, or a test directory renamed without its script), so skip
@@ -165,7 +186,7 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
 
     await fixTestDirectoriesUpdatingPackageJson([rootDirPath, ...subDirPaths]);
 
-    const rootConfig = await getPackageConfig(rootDirPath);
+    const rootConfig = await getPackageConfig(rootDirPath, { isRoot: true });
     if (options.isVerbose) {
       console.log('rootConfig:', rootConfig);
     }
@@ -176,7 +197,11 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
     }
     const abbreviationPromise = fixTypos(rootConfig);
 
-    const nullableSubPackageConfigs = await Promise.all(subDirPaths.map((subDirPath) => getPackageConfig(subDirPath)));
+    // Every discovered workspace (including non-packages/* layouts such as apps/*) is a child
+    // package; the packages/* heuristic inside getPackageConfig would misclassify apps/* as roots.
+    const nullableSubPackageConfigs = await Promise.all(
+      subDirPaths.map((subDirPath) => getPackageConfig(subDirPath, { isRoot: false }))
+    );
     const subPackageConfigs = nullableSubPackageConfigs.filter((config) => !!config);
     const allPackageConfigs = [rootConfig, ...subPackageConfigs];
 
@@ -197,6 +222,9 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
     // Must finish before setupSecrets below: it rewrites the age recipients in fnox.toml and
     // re-encrypts the secrets that FNOX_AGE_KEY (uploaded by setupSecrets) must be able to decrypt.
     await generateFnoxToml(rootConfig);
+    // After generateFnoxToml so the insertion can never race the transactional recipient
+    // migration (which snapshots and may restore every fnox.toml).
+    await ensureWbEnvDefinitions(rootConfig, allPackageConfigs);
     // promisePool.run resolves when a task STARTS, so the generated bunfig.toml is not
     // guaranteed to be on disk yet; the probe below must not validate a stale configuration.
     await promisePool.promiseAll();
@@ -235,7 +263,7 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
       setupRepositoryRulesets(rootConfig),
       setupSecrets(rootConfig),
       setupGitHubSettings(rootConfig),
-      generateLefthookUpdatingPackageJson(rootConfig),
+      generateLefthookUpdatingPackageJson(rootConfig, allPackageConfigs),
       generateLintstagedrc(rootConfig),
     ]);
     await promisePool.promiseAll();
@@ -264,6 +292,12 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
       // partial run is possible) would delete the declaration with nothing recreating it on fresh checkouts.
       if (generatesWorkerTypes(config)) {
         await untrackWorkerTypes(config);
+      }
+      // Same barrier reasoning as untrackWorkerTypes: the pooled .gitignore write (which carries
+      // the managed .env.cloudflare rule) completed above, and the fixer re-verifies the rule via
+      // `git check-ignore` before untracking.
+      if (config.isCloudflare || rootConfig.isCloudflare) {
+        await untrackCloudflareEnv(config);
       }
 
       promises.push(generateLintstagedrc(config));

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -137,12 +137,10 @@ export async function getPackageConfig(
     }
 
     // The caller may classify explicitly (index.ts passes false for every discovered workspace,
-    // including non-packages/* layouts such as apps/*); the packages/* heuristic classifies the
-    // CLI entry path itself, so `wbfy <repo>/packages/<app>` keeps its child classification.
-    const isRoot =
-      options?.isRoot ??
-      (path.basename(path.resolve(dirPath, '..')) !== 'packages' ||
-        !fs.existsSync(path.resolve(dirPath, '..', '..', 'package.json')));
+    // including non-packages/* layouts such as apps/*); the heuristic classifies the CLI entry
+    // path itself, so `wbfy <repo>/packages/<app>` and `wbfy <repo>/apps/<app>` keep their child
+    // classification.
+    const isRoot = options?.isRoot ?? !isWorkspaceOfEnclosingRoot(dirPath);
 
     let repoInfo: Record<string, unknown> | undefined;
     if (isRoot) {
@@ -645,6 +643,40 @@ function readMiseTaskCommand(value: unknown): string {
   if (Array.isArray(value)) return value.filter((command): command is string => typeof command === 'string').join('\n');
   if (value && typeof value === 'object') return readMiseTaskCommand((value as { run?: unknown }).run);
   return '';
+}
+
+/**
+ * Whether dirPath is a child workspace of an enclosing monorepo root: either the conventional
+ * `<root>/packages/<name>` layout, or a directory matching a workspace pattern declared by an
+ * enclosing package.json (checked one and two levels up, covering `apps/<name>`-style layouts).
+ */
+function isWorkspaceOfEnclosingRoot(dirPath: string): boolean {
+  const resolvedDirPath = path.resolve(dirPath);
+  if (
+    path.basename(path.resolve(resolvedDirPath, '..')) === 'packages' &&
+    fs.existsSync(path.resolve(resolvedDirPath, '..', '..', 'package.json'))
+  ) {
+    return true;
+  }
+  for (const candidateRootDirPath of [path.resolve(resolvedDirPath, '..'), path.resolve(resolvedDirPath, '..', '..')]) {
+    if (candidateRootDirPath === resolvedDirPath) continue;
+    let rootPackageJson: PackageJson;
+    try {
+      rootPackageJson = JSON.parse(
+        fs.readFileSync(path.resolve(candidateRootDirPath, 'package.json'), 'utf8')
+      ) as PackageJson;
+    } catch {
+      continue;
+    }
+    const relativeDirPath = path.relative(candidateRootDirPath, resolvedDirPath).replaceAll('\\', '/');
+    const workspaceDirPaths = getWorkspacePackageJsonPaths({
+      dirPath: candidateRootDirPath,
+      packageJson: rootPackageJson,
+      doesContainSubPackageJsons: false,
+    }).map((packageJsonPath) => path.posix.dirname(packageJsonPath));
+    if (workspaceDirPaths.includes(relativeDirPath)) return true;
+  }
+  return false;
 }
 
 function containsAny(pattern: string, dirPath: string): boolean {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -14,6 +14,7 @@ import { globIgnore } from './utils/globUtil.js';
 import { jsoncUtil } from './utils/jsoncUtil.js';
 import { spawnSyncAndReturnStdout } from './utils/spawnUtil.js';
 import { selectProjectWranglerTypesGenerator } from './utils/wranglerTypesCommand.js';
+import { getWorkspacePackageJsonPaths } from './utils/workspaceUtil.js';
 
 export interface PackageConfig {
   dirPath: string;
@@ -136,8 +137,8 @@ export async function getPackageConfig(
     }
 
     // The caller may classify explicitly (index.ts passes false for every discovered workspace,
-    // including non-packages/* layouts such as apps/*); the packages/* heuristic remains the
-    // fallback for direct calls.
+    // including non-packages/* layouts such as apps/*); the packages/* heuristic classifies the
+    // CLI entry path itself, so `wbfy <repo>/packages/<app>` keeps its child classification.
     const isRoot =
       options?.isRoot ??
       (path.basename(path.resolve(dirPath, '..')) !== 'packages' ||
@@ -198,7 +199,12 @@ export async function getPackageConfig(
       isEsmPackage: esmPackage,
       isWillBoosterConfigs: packageJsonPath.includes('/willbooster-configs'),
       cargoTomlDirPaths: findCargoTomlDirPaths(dirPath),
-      doesContainSubPackageJsons: containsAny('packages/**/package.json', dirPath),
+      // Also honor declared workspace patterns beyond packages/* (e.g. apps/*): treating an
+      // apps/*-only monorepo as a plain package would delete its `workspaces` declaration in
+      // generatePackageJson and skip monorepo-only conventions such as root `private: true`.
+      doesContainSubPackageJsons:
+        containsAny('packages/**/package.json', dirPath) ||
+        getWorkspacePackageJsonPaths({ dirPath, packageJson, doesContainSubPackageJsons: false }).length > 0,
       doesContainDockerfile: !!dockerfile || fs.existsSync(path.resolve(dirPath, 'docker-compose.yml')),
       doesContainGemfile: fs.existsSync(path.resolve(dirPath, 'Gemfile')),
       doesContainGoMod: fs.existsSync(path.resolve(dirPath, 'go.mod')),

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -100,7 +100,10 @@ const wbfyJsonSchema = z.object({
     .optional(),
 });
 
-export async function getPackageConfig(dirPath: string): Promise<PackageConfig | undefined> {
+export async function getPackageConfig(
+  dirPath: string,
+  options?: { isRoot?: boolean }
+): Promise<PackageConfig | undefined> {
   const packageJsonPath = path.resolve(dirPath, 'package.json');
   try {
     const doesContainPackageJson = fs.existsSync(packageJsonPath);
@@ -132,9 +135,13 @@ export async function getPackageConfig(dirPath: string): Promise<PackageConfig |
       // do nothing
     }
 
+    // The caller may classify explicitly (index.ts passes false for every discovered workspace,
+    // including non-packages/* layouts such as apps/*); the packages/* heuristic remains the
+    // fallback for direct calls.
     const isRoot =
-      path.basename(path.resolve(dirPath, '..')) !== 'packages' ||
-      !fs.existsSync(path.resolve(dirPath, '..', '..', 'package.json'));
+      options?.isRoot ??
+      (path.basename(path.resolve(dirPath, '..')) !== 'packages' ||
+        !fs.existsSync(path.resolve(dirPath, '..', '..', 'package.json')));
 
     let repoInfo: Record<string, unknown> | undefined;
     if (isRoot) {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -648,7 +648,9 @@ function readMiseTaskCommand(value: unknown): string {
 /**
  * Whether dirPath is a child workspace of an enclosing monorepo root: either the conventional
  * `<root>/packages/<name>` layout, or a directory matching a workspace pattern declared by an
- * enclosing package.json (checked one and two levels up, covering `apps/<name>`-style layouts).
+ * ancestor package.json (patterns may be arbitrarily deep, e.g. `examples/**`). The walk stops
+ * at the first git repository boundary so an unrelated enclosing repository's workspaces can
+ * never reclassify an independent repository as a child.
  */
 function isWorkspaceOfEnclosingRoot(dirPath: string): boolean {
   const resolvedDirPath = path.resolve(dirPath);
@@ -658,25 +660,31 @@ function isWorkspaceOfEnclosingRoot(dirPath: string): boolean {
   ) {
     return true;
   }
-  for (const candidateRootDirPath of [path.resolve(resolvedDirPath, '..'), path.resolve(resolvedDirPath, '..', '..')]) {
-    if (candidateRootDirPath === resolvedDirPath) continue;
-    let rootPackageJson: PackageJson;
+  // A directory with its own .git is a repository in its own right, never a child workspace.
+  if (fs.existsSync(path.resolve(resolvedDirPath, '.git'))) return false;
+  for (
+    let candidateRootDirPath = path.dirname(resolvedDirPath);
+    ;
+    candidateRootDirPath = path.dirname(candidateRootDirPath)
+  ) {
     try {
-      rootPackageJson = JSON.parse(
+      const rootPackageJson = JSON.parse(
         fs.readFileSync(path.resolve(candidateRootDirPath, 'package.json'), 'utf8')
       ) as PackageJson;
+      const relativeDirPath = path.relative(candidateRootDirPath, resolvedDirPath).replaceAll('\\', '/');
+      const workspaceDirPaths = getWorkspacePackageJsonPaths({
+        dirPath: candidateRootDirPath,
+        packageJson: rootPackageJson,
+        doesContainSubPackageJsons: false,
+      }).map((packageJsonPath) => path.posix.dirname(packageJsonPath));
+      if (workspaceDirPaths.includes(relativeDirPath)) return true;
     } catch {
-      continue;
+      // No or unparsable manifest at this ancestor: keep walking.
     }
-    const relativeDirPath = path.relative(candidateRootDirPath, resolvedDirPath).replaceAll('\\', '/');
-    const workspaceDirPaths = getWorkspacePackageJsonPaths({
-      dirPath: candidateRootDirPath,
-      packageJson: rootPackageJson,
-      doesContainSubPackageJsons: false,
-    }).map((packageJsonPath) => path.posix.dirname(packageJsonPath));
-    if (workspaceDirPaths.includes(relativeDirPath)) return true;
+    const isRepoBoundary = fs.existsSync(path.resolve(candidateRootDirPath, '.git'));
+    const isFilesystemRoot = candidateRootDirPath === path.dirname(candidateRootDirPath);
+    if (isRepoBoundary || isFilesystemRoot) return false;
   }
-  return false;
 }
 
 function containsAny(pattern: string, dirPath: string): boolean {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -654,14 +654,15 @@ function readMiseTaskCommand(value: unknown): string {
  */
 function isWorkspaceOfEnclosingRoot(dirPath: string): boolean {
   const resolvedDirPath = path.resolve(dirPath);
+  // A directory with its own .git is a repository in its own right, never a child workspace —
+  // checked FIRST so an independent repository under some `packages/` directory stays a root.
+  if (fs.existsSync(path.resolve(resolvedDirPath, '.git'))) return false;
   if (
     path.basename(path.resolve(resolvedDirPath, '..')) === 'packages' &&
     fs.existsSync(path.resolve(resolvedDirPath, '..', '..', 'package.json'))
   ) {
     return true;
   }
-  // A directory with its own .git is a repository in its own right, never a child workspace.
-  if (fs.existsSync(path.resolve(resolvedDirPath, '.git'))) return false;
   for (
     let candidateRootDirPath = path.dirname(resolvedDirPath);
     ;

--- a/packages/wbfy/src/utils/fsUtil.ts
+++ b/packages/wbfy/src/utils/fsUtil.ts
@@ -25,16 +25,31 @@ export const fsUtil = {
     return await isConfinedWritablePath(filePath);
   },
   /**
-   * Reads a migration source, returning undefined when the file does not exist OR when it is a
-   * symlink / resolves outside the repository — a committed symlink pointing outside the
-   * repository must not get its target's content copied into a tracked file.
+   * Reads a migration source, returning undefined when the file does not exist OR when it
+   * resolves outside the repository — a committed symlink pointing outside the repository must
+   * not get its target's content copied into a tracked file. A symlink whose resolved target
+   * stays inside the repository is legitimate (e.g. `.node-version -> .nvmrc`) and is read.
    */
   async readFileConfinedIfExists(filePath: string): Promise<string | undefined> {
     const stats = await fs.promises.lstat(filePath).catch(() => {});
     if (!stats) return undefined;
     if (stats.isSymbolicLink()) {
-      console.warn(`Skipped reading ${filePath} because it is a symbolic link.`);
-      return undefined;
+      let realFilePath: string;
+      try {
+        realFilePath = await fs.promises.realpath(filePath);
+      } catch {
+        console.warn(`Skipped reading ${filePath} because it is a dangling symbolic link.`);
+        return undefined;
+      }
+      if (
+        realRootDirPath !== undefined &&
+        realFilePath !== realRootDirPath &&
+        !realFilePath.startsWith(realRootDirPath + path.sep)
+      ) {
+        console.warn(`Skipped reading ${filePath} because it resolves outside the repository.`);
+        return undefined;
+      }
+      return await fsUtil.readFileIfExists(filePath);
     }
     if (!(await hasConfinedParent(filePath))) {
       console.warn(`Skipped reading ${filePath} because it resolves outside the repository.`);

--- a/packages/wbfy/src/utils/fsUtil.ts
+++ b/packages/wbfy/src/utils/fsUtil.ts
@@ -24,6 +24,38 @@ export const fsUtil = {
   async isConfinedWritablePath(filePath: string): Promise<boolean> {
     return await isConfinedWritablePath(filePath);
   },
+  /**
+   * Reads a migration source, returning undefined when the file does not exist OR when it is a
+   * symlink / resolves outside the repository — a committed symlink pointing outside the
+   * repository must not get its target's content copied into a tracked file.
+   */
+  async readFileConfinedIfExists(filePath: string): Promise<string | undefined> {
+    const stats = await fs.promises.lstat(filePath).catch(() => {});
+    if (!stats) return undefined;
+    if (stats.isSymbolicLink()) {
+      console.warn(`Skipped reading ${filePath} because it is a symbolic link.`);
+      return undefined;
+    }
+    if (!(await hasConfinedParent(filePath))) {
+      console.warn(`Skipped reading ${filePath} because it resolves outside the repository.`);
+      return undefined;
+    }
+    return await fsUtil.readFileIfExists(filePath);
+  },
+  /**
+   * Removes filePath (force, optionally recursive) only when its PARENT directory resolves inside
+   * the repository, so a symlinked directory (e.g. a committed .github/workflows link) can never
+   * make cleanup delete files outside the repository. Removing a symlink entry itself is allowed:
+   * that deletes only the link, never its target. Returns whether the removal was performed.
+   */
+  async removeConfined(filePath: string, options?: { recursive?: boolean }): Promise<boolean> {
+    if (!(await hasConfinedParent(filePath))) {
+      console.warn(`Skipped removing ${filePath} because it resolves outside the repository.`);
+      return false;
+    }
+    await fs.promises.rm(filePath, { force: true, recursive: options?.recursive ?? false });
+    return true;
+  },
   /** Writes content verbatim, applying the same symlink/repository-containment guards as generateFile. */
   async writeFileConfined(filePath: string, content: string): Promise<boolean> {
     if (!(await isConfinedWritablePath(filePath))) return false;
@@ -52,18 +84,21 @@ async function isConfinedWritablePath(filePath: string): Promise<boolean> {
     console.warn(`Skipped writing ${filePath} because it is a symbolic link.`);
     return false;
   }
-  // A symlinked parent directory would also redirect the write outside the repository, so
-  // require the closest existing ancestor to resolve inside the root set by the CLI entry point.
-  if (realRootDirPath !== undefined) {
-    let ancestorPath = path.dirname(filePath);
-    while (!fs.existsSync(ancestorPath)) {
-      ancestorPath = path.dirname(ancestorPath);
-    }
-    const realAncestorPath = await fs.promises.realpath(ancestorPath);
-    if (realAncestorPath !== realRootDirPath && !realAncestorPath.startsWith(realRootDirPath + path.sep)) {
-      console.warn(`Skipped writing ${filePath} because it resolves outside the repository.`);
-      return false;
-    }
+  if (!(await hasConfinedParent(filePath))) {
+    console.warn(`Skipped writing ${filePath} because it resolves outside the repository.`);
+    return false;
   }
   return true;
+}
+
+// A symlinked parent directory would redirect reads, writes, and removals outside the repository,
+// so require the closest existing ancestor to resolve inside the root set by the CLI entry point.
+async function hasConfinedParent(filePath: string): Promise<boolean> {
+  if (realRootDirPath === undefined) return true;
+  let ancestorPath = path.dirname(filePath);
+  while (!fs.existsSync(ancestorPath)) {
+    ancestorPath = path.dirname(ancestorPath);
+  }
+  const realAncestorPath = await fs.promises.realpath(ancestorPath);
+  return realAncestorPath === realRootDirPath || realAncestorPath.startsWith(realRootDirPath + path.sep);
 }

--- a/packages/wbfy/src/utils/spawnUtil.ts
+++ b/packages/wbfy/src/utils/spawnUtil.ts
@@ -17,7 +17,19 @@ export function spawnSyncAndReturnStatus(command: string, args: string[], cwd: s
   return 0;
 }
 
+/**
+ * Like spawnSyncAndReturnStdout but WITHOUT trimming, for NUL-delimited output (e.g.
+ * `git ls-files -z`) where a leading/trailing whitespace byte belongs to a file name.
+ */
+export function spawnSyncAndReturnRawStdout(command: string, args: string[], cwd: string): string {
+  return spawnSyncAndReturnStdoutInternal(command, args, cwd, false);
+}
+
 export function spawnSyncAndReturnStdout(command: string, args: string[], cwd: string): string {
+  return spawnSyncAndReturnStdoutInternal(command, args, cwd, true);
+}
+
+function spawnSyncAndReturnStdoutInternal(command: string, args: string[], cwd: string, trims: boolean): string {
   const [newCmd, newArgs, options] = getSpawnSyncArgs(command, args, cwd);
   options.stdio = 'pipe';
   const proc = child_process.spawnSync(newCmd, newArgs, options);
@@ -33,7 +45,8 @@ export function spawnSyncAndReturnStdout(command: string, args: string[], cwd: s
   }
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- spawnSync returns null stdout on ENOENT.
   const stdout = proc.stdout ?? '';
-  return typeof stdout === 'string' ? stdout.trim() : stdout.toString().trim();
+  const stdoutText = typeof stdout === 'string' ? stdout : stdout.toString();
+  return trims ? stdoutText.trim() : stdoutText;
 }
 
 export function getSpawnSyncArgs(command: string, args: string[], cwd: string): [string, string[], SpawnSyncOptions] {

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -1,0 +1,68 @@
+import path from 'node:path';
+
+import fg from 'fast-glob';
+import type { PackageJson } from 'type-fest';
+
+import type { PackageConfig } from '../packageConfig.js';
+
+/** The subset of PackageConfig that workspace discovery needs, so it can run before configs exist. */
+export type WorkspaceRootLike = Pick<PackageConfig, 'dirPath' | 'doesContainSubPackageJsons' | 'packageJson'>;
+
+/**
+ * Every declared workspace directory (absolute, deduplicated) of the monorepo root, covering
+ * non-packages/* layouts such as apps/*. Uncached because index.ts calls it before wbfy mutates
+ * the root package.json (getWorkspacePackageDirs caches the post-mutation state).
+ */
+export function getWorkspaceSubDirPaths(rootLike: WorkspaceRootLike): string[] {
+  return [
+    ...new Set(
+      getWorkspacePackageJsonPaths(rootLike).map((packageJsonPath) =>
+        path.resolve(rootLike.dirPath, path.posix.dirname(packageJsonPath))
+      )
+    ),
+  ].toSorted();
+}
+
+/**
+ * Every workspace package.json path (relative to the monorepo root), including manifests without
+ * a `name` field — wbfy names those later, so dependency scans must not skip them.
+ */
+export function getWorkspacePackageJsonPaths(rootConfig: WorkspaceRootLike): string[] {
+  // applyPackageJsonConventions forces `packages/*` into every monorepo's workspaces, but it may
+  // not have written the root package.json yet, so mirror that normalization here.
+  const workspacePatterns = [
+    ...new Set([
+      ...getDeclaredWorkspacePatterns(rootConfig.packageJson?.workspaces),
+      ...(rootConfig.doesContainSubPackageJsons ? ['packages/*'] : []),
+    ]),
+  ];
+  // Expand all patterns in one glob call so Bun-supported negative patterns (e.g.
+  // `!packages/excluded`) actually exclude their matches. Do not apply globIgnore here: workspace
+  // membership is defined solely by the declared patterns, and source-scanning ignores such as
+  // `build` or `dist` would hide legitimately named workspace directories.
+  const packageJsonGlobs = workspacePatterns
+    // Workspace directories must stay inside the repository: absolute or `..`-traversing patterns
+    // would make consumers such as removeNodeModules operate on another repository's files.
+    .filter((workspacePattern) => {
+      const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
+      return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
+    })
+    .map((workspacePattern) =>
+      workspacePattern.startsWith('!')
+        ? `!${path.posix.join(workspacePattern.slice(1), 'package.json')}`
+        : path.posix.join(workspacePattern, 'package.json')
+    );
+  // followSymbolicLinks: false — a workspace symlink pointing outside the repository must not be
+  // treated as a workspace directory (removeNodeModules would delete through it).
+  return fg.globSync(packageJsonGlobs, {
+    cwd: rootConfig.dirPath,
+    followSymbolicLinks: false,
+    ignore: ['**/node_modules/**'],
+  });
+}
+
+/** Workspace patterns from either the array form or Yarn v1's `{ packages: […] }` object form. */
+export function getDeclaredWorkspacePatterns(workspaces: PackageJson['workspaces']): string[] {
+  if (Array.isArray(workspaces)) return workspaces;
+  return Array.isArray(workspaces?.packages) ? workspaces.packages : [];
+}

--- a/packages/wbfy/test/fsUtil.test.ts
+++ b/packages/wbfy/test/fsUtil.test.ts
@@ -23,7 +23,7 @@ test('generateFile refuses to write through a symlinked parent directory', async
   }
 });
 
-test('readFileConfinedIfExists rejects symlink sources and sources outside the repository', async () => {
+test('readFileConfinedIfExists rejects sources resolving outside the repository but reads in-repo symlinks', async () => {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-fsutil-'));
   try {
     const repoDirPath = path.join(tempDirPath, 'repo');
@@ -34,11 +34,17 @@ test('readFileConfinedIfExists rejects symlink sources and sources outside the r
     fs.symlinkSync(path.join(outsideDirPath, 'secret.txt'), path.join(repoDirPath, '.renovaterc.json'));
     fs.symlinkSync(outsideDirPath, path.join(repoDirPath, 'linked'));
     fs.writeFileSync(path.join(repoDirPath, 'regular.txt'), 'regular');
+    fs.writeFileSync(path.join(repoDirPath, '.nvmrc'), '22.11.0');
+    fs.symlinkSync(path.join(repoDirPath, '.nvmrc'), path.join(repoDirPath, '.node-version'));
+    fs.symlinkSync(path.join(repoDirPath, 'nonexistent.txt'), path.join(repoDirPath, 'dangling.txt'));
     fsUtil.setRootDirPath(repoDirPath);
     expect(await fsUtil.readFileConfinedIfExists(path.join(repoDirPath, '.renovaterc.json'))).toBeUndefined();
     expect(await fsUtil.readFileConfinedIfExists(path.join(repoDirPath, 'linked', 'secret.txt'))).toBeUndefined();
     expect(await fsUtil.readFileConfinedIfExists(path.join(repoDirPath, 'missing.txt'))).toBeUndefined();
+    expect(await fsUtil.readFileConfinedIfExists(path.join(repoDirPath, 'dangling.txt'))).toBeUndefined();
     expect(await fsUtil.readFileConfinedIfExists(path.join(repoDirPath, 'regular.txt'))).toBe('regular');
+    // A symlink whose target stays inside the repository is a legitimate source and is read.
+    expect(await fsUtil.readFileConfinedIfExists(path.join(repoDirPath, '.node-version'))).toBe('22.11.0');
   } finally {
     fsUtil.setRootDirPath(undefined);
     fs.rmSync(tempDirPath, { recursive: true, force: true });

--- a/packages/wbfy/test/fsUtil.test.ts
+++ b/packages/wbfy/test/fsUtil.test.ts
@@ -23,6 +23,55 @@ test('generateFile refuses to write through a symlinked parent directory', async
   }
 });
 
+test('readFileConfinedIfExists rejects symlink sources and sources outside the repository', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-fsutil-'));
+  try {
+    const repoDirPath = path.join(tempDirPath, 'repo');
+    const outsideDirPath = path.join(tempDirPath, 'outside');
+    fs.mkdirSync(repoDirPath);
+    fs.mkdirSync(outsideDirPath);
+    fs.writeFileSync(path.join(outsideDirPath, 'secret.txt'), 'secret');
+    fs.symlinkSync(path.join(outsideDirPath, 'secret.txt'), path.join(repoDirPath, '.renovaterc.json'));
+    fs.symlinkSync(outsideDirPath, path.join(repoDirPath, 'linked'));
+    fs.writeFileSync(path.join(repoDirPath, 'regular.txt'), 'regular');
+    fsUtil.setRootDirPath(repoDirPath);
+    expect(await fsUtil.readFileConfinedIfExists(path.join(repoDirPath, '.renovaterc.json'))).toBeUndefined();
+    expect(await fsUtil.readFileConfinedIfExists(path.join(repoDirPath, 'linked', 'secret.txt'))).toBeUndefined();
+    expect(await fsUtil.readFileConfinedIfExists(path.join(repoDirPath, 'missing.txt'))).toBeUndefined();
+    expect(await fsUtil.readFileConfinedIfExists(path.join(repoDirPath, 'regular.txt'))).toBe('regular');
+  } finally {
+    fsUtil.setRootDirPath(undefined);
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('removeConfined refuses to delete through a symlinked directory but removes symlink entries', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-fsutil-'));
+  try {
+    const repoDirPath = path.join(tempDirPath, 'repo');
+    const outsideDirPath = path.join(tempDirPath, 'outside');
+    fs.mkdirSync(repoDirPath);
+    fs.mkdirSync(outsideDirPath);
+    fs.writeFileSync(path.join(outsideDirPath, 'workflow.yml'), 'name: x');
+    fs.symlinkSync(outsideDirPath, path.join(repoDirPath, 'workflows'));
+    fsUtil.setRootDirPath(repoDirPath);
+    // Deletion through the symlinked directory is refused; the outside file survives.
+    expect(await fsUtil.removeConfined(path.join(repoDirPath, 'workflows', 'workflow.yml'))).toBe(false);
+    expect(fs.existsSync(path.join(outsideDirPath, 'workflow.yml'))).toBe(true);
+    // Removing the symlink ENTRY itself deletes only the link, never its target.
+    expect(await fsUtil.removeConfined(path.join(repoDirPath, 'workflows'))).toBe(true);
+    expect(fs.existsSync(path.join(repoDirPath, 'workflows'))).toBe(false);
+    expect(fs.existsSync(path.join(outsideDirPath, 'workflow.yml'))).toBe(true);
+    // A regular in-repository file is removed.
+    fs.writeFileSync(path.join(repoDirPath, 'inside.txt'), 'inside');
+    expect(await fsUtil.removeConfined(path.join(repoDirPath, 'inside.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(repoDirPath, 'inside.txt'))).toBe(false);
+  } finally {
+    fsUtil.setRootDirPath(undefined);
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('generateFile writes normally inside the confined repository root', async () => {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-fsutil-'));
   try {

--- a/packages/wbfy/test/lefthook.test.ts
+++ b/packages/wbfy/test/lefthook.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { generateLefthookUpdatingPackageJson } from '../src/generators/lefthook.js';
+
+import { createConfig } from './testConfig.js';
+
+test('post-merge cache clearing covers workspace frameworks with workspace-relative paths', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-lefthook-'));
+  try {
+    const rootConfig = createConfig({ dirPath: tempDirPath, isRoot: true });
+    const nextConfig = createConfig({
+      dirPath: path.join(tempDirPath, 'apps', 'site'),
+      depending: { ...createConfig().depending, next: true },
+    });
+    const vinextConfig = createConfig({
+      dirPath: path.join(tempDirPath, 'packages', 'web'),
+      depending: { ...createConfig().depending, vinext: true },
+    });
+    await generateLefthookUpdatingPackageJson(rootConfig, [rootConfig, nextConfig, vinextConfig]);
+
+    const prepareScript = fs.readFileSync(path.join(tempDirPath, '.lefthook', 'post-merge', 'prepare.sh'), 'utf8');
+    expect(prepareScript).toContain('bun install && rm -Rf apps/site/.next');
+    expect(prepareScript).toContain(
+      String.raw`run_if_changed "(bunfig\.toml|\.npmrc)" "rm -Rf packages/web/node_modules/.vite"`
+    );
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('post-merge cache clearing stays root-relative for a root-level Next.js app without a Vite cache hook', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-lefthook-'));
+  try {
+    const rootConfig = createConfig({
+      dirPath: tempDirPath,
+      isRoot: true,
+      depending: { ...createConfig().depending, next: true },
+    });
+    await generateLefthookUpdatingPackageJson(rootConfig, [rootConfig]);
+
+    const prepareScript = fs.readFileSync(path.join(tempDirPath, '.lefthook', 'post-merge', 'prepare.sh'), 'utf8');
+    expect(prepareScript).toContain('bun install && rm -Rf .next');
+    expect(prepareScript).not.toContain('node_modules/.vite');
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});

--- a/packages/wbfy/test/lefthook.test.ts
+++ b/packages/wbfy/test/lefthook.test.ts
@@ -23,9 +23,9 @@ test('post-merge cache clearing covers workspace frameworks with workspace-relat
     await generateLefthookUpdatingPackageJson(rootConfig, [rootConfig, nextConfig, vinextConfig]);
 
     const prepareScript = fs.readFileSync(path.join(tempDirPath, '.lefthook', 'post-merge', 'prepare.sh'), 'utf8');
-    expect(prepareScript).toContain('bun install && rm -Rf apps/site/.next');
+    expect(prepareScript).toContain("bun install && rm -Rf -- 'apps/site/.next'");
     expect(prepareScript).toContain(
-      String.raw`run_if_changed "(bunfig\.toml|\.npmrc)" "rm -Rf packages/web/node_modules/.vite"`
+      String.raw`run_if_changed "(bunfig\.toml|\.npmrc)" "rm -Rf -- 'packages/web/node_modules/.vite'"`
     );
   } finally {
     fs.rmSync(tempDirPath, { recursive: true, force: true });
@@ -43,7 +43,7 @@ test('post-merge cache clearing stays root-relative for a root-level Next.js app
     await generateLefthookUpdatingPackageJson(rootConfig, [rootConfig]);
 
     const prepareScript = fs.readFileSync(path.join(tempDirPath, '.lefthook', 'post-merge', 'prepare.sh'), 'utf8');
-    expect(prepareScript).toContain('bun install && rm -Rf .next');
+    expect(prepareScript).toContain("bun install && rm -Rf -- '.next'");
     expect(prepareScript).not.toContain('node_modules/.vite');
   } finally {
     fs.rmSync(tempDirPath, { recursive: true, force: true });

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1444,6 +1444,40 @@ test('keeps custom database scripts for drizzle projects', async () => {
   });
 });
 
+test('preserves custom wrapper bodies of managed db scripts that contain a wb db call', async () => {
+  const wrapperScripts = {
+    'db-create-migration': 'prepare-sqlite && wb db migrate-dev',
+    'db-migrate': 'for t in a b; do DATABASE_URL=$t wb prisma migrate; done',
+    // oxlint-disable-next-line no-template-curly-in-string -- the shell-default form under test
+    'db-view': 'prepare-sqlite && WB_ENV=${WB_ENV:-development} wb db studio',
+  };
+  const packageJson = await generatePackageJsonFrom(
+    { scripts: wrapperScripts },
+    { depending: { ...createConfig().depending, prisma: true } }
+  );
+
+  expect(packageJson.scripts).toMatchObject(wrapperScripts);
+});
+
+test('replaces plain generated db script bodies (with or without runner prefixes)', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      scripts: {
+        'db-create-migration': 'yarn wb prisma migrate-dev',
+        'db-migrate': 'bun wb prisma migrate',
+        'db-view': 'wb prisma studio',
+      },
+    },
+    { depending: { ...createConfig().depending, prisma: true } }
+  );
+
+  expect(packageJson.scripts).toMatchObject({
+    'db-create-migration': 'bun wb prisma migrate-dev',
+    'db-migrate': 'bun wb prisma migrate --check-idempotency',
+    'db-view': 'bun wb prisma studio',
+  });
+});
+
 test('uses bun runner for generated Python scripts in bun projects', async () => {
   const packageJson = await generatePackageJsonFrom(
     { scripts: {} },

--- a/packages/wbfy/test/wbEnv.test.ts
+++ b/packages/wbfy/test/wbEnv.test.ts
@@ -1,0 +1,129 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { parse } from 'smol-toml';
+import { expect, test } from 'vitest';
+
+import { ensureWbEnvDefinitions, insertWbEnvIntoEnvFile, insertWbEnvIntoFnoxToml } from '../src/generators/wbEnv.js';
+
+import { createConfig } from './testConfig.js';
+
+const fnoxTomlWithoutWbEnv = `[providers.age]
+type = "age"
+recipients = [
+  "age1example", # exkazuu
+]
+
+[secrets]
+PORT = { default = "3000" }
+
+[profiles.test.secrets]
+API_KEY = { provider = "age", value = "abc" }
+
+[profiles.production.secrets]
+API_KEY = { provider = "age", value = "def" }
+`;
+
+interface FnoxSubtree {
+  secrets?: Record<string, { default?: string }>;
+  profiles?: Record<string, { secrets?: Record<string, { default?: string }> } | undefined>;
+}
+
+test('inserts WB_ENV into the base secrets and every profile of a fnox.toml', () => {
+  const updated = insertWbEnvIntoFnoxToml(fnoxTomlWithoutWbEnv, false);
+  expect(updated).toBeDefined();
+  const settings = parse(updated ?? '') as FnoxSubtree;
+  expect(settings.secrets?.WB_ENV).toEqual({ default: 'development' });
+  expect(settings.profiles?.test?.secrets?.WB_ENV).toEqual({ default: 'test' });
+  expect(settings.profiles?.production?.secrets?.WB_ENV).toEqual({ default: 'production' });
+  // The staging profile does not exist and must not be created.
+  expect(settings.profiles?.staging).toBeUndefined();
+  // Existing entries and formatting survive.
+  expect(updated).toContain('PORT = { default = "3000" }');
+  expect(updated).toContain('# exkazuu');
+});
+
+test('creates missing profile sections for the standard modes', () => {
+  const minimal = '[secrets]\nPORT = { default = "3000" }\n';
+  const updated = insertWbEnvIntoFnoxToml(minimal, false);
+  const settings = parse(updated ?? '') as FnoxSubtree;
+  expect(settings.secrets?.WB_ENV).toEqual({ default: 'development' });
+  expect(settings.profiles?.test?.secrets?.WB_ENV).toEqual({ default: 'test' });
+  expect(settings.profiles?.production?.secrets?.WB_ENV).toEqual({ default: 'production' });
+});
+
+test('completes an existing staging profile', () => {
+  const withStaging = `${fnoxTomlWithoutWbEnv}
+[profiles.staging.secrets]
+API_KEY = { provider = "age", value = "ghi" }
+`;
+  const updated = insertWbEnvIntoFnoxToml(withStaging, false);
+  const settings = parse(updated ?? '') as FnoxSubtree;
+  expect(settings.profiles?.staging?.secrets?.WB_ENV).toEqual({ default: 'staging' });
+});
+
+test('adds NEXT_PUBLIC_WB_ENV for Next.js/vinext repositories', () => {
+  const updated = insertWbEnvIntoFnoxToml(fnoxTomlWithoutWbEnv, true);
+  const settings = parse(updated ?? '') as FnoxSubtree;
+  expect(settings.secrets?.NEXT_PUBLIC_WB_ENV).toEqual({ default: 'development' });
+  expect(settings.profiles?.test?.secrets?.NEXT_PUBLIC_WB_ENV).toEqual({ default: 'test' });
+  expect(settings.profiles?.production?.secrets?.NEXT_PUBLIC_WB_ENV).toEqual({ default: 'production' });
+});
+
+test('is idempotent and leaves already-defined values untouched', () => {
+  const firstPass = insertWbEnvIntoFnoxToml(fnoxTomlWithoutWbEnv, true) ?? '';
+  expect(insertWbEnvIntoFnoxToml(firstPass, true)).toBe(firstPass);
+
+  const customized = firstPass.replace('WB_ENV = { default = "test" }', 'WB_ENV = { default = "custom-test" }');
+  const secondPass = insertWbEnvIntoFnoxToml(customized, true);
+  expect(secondPass).toBe(customized);
+});
+
+test('refuses to edit an unparsable fnox.toml', () => {
+  expect(insertWbEnvIntoFnoxToml('[secrets\nbroken', false)).toBeUndefined();
+});
+
+test('appends missing WB_ENV assignments to legacy .env mode files', () => {
+  expect(insertWbEnvIntoEnvFile('PORT=3000\n', 'test', false)).toBe('PORT=3000\nWB_ENV=test\n');
+  expect(insertWbEnvIntoEnvFile('', 'production', true)).toBe('WB_ENV=production\nNEXT_PUBLIC_WB_ENV=production\n');
+});
+
+test('leaves existing legacy WB_ENV assignments untouched (idempotent)', () => {
+  const content = 'WB_ENV=custom\nexport NEXT_PUBLIC_WB_ENV=custom\n';
+  expect(insertWbEnvIntoEnvFile(content, 'staging', true)).toBe(content);
+  const inserted = insertWbEnvIntoEnvFile('PORT=3000\n', 'staging', true);
+  expect(insertWbEnvIntoEnvFile(inserted, 'staging', true)).toBe(inserted);
+});
+
+test('ensureWbEnvDefinitions updates existing legacy mode files only', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-wbenv-'));
+  try {
+    fs.writeFileSync(path.join(tempDirPath, '.env'), 'PORT=3000\n');
+    fs.writeFileSync(path.join(tempDirPath, '.env.test'), '');
+    const rootConfig = createConfig({ dirPath: tempDirPath, isRoot: true });
+    await ensureWbEnvDefinitions(rootConfig, [rootConfig]);
+    expect(fs.readFileSync(path.join(tempDirPath, '.env'), 'utf8')).toBe('PORT=3000\nWB_ENV=development\n');
+    expect(fs.readFileSync(path.join(tempDirPath, '.env.test'), 'utf8')).toBe('WB_ENV=test\n');
+    expect(fs.existsSync(path.join(tempDirPath, '.env.production'))).toBe(false);
+    expect(fs.existsSync(path.join(tempDirPath, '.env.staging'))).toBe(false);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('ensureWbEnvDefinitions prefers fnox.toml over legacy .env files', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-wbenv-'));
+  try {
+    fs.writeFileSync(path.join(tempDirPath, 'fnox.toml'), fnoxTomlWithoutWbEnv);
+    fs.writeFileSync(path.join(tempDirPath, '.env'), 'PORT=3000\n');
+    const rootConfig = createConfig({ dirPath: tempDirPath, isRoot: true });
+    await ensureWbEnvDefinitions(rootConfig, [rootConfig]);
+    const settings = parse(fs.readFileSync(path.join(tempDirPath, 'fnox.toml'), 'utf8')) as FnoxSubtree;
+    expect(settings.secrets?.WB_ENV).toEqual({ default: 'development' });
+    // Legacy files are left alone while fnox.toml exists.
+    expect(fs.readFileSync(path.join(tempDirPath, '.env'), 'utf8')).toBe('PORT=3000\n');
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});

--- a/packages/wbfy/test/wbEnv.test.ts
+++ b/packages/wbfy/test/wbEnv.test.ts
@@ -80,6 +80,15 @@ test('is idempotent and leaves already-defined values untouched', () => {
   expect(secondPass).toBe(customized);
 });
 
+test('does not duplicate the explanatory comment when only NEXT_PUBLIC_WB_ENV is inserted later', () => {
+  const wbEnvOnly = insertWbEnvIntoFnoxToml(fnoxTomlWithoutWbEnv, false) ?? '';
+  const withNextPublic = insertWbEnvIntoFnoxToml(wbEnvOnly, true) ?? '';
+  const commentCount = withNextPublic.split('# CI sets WB_ENV').length - 1;
+  expect(commentCount).toBe(1);
+  const settings = parse(withNextPublic) as FnoxSubtree;
+  expect(settings.secrets?.NEXT_PUBLIC_WB_ENV).toEqual({ default: 'development' });
+});
+
 test('refuses to edit an unparsable fnox.toml', () => {
   expect(insertWbEnvIntoFnoxToml('[secrets\nbroken', false)).toBeUndefined();
 });
@@ -94,6 +103,11 @@ test('leaves existing legacy WB_ENV assignments untouched (idempotent)', () => {
   expect(insertWbEnvIntoEnvFile(content, 'staging', true)).toBe(content);
   const inserted = insertWbEnvIntoEnvFile('PORT=3000\n', 'staging', true);
   expect(insertWbEnvIntoEnvFile(inserted, 'staging', true)).toBe(inserted);
+});
+
+test('a WB_ENV line embedded in a quoted multiline value does not suppress the insertion', () => {
+  const content = 'CERT="line1\nWB_ENV=embedded\nline3"\n';
+  expect(insertWbEnvIntoEnvFile(content, 'test', false)).toBe(`${content}WB_ENV=test\n`);
 });
 
 test('ensureWbEnvDefinitions updates existing legacy mode files only', async () => {

--- a/packages/wbfy/test/workspaceDiscovery.test.ts
+++ b/packages/wbfy/test/workspaceDiscovery.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { expect, test } from 'vitest';
 
-import { getWorkspaceSubDirPaths } from '../src/generators/packageJson.js';
+import { getWorkspaceSubDirPaths } from '../src/utils/workspaceUtil.js';
 import { generateTsconfig } from '../src/generators/tsconfig.js';
 import { getPackageConfig } from '../src/packageConfig.js';
 import { promisePool } from '../src/utils/promisePool.js';

--- a/packages/wbfy/test/workspaceDiscovery.test.ts
+++ b/packages/wbfy/test/workspaceDiscovery.test.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { getWorkspaceSubDirPaths } from '../src/generators/packageJson.js';
+import { generateTsconfig } from '../src/generators/tsconfig.js';
+import { getPackageConfig } from '../src/packageConfig.js';
+import { promisePool } from '../src/utils/promisePool.js';
+
+test('discovers and manages workspaces declared outside packages/* (e.g. apps/*)', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    fs.writeFileSync(
+      path.join(tempDirPath, 'package.json'),
+      JSON.stringify({ name: 'root', workspaces: ['apps/*', 'packages/*'] })
+    );
+    const appDirPath = path.join(tempDirPath, 'apps', 'web');
+    fs.mkdirSync(path.join(appDirPath, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(appDirPath, 'package.json'), JSON.stringify({ name: 'web' }));
+    fs.writeFileSync(path.join(appDirPath, 'src', 'index.ts'), 'export {};\n');
+
+    const subDirPaths = getWorkspaceSubDirPaths({
+      dirPath: tempDirPath,
+      doesContainSubPackageJsons: false,
+      packageJson: { workspaces: ['apps/*', 'packages/*'] },
+    });
+    expect(subDirPaths).toEqual([appDirPath]);
+
+    // apps/* workspaces are classified as child packages, not roots.
+    const config = await getPackageConfig(appDirPath, { isRoot: false });
+    expect(config).toBeDefined();
+    expect(config?.isRoot).toBe(false);
+    expect(config?.doesContainTypeScript).toBe(true);
+
+    // …and therefore receive managed settings such as tsconfig.json.
+    if (!config) throw new Error('unreachable');
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    const tsconfig = JSON.parse(fs.readFileSync(path.join(appDirPath, 'tsconfig.json'), 'utf8')) as {
+      compilerOptions?: object;
+    };
+    expect(tsconfig.compilerOptions).toBeDefined();
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('ignores workspace patterns escaping the repository', () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), JSON.stringify({ workspaces: ['../outside/*'] }));
+    expect(
+      getWorkspaceSubDirPaths({
+        dirPath: tempDirPath,
+        doesContainSubPackageJsons: false,
+        packageJson: { workspaces: ['../outside/*'] },
+      })
+    ).toEqual([]);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #984
Fixes #983
Fixes #974
Fixes #971
Fixes #966
Fixes #965
Fixes #955
Fixes #993

## Customer Summary

- Repositories managed by wbfy now always define the standard `WB_ENV` environment variable for every mode (development / test / staging / production), and `NEXT_PUBLIC_WB_ENV` for Next.js/vinext workspaces — in `fnox.toml` for fnox-based repos and in existing `.env` mode files (per workspace) otherwise. Existing definitions are never touched.
- Several long-standing wbfy issues are fixed: custom database scripts are no longer overwritten, monorepo cache clearing works for workspaces (including `apps/*` layouts), pending release runs are no longer silently cancelled, committed `.env.cloudflare` credential files (including nested ones) are untracked with a rotation warning, multi-identity CI age key files work, and the generated `.gitignore` covers `@willbooster-private/`.
- Workspaces declared outside `packages/*` (e.g. `apps/*`) now receive the same managed configuration as conventional layouts.

## Technical Summary

- New `generators/wbEnv.ts`: idempotent text-based insertion into `fnox.toml` (`[secrets]` + `[profiles.<mode>.secrets]`, staging only when already declared, re-parse validation, no duplicated explanatory comment) and per-workspace legacy `.env` completion using `dotenv.parse` for key detection; `NEXT_PUBLIC_WB_ENV` mirrors wb's `requiresNextPublicWbEnv` contract (all four dependency sections). A dangling `fnox.toml` symlink aborts instead of falling back to the legacy branch.
- Workspace discovery honors declared workspace patterns via a new `utils/workspaceUtil.ts` (shared by `packageConfig.ts`, `generators/packageJson.ts`, `index.ts`); `doesContainSubPackageJsons` and the `isRoot` heuristic (`isWorkspaceOfEnclosingRoot`: ancestor walk up to the first git boundary, own-`.git` short-circuit) cover `apps/*` and deeper layouts; `packages/*` is forced into `workspaces` only when it matches a manifest; Lefthook generation is skipped for child-workspace CLI entries.
- #984: `isGeneratedDatabaseScript` is anchored on the whole body AND each managed script's exact generated argument variants (accepting historical `bun --bun` prefixes; horizontal whitespace only), so wrappers, extra flags, and cross-script reuse survive.
- #983: post-merge hooks clear workspace-relative `.next` (single `rm -Rf --`) and `node_modules/.vite` for vinext/Vite workspaces; interpolated paths are quoted for BOTH shell stages (double-quoted argument parse, then eval).
- #974: the generated caller `release.yml` keeps `group: ${{ github.workflow }}` and adds `queue: max` (the default `single` queue cancels pending caller runs; reusing the reusable workflow's job-level `release-${{ github.repository }}` group would deadlock). Deploy callers intentionally keep the default queue.
- #971: confined read/remove helpers in `fsUtil` (`readFileConfinedIfExists` accepts in-repo symlink targets, rejects dangling/escaping ones); refused migration sources abort `mise.toml` / `renovate.json` generation instead of shadowing or replacing their settings; a symlinked `renovate.json` is refused up front.
- #966: the CI age identity upload keeps every `AGE-SECRET-KEY-` line and verifies that SOME `# public key:` comment equals the registered CI key (order-independent multi-identity support).
- #955: `fixers/cloudflareEnv.ts` untracks every tracked `**/.env.cloudflare` covered by the managed ignore rule (`git -c core.quotePath=false ls-files -z` via a new untrimmed `spawnSyncAndReturnRawStdout`), checks `git rm --cached`'s status, sets `process.exitCode = 1` on failure, and prints a prominent rotation warning listing all paths.
- #993: generated `.gitignore` adds `@willbooster-private/`.

## Why

- The org-standard `WB_ENV` convention was enforced only by convention, and eight reported wbfy defects (data-loss, security, and correctness issues) shared this code area, so they are fixed together.
- Six multi-agent review rounds (Codex / Claude Code / Antigravity) hardened the changes; every validated finding is fixed in this PR, and the remaining `packages/**` hardcoding of root-level signals is tracked in #995.

## Testing

- `bun verify` (typecheck + lint across all packages) passes.
- Full wbfy suite: 13 files, 145 tests, all passing — including new tests for WB_ENV insertion (fnox/legacy, multiline dotenv values, comment dedup), workspace discovery (`apps/*`), lefthook path quoting, confined reads (in-repo symlink accepted, escaping/dangling rejected), and db-script preservation.
- Shell quoting verified round-trip through bash and sh for paths containing spaces, `$`, backticks, quotes, and backslashes.
- Smoke test: scratch clone of WillBooster/cheerlings (origin repointed to a dummy URL); first run produced only the expected fnox.toml/release.yml/prepare.sh insertions, second run was fully idempotent.

## Notes

- Follow-up: #995 tracks deriving root-level `doesContain*InPackages` signals and the root tsconfig include/exclude from declared workspace patterns for `apps/*`-only monorepos.
