### PR TITLE
fix: derive root monorepo signals and root tsconfig from declared workspace patterns

### DIFF
--- a/packages/wbfy/src/fixers/typos.ts
+++ b/packages/wbfy/src/fixers/typos.ts
@@ -34,16 +34,22 @@ export async function fixTypos(packageConfig: PackageConfig): Promise<void> {
     }
 
     // fixTypos runs once on the root config, so this glob set must cover every declared workspace
-    // layout (e.g. apps/*), not just the conventional packages/* directory.
+    // layout (e.g. apps/*), not just the conventional packages/* directory — while honoring
+    // declared negations (e.g. `!apps/excluded`), whose sources are not part of the monorepo.
+    const workspaceDirPatterns = getWorkspaceDirPatterns(packageConfig);
     const tsFiles = await fg.glob(
       [
         '{app,src,test,scripts}/**/*.{cjs,mjs,js,jsx,cts,mts,ts,tsx}',
         'packages/**/{app,src,test,scripts}/**/*.{cjs,mjs,js,jsx,cts,mts,ts,tsx}',
-        ...getWorkspaceDirPatterns(packageConfig).includes.map(
+        ...workspaceDirPatterns.includes.map(
           (dirPattern) => `${dirPattern}/**/{app,src,test,scripts}/**/*.{cjs,mjs,js,jsx,cts,mts,ts,tsx}`
         ),
       ],
-      { dot: true, cwd: dirPath, ignore: globIgnore }
+      {
+        dot: true,
+        cwd: dirPath,
+        ignore: [...globIgnore, ...workspaceDirPatterns.excludes.map((dirPattern) => `${dirPattern}/**`)],
+      }
     );
     if (options.isVerbose) {
       console.info(`Found ${tsFiles.length} TypeScript files in ${dirPath}`);

--- a/packages/wbfy/src/fixers/typos.ts
+++ b/packages/wbfy/src/fixers/typos.ts
@@ -9,6 +9,7 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
 import { promisePool } from '../utils/promisePool.js';
+import { getWorkspaceDirPatterns } from '../utils/workspaceUtil.js';
 
 export async function fixTypos(packageConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('fixTypos', async () => {
@@ -32,10 +33,15 @@ export async function fixTypos(packageConfig: PackageConfig): Promise<void> {
       });
     }
 
+    // fixTypos runs once on the root config, so this glob set must cover every declared workspace
+    // layout (e.g. apps/*), not just the conventional packages/* directory.
     const tsFiles = await fg.glob(
       [
         '{app,src,test,scripts}/**/*.{cjs,mjs,js,jsx,cts,mts,ts,tsx}',
         'packages/**/{app,src,test,scripts}/**/*.{cjs,mjs,js,jsx,cts,mts,ts,tsx}',
+        ...getWorkspaceDirPatterns(packageConfig).includes.map(
+          (dirPattern) => `${dirPattern}/**/{app,src,test,scripts}/**/*.{cjs,mjs,js,jsx,cts,mts,ts,tsx}`
+        ),
       ],
       { dot: true, cwd: dirPath, ignore: globIgnore }
     );

--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -40,10 +40,11 @@ export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs =
     // A pass must not rewrite files owned by another (possibly nested) package: each package has
     // its own pass with its own resolved command, and overlapping passes would race
     // read-modify-write on the same files. Concrete directories of the actually processed
-    // packages are used instead of workspace patterns, so a directory a pattern matches without a
-    // manifest (or one removed by a negation) — which gets no pass of its own — stays covered by
-    // the enclosing pass. The literal packages/** keeps shielding legacy packages/* layouts that
-    // predate a `workspaces` declaration.
+    // packages are used instead of workspace patterns or a blanket packages/** glob, so a
+    // directory a pattern matches without a manifest, a negation-removed directory, or an
+    // ORM-free package — none of which get a rewrite pass of their own — stays covered by the
+    // enclosing pass. Legacy packages/* layouts need no extra shielding either: workspace
+    // discovery's unconditional packages/* fallback gives each of them its own config.
     const configDirPath = path.resolve(config.dirPath);
     const nestedPackageIgnores = packageConfigs
       .filter(
@@ -61,7 +62,7 @@ export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs =
       absolute: true,
       cwd: config.dirPath,
       dot: true,
-      ignore: ['**/.git/**', ...(config.isRoot ? ['packages/**'] : []), ...nestedPackageIgnores, ...globIgnore],
+      ignore: ['**/.git/**', ...nestedPackageIgnores, ...globIgnore],
       onlyFiles: true,
     });
     for (const filePath of filePaths) {

--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
 
 import fg from 'fast-glob';
 import { PromisePool } from 'minimal-promise-pool';
@@ -6,7 +7,6 @@ import { PromisePool } from 'minimal-promise-pool';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
-import { getWorkspaceDirPatterns } from '../utils/workspaceUtil.js';
 
 const wbDatabaseCommandRegex = /\bwb\s+(?:db|prisma)\b/gu;
 const maxTextFileBytes = 1024 * 1024;
@@ -37,20 +37,21 @@ export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs =
     const command = selectWbDatabaseCommand(config);
     if (!command) continue;
 
+    // A pass must not rewrite files owned by another (possibly nested) package: each package has
+    // its own pass with its own resolved command, and overlapping passes would race
+    // read-modify-write on the same files. Concrete directories of the actually processed
+    // packages are used instead of workspace patterns, so a directory a pattern matches without a
+    // manifest (or one removed by a negation) — which gets no pass of its own — stays covered by
+    // the enclosing pass. The literal packages/** keeps shielding legacy packages/* layouts that
+    // predate a `workspaces` declaration.
+    const nestedPackageIgnores = packageConfigs
+      .filter((other) => other !== config && other.dirPath.startsWith(`${config.dirPath}${path.sep}`))
+      .map((other) => `${path.relative(config.dirPath, other.dirPath).replaceAll('\\', '/')}/**`);
     const filePaths = await fg(migrationTargets, {
       absolute: true,
       cwd: config.dirPath,
       dot: true,
-      // The root pass must not rewrite files owned by workspace packages, whatever layout the
-      // workspaces declare (e.g. apps/*): each workspace has its own pass with its own resolved
-      // command, and overlapping passes would race read-modify-write on the same files.
-      ignore: [
-        '**/.git/**',
-        ...(config.isRoot
-          ? ['packages/**', ...getWorkspaceDirPatterns(config).includes.map((dirPattern) => `${dirPattern}/**`)]
-          : []),
-        ...globIgnore,
-      ],
+      ignore: ['**/.git/**', ...(config.isRoot ? ['packages/**'] : []), ...nestedPackageIgnores, ...globIgnore],
       onlyFiles: true,
     });
     for (const filePath of filePaths) {

--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -57,7 +57,9 @@ export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs =
           // for workspaces, so resolve both sides before the containment check.
           path.resolve(other.dirPath).startsWith(`${configDirPath}${path.sep}`)
       )
-      .map((other) => `${path.relative(configDirPath, path.resolve(other.dirPath)).replaceAll('\\', '/')}/**`);
+      // escapePath: a directory name containing glob syntax (e.g. `apps/[web]`) must be ignored
+      // literally, not as a character class that also matches sibling directories.
+      .map((other) => `${fg.escapePath(path.relative(configDirPath, path.resolve(other.dirPath)))}/**`);
     const filePaths = await fg(migrationTargets, {
       absolute: true,
       cwd: config.dirPath,

--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -44,9 +44,19 @@ export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs =
     // manifest (or one removed by a negation) — which gets no pass of its own — stays covered by
     // the enclosing pass. The literal packages/** keeps shielding legacy packages/* layouts that
     // predate a `workspaces` declaration.
+    const configDirPath = path.resolve(config.dirPath);
     const nestedPackageIgnores = packageConfigs
-      .filter((other) => other !== config && other.dirPath.startsWith(`${config.dirPath}${path.sep}`))
-      .map((other) => `${path.relative(config.dirPath, other.dirPath).replaceAll('\\', '/')}/**`);
+      .filter(
+        (other) =>
+          other !== config &&
+          // Only packages that get a rewrite pass of their own are shielded: an ORM-free package
+          // has no pass, so the enclosing pass must keep covering its files.
+          selectWbDatabaseCommand(other) !== undefined &&
+          // dirPath may be relative for the root config (the verbatim CLI argument) and absolute
+          // for workspaces, so resolve both sides before the containment check.
+          path.resolve(other.dirPath).startsWith(`${configDirPath}${path.sep}`)
+      )
+      .map((other) => `${path.relative(configDirPath, path.resolve(other.dirPath)).replaceAll('\\', '/')}/**`);
     const filePaths = await fg(migrationTargets, {
       absolute: true,
       cwd: config.dirPath,

--- a/packages/wbfy/src/fixers/wbDbCommand.ts
+++ b/packages/wbfy/src/fixers/wbDbCommand.ts
@@ -6,6 +6,7 @@ import { PromisePool } from 'minimal-promise-pool';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
+import { getWorkspaceDirPatterns } from '../utils/workspaceUtil.js';
 
 const wbDatabaseCommandRegex = /\bwb\s+(?:db|prisma)\b/gu;
 const maxTextFileBytes = 1024 * 1024;
@@ -40,7 +41,16 @@ export async function fixWbDbCommand(rootConfig: PackageConfig, packageConfigs =
       absolute: true,
       cwd: config.dirPath,
       dot: true,
-      ignore: ['**/.git/**', ...(config.isRoot ? ['packages/**'] : []), ...globIgnore],
+      // The root pass must not rewrite files owned by workspace packages, whatever layout the
+      // workspaces declare (e.g. apps/*): each workspace has its own pass with its own resolved
+      // command, and overlapping passes would race read-modify-write on the same files.
+      ignore: [
+        '**/.git/**',
+        ...(config.isRoot
+          ? ['packages/**', ...getWorkspaceDirPatterns(config).includes.map((dirPattern) => `${dirPattern}/**`)]
+          : []),
+        ...globIgnore,
+      ],
       onlyFiles: true,
     });
     for (const filePath of filePaths) {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -487,7 +487,9 @@ async function applyPackageJsonConventions(
       const forcedPatterns =
         fg.globSync('packages/*/package.json', { cwd: config.dirPath, ignore: ['**/node_modules/**'] }).length > 0
           ? hasOnlyNegativeDeclaredWorkspacePatterns(jsonObj.workspaces)
-            ? ['*/*', 'packages/*']
+            ? // `*/*` already covers every packages/<name>, so appending `packages/*` too would
+              // just persist dead configuration.
+              ['*/*']
             : ['packages/*']
           : [];
       jsonObj.workspaces = merge.all([getDeclaredWorkspacePatterns(jsonObj.workspaces), forcedPatterns], {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -32,7 +32,11 @@ import { spawnSync, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
 import { getTsconfigBaseDependencies, managedTsconfigBaseDependencies } from '../utils/tsconfigBase.js';
 import { parseSourceFile } from '../utils/typescriptApi.js';
 import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfigsUtil.js';
-import { getDeclaredWorkspacePatterns, getWorkspacePackageJsonPaths } from '../utils/workspaceUtil.js';
+import {
+  getDeclaredWorkspacePatterns,
+  getWorkspacePackageJsonPaths,
+  hasOnlyNegativeDeclaredWorkspacePatterns,
+} from '../utils/workspaceUtil.js';
 import { bunMinimumReleaseAgeExcludes, bunMinimumReleaseAgeSeconds } from './bunfig.js';
 
 const oxlintDeps = ['@willbooster/oxfmt-config', '@willbooster/oxlint-config', 'oxfmt', 'oxlint', 'oxlint-tsgolint'];
@@ -477,10 +481,14 @@ async function applyPackageJsonConventions(
       // We don't allow non-array workspaces in monorepo. Yarn v1's object form keeps its
       // declared patterns (workspaces.packages); only extras such as nohoist are dropped.
       // Force `packages/*` only when it actually matches a workspace manifest: an apps/*-only
-      // monorepo must not get a never-matching pattern appended to its declaration.
+      // monorepo must not get a never-matching pattern appended to its declaration. When the
+      // declaration is negative-only, appending a positive pattern would disable Bun's implicit
+      // `*/*` baseline and silently drop the other workspaces, so declare the baseline explicitly.
       const forcedPatterns =
         fg.globSync('packages/*/package.json', { cwd: config.dirPath, ignore: ['**/node_modules/**'] }).length > 0
-          ? ['packages/*']
+          ? hasOnlyNegativeDeclaredWorkspacePatterns(jsonObj.workspaces)
+            ? ['*/*', 'packages/*']
+            : ['packages/*']
           : [];
       jsonObj.workspaces = merge.all([getDeclaredWorkspacePatterns(jsonObj.workspaces), forcedPatterns], {
         arrayMerge: combineMerge,

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -35,7 +35,7 @@ import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfig
 import {
   getDeclaredWorkspacePatterns,
   getWorkspacePackageJsonPaths,
-  hasOnlyNegativeDeclaredWorkspacePatterns,
+  hasImplicitWorkspaceBaseline,
 } from '../utils/workspaceUtil.js';
 import { bunMinimumReleaseAgeExcludes, bunMinimumReleaseAgeSeconds } from './bunfig.js';
 
@@ -482,12 +482,12 @@ async function applyPackageJsonConventions(
       // declared patterns (workspaces.packages); only extras such as nohoist are dropped.
       // Force `packages/*` only when it actually matches a workspace manifest: an apps/*-only
       // monorepo must not get a never-matching pattern appended to its declaration. A
-      // negative-only declaration needs no forced pattern at all, because Bun's implicit `*/*`
-      // baseline already covers packages/*. The forced pattern is PREPENDED: Bun evaluates
-      // workspace patterns sequentially, so a positive pattern placed after a user negation
-      // would re-include the negated packages.
+      // baseline-active declaration needs no forced pattern at all (the implicit `*/*` already
+      // covers packages/*), and adding one would disable the baseline. The forced pattern is
+      // PREPENDED: Bun evaluates workspace patterns sequentially, so a positive pattern placed
+      // after a user negation would re-include the negated packages.
       const forcedPatterns =
-        !hasOnlyNegativeDeclaredWorkspacePatterns(jsonObj.workspaces) &&
+        !hasImplicitWorkspaceBaseline(jsonObj.workspaces) &&
         fg.globSync('packages/*/package.json', { cwd: config.dirPath, ignore: ['**/node_modules/**'] }).length > 0
           ? ['packages/*']
           : [];

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -481,18 +481,17 @@ async function applyPackageJsonConventions(
       // We don't allow non-array workspaces in monorepo. Yarn v1's object form keeps its
       // declared patterns (workspaces.packages); only extras such as nohoist are dropped.
       // Force `packages/*` only when it actually matches a workspace manifest: an apps/*-only
-      // monorepo must not get a never-matching pattern appended to its declaration. When the
-      // declaration is negative-only, appending a positive pattern would disable Bun's implicit
-      // `*/*` baseline and silently drop the other workspaces, so declare the baseline explicitly.
+      // monorepo must not get a never-matching pattern appended to its declaration. A
+      // negative-only declaration needs no forced pattern at all, because Bun's implicit `*/*`
+      // baseline already covers packages/*. The forced pattern is PREPENDED: Bun evaluates
+      // workspace patterns sequentially, so a positive pattern placed after a user negation
+      // would re-include the negated packages.
       const forcedPatterns =
+        !hasOnlyNegativeDeclaredWorkspacePatterns(jsonObj.workspaces) &&
         fg.globSync('packages/*/package.json', { cwd: config.dirPath, ignore: ['**/node_modules/**'] }).length > 0
-          ? hasOnlyNegativeDeclaredWorkspacePatterns(jsonObj.workspaces)
-            ? // `*/*` already covers every packages/<name>, so appending `packages/*` too would
-              // just persist dead configuration.
-              ['*/*']
-            : ['packages/*']
+          ? ['packages/*']
           : [];
-      jsonObj.workspaces = merge.all([getDeclaredWorkspacePatterns(jsonObj.workspaces), forcedPatterns], {
+      jsonObj.workspaces = merge.all([forcedPatterns, getDeclaredWorkspacePatterns(jsonObj.workspaces)], {
         arrayMerge: combineMerge,
       });
       // Both inputs can be empty (e.g. packages/package.json without any packages/*/package.json

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -221,8 +221,10 @@ function removeStaleManagedWorkspaceEntries(
     //   matches it;
     // - each current include, as a path, against a wildcard-shaped entry (a negation like
     //   `!apps/excluded/*`) when the includes are concrete (expanded from Bun-only glob syntax);
-    // - each discovered workspace directory against the entry, catching overlapping wildcard
-    //   layouts (e.g. old `!apps/*b` vs new `apps/a*`).
+    // - each discovered workspace directory against a workspace-layout-shaped entry (no `**`
+    //   segment, same depth as the matched directory), catching overlapping wildcard layouts
+    //   (e.g. old `!apps/*b` vs new `apps/a*`) — the shape gate keeps hygiene globs such as
+    //   `**/e2e` from being deleted just because a workspace directory basename matches them.
     return !(
       (!/[*?]/u.test(entry) &&
         workspaceDirPaths.some(
@@ -230,7 +232,12 @@ function removeStaleManagedWorkspaceEntries(
         ) &&
         isCoveredByWorkspaceDirPattern(entry, workspaceIncludePatterns)) ||
       workspaceIncludePatterns.some((includePattern) => isCoveredByWorkspaceDirPattern(includePattern, [entry])) ||
-      workspaceDirPaths.some((workspaceDirPath) => isCoveredByWorkspaceDirPattern(workspaceDirPath, [entry]))
+      workspaceDirPaths.some(
+        (workspaceDirPath) =>
+          !entry.split('/').includes('**') &&
+          entry.split('/').length === workspaceDirPath.split('/').length &&
+          isCoveredByWorkspaceDirPattern(workspaceDirPath, [entry])
+      )
     );
   });
 }

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -215,14 +215,20 @@ function removeStaleManagedWorkspaceEntries(
     // who wants such a directory excluded permanently should keep the workspace negation, which
     // regenerates the entry on every run. Three checks, because either side can be the pattern:
     // - a CONCRETE entry (a negation like `!apps/excluded`) against the current include patterns
-    //   — gated on concreteness so a user glob such as `**/node_modules` is never treated as a
-    //   path that a `*/*` include pattern textually matches;
+    //   — gated on concreteness AND on the entry covering a discovered workspace directory, so a
+    //   user glob such as `**/node_modules` or a hygiene exclude such as `dist` is never dropped
+    //   just because a wildcard-leading include pattern (e.g. the `*/*` baseline) textually
+    //   matches it;
     // - each current include, as a path, against a wildcard-shaped entry (a negation like
     //   `!apps/excluded/*`) when the includes are concrete (expanded from Bun-only glob syntax);
     // - each discovered workspace directory against the entry, catching overlapping wildcard
     //   layouts (e.g. old `!apps/*b` vs new `apps/a*`).
     return !(
-      (!/[*?]/u.test(entry) && isCoveredByWorkspaceDirPattern(entry, workspaceIncludePatterns)) ||
+      (!/[*?]/u.test(entry) &&
+        workspaceDirPaths.some(
+          (workspaceDirPath) => workspaceDirPath === entry || workspaceDirPath.startsWith(`${entry}/`)
+        ) &&
+        isCoveredByWorkspaceDirPattern(entry, workspaceIncludePatterns)) ||
       workspaceIncludePatterns.some((includePattern) => isCoveredByWorkspaceDirPattern(includePattern, [entry])) ||
       workspaceDirPaths.some((workspaceDirPath) => isCoveredByWorkspaceDirPattern(workspaceDirPath, [entry]))
     );

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -155,36 +155,51 @@ function buildRootJsonObj(config: PackageConfig): TsConfigJson {
   return settings;
 }
 
+const managedWorkspaceIncludeSuffixes = ['*.config.ts', 'scripts/**/*', 'src/**/*', 'test/**/*'];
+
 /**
  * Root include/exclude entries wbfy generated for an earlier workspace layout (e.g. `packages/*`
  * globs in a repo that now declares only `apps/*`) must not survive the merge with the existing
- * tsconfig, or the obsolete directories would keep entering root type checking forever. Only
- * pattern-shaped prefixes (containing `*`) are treated as wbfy-managed, so concrete user-authored
- * entries are preserved.
+ * tsconfig, or the obsolete directories would keep entering root type checking forever. A prefix
+ * counts as wbfy-managed only when the COMPLETE generated include set for it is present and no
+ * longer generated — a user-authored entry such as a lone `tools/*\/src/**\/*` never qualifies.
  */
 function removeStaleManagedWorkspaceEntries(oldSettings: TsConfigJson, newSettings: TsConfigJson): void {
+  if (!Array.isArray(oldSettings.include)) return;
+  const oldInclude = oldSettings.include.filter((entry): entry is string => typeof entry === 'string');
   const generatedInclude = new Set(newSettings.include);
-  const generatedExclude = new Set(newSettings.exclude);
-  if (Array.isArray(oldSettings.include)) {
-    oldSettings.include = oldSettings.include.filter(
-      (entry) =>
-        generatedInclude.has(entry) ||
-        !isManagedWorkspaceEntry(entry, ['*.config.ts', 'scripts/**/*', 'src/**/*', 'test/**/*'])
+  const stalePrefixes = new Set<string>();
+  for (const entry of oldInclude) {
+    const workspacePrefix = getManagedWorkspacePrefix(entry);
+    if (workspacePrefix === undefined || stalePrefixes.has(workspacePrefix)) continue;
+    const isComplete = managedWorkspaceIncludeSuffixes.every((suffix) =>
+      oldInclude.includes(`${workspacePrefix}/${suffix}`)
     );
+    const isStillGenerated = managedWorkspaceIncludeSuffixes.some((suffix) =>
+      generatedInclude.has(`${workspacePrefix}/${suffix}`)
+    );
+    if (isComplete && !isStillGenerated) stalePrefixes.add(workspacePrefix);
   }
+  if (stalePrefixes.size === 0) return;
+  oldSettings.include = oldSettings.include.filter((entry) => {
+    const workspacePrefix = typeof entry === 'string' ? getManagedWorkspacePrefix(entry) : undefined;
+    return workspacePrefix === undefined || !stalePrefixes.has(workspacePrefix);
+  });
   if (Array.isArray(oldSettings.exclude)) {
     oldSettings.exclude = oldSettings.exclude.filter(
-      (entry) => generatedExclude.has(entry) || !isManagedWorkspaceEntry(entry, ['test/fixtures'])
+      (entry) =>
+        typeof entry !== 'string' ||
+        !entry.endsWith('/test/fixtures') ||
+        !stalePrefixes.has(entry.slice(0, -'/test/fixtures'.length))
     );
   }
 }
 
-function isManagedWorkspaceEntry(entry: string, managedSuffixes: string[]): boolean {
-  if (typeof entry !== 'string') return false;
-  const matchedSuffix = managedSuffixes.find((suffix) => entry.endsWith(`/${suffix}`));
-  if (!matchedSuffix) return false;
+function getManagedWorkspacePrefix(entry: string): string | undefined {
+  const matchedSuffix = managedWorkspaceIncludeSuffixes.find((suffix) => entry.endsWith(`/${suffix}`));
+  if (!matchedSuffix) return undefined;
   const workspacePrefix = entry.slice(0, -(matchedSuffix.length + 1));
-  return workspacePrefix.includes('*');
+  return workspacePrefix === '' ? undefined : workspacePrefix;
 }
 
 async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promise<void> {
@@ -222,14 +237,19 @@ function addUndiciTypesPathMapping(settings: TsConfigJson, config: PackageConfig
   // for every TypeScript project except React Native, which uses @tsconfig/react-native instead.
   const types = settings.compilerOptions?.types;
   if (types ? !types.includes('bun') : config.depending.reactNative) return;
+  const correctMapping = `${getRootDir(config)}/node_modules/undici-types/index.d.ts`;
   const existingMapping = settings.compilerOptions?.paths?.['undici-types'];
   if (existingMapping) {
-    // Normalize the package-directory form older wbfy versions generated: it resolves through the
-    // package's `types` condition today but breaks once TypeScript needs the concrete file. Any
-    // other value is a deliberate repo-local mapping (e.g. patched types) and must be kept.
-    const legacyDirMapping = `${getRootDir(config)}/node_modules/undici-types`;
-    if (existingMapping.length === 1 && existingMapping[0] === legacyDirMapping) {
-      settings.compilerOptions!.paths!['undici-types'] = [`${legacyDirMapping}/index.d.ts`];
+    // Rewrite any mapping wbfy could have generated — a `…/node_modules/undici-types` target with
+    // or without the concrete index.d.ts, at whatever root depth an older getRootDir computed
+    // (its fixed two-level probe mis-resolved workspaces deeper than two levels). Any other value
+    // is a deliberate repo-local mapping (e.g. patched types) and must be kept.
+    if (
+      existingMapping.length === 1 &&
+      typeof existingMapping[0] === 'string' &&
+      /(?:^|\/)node_modules\/undici-types(?:\/index\.d\.ts)?$/u.test(existingMapping[0])
+    ) {
+      settings.compilerOptions!.paths!['undici-types'] = [correctMapping];
     }
     return;
   }
@@ -237,7 +257,7 @@ function addUndiciTypesPathMapping(settings: TsConfigJson, config: PackageConfig
   settings.compilerOptions ??= {};
   settings.compilerOptions.paths = {
     ...settings.compilerOptions.paths,
-    'undici-types': [`${getRootDir(config)}/node_modules/undici-types/index.d.ts`],
+    'undici-types': [correctMapping],
   };
 }
 

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -12,7 +12,7 @@ import { combineMerge } from '../utils/mergeUtil.js';
 import { sortKeys } from '../utils/objectUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 import { getTsconfigExtends } from '../utils/tsconfigBase.js';
-import { getDeclaredWorkspacePatterns, getWorkspaceDirPatterns } from '../utils/workspaceUtil.js';
+import { getMeaningfulDeclaredWorkspacePatterns, getWorkspaceDirPatterns } from '../utils/workspaceUtil.js';
 
 const subJsonObj = {
   compilerOptions: {
@@ -367,7 +367,8 @@ function getRootDir(config: PackageConfig): string {
       rootDirPath ??= ancestorDirPath;
       try {
         const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as PackageJson;
-        if (getDeclaredWorkspacePatterns(manifest.workspaces).length > 0) {
+        // Bun no-op patterns (e.g. `workspaces: [""]`) do not make a manifest a workspace root.
+        if (getMeaningfulDeclaredWorkspacePatterns(manifest.workspaces).length > 0) {
           rootDirPath = ancestorDirPath;
           break;
         }

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -77,7 +77,7 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
       delete oldSettings.extends;
       delete oldSettings.compilerOptions?.jsx;
       if (config.isRoot) {
-        removeStaleManagedWorkspaceEntries(oldSettings, newSettings);
+        removeStaleManagedWorkspaceEntries(config, oldSettings, newSettings);
       }
       newSettings = merge.all([newSettings, oldSettings, newSettings], { arrayMerge: combineMerge });
       newSettings.include = newSettings.include?.filter(
@@ -164,35 +164,65 @@ const managedWorkspaceIncludeSuffixes = ['*.config.ts', 'scripts/**/*', 'src/**/
  * counts as wbfy-managed only when the COMPLETE generated include set for it is present and no
  * longer generated — a user-authored entry such as a lone `tools/*\/src/**\/*` never qualifies.
  */
-function removeStaleManagedWorkspaceEntries(oldSettings: TsConfigJson, newSettings: TsConfigJson): void {
-  if (!Array.isArray(oldSettings.include)) return;
-  const oldInclude = oldSettings.include.filter((entry): entry is string => typeof entry === 'string');
-  const generatedInclude = new Set(newSettings.include);
+function removeStaleManagedWorkspaceEntries(
+  config: PackageConfig,
+  oldSettings: TsConfigJson,
+  newSettings: TsConfigJson
+): void {
   const stalePrefixes = new Set<string>();
-  for (const entry of oldInclude) {
-    const workspacePrefix = getManagedWorkspacePrefix(entry);
-    if (workspacePrefix === undefined || stalePrefixes.has(workspacePrefix)) continue;
-    const isComplete = managedWorkspaceIncludeSuffixes.every((suffix) =>
-      oldInclude.includes(`${workspacePrefix}/${suffix}`)
-    );
-    const isStillGenerated = managedWorkspaceIncludeSuffixes.some((suffix) =>
-      generatedInclude.has(`${workspacePrefix}/${suffix}`)
-    );
-    if (isComplete && !isStillGenerated) stalePrefixes.add(workspacePrefix);
+  if (Array.isArray(oldSettings.include)) {
+    const oldInclude = oldSettings.include.filter((entry): entry is string => typeof entry === 'string');
+    const generatedInclude = new Set(newSettings.include);
+    for (const entry of oldInclude) {
+      const workspacePrefix = getManagedWorkspacePrefix(entry);
+      if (workspacePrefix === undefined || stalePrefixes.has(workspacePrefix)) continue;
+      const isComplete = managedWorkspaceIncludeSuffixes.every((suffix) =>
+        oldInclude.includes(`${workspacePrefix}/${suffix}`)
+      );
+      const isStillGenerated = managedWorkspaceIncludeSuffixes.some((suffix) =>
+        generatedInclude.has(`${workspacePrefix}/${suffix}`)
+      );
+      if (isComplete && !isStillGenerated) stalePrefixes.add(workspacePrefix);
+    }
+    if (stalePrefixes.size > 0) {
+      oldSettings.include = oldSettings.include.filter((entry) => {
+        const workspacePrefix = typeof entry === 'string' ? getManagedWorkspacePrefix(entry) : undefined;
+        return workspacePrefix === undefined || !stalePrefixes.has(workspacePrefix);
+      });
+    }
   }
-  if (stalePrefixes.size === 0) return;
-  oldSettings.include = oldSettings.include.filter((entry) => {
-    const workspacePrefix = typeof entry === 'string' ? getManagedWorkspacePrefix(entry) : undefined;
-    return workspacePrefix === undefined || !stalePrefixes.has(workspacePrefix);
+  if (!Array.isArray(oldSettings.exclude)) return;
+  const generatedExclude = new Set(newSettings.exclude);
+  const workspaceIncludePatterns = config.doesContainSubPackageJsons ? getWorkspaceDirPatterns(config).includes : [];
+  oldSettings.exclude = oldSettings.exclude.filter((entry) => {
+    if (typeof entry !== 'string' || generatedExclude.has(entry)) return true;
+    if (entry.endsWith('/test/fixtures')) {
+      return !stalePrefixes.has(entry.slice(0, -'/test/fixtures'.length));
+    }
+    // A negation-derived exclude whose `!pattern` was removed from `workspaces`: the directory is
+    // covered by a positive workspace pattern again and must re-enter the root project. A user
+    // who wants such a directory excluded permanently should keep the workspace negation, which
+    // regenerates the entry on every run.
+    return !isCoveredByWorkspaceDirPattern(entry, workspaceIncludePatterns);
   });
-  if (Array.isArray(oldSettings.exclude)) {
-    oldSettings.exclude = oldSettings.exclude.filter(
-      (entry) =>
-        typeof entry !== 'string' ||
-        !entry.endsWith('/test/fixtures') ||
-        !stalePrefixes.has(entry.slice(0, -'/test/fixtures'.length))
-    );
-  }
+}
+
+/** Matches a concrete directory path against tsconfig-safe workspace dir patterns (`*`, `?`, `**`). */
+function isCoveredByWorkspaceDirPattern(dirPath: string, workspacePatterns: string[]): boolean {
+  return workspacePatterns.some((workspacePattern) => {
+    const regexSource = workspacePattern
+      .split('/')
+      .map((segment) =>
+        segment === '**'
+          ? String.raw`[^/]+(?:/[^/]+)*`
+          : segment
+              .replaceAll(/[.+^${}()|[\]\\]/gu, String.raw`\$&`)
+              .replaceAll('*', '[^/]*')
+              .replaceAll('?', '[^/]')
+      )
+      .join('/');
+    return new RegExp(`^${regexSource}$`, 'u').test(dirPath);
+  });
 }
 
 function getManagedWorkspacePrefix(entry: string): string | undefined {

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -12,29 +12,7 @@ import { combineMerge } from '../utils/mergeUtil.js';
 import { sortKeys } from '../utils/objectUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 import { getTsconfigExtends } from '../utils/tsconfigBase.js';
-
-const rootJsonObj = {
-  compilerOptions: {
-    alwaysStrict: true,
-    noUncheckedIndexedAccess: true, // for @typescript-eslint/prefer-nullish-coalescing
-    allowSyntheticDefaultImports: true, // allow `import React from 'react'`
-    esModuleInterop: true, // allow default import from CommonJS/AMD/UMD modules
-    resolveJsonModule: true, // allow to import JSON files
-    importHelpers: false,
-    noEmit: true,
-  },
-  exclude: ['packages/*/test/fixtures', 'test/fixtures'],
-  include: [
-    '*.config.ts',
-    'packages/*/*.config.ts',
-    'packages/*/scripts/**/*',
-    'packages/*/src/**/*',
-    'packages/*/test/**/*',
-    'scripts/**/*',
-    'src/**/*',
-    'test/**/*',
-  ],
-};
+import { getWorkspaceDirPatterns } from '../utils/workspaceUtil.js';
 
 const subJsonObj = {
   compilerOptions: {
@@ -59,7 +37,7 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
       return;
     }
 
-    let newSettings = structuredClone(config.isRoot ? rootJsonObj : subJsonObj) as TsConfigJson;
+    let newSettings = (config.isRoot ? buildRootJsonObj(config) : structuredClone(subJsonObj)) as TsConfigJson;
     const generatedTypes = getGeneratedTypes(config);
     newSettings.extends = getTsconfigExtends(config);
     newSettings.compilerOptions ??= {};
@@ -69,10 +47,6 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     }
     if (!config.doesContainJsxOrTsx && !config.doesContainJsxOrTsxInPackages) {
       delete newSettings.compilerOptions?.jsx;
-    }
-    if (config.isRoot && !config.doesContainSubPackageJsons) {
-      newSettings.include = newSettings.include?.filter((dirPath: string) => !dirPath.startsWith('packages/*/'));
-      newSettings.exclude = newSettings.exclude?.filter((dirPath: string) => !dirPath.startsWith('packages/*/'));
     }
     if (config.depending.prisma) {
       // Prisma seeds and migration helper scripts often live outside src, but
@@ -141,6 +115,30 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
     const newContent = JSON.stringify(newSettings, undefined, 2);
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
   });
+}
+
+/**
+ * The monorepo-root tsconfig, whose include/exclude cover every DECLARED workspace layout (e.g.
+ * `apps/*` alongside `packages/*`) so type-aware linting run from the root sees all workspace
+ * sources, not just the conventional packages/* directory.
+ */
+function buildRootJsonObj(config: PackageConfig): TsConfigJson {
+  const workspacePatterns = config.doesContainSubPackageJsons ? getWorkspaceDirPatterns(config) : [];
+  const settings = structuredClone(subJsonObj) as TsConfigJson;
+  settings.exclude = [
+    ...workspacePatterns.map((workspacePattern) => `${workspacePattern}/test/fixtures`),
+    ...(settings.exclude ?? []),
+  ];
+  settings.include = [
+    ...(settings.include ?? []),
+    ...workspacePatterns.flatMap((workspacePattern) => [
+      `${workspacePattern}/*.config.ts`,
+      `${workspacePattern}/scripts/**/*`,
+      `${workspacePattern}/src/**/*`,
+      `${workspacePattern}/test/**/*`,
+    ]),
+  ];
+  return settings;
 }
 
 async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promise<void> {

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -227,6 +227,10 @@ function removeStaleManagedWorkspaceEntries(
     //   segment, same depth as the matched directory), catching overlapping wildcard layouts
     //   (e.g. old `!apps/*b` vs new `apps/a*`) — the shape gate keeps hygiene globs such as
     //   `**/e2e` from being deleted just because a workspace directory basename matches them.
+    // Provenance is not tracked, so two residual gaps are ACCEPTED by design: a workspace-shaped
+    // entry covering a discovered workspace is presumed negation-derived even if hand-written
+    // (the policy above), and a negation-derived entry for a manifest-less directory survives
+    // after its negation is removed (it only narrows the root program conservatively).
     return !(
       (!/[*?]/u.test(entry) &&
         workspaceDirPaths.some(

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -12,7 +12,11 @@ import { combineMerge } from '../utils/mergeUtil.js';
 import { sortKeys } from '../utils/objectUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 import { getTsconfigExtends } from '../utils/tsconfigBase.js';
-import { getMeaningfulDeclaredWorkspacePatterns, getWorkspaceDirPatterns } from '../utils/workspaceUtil.js';
+import {
+  getMeaningfulDeclaredWorkspacePatterns,
+  getWorkspaceDirPatterns,
+  getWorkspaceSubDirPaths,
+} from '../utils/workspaceUtil.js';
 
 const subJsonObj = {
   compilerOptions: {
@@ -194,6 +198,13 @@ function removeStaleManagedWorkspaceEntries(
   if (!Array.isArray(oldSettings.exclude)) return;
   const generatedExclude = new Set(newSettings.exclude);
   const workspaceIncludePatterns = config.doesContainSubPackageJsons ? getWorkspaceDirPatterns(config).includes : [];
+  // Concrete discovered workspace directories (relative), for detecting overlap between old and
+  // new wildcard layouts that pattern-vs-pattern string comparison cannot see.
+  const workspaceDirPaths = config.doesContainSubPackageJsons
+    ? getWorkspaceSubDirPaths(config).map((workspaceDirPath) =>
+        path.relative(path.resolve(config.dirPath), workspaceDirPath).replaceAll('\\', '/')
+      )
+    : [];
   oldSettings.exclude = oldSettings.exclude.filter((entry) => {
     if (typeof entry !== 'string' || generatedExclude.has(entry)) return true;
     if (entry.endsWith('/test/fixtures')) {
@@ -202,12 +213,18 @@ function removeStaleManagedWorkspaceEntries(
     // A negation-derived exclude whose `!pattern` was removed from `workspaces`: the directory is
     // covered by a positive workspace pattern again and must re-enter the root project. A user
     // who wants such a directory excluded permanently should keep the workspace negation, which
-    // regenerates the entry on every run. The check runs in both directions because either side
-    // can be the pattern: the entry may be wildcard-shaped (a negation like `!apps/excluded/*`)
-    // while the current includes are concrete (expanded from Bun-only glob syntax), or vice versa.
+    // regenerates the entry on every run. Three checks, because either side can be the pattern:
+    // - a CONCRETE entry (a negation like `!apps/excluded`) against the current include patterns
+    //   — gated on concreteness so a user glob such as `**/node_modules` is never treated as a
+    //   path that a `*/*` include pattern textually matches;
+    // - each current include, as a path, against a wildcard-shaped entry (a negation like
+    //   `!apps/excluded/*`) when the includes are concrete (expanded from Bun-only glob syntax);
+    // - each discovered workspace directory against the entry, catching overlapping wildcard
+    //   layouts (e.g. old `!apps/*b` vs new `apps/a*`).
     return !(
-      isCoveredByWorkspaceDirPattern(entry, workspaceIncludePatterns) ||
-      workspaceIncludePatterns.some((includePattern) => isCoveredByWorkspaceDirPattern(includePattern, [entry]))
+      (!/[*?]/u.test(entry) && isCoveredByWorkspaceDirPattern(entry, workspaceIncludePatterns)) ||
+      workspaceIncludePatterns.some((includePattern) => isCoveredByWorkspaceDirPattern(includePattern, [entry])) ||
+      workspaceDirPaths.some((workspaceDirPath) => isCoveredByWorkspaceDirPattern(workspaceDirPath, [entry]))
     );
   });
 }

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -238,6 +238,8 @@ function isCoveredByWorkspaceDirPattern(dirPath: string, workspacePatterns: stri
     const globStarPlaceholder = '\u0000';
     const regexSource = workspacePattern
       .split('/')
+      // Adjacent globstars are one globstar (`**/**/foo` matches root-level `foo` too).
+      .filter((segment, index, segments) => segment !== '**' || segments[index - 1] !== '**')
       .map((segment) =>
         segment === '**'
           ? globStarPlaceholder

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -219,8 +219,10 @@ function removeStaleManagedWorkspaceEntries(
     //   user glob such as `**/node_modules` or a hygiene exclude such as `dist` is never dropped
     //   just because a wildcard-leading include pattern (e.g. the `*/*` baseline) textually
     //   matches it;
-    // - each current include, as a path, against a wildcard-shaped entry (a negation like
-    //   `!apps/excluded/*`) when the includes are concrete (expanded from Bun-only glob syntax);
+    // - each CONCRETE current include (expanded from Bun-only glob syntax), as a path, against a
+    //   wildcard-shaped entry (a negation like `!apps/excluded/*`) — gated on the include being
+    //   concrete (a wildcard include's literal `*` character could satisfy the entry's `?`) and
+    //   on the entry containing no `**` segment (hygiene globs such as `**/e2e` must survive);
     // - each discovered workspace directory against a workspace-layout-shaped entry (no `**`
     //   segment, same depth as the matched directory), catching overlapping wildcard layouts
     //   (e.g. old `!apps/*b` vs new `apps/a*`) — the shape gate keeps hygiene globs such as
@@ -231,7 +233,12 @@ function removeStaleManagedWorkspaceEntries(
           (workspaceDirPath) => workspaceDirPath === entry || workspaceDirPath.startsWith(`${entry}/`)
         ) &&
         isCoveredByWorkspaceDirPattern(entry, workspaceIncludePatterns)) ||
-      workspaceIncludePatterns.some((includePattern) => isCoveredByWorkspaceDirPattern(includePattern, [entry])) ||
+      workspaceIncludePatterns.some(
+        (includePattern) =>
+          !/[!()*?[\]{}]/u.test(includePattern) &&
+          !entry.split('/').includes('**') &&
+          isCoveredByWorkspaceDirPattern(includePattern, [entry])
+      ) ||
       workspaceDirPaths.some(
         (workspaceDirPath) =>
           !entry.split('/').includes('**') &&

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -215,17 +215,24 @@ function removeStaleManagedWorkspaceEntries(
 /** Matches a concrete directory path against tsconfig-safe workspace dir patterns (`*`, `?`, `**`). */
 function isCoveredByWorkspaceDirPattern(dirPath: string, workspacePatterns: string[]): boolean {
   return workspacePatterns.some((workspacePattern) => {
+    // `**` matches ZERO or more path segments (`apps/**` covers `apps` itself), matching the
+    // fast-glob/Bun semantics workspace discovery uses; the placeholder dance makes the adjacent
+    // separator optional.
+    const globStarPlaceholder = '\u0000';
     const regexSource = workspacePattern
       .split('/')
       .map((segment) =>
         segment === '**'
-          ? String.raw`[^/]+(?:/[^/]+)*`
+          ? globStarPlaceholder
           : segment
               .replaceAll(/[.+^${}()|[\]\\]/gu, String.raw`\$&`)
               .replaceAll('*', '[^/]*')
               .replaceAll('?', '[^/]')
       )
-      .join('/');
+      .join('/')
+      .replaceAll(`/${globStarPlaceholder}`, '(?:/.+)?')
+      .replaceAll(`${globStarPlaceholder}/`, '(?:.+/)?')
+      .replaceAll(globStarPlaceholder, '.*');
     return new RegExp(`^${regexSource}$`, 'u').test(dirPath);
   });
 }

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -202,8 +202,13 @@ function removeStaleManagedWorkspaceEntries(
     // A negation-derived exclude whose `!pattern` was removed from `workspaces`: the directory is
     // covered by a positive workspace pattern again and must re-enter the root project. A user
     // who wants such a directory excluded permanently should keep the workspace negation, which
-    // regenerates the entry on every run.
-    return !isCoveredByWorkspaceDirPattern(entry, workspaceIncludePatterns);
+    // regenerates the entry on every run. The check runs in both directions because either side
+    // can be the pattern: the entry may be wildcard-shaped (a negation like `!apps/excluded/*`)
+    // while the current includes are concrete (expanded from Bun-only glob syntax), or vice versa.
+    return !(
+      isCoveredByWorkspaceDirPattern(entry, workspaceIncludePatterns) ||
+      workspaceIncludePatterns.some((includePattern) => isCoveredByWorkspaceDirPattern(includePattern, [entry]))
+    );
   });
 }
 

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -27,6 +27,10 @@ const subJsonObj = {
   exclude: ['test/fixtures'],
   // wbfy generates root-level tool configs such as playwright.config.ts, and
   // type-aware linting needs those files in the project to see Node/Bun globals.
+  // `app/**` is deliberately absent even though the doesContain*Script signals scan it: app
+  // directories belong to framework packages (Next.js/Blitz), which own their tsconfig
+  // (generateTsconfig skips them), and checking framework sources under this project's compiler
+  // options would produce false errors.
   include: ['*.config.ts', 'scripts/**/*', 'src/**/*', 'test/**/*'],
 };
 
@@ -123,15 +127,22 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
  * sources, not just the conventional packages/* directory.
  */
 function buildRootJsonObj(config: PackageConfig): TsConfigJson {
-  const workspacePatterns = config.doesContainSubPackageJsons ? getWorkspaceDirPatterns(config) : [];
+  const workspacePatterns = config.doesContainSubPackageJsons
+    ? getWorkspaceDirPatterns(config)
+    : { excludes: [], includes: [] };
   const settings = structuredClone(subJsonObj) as TsConfigJson;
   settings.exclude = [
-    ...workspacePatterns.map((workspacePattern) => `${workspacePattern}/test/fixtures`),
-    ...(settings.exclude ?? []),
-  ];
+    ...new Set([
+      ...workspacePatterns.includes.map((workspacePattern) => `${workspacePattern}/test/fixtures`),
+      // Negative workspace patterns (e.g. `!packages/excluded`) opt whole workspace subtrees out
+      // of the monorepo, so their sources must not enter the root type-check project either.
+      ...workspacePatterns.excludes,
+      ...(settings.exclude ?? []),
+    ]),
+  ].toSorted();
   settings.include = [
     ...(settings.include ?? []),
-    ...workspacePatterns.flatMap((workspacePattern) => [
+    ...workspacePatterns.includes.flatMap((workspacePattern) => [
       `${workspacePattern}/*.config.ts`,
       `${workspacePattern}/scripts/**/*`,
       `${workspacePattern}/src/**/*`,

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import merge from 'deepmerge';
-import type { TsConfigJson } from 'type-fest';
+import type { PackageJson, TsConfigJson } from 'type-fest';
 
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
@@ -12,7 +12,7 @@ import { combineMerge } from '../utils/mergeUtil.js';
 import { sortKeys } from '../utils/objectUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 import { getTsconfigExtends } from '../utils/tsconfigBase.js';
-import { getWorkspaceDirPatterns } from '../utils/workspaceUtil.js';
+import { getDeclaredWorkspacePatterns, getWorkspaceDirPatterns } from '../utils/workspaceUtil.js';
 
 const subJsonObj = {
   compilerOptions: {
@@ -76,6 +76,9 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
       newSettings.extends = mergeTsconfigExtends(newSettings.extends, oldSettings.extends);
       delete oldSettings.extends;
       delete oldSettings.compilerOptions?.jsx;
+      if (config.isRoot) {
+        removeStaleManagedWorkspaceEntries(oldSettings, newSettings);
+      }
       newSettings = merge.all([newSettings, oldSettings, newSettings], { arrayMerge: combineMerge });
       newSettings.include = newSettings.include?.filter(
         (dirPath: string) =>
@@ -150,6 +153,38 @@ function buildRootJsonObj(config: PackageConfig): TsConfigJson {
     ]),
   ];
   return settings;
+}
+
+/**
+ * Root include/exclude entries wbfy generated for an earlier workspace layout (e.g. `packages/*`
+ * globs in a repo that now declares only `apps/*`) must not survive the merge with the existing
+ * tsconfig, or the obsolete directories would keep entering root type checking forever. Only
+ * pattern-shaped prefixes (containing `*`) are treated as wbfy-managed, so concrete user-authored
+ * entries are preserved.
+ */
+function removeStaleManagedWorkspaceEntries(oldSettings: TsConfigJson, newSettings: TsConfigJson): void {
+  const generatedInclude = new Set(newSettings.include);
+  const generatedExclude = new Set(newSettings.exclude);
+  if (Array.isArray(oldSettings.include)) {
+    oldSettings.include = oldSettings.include.filter(
+      (entry) =>
+        generatedInclude.has(entry) ||
+        !isManagedWorkspaceEntry(entry, ['*.config.ts', 'scripts/**/*', 'src/**/*', 'test/**/*'])
+    );
+  }
+  if (Array.isArray(oldSettings.exclude)) {
+    oldSettings.exclude = oldSettings.exclude.filter(
+      (entry) => generatedExclude.has(entry) || !isManagedWorkspaceEntry(entry, ['test/fixtures'])
+    );
+  }
+}
+
+function isManagedWorkspaceEntry(entry: string, managedSuffixes: string[]): boolean {
+  if (typeof entry !== 'string') return false;
+  const matchedSuffix = managedSuffixes.find((suffix) => entry.endsWith(`/${suffix}`));
+  if (!matchedSuffix) return false;
+  const workspacePrefix = entry.slice(0, -(matchedSuffix.length + 1));
+  return workspacePrefix.includes('*');
 }
 
 async function cleanupLegacyTsconfigModuleSettings(config: PackageConfig): Promise<void> {
@@ -256,7 +291,34 @@ function normalizePathAliasTargets(targets: string[]): string[] {
 
 function getRootDir(config: PackageConfig): string {
   if (config.isRoot) return '.';
-  return fs.existsSync(path.resolve(config.dirPath, '..', '..', 'package.json')) ? '../..' : '.';
+  // The undici-types path mapping must reach the monorepo root's node_modules (bunfig.toml's
+  // publicHoistPattern hoists the package there), and workspace patterns may be arbitrarily deep
+  // (e.g. `examples/**`), so a fixed two-level probe is not enough. Prefer the nearest ancestor
+  // manifest that declares workspaces (the monorepo root); otherwise fall back to the nearest
+  // ancestor manifest. Stop at the first git repository boundary so an unrelated enclosing
+  // repository's manifest can never be chosen.
+  const dirPath = path.resolve(config.dirPath);
+  let rootDirPath: string | undefined;
+  for (let ancestorDirPath = path.dirname(dirPath); ; ancestorDirPath = path.dirname(ancestorDirPath)) {
+    const manifestPath = path.resolve(ancestorDirPath, 'package.json');
+    if (fs.existsSync(manifestPath)) {
+      rootDirPath ??= ancestorDirPath;
+      try {
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as PackageJson;
+        if (getDeclaredWorkspacePatterns(manifest.workspaces).length > 0) {
+          rootDirPath = ancestorDirPath;
+          break;
+        }
+      } catch {
+        // An unparsable manifest still marks a project directory; keep climbing for a workspace root.
+      }
+    }
+    const isRepoBoundary = fs.existsSync(path.resolve(ancestorDirPath, '.git'));
+    const isFilesystemRoot = ancestorDirPath === path.dirname(ancestorDirPath);
+    if (isRepoBoundary || isFilesystemRoot) break;
+  }
+  if (!rootDirPath) return '.';
+  return path.relative(dirPath, rootDirPath).replaceAll('\\', '/') || '.';
 }
 
 function mergeTsconfigExtends(

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -14,7 +14,11 @@ import { globIgnore } from './utils/globUtil.js';
 import { jsoncUtil } from './utils/jsoncUtil.js';
 import { spawnSyncAndReturnStdout } from './utils/spawnUtil.js';
 import { selectProjectWranglerTypesGenerator } from './utils/wranglerTypesCommand.js';
-import { getWorkspacePackageJsonPaths, getWorkspaceSubDirPaths } from './utils/workspaceUtil.js';
+import {
+  getDeclaredWorkspacePatterns,
+  getWorkspacePackageJsonPaths,
+  getWorkspaceSubDirPaths,
+} from './utils/workspaceUtil.js';
 
 export interface PackageConfig {
   dirPath: string;
@@ -180,13 +184,20 @@ export async function getPackageConfig(
       fs.existsSync(path.resolve(dirPath, 'src-tauri', fileName))
     );
     // Root-level "InPackages" signals must see every DECLARED workspace layout (e.g. apps/*), not
-    // just the conventional packages/* directory, so scan each discovered workspace directory too.
-    // The packages/** fallback stays for repositories whose packages/* layout predates a
-    // `workspaces` declaration (wbfy adds the declaration only on a later generator pass).
-    const workspaceSubDirPaths = getWorkspaceSubDirPaths({ dirPath, packageJson, doesContainSubPackageJsons: false });
+    // just the conventional packages/* directory, so scan each discovered workspace directory.
+    // The packages/* fallback is routed through discovery's combined glob so declared negations
+    // (e.g. `!packages/excluded`) exclude a package from the signals too; the broad packages/**
+    // scan remains only for legacy repos with no `workspaces` declaration at all (wbfy adds the
+    // declaration only on a later generator pass), where discovery has nothing to honor.
+    const declaredWorkspacePatterns = getDeclaredWorkspacePatterns(packageJson.workspaces);
+    const workspaceSubDirPaths = getWorkspaceSubDirPaths({
+      dirPath,
+      packageJson,
+      doesContainSubPackageJsons: containsAny('packages/*/package.json', dirPath),
+    });
     const containsAnyInWorkspaces = (pattern: string): boolean =>
-      containsAny(`packages/**/${pattern}`, dirPath) ||
-      workspaceSubDirPaths.some((workspaceSubDirPath) => containsAny(pattern, workspaceSubDirPath));
+      workspaceSubDirPaths.some((workspaceSubDirPath) => containsAny(pattern, workspaceSubDirPath)) ||
+      (declaredWorkspacePatterns.length === 0 && containsAny(`packages/**/${pattern}`, dirPath));
     const config: PackageConfig = {
       dirPath,
       dockerfile,

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -14,7 +14,7 @@ import { globIgnore } from './utils/globUtil.js';
 import { jsoncUtil } from './utils/jsoncUtil.js';
 import { spawnSyncAndReturnStdout } from './utils/spawnUtil.js';
 import { selectProjectWranglerTypesGenerator } from './utils/wranglerTypesCommand.js';
-import { getWorkspacePackageJsonPaths } from './utils/workspaceUtil.js';
+import { getWorkspacePackageJsonPaths, getWorkspaceSubDirPaths } from './utils/workspaceUtil.js';
 
 export interface PackageConfig {
   dirPath: string;
@@ -179,6 +179,14 @@ export async function getPackageConfig(
     const doesContainTauriConfig = ['tauri.conf.json', 'tauri.conf.json5', 'Tauri.toml'].some((fileName) =>
       fs.existsSync(path.resolve(dirPath, 'src-tauri', fileName))
     );
+    // Root-level "InPackages" signals must see every DECLARED workspace layout (e.g. apps/*), not
+    // just the conventional packages/* directory, so scan each discovered workspace directory too.
+    // The packages/** fallback stays for repositories whose packages/* layout predates a
+    // `workspaces` declaration (wbfy adds the declaration only on a later generator pass).
+    const workspaceSubDirPaths = getWorkspaceSubDirPaths({ dirPath, packageJson, doesContainSubPackageJsons: false });
+    const containsAnyInWorkspaces = (pattern: string): boolean =>
+      containsAny(`packages/**/${pattern}`, dirPath) ||
+      workspaceSubDirPaths.some((workspaceSubDirPath) => containsAny(pattern, workspaceSubDirPath));
     const config: PackageConfig = {
       dirPath,
       dockerfile,
@@ -200,9 +208,7 @@ export async function getPackageConfig(
       // Also honor declared workspace patterns beyond packages/* (e.g. apps/*): treating an
       // apps/*-only monorepo as a plain package would delete its `workspaces` declaration in
       // generatePackageJson and skip monorepo-only conventions such as root `private: true`.
-      doesContainSubPackageJsons:
-        containsAny('packages/**/package.json', dirPath) ||
-        getWorkspacePackageJsonPaths({ dirPath, packageJson, doesContainSubPackageJsons: false }).length > 0,
+      doesContainSubPackageJsons: containsAny('packages/**/package.json', dirPath) || workspaceSubDirPaths.length > 0,
       doesContainDockerfile: !!dockerfile || fs.existsSync(path.resolve(dirPath, 'docker-compose.yml')),
       doesContainGemfile: fs.existsSync(path.resolve(dirPath, 'Gemfile')),
       doesContainGoMod: fs.existsSync(path.resolve(dirPath, 'go.mod')),
@@ -212,9 +218,8 @@ export async function getPackageConfig(
       doesContainPomXml: fs.existsSync(path.resolve(dirPath, 'pom.xml')),
       doesContainPubspecYaml: fs.existsSync(path.resolve(dirPath, 'pubspec.yaml')),
       doesContainTauriConfig,
-      doesContainTauriConfigInPackages: containsAny(
-        'packages/**/src-tauri/{tauri.conf.json,tauri.conf.json5,Tauri.toml}',
-        dirPath
+      doesContainTauriConfigInPackages: containsAnyInWorkspaces(
+        'src-tauri/{tauri.conf.json,tauri.conf.json5,Tauri.toml}'
       ),
       doesContainTemplateYaml: fs.existsSync(path.resolve(dirPath, 'template.yaml')),
       doesContainVscodeSettingsJson: fs.existsSync(path.resolve(dirPath, '.vscode', 'settings.json')),
@@ -222,10 +227,10 @@ export async function getPackageConfig(
       doesContainTypeScript: containsAny('{app,src,test,scripts}/**/*.{cts,mts,ts,tsx}', dirPath),
       doesContainJsxOrTsx: containsAny('{app,src,test}/**/*.{t,j}sx', dirPath),
       doesContainJava: containsAny('**/*.java', dirPath),
-      doesContainJavaScriptInPackages: containsAny('packages/**/{app,src,test,scripts}/**/*.{cjs,mjs,js,jsx}', dirPath),
-      doesContainTypeScriptInPackages: containsAny('packages/**/{app,src,test,scripts}/**/*.{cts,mts,ts,tsx}', dirPath),
-      doesContainJsxOrTsxInPackages: containsAny('packages/**/{app,src,test}/**/*.{t,j}sx', dirPath),
-      doesContainJavaInPackages: containsAny('packages/**/*.java', dirPath),
+      doesContainJavaScriptInPackages: containsAnyInWorkspaces('{app,src,test,scripts}/**/*.{cjs,mjs,js,jsx}'),
+      doesContainTypeScriptInPackages: containsAnyInWorkspaces('{app,src,test,scripts}/**/*.{cts,mts,ts,tsx}'),
+      doesContainJsxOrTsxInPackages: containsAnyInWorkspaces('{app,src,test}/**/*.{t,j}sx'),
+      doesContainJavaInPackages: containsAnyInWorkspaces('**/*.java'),
       depending: {
         blitz: !!dependencies.blitz,
         chakra: !!devDependencies['@chakra-ui/cli'],

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -121,7 +121,13 @@ function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
   // yet, so mirror that normalization here. Discovery callers pass the fallback unconditionally
   // for monorepos — a never-matching pattern contributes no paths there — while pattern-shaped
   // callers (getWorkspaceDirPatterns) gate it on an actual match.
-  const declaredPatterns = getDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces);
+  // Bun ignores empty patterns (`""` and a lone `"!"`), so they must not count as declarations —
+  // a lone `"!"` would otherwise trigger the negative-only implicit baseline below, and `""`
+  // would make the repository root itself a discovered workspace.
+  const declaredPatterns = getDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces).filter((workspacePattern) => {
+    const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
+    return patternBody !== '' && patternBody !== '.';
+  });
   // Bun applies an implicit `*/*` baseline when the declaration contains only negative patterns
   // (verified with Bun 1.3.14: `workspaces: ["!excluded/*"]` makes every other two-level
   // package.json a workspace, while depth-1 and depth-3 manifests stay out).

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -60,7 +60,10 @@ export interface WorkspaceDirPatterns {
  * workspace package is added or removed. Every returned pattern is valid tsconfig glob syntax.
  * A pattern can match a sibling directory without a package.json (not a workspace to Bun); that
  * is deliberate, mirroring the long-standing `packages/*` entries' behavior in favor of stable
- * generated output.
+ * generated output. Known limitation (#1004): a negation whose directory is an ANCESTOR of
+ * another workspace (e.g. `["apps/**", "!apps"]`) excludes the whole subtree here, although Bun
+ * excludes only the package at that directory; such nested workspace layouts do not occur in
+ * WillBooster repositories.
  */
 export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): WorkspaceDirPatterns {
   // Unlike discovery, generated output must not contain a never-matching `packages/*` fallback:

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -29,9 +29,13 @@ export function getWorkspaceSubDirPaths(rootLike: WorkspaceRootLike): string[] {
  */
 export function getWorkspacePackageJsonPaths(rootConfig: WorkspaceRootLike): string[] {
   // Expand all patterns in one glob call so Bun-supported negative patterns (e.g.
-  // `!packages/excluded`) actually exclude their matches. Do not apply globIgnore here: workspace
-  // membership is defined solely by the declared patterns, and source-scanning ignores such as
-  // `build` or `dist` would hide legitimately named workspace directories.
+  // `!packages/excluded`) actually exclude their matches. Known limitation (#1005): Bun evaluates
+  // patterns sequentially (a positive pattern after a negation re-includes its matches), while
+  // fast-glob treats negations as order-independent global ignores; declarations relying on
+  // positional re-inclusion do not occur in WillBooster repositories and are unsupported.
+  // Do not apply globIgnore here: workspace membership is defined solely by the declared
+  // patterns, and source-scanning ignores such as `build` or `dist` would hide legitimately
+  // named workspace directories.
   const packageJsonGlobs = getSanitizedWorkspacePatterns(rootConfig).map((workspacePattern) =>
     workspacePattern.startsWith('!')
       ? `!${path.posix.join(workspacePattern.slice(1), 'package.json')}`
@@ -123,7 +127,7 @@ function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
   // callers (getWorkspaceDirPatterns) gate it on an actual match.
   const workspacePatterns = [
     ...new Set([
-      ...(hasOnlyNegativeDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces) ? ['*/*'] : []),
+      ...(hasImplicitWorkspaceBaseline(rootLike.packageJson?.workspaces) ? ['*/*'] : []),
       ...getMeaningfulDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces),
       ...(rootLike.doesContainSubPackageJsons ? ['packages/*'] : []),
     ]),
@@ -135,16 +139,21 @@ function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
 }
 
 /**
- * Whether the declaration (ignoring Bun no-op patterns) contains ONLY negative patterns, which
- * activates Bun's implicit `*\/*` baseline (verified with Bun 1.3.14: `workspaces:
- * ["!excluded/*"]` makes every other two-level package.json a workspace, while depth-1 and
- * depth-3 manifests stay out). Appending a positive pattern to such a declaration would disable
- * the baseline, so generators must mirror it explicitly first.
+ * Whether Bun applies its implicit `*\/*` workspace baseline: the declaration (ignoring no-op
+ * patterns) contains ONLY negative patterns AND at least one of them ends in a `*` or `**`
+ * segment. Verified with Bun 1.3.14: `["!excluded/*"]` and `["!apps/**"]` seed the baseline
+ * (every other two-level package.json becomes a workspace), while `["!apps/excluded"]` and
+ * `["!apps/*d"]` link ZERO workspaces.
  */
-export function hasOnlyNegativeDeclaredWorkspacePatterns(workspaces: PackageJson['workspaces']): boolean {
+export function hasImplicitWorkspaceBaseline(workspaces: PackageJson['workspaces']): boolean {
   const workspacePatterns = getMeaningfulDeclaredWorkspacePatterns(workspaces);
   return (
-    workspacePatterns.length > 0 && workspacePatterns.every((workspacePattern) => workspacePattern.startsWith('!'))
+    workspacePatterns.length > 0 &&
+    workspacePatterns.every((workspacePattern) => workspacePattern.startsWith('!')) &&
+    workspacePatterns.some((workspacePattern) => {
+      const lastSegment = workspacePattern.slice(1).split('/').at(-1);
+      return lastSegment === '*' || lastSegment === '**';
+    })
   );
 }
 

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -154,12 +154,20 @@ export function hasOnlyNegativeDeclaredWorkspacePatterns(workspaces: PackageJson
  * must not make the repository root itself a discovered workspace.
  */
 export function getMeaningfulDeclaredWorkspacePatterns(workspaces: PackageJson['workspaces']): string[] {
-  return getDeclaredWorkspacePatterns(workspaces).filter((workspacePattern) => {
-    const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
-    // Normalize so spellings like `./`, `./.`, and `!./` are recognized as the same no-ops
-    // (path.posix.normalize('') === '.', so the empty pattern is covered too).
-    return path.posix.normalize(patternBody).replace(/\/+$/u, '') !== '.';
-  });
+  return getDeclaredWorkspacePatterns(workspaces)
+    .map((workspacePattern) => {
+      // Bun applies leading-bang PARITY (verified with Bun 1.3.14): `!!p` is the positive `p`
+      // and `!!!p` the negation `!p`, so canonicalize to at most one bang.
+      const bangCount = /^!*/u.exec(workspacePattern)![0].length;
+      const patternBody = workspacePattern.slice(bangCount);
+      return bangCount % 2 === 1 ? `!${patternBody}` : patternBody;
+    })
+    .filter((workspacePattern) => {
+      const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
+      // Normalize so spellings like `./`, `./.`, and `!./` are recognized as the same no-ops
+      // (path.posix.normalize('') === '.', so the empty pattern is covered too).
+      return path.posix.normalize(patternBody).replace(/\/+$/u, '') !== '.';
+    });
 }
 
 /** Workspace patterns from either the array form or Yarn v1's `{ packages: […] }` object form. */

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -121,28 +121,42 @@ function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
   // yet, so mirror that normalization here. Discovery callers pass the fallback unconditionally
   // for monorepos — a never-matching pattern contributes no paths there — while pattern-shaped
   // callers (getWorkspaceDirPatterns) gate it on an actual match.
-  // Bun ignores empty patterns (`""` and a lone `"!"`), so they must not count as declarations —
-  // a lone `"!"` would otherwise trigger the negative-only implicit baseline below, and `""`
-  // would make the repository root itself a discovered workspace.
-  const declaredPatterns = getDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces).filter((workspacePattern) => {
-    const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
-    return patternBody !== '' && patternBody !== '.';
-  });
-  // Bun applies an implicit `*/*` baseline when the declaration contains only negative patterns
-  // (verified with Bun 1.3.14: `workspaces: ["!excluded/*"]` makes every other two-level
-  // package.json a workspace, while depth-1 and depth-3 manifests stay out).
-  const hasOnlyNegativePatterns =
-    declaredPatterns.length > 0 && declaredPatterns.every((workspacePattern) => workspacePattern.startsWith('!'));
   const workspacePatterns = [
     ...new Set([
-      ...(hasOnlyNegativePatterns ? ['*/*'] : []),
-      ...declaredPatterns,
+      ...(hasOnlyNegativeDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces) ? ['*/*'] : []),
+      ...getMeaningfulDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces),
       ...(rootLike.doesContainSubPackageJsons ? ['packages/*'] : []),
     ]),
   ];
   return workspacePatterns.filter((workspacePattern) => {
     const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
     return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
+  });
+}
+
+/**
+ * Whether the declaration (ignoring Bun no-op patterns) contains ONLY negative patterns, which
+ * activates Bun's implicit `*\/*` baseline (verified with Bun 1.3.14: `workspaces:
+ * ["!excluded/*"]` makes every other two-level package.json a workspace, while depth-1 and
+ * depth-3 manifests stay out). Appending a positive pattern to such a declaration would disable
+ * the baseline, so generators must mirror it explicitly first.
+ */
+export function hasOnlyNegativeDeclaredWorkspacePatterns(workspaces: PackageJson['workspaces']): boolean {
+  const workspacePatterns = getMeaningfulDeclaredWorkspacePatterns(workspaces);
+  return (
+    workspacePatterns.length > 0 && workspacePatterns.every((workspacePattern) => workspacePattern.startsWith('!'))
+  );
+}
+
+/**
+ * Declared workspace patterns without Bun's no-op ones (`""`, a lone `"!"`, and `"."`), which Bun
+ * ignores entirely — a lone `"!"` must not activate the negative-only implicit baseline, and `""`
+ * must not make the repository root itself a discovered workspace.
+ */
+export function getMeaningfulDeclaredWorkspacePatterns(workspaces: PackageJson['workspaces']): string[] {
+  return getDeclaredWorkspacePatterns(workspaces).filter((workspacePattern) => {
+    const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
+    return patternBody !== '' && patternBody !== '.';
   });
 }
 

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -28,36 +28,53 @@ export function getWorkspaceSubDirPaths(rootLike: WorkspaceRootLike): string[] {
  * a `name` field — wbfy names those later, so dependency scans must not skip them.
  */
 export function getWorkspacePackageJsonPaths(rootConfig: WorkspaceRootLike): string[] {
-  // applyPackageJsonConventions forces `packages/*` into every monorepo's workspaces, but it may
-  // not have written the root package.json yet, so mirror that normalization here.
-  const workspacePatterns = [
-    ...new Set([
-      ...getDeclaredWorkspacePatterns(rootConfig.packageJson?.workspaces),
-      ...(rootConfig.doesContainSubPackageJsons ? ['packages/*'] : []),
-    ]),
-  ];
   // Expand all patterns in one glob call so Bun-supported negative patterns (e.g.
   // `!packages/excluded`) actually exclude their matches. Do not apply globIgnore here: workspace
   // membership is defined solely by the declared patterns, and source-scanning ignores such as
   // `build` or `dist` would hide legitimately named workspace directories.
-  const packageJsonGlobs = workspacePatterns
-    // Workspace directories must stay inside the repository: absolute or `..`-traversing patterns
-    // would make consumers such as removeNodeModules operate on another repository's files.
-    .filter((workspacePattern) => {
-      const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
-      return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
-    })
-    .map((workspacePattern) =>
-      workspacePattern.startsWith('!')
-        ? `!${path.posix.join(workspacePattern.slice(1), 'package.json')}`
-        : path.posix.join(workspacePattern, 'package.json')
-    );
+  const packageJsonGlobs = getSanitizedWorkspacePatterns(rootConfig).map((workspacePattern) =>
+    workspacePattern.startsWith('!')
+      ? `!${path.posix.join(workspacePattern.slice(1), 'package.json')}`
+      : path.posix.join(workspacePattern, 'package.json')
+  );
   // followSymbolicLinks: false — a workspace symlink pointing outside the repository must not be
   // treated as a workspace directory (removeNodeModules would delete through it).
   return fg.globSync(packageJsonGlobs, {
     cwd: rootConfig.dirPath,
     followSymbolicLinks: false,
     ignore: ['**/node_modules/**'],
+  });
+}
+
+/**
+ * Sorted non-negative workspace directory patterns (posix, relative to the monorepo root), for
+ * generators that need pattern-shaped globs covering every workspace layout — e.g. the root
+ * tsconfig's `apps/*` include entries — instead of concrete directories, which would churn
+ * generated files whenever a workspace package is added or removed.
+ */
+export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): string[] {
+  return getSanitizedWorkspacePatterns(rootLike)
+    .filter((workspacePattern) => !workspacePattern.startsWith('!'))
+    .toSorted();
+}
+
+/**
+ * Declared workspace patterns (negative ones included) that stay inside the repository: absolute
+ * or `..`-traversing patterns would make consumers such as removeNodeModules operate on another
+ * repository's files.
+ */
+function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
+  // applyPackageJsonConventions forces `packages/*` into every monorepo's workspaces, but it may
+  // not have written the root package.json yet, so mirror that normalization here.
+  const workspacePatterns = [
+    ...new Set([
+      ...getDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces),
+      ...(rootLike.doesContainSubPackageJsons ? ['packages/*'] : []),
+    ]),
+  ];
+  return workspacePatterns.filter((workspacePattern) => {
+    const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
+    return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
   });
 }
 

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -151,7 +151,8 @@ export function hasImplicitWorkspaceBaseline(workspaces: PackageJson['workspaces
     workspacePatterns.length > 0 &&
     workspacePatterns.every((workspacePattern) => workspacePattern.startsWith('!')) &&
     workspacePatterns.some((workspacePattern) => {
-      const lastSegment = workspacePattern.slice(1).split('/').at(-1);
+      // Normalize first: Bun ignores trailing slashes, so `!apps/*/` seeds the baseline too.
+      const lastSegment = path.posix.normalize(workspacePattern.slice(1)).replace(/\/+$/u, '').split('/').at(-1);
       return lastSegment === '*' || lastSegment === '**';
     })
   );

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -153,7 +153,17 @@ export function hasImplicitWorkspaceBaseline(workspaces: PackageJson['workspaces
     workspacePatterns.some((workspacePattern) => {
       // Normalize first: Bun ignores trailing slashes, so `!apps/*/` seeds the baseline too.
       const lastSegment = path.posix.normalize(workspacePattern.slice(1)).replace(/\/+$/u, '').split('/').at(-1);
-      return lastSegment === '*' || lastSegment === '**';
+      // Bun activates the baseline when the last segment is a STANDALONE glob construct
+      // (measured with Bun 1.3.14: `*`, `**`, `***`, `?`, `{a,b}`, and `[ab]` seed it, while
+      // mixed literal segments such as `*d`, `a*`, `??`, and `{a,b}c` link zero workspaces).
+      // Remaining sequential-evaluation quirks are tracked in #1005.
+      return (
+        lastSegment !== undefined &&
+        (/^\*+$/u.test(lastSegment) ||
+          lastSegment === '?' ||
+          /^\{[^}]*\}$/u.test(lastSegment) ||
+          /^\[[^\]]*\]$/u.test(lastSegment))
+      );
     })
   );
 }

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -75,6 +75,9 @@ export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): WorkspaceD
   // applyPackageJsonConventions, which forces `packages/*` only when a manifest actually matches.
   const hasPackagesLayout =
     rootLike.doesContainSubPackageJsons &&
+    // Mirror applyPackageJsonConventions' baseline gate too: with the implicit `*/*` baseline
+    // active, `packages/*` entries would be dead globs subsumed by the `*/*` ones.
+    !hasImplicitWorkspaceBaseline(rootLike.packageJson?.workspaces) &&
     fg.globSync('packages/*/package.json', {
       cwd: rootLike.dirPath,
       followSymbolicLinks: false,
@@ -140,10 +143,12 @@ function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
 
 /**
  * Whether Bun applies its implicit `*\/*` workspace baseline: the declaration (ignoring no-op
- * patterns) contains ONLY negative patterns AND at least one of them ends in a `*` or `**`
- * segment. Verified with Bun 1.3.14: `["!excluded/*"]` and `["!apps/**"]` seed the baseline
- * (every other two-level package.json becomes a workspace), while `["!apps/excluded"]` and
- * `["!apps/*d"]` link ZERO workspaces.
+ * patterns) contains ONLY negative patterns AND at least one of them ends in a standalone
+ * star-run segment (`*`, `**`, `***`, ...). Measured with Bun 1.3.14: those forms consistently
+ * seed the baseline, while concrete or mixed-literal last segments (`!apps/excluded`,
+ * `!apps/*d`, `??`) link ZERO workspaces. `?`, brace, and character-class last segments behaved
+ * inconsistently across fixtures (sometimes dropping even unrelated sibling workspaces), so they
+ * are conservatively treated as not seeding; see #1005.
  */
 export function hasImplicitWorkspaceBaseline(workspaces: PackageJson['workspaces']): boolean {
   const workspacePatterns = getMeaningfulDeclaredWorkspacePatterns(workspaces);
@@ -153,17 +158,7 @@ export function hasImplicitWorkspaceBaseline(workspaces: PackageJson['workspaces
     workspacePatterns.some((workspacePattern) => {
       // Normalize first: Bun ignores trailing slashes, so `!apps/*/` seeds the baseline too.
       const lastSegment = path.posix.normalize(workspacePattern.slice(1)).replace(/\/+$/u, '').split('/').at(-1);
-      // Bun activates the baseline when the last segment is a STANDALONE glob construct
-      // (measured with Bun 1.3.14: `*`, `**`, `***`, `?`, `{a,b}`, and `[ab]` seed it, while
-      // mixed literal segments such as `*d`, `a*`, `??`, and `{a,b}c` link zero workspaces).
-      // Remaining sequential-evaluation quirks are tracked in #1005.
-      return (
-        lastSegment !== undefined &&
-        (/^\*+$/u.test(lastSegment) ||
-          lastSegment === '?' ||
-          /^\{[^}]*\}$/u.test(lastSegment) ||
-          /^\[[^\]]*\]$/u.test(lastSegment))
-      );
+      return lastSegment !== undefined && /^\*+$/u.test(lastSegment);
     })
   );
 }

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -156,7 +156,9 @@ export function hasOnlyNegativeDeclaredWorkspacePatterns(workspaces: PackageJson
 export function getMeaningfulDeclaredWorkspacePatterns(workspaces: PackageJson['workspaces']): string[] {
   return getDeclaredWorkspacePatterns(workspaces).filter((workspacePattern) => {
     const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
-    return patternBody !== '' && patternBody !== '.';
+    // Normalize so spellings like `./`, `./.`, and `!./` are recognized as the same no-ops
+    // (path.posix.normalize('') === '.', so the empty pattern is covered too).
+    return path.posix.normalize(patternBody).replace(/\/+$/u, '') !== '.';
   });
 }
 

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -46,16 +46,62 @@ export function getWorkspacePackageJsonPaths(rootConfig: WorkspaceRootLike): str
   });
 }
 
+export interface WorkspaceDirPatterns {
+  /** Directory subtrees matched by negative workspace patterns, for tsconfig `exclude` entries. */
+  excludes: string[];
+  /** Positive directory patterns (or concrete directories for Bun-only glob syntax). */
+  includes: string[];
+}
+
 /**
- * Sorted non-negative workspace directory patterns (posix, relative to the monorepo root), for
- * generators that need pattern-shaped globs covering every workspace layout — e.g. the root
- * tsconfig's `apps/*` include entries — instead of concrete directories, which would churn
- * generated files whenever a workspace package is added or removed.
+ * Sorted workspace directory patterns (posix, relative to the monorepo root) for generators that
+ * need pattern-shaped globs covering every workspace layout — e.g. the root tsconfig's `apps/*`
+ * include entries — instead of concrete directories, which would churn generated files whenever a
+ * workspace package is added or removed. Every returned pattern is valid tsconfig glob syntax.
  */
-export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): string[] {
-  return getSanitizedWorkspacePatterns(rootLike)
-    .filter((workspacePattern) => !workspacePattern.startsWith('!'))
-    .toSorted();
+export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): WorkspaceDirPatterns {
+  // Unlike discovery, generated output must not contain a never-matching `packages/*` fallback:
+  // an apps/*-only monorepo would get dead globs committed into its root tsconfig. Mirror
+  // applyPackageJsonConventions, which forces `packages/*` only when a manifest actually matches.
+  const hasPackagesLayout =
+    rootLike.doesContainSubPackageJsons &&
+    fg.globSync('packages/*/package.json', {
+      cwd: rootLike.dirPath,
+      followSymbolicLinks: false,
+      ignore: ['**/node_modules/**'],
+    }).length > 0;
+  const excludes = new Set<string>();
+  const includes = new Set<string>();
+  for (const workspacePattern of getSanitizedWorkspacePatterns({
+    ...rootLike,
+    doesContainSubPackageJsons: hasPackagesLayout,
+  })) {
+    const isNegative = workspacePattern.startsWith('!');
+    // Normalization collapses `//` and strips trailing slashes so template-literal consumers
+    // (e.g. `${pattern}/src/**/*`) never emit doubled separators for patterns like `apps/*/`.
+    const patternBody = path.posix
+      .normalize(isNegative ? workspacePattern.slice(1) : workspacePattern)
+      .replace(/\/+$/u, '');
+    for (const dirPattern of toTsconfigCompatibleDirPatterns(patternBody, rootLike.dirPath)) {
+      (isNegative ? excludes : includes).add(dirPattern);
+    }
+  }
+  return { excludes: [...excludes].toSorted(), includes: [...includes].toSorted() };
+}
+
+/**
+ * tsconfig include/exclude support only the `*`, `?`, and `**` wildcards, while Bun workspaces
+ * accept full glob syntax (brace expansion, character classes, …), so expand Bun-only patterns to
+ * the concrete directories they match to keep the generated globs valid for TypeScript.
+ */
+function toTsconfigCompatibleDirPatterns(patternBody: string, rootDirPath: string): string[] {
+  if (!/[()[\]{}]/u.test(patternBody)) return [patternBody];
+  return fg.globSync(patternBody, {
+    cwd: rootDirPath,
+    followSymbolicLinks: false,
+    ignore: ['**/node_modules/**'],
+    onlyDirectories: true,
+  });
 }
 
 /**
@@ -64,8 +110,11 @@ export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): string[] {
  * repository's files.
  */
 function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
-  // applyPackageJsonConventions forces `packages/*` into every monorepo's workspaces, but it may
-  // not have written the root package.json yet, so mirror that normalization here.
+  // applyPackageJsonConventions forces `packages/*` into a monorepo's workspaces when a
+  // packages/*/package.json actually matches, but it may not have written the root package.json
+  // yet, so mirror that normalization here. Discovery callers pass the fallback unconditionally
+  // for monorepos — a never-matching pattern contributes no paths there — while pattern-shaped
+  // callers (getWorkspaceDirPatterns) gate it on an actual match.
   const workspacePatterns = [
     ...new Set([
       ...getDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces),

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -58,6 +58,9 @@ export interface WorkspaceDirPatterns {
  * need pattern-shaped globs covering every workspace layout — e.g. the root tsconfig's `apps/*`
  * include entries — instead of concrete directories, which would churn generated files whenever a
  * workspace package is added or removed. Every returned pattern is valid tsconfig glob syntax.
+ * A pattern can match a sibling directory without a package.json (not a workspace to Bun); that
+ * is deliberate, mirroring the long-standing `packages/*` entries' behavior in favor of stable
+ * generated output.
  */
 export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): WorkspaceDirPatterns {
   // Unlike discovery, generated output must not contain a never-matching `packages/*` fallback:

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -118,9 +118,16 @@ function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
   // yet, so mirror that normalization here. Discovery callers pass the fallback unconditionally
   // for monorepos — a never-matching pattern contributes no paths there — while pattern-shaped
   // callers (getWorkspaceDirPatterns) gate it on an actual match.
+  const declaredPatterns = getDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces);
+  // Bun applies an implicit `*/*` baseline when the declaration contains only negative patterns
+  // (verified with Bun 1.3.14: `workspaces: ["!excluded/*"]` makes every other two-level
+  // package.json a workspace, while depth-1 and depth-3 manifests stay out).
+  const hasOnlyNegativePatterns =
+    declaredPatterns.length > 0 && declaredPatterns.every((workspacePattern) => workspacePattern.startsWith('!'));
   const workspacePatterns = [
     ...new Set([
-      ...getDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces),
+      ...(hasOnlyNegativePatterns ? ['*/*'] : []),
+      ...declaredPatterns,
       ...(rootLike.doesContainSubPackageJsons ? ['packages/*'] : []),
     ]),
   ];

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -57,6 +57,15 @@ test('merges settings from a tsconfig containing JSONC comments instead of repla
   expect(compilerOptions.paths).toEqual({ 'undici-types': ['./node_modules/undici-types/index.d.ts'] });
 });
 
+test('rewrites a stale wbfy-generated undici-types mapping to the current root depth', async () => {
+  // An older getRootDir mis-resolved deep workspaces, so wbfy-generated mappings may carry a
+  // wrong depth; they must be migrated to the depth the current getRootDir computes ('.' here).
+  const compilerOptions = await generateCompilerOptionsFromContent(
+    JSON.stringify({ compilerOptions: { paths: { 'undici-types': ['../../node_modules/undici-types/index.d.ts'] } } })
+  );
+  expect(compilerOptions.paths).toEqual({ 'undici-types': ['./node_modules/undici-types/index.d.ts'] });
+});
+
 test('keeps a deliberate repo-local undici-types mapping untouched', async () => {
   const compilerOptions = await generateCompilerOptionsFromContent(
     JSON.stringify({ compilerOptions: { paths: { 'undici-types': ['./patched-types/undici-types/index.d.ts'] } } })

--- a/packages/wbfy/test/wbDbCommand.test.ts
+++ b/packages/wbfy/test/wbDbCommand.test.ts
@@ -110,6 +110,54 @@ test('root pass covers pattern-matched directories without a manifest but not pr
   }
 });
 
+test('shields nested packages with a relative root path and covers ORM-free packages', async () => {
+  // realpath so process.cwd() (which resolves macOS's /var -> /private/var symlink) and the
+  // workspace paths below stay consistent, as they are in production.
+  const dirPath = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-wb-db-command-')));
+  const drizzlePackagePath = path.join(dirPath, 'apps', 'web');
+  const ormFreePackagePath = path.join(dirPath, 'apps', 'docs');
+
+  await fs.mkdir(drizzlePackagePath, { recursive: true });
+  await fs.mkdir(ormFreePackagePath, { recursive: true });
+  await fs.writeFile(
+    path.join(drizzlePackagePath, 'package.json'),
+    JSON.stringify({ scripts: { migrate: 'wb db push' } })
+  );
+  // An ORM-free package gets no pass of its own, so the root pass must migrate its files.
+  await fs.writeFile(path.join(ormFreePackagePath, 'package.json'), JSON.stringify({}));
+  await fs.writeFile(path.join(ormFreePackagePath, 'README.md'), 'Run `wb db push`.\n');
+
+  const previousCwd = process.cwd();
+  process.chdir(dirPath);
+  try {
+    // The CLI stores the verbatim (possibly relative) argument as the root dirPath while
+    // workspace dirPaths are absolute; the containment check must handle the mix.
+    const rootConfig = createConfig({
+      dirPath: '.',
+      isRoot: true,
+      depending: { ...createConfig().depending, prisma: true },
+      repoAuthor: 'WillBoosterLab',
+      repoName: 'example',
+    });
+    const drizzleConfig = createConfig({
+      dirPath: drizzlePackagePath,
+      depending: { ...createConfig().depending, drizzle: true },
+    });
+    const ormFreeConfig = createConfig({ dirPath: ormFreePackagePath });
+    await fixWbDbCommand(rootConfig, [rootConfig, drizzleConfig, ormFreeConfig]);
+
+    await expect(fs.readFile(path.join(drizzlePackagePath, 'package.json'), 'utf8')).resolves.toBe(
+      JSON.stringify({ scripts: { migrate: 'wb db push' } })
+    );
+    await expect(fs.readFile(path.join(ormFreePackagePath, 'README.md'), 'utf8')).resolves.toBe(
+      'Run `wb prisma push`.\n'
+    );
+  } finally {
+    process.chdir(previousCwd);
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+});
+
 test('normalizes monorepo packages independently', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-wb-db-command-'));
   const prismaPackagePath = path.join(dirPath, 'packages', 'prisma-app');

--- a/packages/wbfy/test/wbDbCommand.test.ts
+++ b/packages/wbfy/test/wbDbCommand.test.ts
@@ -68,6 +68,48 @@ test('uses wb db for drizzle projects', async () => {
   }
 });
 
+test('root pass covers pattern-matched directories without a manifest but not processed packages', async () => {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-wb-db-command-'));
+  const webPackagePath = path.join(dirPath, 'apps', 'web');
+  const docsDirPath = path.join(dirPath, 'apps', 'docs');
+
+  await fs.mkdir(webPackagePath, { recursive: true });
+  await fs.mkdir(docsDirPath, { recursive: true });
+  await fs.writeFile(
+    path.join(dirPath, 'package.json'),
+    JSON.stringify({ name: 'root', workspaces: ['apps/*'], scripts: { migrate: 'wb db push' } })
+  );
+  // apps/web is a processed package with its own pass; apps/docs matches the workspace pattern
+  // but has no manifest, so ONLY the root pass can migrate its files.
+  await fs.writeFile(path.join(webPackagePath, 'package.json'), JSON.stringify({ scripts: { migrate: 'wb db push' } }));
+  await fs.writeFile(path.join(docsDirPath, 'setup.md'), 'Run `wb db push`.\n');
+
+  try {
+    const rootConfig = createConfig({
+      dirPath,
+      isRoot: true,
+      depending: { ...createConfig().depending, prisma: true },
+      packageJson: { workspaces: ['apps/*'] },
+      repoAuthor: 'WillBoosterLab',
+      repoName: 'example',
+    });
+    const webConfig = createConfig({
+      dirPath: webPackagePath,
+      depending: { ...createConfig().depending, drizzle: true },
+    });
+    await fixWbDbCommand(rootConfig, [rootConfig, webConfig]);
+
+    await expect(fs.readFile(path.join(docsDirPath, 'setup.md'), 'utf8')).resolves.toBe('Run `wb prisma push`.\n');
+    // The web package is shielded from the root pass and its own drizzle pass is a no-op, so the
+    // file stays byte-identical (a root-pass rewrite would have stamped `wb prisma push`).
+    await expect(fs.readFile(path.join(webPackagePath, 'package.json'), 'utf8')).resolves.toBe(
+      JSON.stringify({ scripts: { migrate: 'wb db push' } })
+    );
+  } finally {
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+});
+
 test('normalizes monorepo packages independently', async () => {
   const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-wb-db-command-'));
   const prismaPackagePath = path.join(dirPath, 'packages', 'prisma-app');

--- a/packages/wbfy/test/workspaceDiscovery.test.ts
+++ b/packages/wbfy/test/workspaceDiscovery.test.ts
@@ -239,6 +239,24 @@ test('drops a negation-derived exclude after the workspace negation is removed',
   }
 });
 
+test('ignores empty workspace patterns as Bun does', () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    const appDirPath = path.join(tempDirPath, 'apps', 'web');
+    fs.mkdirSync(appDirPath, { recursive: true });
+    fs.writeFileSync(path.join(appDirPath, 'package.json'), JSON.stringify({}));
+    for (const workspaces of [[''], ['!']]) {
+      fs.writeFileSync(path.join(tempDirPath, 'package.json'), JSON.stringify({ name: 'root', workspaces }));
+      const rootLike = { dirPath: tempDirPath, doesContainSubPackageJsons: false, packageJson: { workspaces } };
+      // Bun treats '' and a lone '!' as no-ops: no workspaces, no implicit baseline.
+      expect(getWorkspaceSubDirPaths(rootLike)).toEqual([]);
+      expect(getWorkspaceDirPatterns(rootLike)).toEqual({ excludes: [], includes: [] });
+    }
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('ignores workspace patterns escaping the repository', () => {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
   try {

--- a/packages/wbfy/test/workspaceDiscovery.test.ts
+++ b/packages/wbfy/test/workspaceDiscovery.test.ts
@@ -124,12 +124,22 @@ test('removes stale wbfy-managed packages/* entries from an existing root tsconf
     fs.writeFileSync(path.join(appDirPath, 'package.json'), JSON.stringify({ name: 'web' }));
     fs.writeFileSync(path.join(appDirPath, 'src', 'index.ts'), 'export {};\n');
     // The upgrade path for #995: an apps/*-only repo whose root tsconfig still carries the
-    // packages/* entries an older wbfy generated, plus a concrete user-authored entry.
+    // complete packages/* entry set an older wbfy generated, plus user-authored entries (one
+    // concrete, one wildcard-shaped but incomplete) that must survive.
     fs.writeFileSync(
       path.join(tempDirPath, 'tsconfig.json'),
       JSON.stringify({
         exclude: ['packages/*/test/fixtures', 'test/fixtures'],
-        include: ['*.config.ts', 'packages/*/src/**/*', 'tools/generator/src/**/*', 'src/**/*'],
+        include: [
+          '*.config.ts',
+          'packages/*/*.config.ts',
+          'packages/*/scripts/**/*',
+          'packages/*/src/**/*',
+          'packages/*/test/**/*',
+          'tools/generator/src/**/*',
+          'tools/*/src/**/*',
+          'src/**/*',
+        ],
       })
     );
 
@@ -143,10 +153,13 @@ test('removes stale wbfy-managed packages/* entries from an existing root tsconf
       include?: string[];
     };
     expect(tsconfig.include).not.toContain('packages/*/src/**/*');
+    expect(tsconfig.include).not.toContain('packages/*/*.config.ts');
     expect(tsconfig.exclude).not.toContain('packages/*/test/fixtures');
     expect(tsconfig.include).toContain('apps/*/src/**/*');
-    // Concrete (non-pattern) user entries are not wbfy-managed and must survive.
+    // User-authored entries are not wbfy-managed and must survive: neither concrete ones nor
+    // wildcard-shaped ones lacking the complete generated entry set.
     expect(tsconfig.include).toContain('tools/generator/src/**/*');
+    expect(tsconfig.include).toContain('tools/*/src/**/*');
   } finally {
     fs.rmSync(tempDirPath, { recursive: true, force: true });
   }

--- a/packages/wbfy/test/workspaceDiscovery.test.ts
+++ b/packages/wbfy/test/workspaceDiscovery.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { expect, test } from 'vitest';
 
-import { getWorkspaceSubDirPaths } from '../src/utils/workspaceUtil.js';
+import { getWorkspaceDirPatterns, getWorkspaceSubDirPaths } from '../src/utils/workspaceUtil.js';
 import { generateTsconfig } from '../src/generators/tsconfig.js';
 import { getPackageConfig } from '../src/packageConfig.js';
 import { promisePool } from '../src/utils/promisePool.js';
@@ -75,10 +75,38 @@ test('derives root signals and root tsconfig coverage from an apps/*-only monore
       exclude?: string[];
       include?: string[];
     };
-    expect(tsconfig.include).toEqual(
-      expect.arrayContaining(['apps/*/*.config.ts', 'apps/*/scripts/**/*', 'apps/*/src/**/*', 'apps/*/test/**/*'])
-    );
-    expect(tsconfig.exclude).toEqual(expect.arrayContaining(['apps/*/test/fixtures', 'test/fixtures']));
+    // Exact arrays: the never-matching packages/* fallback must not leak into apps/*-only output.
+    expect(tsconfig.include).toEqual([
+      '*.config.ts',
+      'apps/*/*.config.ts',
+      'apps/*/scripts/**/*',
+      'apps/*/src/**/*',
+      'apps/*/test/**/*',
+      'scripts/**/*',
+      'src/**/*',
+      'test/**/*',
+    ]);
+    expect(tsconfig.exclude).toEqual(['apps/*/test/fixtures', 'test/fixtures']);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('translates Bun-only workspace glob syntax and negations into tsconfig-safe patterns', () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    for (const workspaceDirName of ['apps/web', 'apps/excluded', 'tools/cli']) {
+      const workspaceDirPath = path.join(tempDirPath, workspaceDirName);
+      fs.mkdirSync(workspaceDirPath, { recursive: true });
+      fs.writeFileSync(path.join(workspaceDirPath, 'package.json'), JSON.stringify({}));
+    }
+    // Trailing slash must not double separators; braces (Bun-only glob syntax, invalid in
+    // tsconfig include) must expand to concrete directories; negations must become excludes.
+    const workspaces = ['apps/*/', '!apps/excluded', '{tools,services}/*'];
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), JSON.stringify({ name: 'root', workspaces }));
+    expect(
+      getWorkspaceDirPatterns({ dirPath: tempDirPath, doesContainSubPackageJsons: true, packageJson: { workspaces } })
+    ).toEqual({ excludes: ['apps/excluded'], includes: ['apps/*', 'tools/cli'] });
   } finally {
     fs.rmSync(tempDirPath, { recursive: true, force: true });
   }

--- a/packages/wbfy/test/workspaceDiscovery.test.ts
+++ b/packages/wbfy/test/workspaceDiscovery.test.ts
@@ -112,6 +112,65 @@ test('translates Bun-only workspace glob syntax and negations into tsconfig-safe
   }
 });
 
+test('removes stale wbfy-managed packages/* entries from an existing root tsconfig', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    fs.writeFileSync(
+      path.join(tempDirPath, 'package.json'),
+      JSON.stringify({ name: 'root', private: true, workspaces: ['apps/*'] })
+    );
+    const appDirPath = path.join(tempDirPath, 'apps', 'web');
+    fs.mkdirSync(path.join(appDirPath, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(appDirPath, 'package.json'), JSON.stringify({ name: 'web' }));
+    fs.writeFileSync(path.join(appDirPath, 'src', 'index.ts'), 'export {};\n');
+    // The upgrade path for #995: an apps/*-only repo whose root tsconfig still carries the
+    // packages/* entries an older wbfy generated, plus a concrete user-authored entry.
+    fs.writeFileSync(
+      path.join(tempDirPath, 'tsconfig.json'),
+      JSON.stringify({
+        exclude: ['packages/*/test/fixtures', 'test/fixtures'],
+        include: ['*.config.ts', 'packages/*/src/**/*', 'tools/generator/src/**/*', 'src/**/*'],
+      })
+    );
+
+    const config = await getPackageConfig(tempDirPath, { isRoot: false });
+    if (!config) throw new Error('unreachable');
+    config.isRoot = true;
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    const tsconfig = JSON.parse(fs.readFileSync(path.join(tempDirPath, 'tsconfig.json'), 'utf8')) as {
+      exclude?: string[];
+      include?: string[];
+    };
+    expect(tsconfig.include).not.toContain('packages/*/src/**/*');
+    expect(tsconfig.exclude).not.toContain('packages/*/test/fixtures');
+    expect(tsconfig.include).toContain('apps/*/src/**/*');
+    // Concrete (non-pattern) user entries are not wbfy-managed and must survive.
+    expect(tsconfig.include).toContain('tools/generator/src/**/*');
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('honors negative workspace patterns in root-level source signals', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    fs.writeFileSync(
+      path.join(tempDirPath, 'package.json'),
+      JSON.stringify({ name: 'root', private: true, workspaces: ['packages/*', '!packages/excluded'] })
+    );
+    const excludedDirPath = path.join(tempDirPath, 'packages', 'excluded');
+    fs.mkdirSync(path.join(excludedDirPath, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(excludedDirPath, 'package.json'), JSON.stringify({ name: 'excluded' }));
+    fs.writeFileSync(path.join(excludedDirPath, 'src', 'index.ts'), 'export {};\n');
+
+    const config = await getPackageConfig(tempDirPath, { isRoot: false });
+    expect(config?.doesContainTypeScriptInPackages).toBe(false);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('ignores workspace patterns escaping the repository', () => {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
   try {

--- a/packages/wbfy/test/workspaceDiscovery.test.ts
+++ b/packages/wbfy/test/workspaceDiscovery.test.ts
@@ -192,7 +192,7 @@ test('applies Bun implicit */* baseline for negative-only workspace declarations
       fs.mkdirSync(workspaceDirPath, { recursive: true });
       fs.writeFileSync(path.join(workspaceDirPath, 'package.json'), JSON.stringify({}));
     }
-    const workspaces = ['!excluded/*'];
+    const workspaces = ['!excluded/*/'];
     fs.writeFileSync(path.join(tempDirPath, 'package.json'), JSON.stringify({ name: 'root', workspaces }));
     const rootLike = { dirPath: tempDirPath, doesContainSubPackageJsons: false, packageJson: { workspaces } };
     expect(getWorkspaceSubDirPaths(rootLike)).toEqual([path.join(tempDirPath, 'apps', 'web')]);

--- a/packages/wbfy/test/workspaceDiscovery.test.ts
+++ b/packages/wbfy/test/workspaceDiscovery.test.ts
@@ -184,6 +184,61 @@ test('honors negative workspace patterns in root-level source signals', async ()
   }
 });
 
+test('applies Bun implicit */* baseline for negative-only workspace declarations', () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    for (const workspaceDirName of ['apps/web', 'excluded/nope']) {
+      const workspaceDirPath = path.join(tempDirPath, workspaceDirName);
+      fs.mkdirSync(workspaceDirPath, { recursive: true });
+      fs.writeFileSync(path.join(workspaceDirPath, 'package.json'), JSON.stringify({}));
+    }
+    const workspaces = ['!excluded/*'];
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), JSON.stringify({ name: 'root', workspaces }));
+    const rootLike = { dirPath: tempDirPath, doesContainSubPackageJsons: false, packageJson: { workspaces } };
+    expect(getWorkspaceSubDirPaths(rootLike)).toEqual([path.join(tempDirPath, 'apps', 'web')]);
+    expect(getWorkspaceDirPatterns(rootLike)).toEqual({ excludes: ['excluded/*'], includes: ['*/*'] });
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('drops a negation-derived exclude after the workspace negation is removed', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    for (const workspaceDirName of ['apps/web', 'apps/excluded']) {
+      const workspaceDirPath = path.join(tempDirPath, workspaceDirName);
+      fs.mkdirSync(path.join(workspaceDirPath, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(workspaceDirPath, 'package.json'), JSON.stringify({}));
+      fs.writeFileSync(path.join(workspaceDirPath, 'src', 'index.ts'), 'export {};\n');
+    }
+    const generate = async (): Promise<{ exclude?: string[] }> => {
+      const config = await getPackageConfig(tempDirPath, { isRoot: false });
+      if (!config) throw new Error('unreachable');
+      config.isRoot = true;
+      await generateTsconfig(config);
+      await promisePool.promiseAll();
+      return JSON.parse(fs.readFileSync(path.join(tempDirPath, 'tsconfig.json'), 'utf8')) as { exclude?: string[] };
+    };
+
+    fs.writeFileSync(
+      path.join(tempDirPath, 'package.json'),
+      JSON.stringify({ name: 'root', private: true, workspaces: ['apps/*', '!apps/excluded'] })
+    );
+    const negatedTsconfig = await generate();
+    expect(negatedTsconfig.exclude).toContain('apps/excluded');
+
+    // Removing the negation must let the workspace re-enter the root project.
+    fs.writeFileSync(
+      path.join(tempDirPath, 'package.json'),
+      JSON.stringify({ name: 'root', private: true, workspaces: ['apps/*'] })
+    );
+    const regeneratedTsconfig = await generate();
+    expect(regeneratedTsconfig.exclude).not.toContain('apps/excluded');
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('ignores workspace patterns escaping the repository', () => {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
   try {

--- a/packages/wbfy/test/workspaceDiscovery.test.ts
+++ b/packages/wbfy/test/workspaceDiscovery.test.ts
@@ -47,6 +47,43 @@ test('discovers and manages workspaces declared outside packages/* (e.g. apps/*)
   }
 });
 
+test('derives root signals and root tsconfig coverage from an apps/*-only monorepo', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    fs.writeFileSync(
+      path.join(tempDirPath, 'package.json'),
+      JSON.stringify({ name: 'root', private: true, workspaces: ['apps/*'] })
+    );
+    const appDirPath = path.join(tempDirPath, 'apps', 'web');
+    fs.mkdirSync(path.join(appDirPath, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(appDirPath, 'package.json'), JSON.stringify({ name: 'web' }));
+    fs.writeFileSync(path.join(appDirPath, 'src', 'App.tsx'), 'export {};\n');
+
+    // isRoot: false skips the network-touching repository lookup; the signals below are computed
+    // the same way for roots.
+    const config = await getPackageConfig(tempDirPath, { isRoot: false });
+    if (!config) throw new Error('unreachable');
+    expect(config.doesContainSubPackageJsons).toBe(true);
+    expect(config.doesContainTypeScriptInPackages).toBe(true);
+    expect(config.doesContainJsxOrTsxInPackages).toBe(true);
+    expect(config.doesContainJavaScriptInPackages).toBe(false);
+
+    config.isRoot = true;
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    const tsconfig = JSON.parse(fs.readFileSync(path.join(tempDirPath, 'tsconfig.json'), 'utf8')) as {
+      exclude?: string[];
+      include?: string[];
+    };
+    expect(tsconfig.include).toEqual(
+      expect.arrayContaining(['apps/*/*.config.ts', 'apps/*/scripts/**/*', 'apps/*/src/**/*', 'apps/*/test/**/*'])
+    );
+    expect(tsconfig.exclude).toEqual(expect.arrayContaining(['apps/*/test/fixtures', 'test/fixtures']));
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('ignores workspace patterns escaping the repository', () => {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
   try {


### PR DESCRIPTION
## Summary

Follow-up to #992: the root-level monorepo signals and the generated root `tsconfig.json` were still hardcoded to `packages/**`, so an `apps/*`-only monorepo got a root tsconfig covering none of its workspace sources, and type-aware oxlint run from the root saw no app code.

- `packages/wbfy/src/packageConfig.ts`: `doesContainTypeScriptInPackages` / `doesContainJavaScriptInPackages` / `doesContainJsxOrTsxInPackages` / `doesContainJavaInPackages` / `doesContainTauriConfigInPackages` now also scan every discovered workspace directory (via `getWorkspaceSubDirPaths`), keeping the `packages/**` fallback for repositories whose `packages/*` layout predates a `workspaces` declaration.
- `packages/wbfy/src/generators/tsconfig.ts`: the root include/exclude entries are built from the declared workspace patterns (new `getWorkspaceDirPatterns` helper) instead of literal `packages/*/…` globs, so an `apps/*` monorepo gets `apps/*/src/**/*` etc. Output for `packages/*`-only monorepos is unchanged.
- `packages/wbfy/src/utils/workspaceUtil.ts`: extracted the pattern sanitization shared by discovery and the new pattern-shaped helper.
- Added a test covering an `apps/*`-only monorepo (root signals + generated root tsconfig).

Fixes #995

## Test

- `bun verify`
- `packages/wbfy`: `vitest run` (146 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
