### PR TITLE
feat!: make WB_ENV lenient locally, strict on CI, and validated everywhere

### DIFF
--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -59,13 +59,15 @@ const standardWbEnvModes = new Set(['development', 'test', 'staging', 'productio
 
 /**
  * Resolves the WB_ENV value wb falls back to when no env source and no exported variable defines
- * it: the forced cascade if any, then the command-level default, then the ambient-NODE_ENV-driven
- * auto cascade clamped to a standard mode (a non-standard NODE_ENV such as `qa` still selects the
- * cascade suffix, but must not produce a non-standard WB_ENV).
+ * it: the command-level default first (`wb test --cascade-env=staging` loads the staging files
+ * but its tests must still run as `test`, mirroring the pre-15 `||= 'test'` behavior), then the
+ * forced cascade, then the ambient-NODE_ENV-driven auto cascade clamped to a standard mode (a
+ * non-standard NODE_ENV such as `qa` still selects the cascade suffix, but must not produce a
+ * non-standard WB_ENV).
  */
 export function resolveFallbackWbEnv(argv: EnvReaderOptions): string {
-  if (argv.cascadeEnv) return argv.cascadeEnv;
   if (argv.commandDefaultWbEnv) return argv.commandDefaultWbEnv;
+  if (argv.cascadeEnv) return argv.cascadeEnv;
   // Read NODE_ENV through the alias for the same bundler-inlining reason as in
   // readEnvironmentVariables, and from the AMBIENT environment (not loaded files) because the
   // cascade selection below uses the ambient value as well.
@@ -90,6 +92,11 @@ export function readEnvironmentVariables(
      * and the file-defined variables themselves are needed (e.g. `wb gen-dev-vars`).
      */
     ignoreProcessEnv?: boolean;
+    /**
+     * Expand `${WB_ENV}` references against the fallback mode when nothing defines WB_ENV.
+     * Only for callers that subsequently COMPLETE WB_ENV with that fallback (wb's Project.env).
+     */
+    expandFallbackWbEnv?: boolean;
   }
 ): [Record<string, string>, [string, string[]][]] {
   let envPaths = (argv.env ?? []).map((envPath) => path.resolve(cwd, envPath.toString()));
@@ -223,9 +230,12 @@ export function readEnvironmentVariables(
     if (value !== undefined && !(key in envVars)) referenceEnv[key] = value.replaceAll('$', String.raw`\$`);
   }
   // A value referencing ${WB_ENV} must expand to what the child will actually see: when nothing
-  // defines WB_ENV, wb later fills it with the fallback mode, so expose that fallback here
-  // instead of expanding the reference to an empty string.
-  if (!('WB_ENV' in envVars) && runtimeEnv.WB_ENV === undefined) {
+  // defines WB_ENV, wb's Project.env later fills it with the fallback mode, so expose that
+  // fallback here instead of expanding the reference to an empty string. Opt-in via the option:
+  // a direct readEnvironmentVariables/readAndApplyEnvironmentVariables caller never receives the
+  // completed WB_ENV, and expanding references against a value that is not actually applied
+  // would make the pair inconsistent.
+  if (options?.expandFallbackWbEnv && !('WB_ENV' in envVars) && runtimeEnv.WB_ENV === undefined) {
     referenceEnv.WB_ENV = resolveFallbackWbEnv(argv);
   }
   // dotenv-expand resolves references in key-insertion order, so a .env value referencing a

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -229,18 +229,6 @@ export function readEnvironmentVariables(
     // recursively re-expanding them (an exported `pa$word` must stay `pa$word`).
     if (value !== undefined && !(key in envVars)) referenceEnv[key] = value.replaceAll('$', String.raw`\$`);
   }
-  // A value referencing ${WB_ENV} must expand to what the child will actually see: when nothing
-  // defines WB_ENV, wb's Project.env later fills it with the fallback mode, so expose that
-  // fallback here instead of expanding the reference to an empty string. Opt-in via the option:
-  // a direct readEnvironmentVariables/readAndApplyEnvironmentVariables caller never receives the
-  // completed WB_ENV, and expanding references against a value that is not actually applied
-  // would make the pair inconsistent.
-  if (options?.expandFallbackWbEnv && !envVars.WB_ENV && !runtimeEnv.WB_ENV) {
-    // An EMPTY definition counts as unset too (Project.completeAndValidateWbEnv treats it so):
-    // drop it so references resolve to the fallback the completed environment will carry.
-    delete envVars.WB_ENV;
-    referenceEnv.WB_ENV = resolveFallbackWbEnv(argv);
-  }
   // dotenv-expand resolves references in key-insertion order, so a .env value referencing a
   // fnox/mise-provided key would see an empty string if the fnox/mise entries stayed appended
   // after the .env entries. Rebuild the expansion input with the lower-priority sources first;
@@ -248,10 +236,23 @@ export function readEnvironmentVariables(
   const orderedEnvVars: Record<string, string> = {};
   for (const key of [...miseEnvVarNames, ...fnoxEnvVarNames]) orderedEnvVars[key] = envVars[key]!;
   Object.assign(orderedEnvVars, envVars);
-  return [
-    expand({ parsed: orderedEnvVars, processEnv: referenceEnv }).parsed ?? orderedEnvVars,
-    envPathAndLoadedEnvVarNames,
-  ];
+  // expand() mutates its parsed input, so keep the pre-expansion values for the re-expansion below.
+  const preExpansionEnvVars = { ...orderedEnvVars };
+  let expandedEnvVars = expand({ parsed: orderedEnvVars, processEnv: referenceEnv }).parsed ?? orderedEnvVars;
+  // A value referencing ${WB_ENV} must expand to what the child will actually see: when the
+  // EFFECTIVE WB_ENV ends up empty — whether it was never defined, defined empty, or emptied by
+  // the expansion itself (e.g. `WB_ENV=${MISSING_MODE}`) — wb's Project.env later fills it with
+  // the fallback mode, so re-expand from the original values with that fallback available.
+  // Opt-in via the option: a direct readEnvironmentVariables/readAndApplyEnvironmentVariables
+  // caller never receives the completed WB_ENV, and expanding references against a value that is
+  // not actually applied would make the pair inconsistent.
+  if (options?.expandFallbackWbEnv && !expandedEnvVars.WB_ENV && !runtimeEnv.WB_ENV) {
+    const reExpansionInput = { ...preExpansionEnvVars };
+    delete reExpansionInput.WB_ENV;
+    referenceEnv.WB_ENV = resolveFallbackWbEnv(argv);
+    expandedEnvVars = expand({ parsed: reExpansionInput, processEnv: referenceEnv }).parsed ?? reExpansionInput;
+  }
+  return [expandedEnvVars, envPathAndLoadedEnvVarNames];
 }
 
 /**

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -249,10 +249,14 @@ export function readEnvironmentVariables(
   // Opt-in via the option: a direct readEnvironmentVariables/readAndApplyEnvironmentVariables
   // caller never receives the completed WB_ENV, and expanding references against a value that is
   // not actually applied would make the pair inconsistent.
-  if (options?.expandFallbackWbEnv && !expandedEnvVars.WB_ENV && !runtimeEnv.WB_ENV) {
+  // The loaded key masks the ambient value, so a loaded-but-emptied WB_ENV needs the retry even
+  // when an exported WB_ENV exists (a forced mode file overrides the export locally): retry with
+  // the value the merged environment will ultimately retain.
+  const effectiveWbEnv = expandedEnvVars.WB_ENV ?? runtimeEnv.WB_ENV;
+  if (options?.expandFallbackWbEnv && !effectiveWbEnv) {
     const reExpansionInput = { ...preExpansionEnvVars };
     delete reExpansionInput.WB_ENV;
-    const retryReferenceEnv = { ...pristineReferenceEnv, WB_ENV: resolveFallbackWbEnv(argv) };
+    const retryReferenceEnv = { ...pristineReferenceEnv, WB_ENV: runtimeEnv.WB_ENV || resolveFallbackWbEnv(argv) };
     expandedEnvVars = expand({ parsed: reExpansionInput, processEnv: retryReferenceEnv }).parsed ?? reExpansionInput;
   }
   return [expandedEnvVars, envPathAndLoadedEnvVarNames];

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -235,7 +235,10 @@ export function readEnvironmentVariables(
   // a direct readEnvironmentVariables/readAndApplyEnvironmentVariables caller never receives the
   // completed WB_ENV, and expanding references against a value that is not actually applied
   // would make the pair inconsistent.
-  if (options?.expandFallbackWbEnv && !('WB_ENV' in envVars) && runtimeEnv.WB_ENV === undefined) {
+  if (options?.expandFallbackWbEnv && !envVars.WB_ENV && !runtimeEnv.WB_ENV) {
+    // An EMPTY definition counts as unset too (Project.completeAndValidateWbEnv treats it so):
+    // drop it so references resolve to the fallback the completed environment will carry.
+    delete envVars.WB_ENV;
     referenceEnv.WB_ENV = resolveFallbackWbEnv(argv);
   }
   // dotenv-expand resolves references in key-insertion order, so a .env value referencing a

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -236,8 +236,11 @@ export function readEnvironmentVariables(
   const orderedEnvVars: Record<string, string> = {};
   for (const key of [...miseEnvVarNames, ...fnoxEnvVarNames]) orderedEnvVars[key] = envVars[key]!;
   Object.assign(orderedEnvVars, envVars);
-  // expand() mutates its parsed input, so keep the pre-expansion values for the re-expansion below.
+  // expand() mutates BOTH its parsed input AND processEnv (dotenv-expand writes every parsed
+  // result into processEnv), so snapshot both for the re-expansion below — the retry must not
+  // see the first pass's stale dependent values.
   const preExpansionEnvVars = { ...orderedEnvVars };
+  const pristineReferenceEnv = { ...referenceEnv };
   let expandedEnvVars = expand({ parsed: orderedEnvVars, processEnv: referenceEnv }).parsed ?? orderedEnvVars;
   // A value referencing ${WB_ENV} must expand to what the child will actually see: when the
   // EFFECTIVE WB_ENV ends up empty — whether it was never defined, defined empty, or emptied by
@@ -249,8 +252,8 @@ export function readEnvironmentVariables(
   if (options?.expandFallbackWbEnv && !expandedEnvVars.WB_ENV && !runtimeEnv.WB_ENV) {
     const reExpansionInput = { ...preExpansionEnvVars };
     delete reExpansionInput.WB_ENV;
-    referenceEnv.WB_ENV = resolveFallbackWbEnv(argv);
-    expandedEnvVars = expand({ parsed: reExpansionInput, processEnv: referenceEnv }).parsed ?? reExpansionInput;
+    const retryReferenceEnv = { ...pristineReferenceEnv, WB_ENV: resolveFallbackWbEnv(argv) };
+    expandedEnvVars = expand({ parsed: reExpansionInput, processEnv: retryReferenceEnv }).parsed ?? reExpansionInput;
   }
   return [expandedEnvVars, envPathAndLoadedEnvVarNames];
 }

--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -47,7 +47,33 @@ export const yargsOptionsBuilderForEnv = {
   },
 } as const;
 
-export type EnvReaderOptions = Partial<ArgumentsCamelCase<InferredOptionTypes<typeof yargsOptionsBuilderForEnv>>>;
+export type EnvReaderOptions = Partial<ArgumentsCamelCase<InferredOptionTypes<typeof yargsOptionsBuilderForEnv>>> & {
+  /**
+   * Command-level fallback for an unset WB_ENV (e.g. `wb test` supplies 'test' when explicit env
+   * flags suppress its default test cascade). Not a CLI flag.
+   */
+  commandDefaultWbEnv?: string;
+};
+
+const standardWbEnvModes = new Set(['development', 'test', 'staging', 'production']);
+
+/**
+ * Resolves the WB_ENV value wb falls back to when no env source and no exported variable defines
+ * it: the forced cascade if any, then the command-level default, then the ambient-NODE_ENV-driven
+ * auto cascade clamped to a standard mode (a non-standard NODE_ENV such as `qa` still selects the
+ * cascade suffix, but must not produce a non-standard WB_ENV).
+ */
+export function resolveFallbackWbEnv(argv: EnvReaderOptions): string {
+  if (argv.cascadeEnv) return argv.cascadeEnv;
+  if (argv.commandDefaultWbEnv) return argv.commandDefaultWbEnv;
+  // Read NODE_ENV through the alias for the same bundler-inlining reason as in
+  // readEnvironmentVariables, and from the AMBIENT environment (not loaded files) because the
+  // cascade selection below uses the ambient value as well.
+  const runtimeEnv = process.env;
+  const derived =
+    argv.cascadeNodeEnv || argv.autoCascadeEnv !== false ? runtimeEnv.NODE_ENV || 'development' : 'development';
+  return standardWbEnvModes.has(derived) ? derived : 'development';
+}
 
 /**
  * This function reads environment variables from `.env` files.
@@ -195,6 +221,12 @@ export function readEnvironmentVariables(
     // Escape dollar signs so dotenv-expand substitutes exported values literally instead of
     // recursively re-expanding them (an exported `pa$word` must stay `pa$word`).
     if (value !== undefined && !(key in envVars)) referenceEnv[key] = value.replaceAll('$', String.raw`\$`);
+  }
+  // A value referencing ${WB_ENV} must expand to what the child will actually see: when nothing
+  // defines WB_ENV, wb later fills it with the fallback mode, so expose that fallback here
+  // instead of expanding the reference to an empty string.
+  if (!('WB_ENV' in envVars) && runtimeEnv.WB_ENV === undefined) {
+    referenceEnv.WB_ENV = resolveFallbackWbEnv(argv);
   }
   // dotenv-expand resolves references in key-insertion order, so a .env value referencing a
   // fnox/mise-provided key would see an empty string if the fnox/mise entries stayed appended

--- a/packages/shared-lib-node/src/index.ts
+++ b/packages/shared-lib-node/src/index.ts
@@ -4,6 +4,7 @@ export {
   readAndApplyEnvironmentVariables,
   readFnoxEnvironmentVariables,
   removeNpmAndYarnEnvironmentVariables,
+  resolveFallbackWbEnv,
   shouldSuppressEnvironmentOutput,
   yargsOptionsBuilderForEnv,
 } from './env.js';

--- a/packages/shared-lib-node/test/fallbackWbEnv.test.ts
+++ b/packages/shared-lib-node/test/fallbackWbEnv.test.ts
@@ -70,4 +70,33 @@ describe('readEnvironmentVariables with expandFallbackWbEnv', () => {
       fs.rmSync(tempDirPath, { recursive: true, force: true });
     }
   });
+
+  it('re-expands with the exported value when a forced mode file empties WB_ENV', () => {
+    // A forced mode's files override the export locally, so the loaded key masks the ambient
+    // value even when it expands to empty; CI is cleared because that override is local-only.
+    const originalCi = process.env.CI;
+    process.env.WB_ENV = 'test';
+    delete process.env.CI;
+    const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'shared-lib-node-wbenv-'));
+    try {
+      fs.writeFileSync(
+        path.join(tempDirPath, '.env.test'),
+        'WB_ENV=${MISSING_MODE}\nDEPENDENT=prefix-${WB_ENV}\n' // eslint-disable-line no-template-curly-in-string
+      );
+      const [envVars] = readEnvironmentVariables(
+        { env: ['.env'], cascadeEnv: 'test', includeRootEnv: false },
+        tempDirPath,
+        { expandFallbackWbEnv: true }
+      );
+      expect(envVars.WB_ENV).toBeUndefined();
+      expect(envVars.DEPENDENT).toBe('prefix-test');
+    } finally {
+      if (originalCi === undefined) {
+        delete process.env.CI;
+      } else {
+        process.env.CI = originalCi;
+      }
+      fs.rmSync(tempDirPath, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/shared-lib-node/test/fallbackWbEnv.test.ts
+++ b/packages/shared-lib-node/test/fallbackWbEnv.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveFallbackWbEnv } from '../src/env.js';
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+  if (originalNodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+});
+
+describe('resolveFallbackWbEnv', () => {
+  it('prefers the command default over the forced cascade (wb test --cascade-env=staging runs as test)', () => {
+    expect(resolveFallbackWbEnv({ commandDefaultWbEnv: 'test', cascadeEnv: 'staging' })).toBe('test');
+  });
+
+  it('uses the forced cascade when no command default exists', () => {
+    expect(resolveFallbackWbEnv({ cascadeEnv: 'staging' })).toBe('staging');
+  });
+
+  it('derives from a standard ambient NODE_ENV', () => {
+    process.env.NODE_ENV = 'production';
+    expect(resolveFallbackWbEnv({})).toBe('production');
+  });
+
+  it('clamps a non-standard ambient NODE_ENV to development', () => {
+    process.env.NODE_ENV = 'qa';
+    expect(resolveFallbackWbEnv({})).toBe('development');
+  });
+});

--- a/packages/shared-lib-node/test/fallbackWbEnv.test.ts
+++ b/packages/shared-lib-node/test/fallbackWbEnv.test.ts
@@ -1,6 +1,10 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { resolveFallbackWbEnv } from '../src/env.js';
+import { readEnvironmentVariables, resolveFallbackWbEnv } from '../src/env.js';
 
 const originalNodeEnv = process.env.NODE_ENV;
 
@@ -29,5 +33,41 @@ describe('resolveFallbackWbEnv', () => {
   it('clamps a non-standard ambient NODE_ENV to development', () => {
     process.env.NODE_ENV = 'qa';
     expect(resolveFallbackWbEnv({})).toBe('development');
+  });
+});
+
+describe('readEnvironmentVariables with expandFallbackWbEnv', () => {
+  const originalWbEnv = process.env.WB_ENV;
+
+  afterEach(() => {
+    if (originalWbEnv === undefined) {
+      delete process.env.WB_ENV;
+    } else {
+      process.env.WB_ENV = originalWbEnv;
+    }
+  });
+
+  it('re-expands dependent references when the expansion empties WB_ENV', () => {
+    delete process.env.WB_ENV;
+    const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'shared-lib-node-wbenv-'));
+    try {
+      // WB_ENV is EMPTIED by the expansion itself; DEPENDENT must still receive the fallback the
+      // completed environment will carry.
+      fs.writeFileSync(
+        path.join(tempDirPath, '.env'),
+        'WB_ENV=${MISSING_MODE}\nDEPENDENT=prefix-${WB_ENV}\n' // eslint-disable-line no-template-curly-in-string
+      );
+      const [envVars] = readEnvironmentVariables(
+        { env: ['.env'], autoCascadeEnv: false, includeRootEnv: false },
+        tempDirPath,
+        { expandFallbackWbEnv: true }
+      );
+      // The emptied WB_ENV is dropped here — wb's Project.completeAndValidateWbEnv fills it with
+      // the same fallback afterwards — while dependent references already use that fallback.
+      expect(envVars.WB_ENV).toBeUndefined();
+      expect(envVars.DEPENDENT).toBe('prefix-development');
+    } finally {
+      fs.rmSync(tempDirPath, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -139,6 +139,21 @@ function readAndApplyEnvironmentVariables(cwd) {
   // child will see.
   validateStandardWbEnv(mode, 'the exported variable');
   validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
+  // The exported mode selected the cascade, so a mode file silently replacing it with a DIFFERENT
+  // valid mode (e.g. `.env.production` containing `WB_ENV=development`) must be rejected as well.
+  if (
+    mode &&
+    process.env.WB_ENV &&
+    process.env.WB_ENV !== mode &&
+    process.env.WB_SKIP_ENV_CHECK !== '1' &&
+    process.env.WB_SKIP_ENV_CHECK !== 'true'
+  ) {
+    console.error(
+      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${mode}" environment was selected. ` +
+        `Fix the WB_ENV defined in the mode's env sources, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
+    );
+    process.exit(1);
+  }
 }
 
 // Mirrors readFnoxEnvironmentVariables in @willbooster/shared-lib-node for this startup fast path.

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -64,9 +64,27 @@ export function runDotenvCommand(args) {
   });
 }
 
+// Mirrors src/commands/dotenv.ts (validateStandardWbEnv) for this startup fast path.
+function validateStandardWbEnv(value, fixTarget) {
+  if (
+    !value ||
+    ['development', 'test', 'staging', 'production'].includes(value) ||
+    process.env.WB_SKIP_ENV_CHECK === '1' ||
+    process.env.WB_SKIP_ENV_CHECK === 'true'
+  ) {
+    return;
+  }
+  console.error(
+    `WB_ENV must be one of development, test, staging, or production, but is "${value}". ` +
+      `Fix ${fixTarget}, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
+  );
+  process.exit(1);
+}
+
 // Mirrors src/commands/dotenv.ts (readAndApplyEnvironmentVariables) for this startup fast path.
 function readAndApplyEnvironmentVariables(cwd) {
   const mode = process.env.WB_ENV;
+  validateStandardWbEnv(mode, 'the exported variable');
   // Mode-specific sources drive the forced-mode override below.
   const modeVars = mode
     ? { ...readEnvFile(path.join(cwd, `.env.${mode}`)), ...readEnvFile(path.join(cwd, `.env.${mode}.local`)) }
@@ -117,6 +135,9 @@ function readAndApplyEnvironmentVariables(cwd) {
     }
     // On CI, inherited variables intentionally win; no warning is emitted.
   }
+  // Validate the FINAL value the child will see: the env sources themselves may define a broken
+  // WB_ENV, and with a forced mode the mode files may even override a VALID exported value.
+  validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
 }
 
 // Mirrors readFnoxEnvironmentVariables in @willbooster/shared-lib-node for this startup fast path.

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -84,7 +84,6 @@ function validateStandardWbEnv(value, fixTarget) {
 // Mirrors src/commands/dotenv.ts (readAndApplyEnvironmentVariables) for this startup fast path.
 function readAndApplyEnvironmentVariables(cwd) {
   const mode = process.env.WB_ENV;
-  validateStandardWbEnv(mode, 'the exported variable');
   // Mode-specific sources drive the forced-mode override below.
   const modeVars = mode
     ? { ...readEnvFile(path.join(cwd, `.env.${mode}`)), ...readEnvFile(path.join(cwd, `.env.${mode}.local`)) }
@@ -135,8 +134,10 @@ function readAndApplyEnvironmentVariables(cwd) {
     }
     // On CI, inherited variables intentionally win; no warning is emitted.
   }
-  // Validate the FINAL value the child will see: the env sources themselves may define a broken
-  // WB_ENV, and with a forced mode the mode files may even override a VALID exported value.
+  // Validate only AFTER applying the sources, so a WB_SKIP_ENV_CHECK defined in an env FILE is
+  // honored: both the captured exported mode (it selected the cascade) and the FINAL value the
+  // child will see.
+  validateStandardWbEnv(mode, 'the exported variable');
   validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
 }
 

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -119,7 +119,6 @@ function validateStandardWbEnv(value: string | undefined, fixTarget: string): vo
 // though — a typo like `prodcution` would otherwise silently select the base (development) values.
 function readAndApplyEnvironmentVariables(cwd: string): void {
   const mode = process.env.WB_ENV;
-  validateStandardWbEnv(mode, 'the exported variable');
   const readEnvFile = (fileName: string): Record<string, string> =>
     config({ path: path.join(cwd, fileName), processEnv: {}, quiet: true }).parsed ?? {};
   // Mode-specific sources drive the forced-mode override below.
@@ -171,8 +170,10 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
     // On CI, inherited variables intentionally win (workflows deliberately inject env vars that
     // override the committed files); this is the designed behavior, so no warning is emitted.
   }
-  // Validate the FINAL value the child will see: the env sources themselves may define a broken
-  // WB_ENV (e.g. `.env` with `WB_ENV=prodcution`), and with a forced mode the mode files may even
-  // override a VALID exported value with a broken one.
+  // Validate only AFTER applying the sources, so a WB_SKIP_ENV_CHECK defined in an env FILE is
+  // honored: both the captured exported mode (it selected the cascade) and the FINAL value the
+  // child will see — the env sources may define a broken WB_ENV (e.g. `.env` with
+  // `WB_ENV=prodcution`), and a forced mode's files may even override a VALID exported value.
+  validateStandardWbEnv(mode, 'the exported variable');
   validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
 }

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -97,24 +97,29 @@ function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
   return { command: separatorIndex === -1 ? args : args.slice(separatorIndex + 1) };
 }
 
+function validateStandardWbEnv(value: string | undefined, fixTarget: string): void {
+  if (
+    !value ||
+    ['development', 'test', 'staging', 'production'].includes(value) ||
+    process.env.WB_SKIP_ENV_CHECK === '1' ||
+    process.env.WB_SKIP_ENV_CHECK === 'true'
+  ) {
+    return;
+  }
+  console.error(
+    `WB_ENV must be one of development, test, staging, or production, but is "${value}". ` +
+      `Fix ${fixTarget}, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
+  );
+  process.exit(1);
+}
+
 // NOTE: `wb dotenv` deliberately skips Project.env's full validation: it is a generic runner also
 // used before env sources exist (bootstrap) and must not fail fast for repositories that have not
 // adopted the org env standard. A NON-EMPTY WB_ENV is still validated against the standard modes,
 // though — a typo like `prodcution` would otherwise silently select the base (development) values.
 function readAndApplyEnvironmentVariables(cwd: string): void {
   const mode = process.env.WB_ENV;
-  if (
-    mode &&
-    !['development', 'test', 'staging', 'production'].includes(mode) &&
-    process.env.WB_SKIP_ENV_CHECK !== '1' &&
-    process.env.WB_SKIP_ENV_CHECK !== 'true'
-  ) {
-    console.error(
-      `WB_ENV must be one of development, test, staging, or production, but is "${mode}". ` +
-        'Fix the exported variable, or set WB_SKIP_ENV_CHECK=1 to skip this check.'
-    );
-    process.exit(1);
-  }
+  validateStandardWbEnv(mode, 'the exported variable');
   const readEnvFile = (fileName: string): Record<string, string> =>
     config({ path: path.join(cwd, fileName), processEnv: {}, quiet: true }).parsed ?? {};
   // Mode-specific sources drive the forced-mode override below.
@@ -148,6 +153,12 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
     }
   }
   const envVars = expand({ parsed, processEnv: referenceEnv }).parsed ?? parsed;
+  // The env sources themselves may define a broken WB_ENV (e.g. `.env` with `WB_ENV=prodcution`),
+  // which would silently select the base values — validate the EFFECTIVE value the child sees.
+  validateStandardWbEnv(
+    mode ?? (typeof envVars.WB_ENV === 'string' ? envVars.WB_ENV : undefined),
+    'the env source or the exported variable'
+  );
   for (const [key, value] of Object.entries(envVars)) {
     if (!(key in process.env)) {
       process.env[key] = value;

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -176,4 +176,19 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
   // `WB_ENV=prodcution`), and a forced mode's files may even override a VALID exported value.
   validateStandardWbEnv(mode, 'the exported variable');
   validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
+  // The exported mode selected the cascade, so a mode file silently replacing it with a DIFFERENT
+  // valid mode (e.g. `.env.production` containing `WB_ENV=development`) must be rejected as well.
+  if (
+    mode &&
+    process.env.WB_ENV &&
+    process.env.WB_ENV !== mode &&
+    process.env.WB_SKIP_ENV_CHECK !== '1' &&
+    process.env.WB_SKIP_ENV_CHECK !== 'true'
+  ) {
+    console.error(
+      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${mode}" environment was selected. ` +
+        `Fix the WB_ENV defined in the mode's env sources, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
+    );
+    process.exit(1);
+  }
 }

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -153,12 +153,6 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
     }
   }
   const envVars = expand({ parsed, processEnv: referenceEnv }).parsed ?? parsed;
-  // The env sources themselves may define a broken WB_ENV (e.g. `.env` with `WB_ENV=prodcution`),
-  // which would silently select the base values — validate the EFFECTIVE value the child sees.
-  validateStandardWbEnv(
-    mode ?? (typeof envVars.WB_ENV === 'string' ? envVars.WB_ENV : undefined),
-    'the env source or the exported variable'
-  );
   for (const [key, value] of Object.entries(envVars)) {
     if (!(key in process.env)) {
       process.env[key] = value;
@@ -177,4 +171,8 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
     // On CI, inherited variables intentionally win (workflows deliberately inject env vars that
     // override the committed files); this is the designed behavior, so no warning is emitted.
   }
+  // Validate the FINAL value the child will see: the env sources themselves may define a broken
+  // WB_ENV (e.g. `.env` with `WB_ENV=prodcution`), and with a forced mode the mode files may even
+  // override a VALID exported value with a broken one.
+  validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
 }

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -97,11 +97,24 @@ function parseDotenvArgs(args: string[]): ParsedDotenvArgs {
   return { command: separatorIndex === -1 ? args : args.slice(separatorIndex + 1) };
 }
 
-// NOTE: `wb dotenv` deliberately skips Project.env's WB_ENV/NEXT_PUBLIC_WB_ENV validation: it is
-// a generic runner also used before env sources exist (bootstrap) and must not fail fast for
-// repositories that have not adopted the org env standard.
+// NOTE: `wb dotenv` deliberately skips Project.env's full validation: it is a generic runner also
+// used before env sources exist (bootstrap) and must not fail fast for repositories that have not
+// adopted the org env standard. A NON-EMPTY WB_ENV is still validated against the standard modes,
+// though — a typo like `prodcution` would otherwise silently select the base (development) values.
 function readAndApplyEnvironmentVariables(cwd: string): void {
   const mode = process.env.WB_ENV;
+  if (
+    mode &&
+    !['development', 'test', 'staging', 'production'].includes(mode) &&
+    process.env.WB_SKIP_ENV_CHECK !== '1' &&
+    process.env.WB_SKIP_ENV_CHECK !== 'true'
+  ) {
+    console.error(
+      `WB_ENV must be one of development, test, staging, or production, but is "${mode}". ` +
+        'Fix the exported variable, or set WB_SKIP_ENV_CHECK=1 to skip this check.'
+    );
+    process.exit(1);
+  }
   const readEnvFile = (fileName: string): Record<string, string> =>
     config({ path: path.join(cwd, fileName), processEnv: {}, quiet: true }).parsed ?? {};
   // Mode-specific sources drive the forced-mode override below.

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -109,8 +109,11 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
   const { shouldRunE2e, shouldRunUnit } = resolveTestExecutionTargets(testTargets, forwardedPlaywrightArgs);
 
   for (const project of projects.descendants) {
-    // project.env already resolves WB_ENV to 'test' here: withDefaultTestCascadeEnv forces the
-    // test cascade, and Project.completeAndValidateWbEnv falls back to the cascade mode.
+    // Resolve the environment eagerly: withDefaultTestCascadeEnv forces the test cascade and
+    // Project.completeAndValidateWbEnv falls back WB_ENV to that mode — but the env getter is
+    // lazy, so a project with no runnable tests would otherwise skip the validation entirely.
+    void project.env;
+
     const deps = project.packageJson.dependencies ?? {};
     const devDeps = project.packageJson.devDependencies ?? {};
     let scripts: BaseScripts;

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -309,7 +309,9 @@ export function warnIfPlaywrightSpecsAreUndiscoverable(
 
 export function withDefaultTestCascadeEnv(argv: TestCommandArgv): TestCommandArgv {
   if (argv.env?.length || argv.cascadeEnv || argv.cascadeNodeEnv || argv.autoCascadeEnv === false) {
-    return argv;
+    // Explicit env flags keep their file-selection semantics, but the spawned tests must still
+    // run as `test` when those files define no WB_ENV (the pre-15 `||= 'test'` behavior).
+    return { ...argv, commandDefaultWbEnv: 'test' };
   }
   return { ...argv, cascadeEnv: 'test' };
 }

--- a/packages/wb/src/commands/test.ts
+++ b/packages/wb/src/commands/test.ts
@@ -109,8 +109,8 @@ export async function test(argv: TestCommandArgv, options: TestRunOptions = {}):
   const { shouldRunE2e, shouldRunUnit } = resolveTestExecutionTargets(testTargets, forwardedPlaywrightArgs);
 
   for (const project of projects.descendants) {
-    project.env.WB_ENV ||= 'test';
-
+    // project.env already resolves WB_ENV to 'test' here: withDefaultTestCascadeEnv forces the
+    // test cascade, and Project.completeAndValidateWbEnv falls back to the cascade mode.
     const deps = project.packageJson.dependencies ?? {};
     const devDeps = project.packageJson.devDependencies ?? {};
     let scripts: BaseScripts;

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -209,8 +209,31 @@ export class Project {
       );
       process.exit(1);
     }
-    if (this.requiresNextPublicWbEnv) {
-      env.NEXT_PUBLIC_WB_ENV ||= env.WB_ENV;
+    // A forced mode (an explicit/command-default --cascade-env, or an exported WB_ENV whose
+    // mode-specific files may override it locally per issue #930) must not be silently replaced
+    // by another mode a mode file defines: `wb test` resolving WB_ENV=development from a
+    // committed `.env` would run the tests against development values, and an exported
+    // WB_ENV=production overridden to development by `.env.production` would build/deploy the
+    // wrong environment while looking successful.
+    const forcedMode = this.argv.cascadeEnv ?? (this.argv.cascadeNodeEnv ? undefined : process.env.WB_ENV || undefined);
+    if (forcedMode && env.WB_ENV !== forcedMode) {
+      console.error(
+        chalk.red(
+          `WB_ENV resolves to "${env.WB_ENV}" although the "${forcedMode}" environment was selected. ` +
+            `Fix the WB_ENV defined in the mode's env source (e.g. .env.${forcedMode} or the fnox "${forcedMode}" profile), ` +
+            'or set WB_SKIP_ENV_CHECK=1 to skip this check.'
+        )
+      );
+      process.exit(1);
+    }
+    if (this.requiresNextPublicWbEnv && env.NEXT_PUBLIC_WB_ENV !== env.WB_ENV) {
+      // Assign unconditionally, not `||=`: the pair must agree by convention, and a stale value
+      // (e.g. a base `.env`'s development default while CI exports WB_ENV=test) would otherwise
+      // be baked into the client bundle even though the server side runs with the correct WB_ENV.
+      if (env.NEXT_PUBLIC_WB_ENV && !shouldSuppressEnvironmentOutput(this.argv)) {
+        console.info(`Overriding NEXT_PUBLIC_WB_ENV ("${env.NEXT_PUBLIC_WB_ENV}") with WB_ENV ("${env.WB_ENV}").`);
+      }
+      env.NEXT_PUBLIC_WB_ENV = env.WB_ENV;
     }
   }
 

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -149,43 +149,67 @@ export class Project {
     // (e.g. `--cascade-env=test`) wins over a stale `mise activate` environment.
     this.envCache = { ...process.env, ...envVars };
     // `mise env` is excluded: it reports tool-activation output (e.g. PATH) even in repos that
-    // declare no environment variables at all, which must not force the WB_ENV requirement.
-    this.validateRequiredEnvironmentVariables(
-      envPathAndLoadedEnvVarNamePairs.some(([source]) => !source.startsWith('mise env'))
-    );
+    // declare no environment variables at all, which must not trigger the CI strictness below.
+    this.completeAndValidateWbEnv(envPathAndLoadedEnvVarNamePairs.some(([source]) => !source.startsWith('mise env')));
     return this.envCache;
   }
 
+  private static readonly standardWbEnvModes = new Set(['development', 'test', 'staging', 'production']);
+
   /**
-   * Fail fast when the resolved environment violates the org standard: every mode
-   * (development/test/staging/production) must define `WB_ENV`, and Next.js/vinext apps must also
-   * define `NEXT_PUBLIC_WB_ENV` (see the guidelines-for-mise-fnox skill). Skipped while no env
-   * sources exist yet (e.g. during `wb setup` bootstrap before env files/fnox.toml are created)
-   * and when `WB_SKIP_ENV_CHECK=1` is set.
+   * Completes and validates the resolved `WB_ENV` per the org standard (see the
+   * guidelines-for-mise-fnox skill):
+   * - Locally, an unset `WB_ENV` falls back to the selected cascade mode (development unless a
+   *   command forces another, e.g. `wb test` forces test), so casual `bun wb ...` invocations
+   *   work in repositories that define no WB_ENV at all.
+   * - On CI, an unset `WB_ENV` is a hard error when env sources exist: workflows must export the
+   *   environment explicitly instead of silently running in an ambiguous mode.
+   * - The value must name a standard mode; an unknown value (e.g. a typo like `prodcution`) would
+   *   otherwise silently select the development cascade, which is the failure this guards against.
+   * - `NEXT_PUBLIC_WB_ENV` is derived from `WB_ENV` for Next.js/vinext apps when missing, so a
+   *   production build can no longer bake a stale development value into the client bundle.
+   * Skipped when `WB_SKIP_ENV_CHECK=1` is set.
    */
-  private validateRequiredEnvironmentVariables(hasEnvironmentSources: boolean): void {
+  private completeAndValidateWbEnv(hasEnvironmentSources: boolean): void {
     const env = this.envCache;
-    if (!env || !hasEnvironmentSources) return;
+    if (!env) return;
     if (env.WB_SKIP_ENV_CHECK === '1' || env.WB_SKIP_ENV_CHECK === 'true') return;
 
-    const missingKeys: string[] = [];
-    if (!env.WB_ENV) missingKeys.push('WB_ENV');
-    if (this.requiresNextPublicWbEnv && !env.NEXT_PUBLIC_WB_ENV) missingKeys.push('NEXT_PUBLIC_WB_ENV');
-    if (missingKeys.length === 0) return;
-
-    // Resolve the mode label from the loaded environment (not process.env): a WB_ENV/NODE_ENV
-    // supplied only by env files or fnox must still name the correct mode in the error message.
-    const mode =
-      this.argv.cascadeEnv ??
-      (this.argv.cascadeNodeEnv ? env.NODE_ENV || 'development' : (env.WB_ENV ?? env.NODE_ENV ?? 'development'));
-    console.error(
-      chalk.red(
-        `${missingKeys.join(' and ')} ${missingKeys.length === 1 ? 'is' : 'are'} not defined for the "${mode}" environment. ` +
-          `Define ${missingKeys.join(' and ')} in the mode's env source (e.g. .env.${mode} or the fnox "${mode}" profile; see guidelines-for-mise-fnox), ` +
-          'or set WB_SKIP_ENV_CHECK=1 to skip this check.'
-      )
-    );
-    process.exit(1);
+    if (!env.WB_ENV) {
+      if (isCI(env.CI) && hasEnvironmentSources) {
+        console.error(
+          chalk.red(
+            'WB_ENV is not defined on CI. Export WB_ENV explicitly (the reusable workflows pass it via the "environment" input), ' +
+              'or set WB_SKIP_ENV_CHECK=1 to skip this check.'
+          )
+        );
+        process.exit(1);
+      }
+      // Resolve the fallback from the selected cascade mode (not a bare 'development'): a command
+      // forcing a mode (e.g. `wb test` forces the test cascade) must fall back to that mode, and
+      // an ambient NODE_ENV drives the auto cascade exactly as in readEnvironmentVariables.
+      const mode =
+        this.argv.cascadeEnv ??
+        (this.argv.cascadeNodeEnv || this.argv.autoCascadeEnv !== false
+          ? env.NODE_ENV || 'development'
+          : 'development');
+      env.WB_ENV = mode;
+      if (hasEnvironmentSources && !shouldSuppressEnvironmentOutput(this.argv)) {
+        console.info(`WB_ENV is not defined; defaulting to "${mode}".`);
+      }
+    }
+    if (!Project.standardWbEnvModes.has(env.WB_ENV)) {
+      console.error(
+        chalk.red(
+          `WB_ENV must be one of development, test, staging, or production, but is "${env.WB_ENV}". ` +
+            'Fix the value in the env source or the exported variable, or set WB_SKIP_ENV_CHECK=1 to skip this check.'
+        )
+      );
+      process.exit(1);
+    }
+    if (this.requiresNextPublicWbEnv) {
+      env.NEXT_PUBLIC_WB_ENV ||= env.WB_ENV;
+    }
   }
 
   @memoizeOne

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -222,10 +222,21 @@ export class Project {
     // committed `.env` would run the tests against development values, and an exported
     // WB_ENV=production overridden to development by `.env.production` would build/deploy the
     // wrong environment while looking successful.
-    const forcedMode = this.argv.cascadeEnv ?? (this.argv.cascadeNodeEnv ? undefined : process.env.WB_ENV || undefined);
+    // --cascade-node-env forces <NODE_ENV || development> (per its own documentation), read from
+    // the AMBIENT environment like the cascade selection. Only a STANDARD forced mode is enforced:
+    // a non-standard one (e.g. NODE_ENV=qa) already had its fallback clamped to development above,
+    // and erroring on that clamp would contradict it.
+    const forcedMode =
+      this.argv.cascadeEnv ??
+      (this.argv.cascadeNodeEnv ? process.env.NODE_ENV || 'development' : process.env.WB_ENV || undefined);
     // The command-level default is a legitimate second expectation: `wb test --cascade-env=staging`
     // loads the staging files while the fallback correctly fills WB_ENV=test.
-    if (forcedMode && env.WB_ENV !== forcedMode && env.WB_ENV !== this.argv.commandDefaultWbEnv) {
+    if (
+      forcedMode &&
+      Project.standardWbEnvModes.has(forcedMode) &&
+      env.WB_ENV !== forcedMode &&
+      env.WB_ENV !== this.argv.commandDefaultWbEnv
+    ) {
       console.error(
         chalk.red(
           `WB_ENV resolves to "${env.WB_ENV}" although the "${forcedMode}" environment was selected. ` +

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -188,11 +188,13 @@ export class Project {
       // Resolve the fallback from the selected cascade mode (not a bare 'development'): a command
       // forcing a mode (e.g. `wb test` forces the test cascade) must fall back to that mode, and
       // an ambient NODE_ENV drives the auto cascade exactly as in readEnvironmentVariables.
-      const mode =
-        this.argv.cascadeEnv ??
-        (this.argv.cascadeNodeEnv || this.argv.autoCascadeEnv !== false
-          ? env.NODE_ENV || 'development'
-          : 'development');
+      // A NON-STANDARD NODE_ENV (e.g. qa) still selects the cascade suffix but is clamped to
+      // 'development' here: the user never set WB_ENV, so failing the standard-mode validation
+      // below with a message blaming WB_ENV would be a misleading hard stop. An explicit
+      // --cascade-env keeps its value and is validated like any other WB_ENV.
+      const derived =
+        this.argv.cascadeNodeEnv || this.argv.autoCascadeEnv !== false ? env.NODE_ENV || 'development' : 'development';
+      const mode = this.argv.cascadeEnv ?? (Project.standardWbEnvModes.has(derived) ? derived : 'development');
       env.WB_ENV = mode;
       if (hasEnvironmentSources && !shouldSuppressEnvironmentOutput(this.argv)) {
         console.info(`WB_ENV is not defined; defaulting to "${mode}".`);

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -229,18 +229,23 @@ export class Project {
     const forcedMode =
       this.argv.cascadeEnv ??
       (this.argv.cascadeNodeEnv ? process.env.NODE_ENV || 'development' : process.env.WB_ENV || undefined);
+    // The AUTO-selected mode counts as the expectation too: with nothing set anywhere, the
+    // development cascade's files are loaded, so a `.env.local` declaring WB_ENV=production would
+    // otherwise run development sources labeled as production.
+    const expectedMode =
+      forcedMode ?? (this.argv.autoCascadeEnv !== false ? resolveFallbackWbEnv(this.argv) : undefined);
     // The command-level default is a legitimate second expectation: `wb test --cascade-env=staging`
     // loads the staging files while the fallback correctly fills WB_ENV=test.
     if (
-      forcedMode &&
-      Project.standardWbEnvModes.has(forcedMode) &&
-      env.WB_ENV !== forcedMode &&
+      expectedMode &&
+      Project.standardWbEnvModes.has(expectedMode) &&
+      env.WB_ENV !== expectedMode &&
       env.WB_ENV !== this.argv.commandDefaultWbEnv
     ) {
       console.error(
         chalk.red(
-          `WB_ENV resolves to "${env.WB_ENV}" although the "${forcedMode}" environment was selected. ` +
-            `Fix the WB_ENV defined in the mode's env source (e.g. .env.${forcedMode} or the fnox "${forcedMode}" profile), ` +
+          `WB_ENV resolves to "${env.WB_ENV}" although the "${expectedMode}" environment was selected. ` +
+            `Fix the WB_ENV defined in the mode's env source (e.g. .env.${expectedMode} or the fnox "${expectedMode}" profile), ` +
             'or set WB_SKIP_ENV_CHECK=1 to skip this check.'
         )
       );

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -140,7 +140,11 @@ export class Project {
       return this.envCache;
     }
 
-    const [envVars, envPathAndLoadedEnvVarNamePairs] = readEnvironmentVariables(this.argv, this.dirPath);
+    const [envVars, envPathAndLoadedEnvVarNamePairs] = readEnvironmentVariables(this.argv, this.dirPath, {
+      // completeAndValidateWbEnv below fills an unset WB_ENV with the same fallback, so expanding
+      // ${WB_ENV} references against it keeps the pair consistent.
+      expandFallbackWbEnv: true,
+    });
     if (!shouldSuppressEnvironmentOutput(this.argv)) {
       for (const [envPath, names] of envPathAndLoadedEnvVarNamePairs) {
         console.info(`Loaded ${names.length} environment variables from ${envPath}`);
@@ -219,7 +223,9 @@ export class Project {
     // WB_ENV=production overridden to development by `.env.production` would build/deploy the
     // wrong environment while looking successful.
     const forcedMode = this.argv.cascadeEnv ?? (this.argv.cascadeNodeEnv ? undefined : process.env.WB_ENV || undefined);
-    if (forcedMode && env.WB_ENV !== forcedMode) {
+    // The command-level default is a legitimate second expectation: `wb test --cascade-env=staging`
+    // loads the staging files while the fallback correctly fills WB_ENV=test.
+    if (forcedMode && env.WB_ENV !== forcedMode && env.WB_ENV !== this.argv.commandDefaultWbEnv) {
       console.error(
         chalk.red(
           `WB_ENV resolves to "${env.WB_ENV}" although the "${forcedMode}" environment was selected. ` +

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -2,7 +2,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type { EnvReaderOptions } from '@willbooster/shared-lib-node/src';
-import { readEnvironmentVariables, shouldSuppressEnvironmentOutput } from '@willbooster/shared-lib-node/src';
+import {
+  readEnvironmentVariables,
+  resolveFallbackWbEnv,
+  shouldSuppressEnvironmentOutput,
+} from '@willbooster/shared-lib-node/src';
 import { memoizeOne } from 'at-decorators';
 import chalk from 'chalk';
 import { globby } from 'globby';
@@ -175,26 +179,25 @@ export class Project {
     if (!env) return;
     if (env.WB_SKIP_ENV_CHECK === '1' || env.WB_SKIP_ENV_CHECK === 'true') return;
 
+    // On CI, WB_ENV must be EXPORTED by the workflow — checked against process.env, not the
+    // merged environment: a committed base default (e.g. fnox's development entry) would
+    // otherwise satisfy the check and silently run CI in development mode.
+    if (isCI(env.CI) && !process.env.WB_ENV && hasEnvironmentSources) {
+      console.error(
+        chalk.red(
+          'WB_ENV is not exported on CI. Export WB_ENV explicitly (the reusable workflows pass it via the "environment" input), ' +
+            'or set WB_SKIP_ENV_CHECK=1 to skip this check.'
+        )
+      );
+      process.exit(1);
+    }
     if (!env.WB_ENV) {
-      if (isCI(env.CI) && hasEnvironmentSources) {
-        console.error(
-          chalk.red(
-            'WB_ENV is not defined on CI. Export WB_ENV explicitly (the reusable workflows pass it via the "environment" input), ' +
-              'or set WB_SKIP_ENV_CHECK=1 to skip this check.'
-          )
-        );
-        process.exit(1);
-      }
-      // Resolve the fallback from the selected cascade mode (not a bare 'development'): a command
-      // forcing a mode (e.g. `wb test` forces the test cascade) must fall back to that mode, and
-      // an ambient NODE_ENV drives the auto cascade exactly as in readEnvironmentVariables.
-      // A NON-STANDARD NODE_ENV (e.g. qa) still selects the cascade suffix but is clamped to
-      // 'development' here: the user never set WB_ENV, so failing the standard-mode validation
-      // below with a message blaming WB_ENV would be a misleading hard stop. An explicit
-      // --cascade-env keeps its value and is validated like any other WB_ENV.
-      const derived =
-        this.argv.cascadeNodeEnv || this.argv.autoCascadeEnv !== false ? env.NODE_ENV || 'development' : 'development';
-      const mode = this.argv.cascadeEnv ?? (Project.standardWbEnvModes.has(derived) ? derived : 'development');
+      // The shared resolver keeps this fallback consistent with the cascade selection AND with
+      // the ${WB_ENV} expansion readEnvironmentVariables already performed: the forced cascade
+      // (e.g. `wb test`), then the command-level default, then the AMBIENT-NODE_ENV-driven auto
+      // cascade clamped to a standard mode (an explicit --cascade-env keeps its value and is
+      // validated below like any other WB_ENV).
+      const mode = resolveFallbackWbEnv(this.argv);
       env.WB_ENV = mode;
       if (hasEnvironmentSources && !shouldSuppressEnvironmentOutput(this.argv)) {
         console.info(`WB_ENV is not defined; defaulting to "${mode}".`);

--- a/packages/wb/test/testCommand.test.ts
+++ b/packages/wb/test/testCommand.test.ts
@@ -99,21 +99,26 @@ describe('withDefaultTestCascadeEnv', () => {
     });
   });
 
-  it('keeps explicit cascade env', () => {
-    const argv = { cascadeEnv: 'staging' } as TestCommandArgv;
-
-    expect(withDefaultTestCascadeEnv(argv)).toBe(argv);
+  // Explicit env flags keep their file/cascade selection, but the command-level WB_ENV default
+  // must still make the spawned tests run as `test` when nothing defines WB_ENV.
+  it('keeps explicit cascade env and adds the command default', () => {
+    expect(withDefaultTestCascadeEnv({ cascadeEnv: 'staging' } as TestCommandArgv)).toEqual({
+      cascadeEnv: 'staging',
+      commandDefaultWbEnv: 'test',
+    });
   });
 
-  it('keeps explicit env files', () => {
-    const argv = { env: ['.env.custom'] } as unknown as TestCommandArgv;
-
-    expect(withDefaultTestCascadeEnv(argv)).toBe(argv);
+  it('keeps explicit env files and adds the command default', () => {
+    expect(withDefaultTestCascadeEnv({ env: ['.env.custom'] } as unknown as TestCommandArgv)).toEqual({
+      env: ['.env.custom'],
+      commandDefaultWbEnv: 'test',
+    });
   });
 
-  it('keeps disabled auto cascade env', () => {
-    const argv = { autoCascadeEnv: false } as TestCommandArgv;
-
-    expect(withDefaultTestCascadeEnv(argv)).toBe(argv);
+  it('keeps disabled auto cascade env and adds the command default', () => {
+    expect(withDefaultTestCascadeEnv({ autoCascadeEnv: false } as TestCommandArgv)).toEqual({
+      autoCascadeEnv: false,
+      commandDefaultWbEnv: 'test',
+    });
   });
 });

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -26,6 +26,13 @@ type WbEnvMode = (typeof wbEnvModes)[number];
 export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfigs: PackageConfig[]): Promise<void> {
   return logger.functionIgnoringException('ensureWbEnvDefinitions', async () => {
     const needsNextPublic = allConfigs.some((config) => requiresNextPublicWbEnv(config));
+    // Warning-only dotenv inspection for EVERY repository flavor, before any mutation: dotenv
+    // values win over fnox at load time, so a leftover mismatched .env* silently overrides even
+    // a correct fnox profile.
+    for (const config of allConfigs) {
+      const needsNextPublicHere = config === rootConfig ? needsNextPublic : requiresNextPublicWbEnv(config);
+      await warnOnMismatchedDotenvWbEnvValues(config.dirPath, needsNextPublicHere);
+    }
     const fnoxTomlPath = path.resolve(rootConfig.dirPath, 'fnox.toml');
     // lstat, not existsSync: existsSync is false for a DANGLING fnox.toml symlink, which would
     // wrongly select the legacy .env branch and mutate the wrong configuration family while the
@@ -46,37 +53,7 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
     // framework dependency (the root keeps the repository-wide signal for shared tooling).
     for (const config of allConfigs) {
       const needsNextPublicHere = config === rootConfig ? needsNextPublic : requiresNextPublicWbEnv(config);
-      // `.env.local` outranks every canonical `.env.<mode>` file in EVERY cascade, so a static
-      // WB_ENV-family definition there breaks each non-matching mode (wb fails fast on the
-      // mismatch); warn regardless of the value.
-      const localContent = await fsUtil.readFileConfinedIfExists(path.resolve(config.dirPath, '.env.local'));
-      if (localContent !== undefined) {
-        const localKeys = dotenv.parse(localContent);
-        for (const keyName of ['WB_ENV', 'NEXT_PUBLIC_WB_ENV']) {
-          const value = localKeys[keyName];
-          if (typeof value === 'string' && !value.includes('$')) {
-            console.warn(
-              `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb fails fast when it mismatches the selected mode).`
-            );
-          }
-        }
-      }
       for (const mode of wbEnvModes) {
-        // Warn-only inspection of the HIGHER-precedence cascade variants the loader also reads
-        // (`.env.development` for the development cascade, `.env.<mode>.local` for every mode):
-        // a mismatched WB_ENV there overrides the canonical file's correct value, so checking
-        // the canonical file alone could even report a broken repository as correct.
-        const keyNames = needsNextPublicHere ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
-        const variantFileNames =
-          mode === 'development' ? ['.env.development', '.env.development.local'] : [`.env.${mode}.local`];
-        for (const variantFileName of variantFileNames) {
-          const variantContent = await fsUtil.readFileConfinedIfExists(path.resolve(config.dirPath, variantFileName));
-          if (variantContent === undefined) continue;
-          const definedVariantKeys = dotenv.parse(variantContent);
-          for (const keyName of keyNames) {
-            warnOnUnexpectedWbEnvValue(keyName, definedVariantKeys[keyName], mode, variantFileName);
-          }
-        }
         const envFilePath = path.resolve(config.dirPath, mode === 'development' ? '.env' : `.env.${mode}`);
         const envContent = await fsUtil.readFileConfinedIfExists(envFilePath);
         // Only existing mode files are completed: creating .env.production (never committed by
@@ -91,6 +68,42 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
       }
     }
   });
+}
+
+/**
+ * Warns on WB_ENV-family definitions in the dotenv cascade that would mislead the selected mode:
+ * `.env.local` overrides EVERY cascade (warn on any static definition), and a mode's own files
+ * (`.env` / `.env.<mode>` plus the higher-precedence `.env.development` and `.env.<mode>.local`
+ * variants) must not name a different mode. Read-only — mutation stays with the callers.
+ */
+async function warnOnMismatchedDotenvWbEnvValues(dirPath: string, needsNextPublic: boolean): Promise<void> {
+  const keyNames = needsNextPublic ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
+  const localContent = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, '.env.local'));
+  if (localContent !== undefined) {
+    const localKeys = dotenv.parse(localContent);
+    for (const keyName of keyNames) {
+      const value = localKeys[keyName];
+      if (typeof value === 'string' && !value.includes('$')) {
+        console.warn(
+          `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb fails fast when it mismatches the selected mode).`
+        );
+      }
+    }
+  }
+  for (const mode of wbEnvModes) {
+    const inspectedFileNames =
+      mode === 'development'
+        ? ['.env', '.env.development', '.env.development.local']
+        : [`.env.${mode}`, `.env.${mode}.local`];
+    for (const fileName of inspectedFileNames) {
+      const content = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, fileName));
+      if (content === undefined) continue;
+      const definedKeys = dotenv.parse(content);
+      for (const keyName of keyNames) {
+        warnOnUnexpectedWbEnvValue(keyName, definedKeys[keyName], mode, fileName);
+      }
+    }
+  }
 }
 
 /**
@@ -211,10 +224,9 @@ export function insertWbEnvIntoEnvFile(content: string, mode: WbEnvMode, needsNe
   // Detect existing keys with dotenv's parser, not a per-line regex: a quoted multiline value may
   // contain a `WB_ENV=...` LINE without defining the key, which a raw line match would treat as an
   // existing definition and skip the insertion.
+  // Mismatch WARNINGS for the dotenv cascade live in warnOnMismatchedDotenvWbEnvValues, which
+  // runs for every repository flavor; this function only completes missing definitions.
   const definedKeys = dotenv.parse(content);
-  for (const keyName of keyNames) {
-    warnOnUnexpectedWbEnvValue(keyName, definedKeys[keyName], mode, mode === 'development' ? '.env' : `.env.${mode}`);
-  }
   const missingLines = keyNames
     .filter((keyName) => definedKeys[keyName] === undefined)
     .map((keyName) => `${keyName}=${mode}`);

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -87,7 +87,9 @@ async function warnOnMismatchedDotenvWbEnvValues(dirPath: string, needsNextPubli
       // evaluated statically.
       if (typeof value === 'string' && value !== '' && !value.includes('$')) {
         console.warn(
-          `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb fails fast when it mismatches the selected mode).`
+          keyName === 'WB_ENV'
+            ? `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb fails fast when it mismatches the selected mode).`
+            : `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb overrides it with WB_ENV, but a direct framework build would inline this value).`
         );
       }
     }
@@ -193,6 +195,12 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
 function warnOnUnexpectedWbEnvValue(keyName: string, value: unknown, mode: WbEnvMode, sourceLabel: string): void {
   // An EMPTY value counts as unset (wb supplies the fallback mode), not as a mismatching mode.
   if (typeof value !== 'string' || value === '' || value === mode) return;
+  if (keyName === 'NEXT_PUBLIC_WB_ENV') {
+    console.warn(
+      `${keyName} in ${sourceLabel} is "${value}" but should be "${mode}" for the ${mode} mode; wb overrides it with WB_ENV, but a direct framework build would inline this value.`
+    );
+    return;
+  }
   // A dynamic value (e.g. `WB_ENV=${MODE}`) may legitimately resolve to the mode through wb's
   // dotenv expansion, which this static check cannot evaluate — skip instead of misfiring.
   if (value.includes('$')) return;

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -54,7 +54,10 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
     for (const config of allConfigs) {
       const needsNextPublicHere = config === rootConfig ? needsNextPublic : requiresNextPublicWbEnv(config);
       for (const mode of wbEnvModes) {
-        const envFilePath = path.resolve(config.dirPath, mode === 'development' ? '.env' : `.env.${mode}`);
+        // MODE-SPECIFIC files only — never the shared `.env`: the loader reads `.env` in EVERY
+        // cascade, so a `WB_ENV=development` written there would mask e.g. the test cascade in a
+        // repository without `.env.test` and make `wb test` fail fast on the mismatch.
+        const envFilePath = path.resolve(config.dirPath, `.env.${mode}`);
         const envContent = await fsUtil.readFileConfinedIfExists(envFilePath);
         // Only existing mode files are completed: creating .env.production (never committed by
         // convention) or a whole legacy layout from nothing is not wbfy's call.
@@ -94,18 +97,37 @@ async function warnOnMismatchedDotenvWbEnvValues(dirPath: string, needsNextPubli
       }
     }
   }
+  const baseContent = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, '.env'));
+  const baseKeys = baseContent === undefined ? {} : dotenv.parse(baseContent);
   for (const mode of wbEnvModes) {
     const inspectedFileNames =
       mode === 'development'
         ? ['.env', '.env.development', '.env.development.local']
         : [`.env.${mode}`, `.env.${mode}.local`];
+    let modeDefinesWbEnv = false;
     for (const fileName of inspectedFileNames) {
       const content = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, fileName));
       if (content === undefined) continue;
       const definedKeys = dotenv.parse(content);
+      if (fileName !== '.env' && definedKeys.WB_ENV) modeDefinesWbEnv = true;
       for (const keyName of keyNames) {
         warnOnUnexpectedWbEnvValue(keyName, definedKeys[keyName], mode, fileName);
       }
+    }
+    // The shared `.env` loads in EVERY cascade, so without a higher-precedence mode definition
+    // its WB_ENV leaks into this cascade and wb fails fast on the mismatch.
+    const baseWbEnv = baseKeys.WB_ENV;
+    if (
+      mode !== 'development' &&
+      !modeDefinesWbEnv &&
+      typeof baseWbEnv === 'string' &&
+      baseWbEnv !== '' &&
+      baseWbEnv !== mode &&
+      !baseWbEnv.includes('$')
+    ) {
+      console.warn(
+        `WB_ENV in .env is "${baseWbEnv}" and no .env.${mode} defines WB_ENV, so the ${mode} cascade would resolve "${baseWbEnv}" and wb fails fast; define WB_ENV=${mode} in .env.${mode} or remove WB_ENV from .env.`
+      );
     }
   }
 }

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -147,6 +147,9 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
  */
 function warnOnUnexpectedWbEnvValue(keyName: string, value: unknown, mode: WbEnvMode, sourceLabel: string): void {
   if (typeof value !== 'string' || value === mode) return;
+  // A dynamic value (e.g. `WB_ENV=${MODE}`) may legitimately resolve to the mode through wb's
+  // dotenv expansion, which this static check cannot evaluate — skip instead of misfiring.
+  if (value.includes('$')) return;
   console.warn(
     `${keyName} in ${sourceLabel} is "${value}" but should be "${mode}" for the ${mode} mode; wb rejects values outside development/test/staging/production.`
   );

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -106,9 +106,11 @@ async function warnOnMismatchedDotenvWbEnvValues(dirPath: string, needsNextPubli
     // definition masks the base `.env` value in the loader, and `.env.local` masks it for every
     // cascade.
     const maskedKeys = new Set(keyNames.filter((keyName) => localKeys[keyName] !== undefined));
+    let modeFileExists = false;
     for (const fileName of inspectedFileNames) {
       const content = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, fileName));
       if (content === undefined) continue;
+      if (fileName !== '.env') modeFileExists = true;
       const definedKeys = dotenv.parse(content);
       for (const keyName of keyNames) {
         if (fileName !== '.env' && definedKeys[keyName] !== undefined) maskedKeys.add(keyName);
@@ -116,6 +118,9 @@ async function warnOnMismatchedDotenvWbEnvValues(dirPath: string, needsNextPubli
       }
     }
     if (mode === 'development') continue;
+    // Staging is optional (see wbEnvModes): a repository without any staging file must not be
+    // told to create one just to silence a leak warning.
+    if (mode === 'staging' && !modeFileExists) continue;
     // The shared `.env` loads in EVERY cascade, so without a higher-precedence definition its
     // values leak into this cascade: a leaked WB_ENV makes wb fail fast on the mismatch, and a
     // leaked NEXT_PUBLIC_WB_ENV would be inlined by a direct framework build.

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -46,6 +46,21 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
     // framework dependency (the root keeps the repository-wide signal for shared tooling).
     for (const config of allConfigs) {
       const needsNextPublicHere = config === rootConfig ? needsNextPublic : requiresNextPublicWbEnv(config);
+      // `.env.local` outranks every canonical `.env.<mode>` file in EVERY cascade, so a static
+      // WB_ENV-family definition there breaks each non-matching mode (wb fails fast on the
+      // mismatch); warn regardless of the value.
+      const localContent = await fsUtil.readFileConfinedIfExists(path.resolve(config.dirPath, '.env.local'));
+      if (localContent !== undefined) {
+        const localKeys = dotenv.parse(localContent);
+        for (const keyName of ['WB_ENV', 'NEXT_PUBLIC_WB_ENV']) {
+          const value = localKeys[keyName];
+          if (typeof value === 'string' && !value.includes('$')) {
+            console.warn(
+              `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb fails fast when it mismatches the selected mode).`
+            );
+          }
+        }
+      }
       for (const mode of wbEnvModes) {
         // Warn-only inspection of the HIGHER-precedence cascade variants the loader also reads
         // (`.env.development` for the development cascade, `.env.<mode>.local` for every mode):

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -82,19 +82,17 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
 async function warnOnMismatchedDotenvWbEnvValues(dirPath: string, needsNextPublic: boolean): Promise<void> {
   const keyNames = needsNextPublic ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
   const localContent = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, '.env.local'));
-  if (localContent !== undefined) {
-    const localKeys = dotenv.parse(localContent);
-    for (const keyName of keyNames) {
-      const value = localKeys[keyName];
-      // Empty values count as unset (wb supplies the fallback), and dynamic values cannot be
-      // evaluated statically.
-      if (typeof value === 'string' && value !== '' && !value.includes('$')) {
-        console.warn(
-          keyName === 'WB_ENV'
-            ? `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb fails fast when it mismatches the selected mode).`
-            : `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb overrides it with WB_ENV, but a direct framework build would inline this value).`
-        );
-      }
+  const localKeys = localContent === undefined ? {} : dotenv.parse(localContent);
+  for (const keyName of keyNames) {
+    const value = localKeys[keyName];
+    // Empty values count as unset (wb supplies the fallback), and dynamic values cannot be
+    // evaluated statically.
+    if (typeof value === 'string' && value !== '' && !value.includes('$')) {
+      console.warn(
+        keyName === 'WB_ENV'
+          ? `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb fails fast when it mismatches the selected mode).`
+          : `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb overrides it with WB_ENV, but a direct framework build would inline this value).`
+      );
     }
   }
   const baseContent = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, '.env'));
@@ -104,29 +102,38 @@ async function warnOnMismatchedDotenvWbEnvValues(dirPath: string, needsNextPubli
       mode === 'development'
         ? ['.env', '.env.development', '.env.development.local']
         : [`.env.${mode}`, `.env.${mode}.local`];
-    let modeDefinesWbEnv = false;
+    // Presence per KEY, by definition (`!== undefined`): even an EMPTY higher-precedence
+    // definition masks the base `.env` value in the loader, and `.env.local` masks it for every
+    // cascade.
+    const maskedKeys = new Set(keyNames.filter((keyName) => localKeys[keyName] !== undefined));
     for (const fileName of inspectedFileNames) {
       const content = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, fileName));
       if (content === undefined) continue;
       const definedKeys = dotenv.parse(content);
-      if (fileName !== '.env' && definedKeys.WB_ENV) modeDefinesWbEnv = true;
       for (const keyName of keyNames) {
+        if (fileName !== '.env' && definedKeys[keyName] !== undefined) maskedKeys.add(keyName);
         warnOnUnexpectedWbEnvValue(keyName, definedKeys[keyName], mode, fileName);
       }
     }
-    // The shared `.env` loads in EVERY cascade, so without a higher-precedence mode definition
-    // its WB_ENV leaks into this cascade and wb fails fast on the mismatch.
-    const baseWbEnv = baseKeys.WB_ENV;
-    if (
-      mode !== 'development' &&
-      !modeDefinesWbEnv &&
-      typeof baseWbEnv === 'string' &&
-      baseWbEnv !== '' &&
-      baseWbEnv !== mode &&
-      !baseWbEnv.includes('$')
-    ) {
+    if (mode === 'development') continue;
+    // The shared `.env` loads in EVERY cascade, so without a higher-precedence definition its
+    // values leak into this cascade: a leaked WB_ENV makes wb fail fast on the mismatch, and a
+    // leaked NEXT_PUBLIC_WB_ENV would be inlined by a direct framework build.
+    for (const keyName of keyNames) {
+      const baseValue = baseKeys[keyName];
+      if (
+        maskedKeys.has(keyName) ||
+        typeof baseValue !== 'string' ||
+        baseValue === '' ||
+        baseValue === mode ||
+        baseValue.includes('$')
+      ) {
+        continue;
+      }
       console.warn(
-        `WB_ENV in .env is "${baseWbEnv}" and no .env.${mode} defines WB_ENV, so the ${mode} cascade would resolve "${baseWbEnv}" and wb fails fast; define WB_ENV=${mode} in .env.${mode} or remove WB_ENV from .env.`
+        keyName === 'WB_ENV'
+          ? `WB_ENV in .env is "${baseValue}" and no .env.${mode} defines WB_ENV, so the ${mode} cascade would resolve "${baseValue}" and wb fails fast; define WB_ENV=${mode} in .env.${mode} or remove WB_ENV from .env.`
+          : `NEXT_PUBLIC_WB_ENV in .env is "${baseValue}" and no .env.${mode} defines NEXT_PUBLIC_WB_ENV, so a direct framework ${mode} build would inline "${baseValue}"; define NEXT_PUBLIC_WB_ENV=${mode} in .env.${mode} (wb itself overrides it with WB_ENV).`
       );
     }
   }

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -83,7 +83,9 @@ async function warnOnMismatchedDotenvWbEnvValues(dirPath: string, needsNextPubli
     const localKeys = dotenv.parse(localContent);
     for (const keyName of keyNames) {
       const value = localKeys[keyName];
-      if (typeof value === 'string' && !value.includes('$')) {
+      // Empty values count as unset (wb supplies the fallback), and dynamic values cannot be
+      // evaluated statically.
+      if (typeof value === 'string' && value !== '' && !value.includes('$')) {
         console.warn(
           `${keyName} in .env.local is "${value}", which overrides every cascade mode; remove it (wb fails fast when it mismatches the selected mode).`
         );
@@ -189,7 +191,8 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
  * field) — encrypted fnox entries are `{ provider, value }` objects whose `default` is absent.
  */
 function warnOnUnexpectedWbEnvValue(keyName: string, value: unknown, mode: WbEnvMode, sourceLabel: string): void {
-  if (typeof value !== 'string' || value === mode) return;
+  // An EMPTY value counts as unset (wb supplies the fallback mode), not as a mismatching mode.
+  if (typeof value !== 'string' || value === '' || value === mode) return;
   // A dynamic value (e.g. `WB_ENV=${MODE}`) may legitimately resolve to the mode through wb's
   // dotenv expansion, which this static check cannot evaluate — skip instead of misfiring.
   if (value.includes('$')) return;

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -140,12 +140,13 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
 
 /**
  * Warns when an existing WB_ENV-family definition names a different mode than the one it is
- * defined for (a typo like `prodcution`, or a copy-pasted wrong mode): wb rejects non-standard
- * values at runtime, so surfacing the mismatch during wbfy is the earliest possible signal.
- * Only plaintext-looking values are checked — an age-encrypted fnox value must not misfire.
+ * defined for (a typo like `prodcution` or `production1`, or a copy-pasted wrong mode): wb
+ * rejects non-standard values at runtime, so surfacing the mismatch during wbfy is the earliest
+ * possible signal. The passed value is always plaintext (a dotenv value or a fnox `default`
+ * field) — encrypted fnox entries are `{ provider, value }` objects whose `default` is absent.
  */
 function warnOnUnexpectedWbEnvValue(keyName: string, value: unknown, mode: WbEnvMode, sourceLabel: string): void {
-  if (typeof value !== 'string' || !/^[A-Za-z-]+$/u.test(value) || value === mode) return;
+  if (typeof value !== 'string' || value === mode) return;
   console.warn(
     `${keyName} in ${sourceLabel} is "${value}" but should be "${mode}" for the ${mode} mode; wb rejects values outside development/test/staging/production.`
   );

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -47,6 +47,21 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
     for (const config of allConfigs) {
       const needsNextPublicHere = config === rootConfig ? needsNextPublic : requiresNextPublicWbEnv(config);
       for (const mode of wbEnvModes) {
+        // Warn-only inspection of the HIGHER-precedence cascade variants the loader also reads
+        // (`.env.development` for the development cascade, `.env.<mode>.local` for every mode):
+        // a mismatched WB_ENV there overrides the canonical file's correct value, so checking
+        // the canonical file alone could even report a broken repository as correct.
+        const keyNames = needsNextPublicHere ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
+        const variantFileNames =
+          mode === 'development' ? ['.env.development', '.env.development.local'] : [`.env.${mode}.local`];
+        for (const variantFileName of variantFileNames) {
+          const variantContent = await fsUtil.readFileConfinedIfExists(path.resolve(config.dirPath, variantFileName));
+          if (variantContent === undefined) continue;
+          const definedVariantKeys = dotenv.parse(variantContent);
+          for (const keyName of keyNames) {
+            warnOnUnexpectedWbEnvValue(keyName, definedVariantKeys[keyName], mode, variantFileName);
+          }
+        }
         const envFilePath = path.resolve(config.dirPath, mode === 'development' ? '.env' : `.env.${mode}`);
         const envContent = await fsUtil.readFileConfinedIfExists(envFilePath);
         // Only existing mode files are completed: creating .env.production (never committed by

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -195,15 +195,16 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
 function warnOnUnexpectedWbEnvValue(keyName: string, value: unknown, mode: WbEnvMode, sourceLabel: string): void {
   // An EMPTY value counts as unset (wb supplies the fallback mode), not as a mismatching mode.
   if (typeof value !== 'string' || value === '' || value === mode) return;
+  // A dynamic value (e.g. `NEXT_PUBLIC_WB_ENV=${WB_ENV}`) may legitimately resolve to the mode
+  // through dotenv expansion (Next.js expands $VARIABLE references in .env* files too), which
+  // this static check cannot evaluate — skip instead of misfiring.
+  if (value.includes('$')) return;
   if (keyName === 'NEXT_PUBLIC_WB_ENV') {
     console.warn(
       `${keyName} in ${sourceLabel} is "${value}" but should be "${mode}" for the ${mode} mode; wb overrides it with WB_ENV, but a direct framework build would inline this value.`
     );
     return;
   }
-  // A dynamic value (e.g. `WB_ENV=${MODE}`) may legitimately resolve to the mode through wb's
-  // dotenv expansion, which this static check cannot evaluate — skip instead of misfiring.
-  if (value.includes('$')) return;
   console.warn(
     `${keyName} in ${sourceLabel} is "${value}" but should be "${mode}" for the ${mode} mode; wb rejects values outside development/test/staging/production.`
   );

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -184,7 +184,7 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
       const defined = definedKeys?.[keyName];
       const definedValue =
         typeof defined === 'string' ? defined : (defined as { default?: unknown } | undefined)?.default;
-      warnOnUnexpectedWbEnvValue(keyName, definedValue, mode, 'fnox.toml');
+      warnOnUnexpectedWbEnvValue(keyName, definedValue, mode, 'fnox.toml', { isFnoxSource: true });
     }
     const missingLines = keyNames
       .filter((keyName) => definedKeys?.[keyName] === undefined)
@@ -226,13 +226,20 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
  * possible signal. The passed value is always plaintext (a dotenv value or a fnox `default`
  * field) — encrypted fnox entries are `{ provider, value }` objects whose `default` is absent.
  */
-function warnOnUnexpectedWbEnvValue(keyName: string, value: unknown, mode: WbEnvMode, sourceLabel: string): void {
+function warnOnUnexpectedWbEnvValue(
+  keyName: string,
+  value: unknown,
+  mode: WbEnvMode,
+  sourceLabel: string,
+  options?: { isFnoxSource?: boolean }
+): void {
   // An EMPTY value counts as unset (wb supplies the fallback mode), not as a mismatching mode.
   if (typeof value !== 'string' || value === '' || value === mode) return;
   // A dynamic value (e.g. `NEXT_PUBLIC_WB_ENV=${WB_ENV}`) may legitimately resolve to the mode
-  // through dotenv expansion (Next.js expands $VARIABLE references in .env* files too), which
-  // this static check cannot evaluate — skip instead of misfiring.
-  if (value.includes('$')) return;
+  // through expansion, which this static check cannot evaluate — skip instead of misfiring.
+  // The dynamic form depends on the source: fnox expands only `${...}` (a bare `$UNSET` stays
+  // literal), while dotenv/Next.js expansion also resolves bare `$VARIABLE` references.
+  if (options?.isFnoxSource ? value.includes('${') : value.includes('$')) return;
   if (keyName === 'NEXT_PUBLIC_WB_ENV') {
     console.warn(
       `${keyName} in ${sourceLabel} is "${value}" but should be "${mode}" for the ${mode} mode; wb overrides it with WB_ENV, but a direct framework build would inline this value.`

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -99,6 +99,12 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
     // The staging mode is optional: complete it only when the repository already declares the profile.
     if (mode === 'staging' && !settings.profiles?.staging) continue;
     const definedKeys = mode === 'development' ? settings.secrets : settings.profiles?.[mode]?.secrets;
+    for (const keyName of keyNames) {
+      const defined = definedKeys?.[keyName];
+      const definedValue =
+        typeof defined === 'string' ? defined : (defined as { default?: unknown } | undefined)?.default;
+      warnOnUnexpectedWbEnvValue(keyName, definedValue, mode, 'fnox.toml');
+    }
     const missingLines = keyNames
       .filter((keyName) => definedKeys?.[keyName] === undefined)
       .map((keyName) => `${keyName} = { default = "${mode}" }`);
@@ -133,6 +139,19 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
 }
 
 /**
+ * Warns when an existing WB_ENV-family definition names a different mode than the one it is
+ * defined for (a typo like `prodcution`, or a copy-pasted wrong mode): wb rejects non-standard
+ * values at runtime, so surfacing the mismatch during wbfy is the earliest possible signal.
+ * Only plaintext-looking values are checked — an age-encrypted fnox value must not misfire.
+ */
+function warnOnUnexpectedWbEnvValue(keyName: string, value: unknown, mode: WbEnvMode, sourceLabel: string): void {
+  if (typeof value !== 'string' || !/^[A-Za-z-]+$/u.test(value) || value === mode) return;
+  console.warn(
+    `${keyName} in ${sourceLabel} is "${value}" but should be "${mode}" for the ${mode} mode; wb rejects values outside development/test/staging/production.`
+  );
+}
+
+/**
  * Inserts lines at the top of a TOML section, right after its `[header]` line so profile-specific
  * entries stay grouped with their header; the section is appended at the end when it is absent.
  */
@@ -159,6 +178,9 @@ export function insertWbEnvIntoEnvFile(content: string, mode: WbEnvMode, needsNe
   // contain a `WB_ENV=...` LINE without defining the key, which a raw line match would treat as an
   // existing definition and skip the insertion.
   const definedKeys = dotenv.parse(content);
+  for (const keyName of keyNames) {
+    warnOnUnexpectedWbEnvValue(keyName, definedKeys[keyName], mode, mode === 'development' ? '.env' : `.env.${mode}`);
+  }
   const missingLines = keyNames
     .filter((keyName) => definedKeys[keyName] === undefined)
     .map((keyName) => `${keyName}=${mode}`);

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -26,19 +26,23 @@ type WbEnvMode = (typeof wbEnvModes)[number];
 export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfigs: PackageConfig[]): Promise<void> {
   return logger.functionIgnoringException('ensureWbEnvDefinitions', async () => {
     const needsNextPublic = allConfigs.some((config) => requiresNextPublicWbEnv(config));
-    // Warning-only dotenv inspection for EVERY repository flavor, before any mutation: dotenv
-    // values win over fnox at load time, so a leftover mismatched .env* silently overrides even
-    // a correct fnox profile.
-    for (const config of allConfigs) {
-      const needsNextPublicHere = config === rootConfig ? needsNextPublic : requiresNextPublicWbEnv(config);
-      await warnOnMismatchedDotenvWbEnvValues(config.dirPath, needsNextPublicHere);
-    }
+    // Warning-only dotenv inspection runs for EVERY repository flavor: dotenv values win over
+    // fnox at load time, so a leftover mismatched .env* silently overrides even a correct fnox
+    // profile. In legacy repositories it runs AFTER the mode-file completion below, so a gap the
+    // same run fixes is not reported as a stale fail-fast warning.
+    const warnOnDotenvMismatches = async (): Promise<void> => {
+      for (const config of allConfigs) {
+        const needsNextPublicHere = config === rootConfig ? needsNextPublic : requiresNextPublicWbEnv(config);
+        await warnOnMismatchedDotenvWbEnvValues(config.dirPath, needsNextPublicHere);
+      }
+    };
     const fnoxTomlPath = path.resolve(rootConfig.dirPath, 'fnox.toml');
     // lstat, not existsSync: existsSync is false for a DANGLING fnox.toml symlink, which would
     // wrongly select the legacy .env branch and mutate the wrong configuration family while the
     // fnox synchronization is failing. Any fnox.toml directory entry marks a fnox repository;
     // a refused/dangling one aborts instead of falling back.
     if (await fs.promises.lstat(fnoxTomlPath).catch(() => {})) {
+      await warnOnDotenvMismatches();
       const content = await fsUtil.readFileConfinedIfExists(fnoxTomlPath);
       if (content === undefined) return;
       const updatedContent = insertWbEnvIntoFnoxToml(content, needsNextPublic);
@@ -70,6 +74,7 @@ export async function ensureWbEnvDefinitions(rootConfig: PackageConfig, allConfi
         }
       }
     }
+    await warnOnDotenvMismatches();
   });
 }
 

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -234,9 +234,17 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
     await promisePool.run(() => fsUtil.removeConfined(semanticYmlPath, { recursive: true }));
 
     const entries = await fs.promises.readdir(workflowsPath, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isFile() || !isObsoleteGenPrWorkflow(workflowsPath, entry.name)) continue;
-      await promisePool.run(() => fsUtil.removeConfined(path.join(workflowsPath, entry.name)));
+    // Decide obsolescence once (the content check reads each file) and AWAIT the deletions:
+    // promisePool.run resolves when a task enters the pool, not when it completes, so a pooled
+    // deletion could race the regeneration below on the same path (e.g. a `test.yml` whose only
+    // job called the retired gen-pr workflow would be merged with its stale on-disk content).
+    const obsoleteGenPrFileNames = new Set(
+      entries
+        .filter((entry) => entry.isFile() && isObsoleteGenPrWorkflow(workflowsPath, entry.name))
+        .map((entry) => entry.name)
+    );
+    for (const fileName of obsoleteGenPrFileNames) {
+      await fsUtil.removeConfined(path.join(workflowsPath, fileName));
     }
     // GitHub accepts both .yml and .yaml workflow files, and a workflow's file name is its public
     // identity (badge URLs, the workflow REST API, same-repository `uses:` references), so .yaml
@@ -245,8 +253,7 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
     // the .yaml twin is left untouched, since merging two workflow definitions is ambiguous.
     const fileNamesByKind = new Map<string, string>();
     for (const entry of entries) {
-      if (!entry.isFile() || !/\.ya?ml$/u.test(entry.name) || isObsoleteGenPrWorkflow(workflowsPath, entry.name))
-        continue;
+      if (!entry.isFile() || !/\.ya?ml$/u.test(entry.name) || obsoleteGenPrFileNames.has(entry.name)) continue;
       const kind = entry.name.replace(/\.ya?ml$/u, '');
       const existingFileName = fileNamesByKind.get(kind);
       if (existingFileName === undefined || existingFileName.endsWith('.yaml')) {
@@ -345,7 +352,9 @@ export function isObsoleteGenPrWorkflow(workflowsPath: string, fileName: string)
   } catch {
     return false;
   }
-  const genPrCallPattern = /\/reusable-workflows\/\.github\/workflows\/gen-pr\.ya?ml@/u;
+  // Owner-restricted: only WillBooster's own reusable gen-pr workflow was retired, so a caller of
+  // some other organization's same-named workflow must not be deleted.
+  const genPrCallPattern = /^(?:WillBooster|WillBoosterLab)\/reusable-workflows\/\.github\/workflows\/gen-pr\.ya?ml@/u;
   try {
     const workflow = yaml.load(content) as Workflow | undefined;
     if (workflow && typeof workflow === 'object' && workflow.jobs && typeof workflow.jobs === 'object') {

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -211,6 +211,23 @@ const workflows = {
 
 type KnownKind = keyof typeof workflows | 'deploy' | 'autofix';
 
+/**
+ * Parses a `uses:` value calling one of WillBooster's own reusable workflows (or the
+ * WillBoosterLab sync mirror) into the workflow name (without extension) and git ref. Only those
+ * follow the contract wbfy enforces — callers of another organization's same-named repository are
+ * left alone. GitHub treats owner/repository names case-insensitively, so the comparison does
+ * too, while the workflow path and ref stay case-sensitive.
+ */
+function parseOrgReusableWorkflowCall(uses: string | undefined): { workflowName: string; ref: string } | undefined {
+  const match = /^([^/]+)\/([^/]+)\/\.github\/workflows\/([^/@]+?)\.ya?ml@(.+)$/u.exec(uses ?? '');
+  if (!match) return undefined;
+  const owner = match[1]!.toLowerCase();
+  if ((owner !== 'willbooster' && owner !== 'willboosterlab') || match[2]!.toLowerCase() !== 'reusable-workflows') {
+    return undefined;
+  }
+  return { workflowName: match[3]!, ref: match[4]! };
+}
+
 export async function generateWorkflows(rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateWorkflow', async () => {
     if (isReusableWorkflowsRepo(rootConfig.repository)) {
@@ -354,12 +371,13 @@ export function isObsoleteGenPrWorkflow(workflowsPath: string, fileName: string)
   }
   // Owner-restricted: only WillBooster's own reusable gen-pr workflow was retired, so a caller of
   // some other organization's same-named workflow must not be deleted.
-  const genPrCallPattern = /^(?:WillBooster|WillBoosterLab)\/reusable-workflows\/\.github\/workflows\/gen-pr\.ya?ml@/u;
+  const isGenPrCall = (uses: unknown): boolean =>
+    typeof uses === 'string' && parseOrgReusableWorkflowCall(uses)?.workflowName === 'gen-pr';
   try {
     const workflow = yaml.load(content) as Workflow | undefined;
     if (workflow && typeof workflow === 'object' && workflow.jobs && typeof workflow.jobs === 'object') {
       const jobs = Object.values(workflow.jobs);
-      return jobs.length > 0 && jobs.every((job) => typeof job?.uses === 'string' && genPrCallPattern.test(job.uses));
+      return jobs.length > 0 && jobs.every((job) => isGenPrCall(job?.uses));
     }
   } catch {
     // Fall through to the filename-only decision above.
@@ -455,8 +473,10 @@ async function writeWorkflowYaml(
 
   let isReusableWorkflow = false;
   for (const job of Object.values(newSettings.jobs)) {
-    // Ignore non-reusable workflows
-    if (!job.uses?.includes('/reusable-workflows/')) continue;
+    // Ignore non-reusable workflows and other organizations' reusable workflows: a same-named
+    // `reusable-workflows` repository elsewhere follows a different contract, and normalizing its
+    // callers (secret injection/removal, permissions) could break them.
+    if (!parseOrgReusableWorkflowCall(job.uses)) continue;
 
     normalizeJob(config, job, kind);
     isReusableWorkflow = true;
@@ -472,7 +492,8 @@ async function writeWorkflowYaml(
   // because arbitrary package scripts may push commits.
   if (!newSettings.permissions) {
     for (const job of Object.values(newSettings.jobs)) {
-      if (!job.permissions && /\/reusable-workflows\/\.github\/workflows\/deploy\.ya?ml@main$/u.test(job.uses ?? '')) {
+      const call = parseOrgReusableWorkflowCall(job.uses);
+      if (!job.permissions && call?.workflowName === 'deploy' && call.ref === 'main') {
         job.permissions = { contents: 'read' };
       }
     }
@@ -675,9 +696,8 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   // older tag or SHA may still declare NPM_TOKEN (and not VERDACCIO_TOKEN), and GitHub rejects a
   // caller whose secrets do not match the selected revision's declarations, so pinned callers keep
   // their secrets untouched.
-  const calledReusableWorkflow = /\/reusable-workflows\/\.github\/workflows\/([^/@]+?)\.ya?ml@main$/u.exec(
-    job.uses ?? ''
-  )?.[1];
+  const orgWorkflowCall = parseOrgReusableWorkflowCall(job.uses);
+  const calledReusableWorkflow = orgWorkflowCall?.ref === 'main' ? orgWorkflowCall.workflowName : undefined;
   if (secrets && calledReusableWorkflow && installCapableReusableWorkflows.has(calledReusableWorkflow)) {
     // The callee generates the workspace .npmrc for @willbooster-private/* from VERDACCIO_TOKEN
     // before installing dependencies, which every repository needs regardless of its fnox

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -437,7 +437,8 @@ async function writeWorkflowYaml(
   if (kind === 'test-rust') {
     // Migrate hand-written Rust workflows (e.g. an inline cargo-check job) to the reusable workflow.
     for (const [jobName, job] of Object.entries(newSettings.jobs)) {
-      if (!job.uses?.includes('/reusable-workflows/')) {
+      // A job written as `jobName:` with no body parses as null.
+      if (!job?.uses?.includes('/reusable-workflows/')) {
         delete newSettings.jobs[jobName];
       }
     }
@@ -473,10 +474,11 @@ async function writeWorkflowYaml(
 
   let isReusableWorkflow = false;
   for (const job of Object.values(newSettings.jobs)) {
-    // Ignore non-reusable workflows and other organizations' reusable workflows: a same-named
-    // `reusable-workflows` repository elsewhere follows a different contract, and normalizing its
-    // callers (secret injection/removal, permissions) could break them.
-    if (!parseOrgReusableWorkflowCall(job.uses)) continue;
+    // Ignore empty jobs (a bare `jobName:` parses as null), non-reusable workflows, and other
+    // organizations' reusable workflows: a same-named `reusable-workflows` repository elsewhere
+    // follows a different contract, and normalizing its callers (secret injection/removal,
+    // permissions) could break them.
+    if (!job || !parseOrgReusableWorkflowCall(job.uses)) continue;
 
     normalizeJob(config, job, kind);
     isReusableWorkflow = true;
@@ -492,6 +494,7 @@ async function writeWorkflowYaml(
   // because arbitrary package scripts may push commits.
   if (!newSettings.permissions) {
     for (const job of Object.values(newSettings.jobs)) {
+      if (!job) continue;
       const call = parseOrgReusableWorkflowCall(job.uses);
       if (!job.permissions && call?.workflowName === 'deploy' && call.ref === 'main') {
         job.permissions = { contents: 'read' };
@@ -742,10 +745,12 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
     }
   }
 
-  if (config.repository?.startsWith('github:WillBooster/')) {
-    job.uses = job.uses?.replace('WillBoosterLab/', 'WillBooster/');
-  } else if (config.repository?.startsWith('github:WillBoosterLab/')) {
-    job.uses = job.uses?.replace('WillBooster/', 'WillBoosterLab/');
+  // Reconstruct from the parsed call so a differently cased owner (GitHub is case-insensitive
+  // there) is also normalized to the repository's own organization / mirror.
+  if (orgWorkflowCall && config.repository?.startsWith('github:WillBooster/')) {
+    job.uses = `WillBooster/reusable-workflows/.github/workflows/${orgWorkflowCall.workflowName}.yml@${orgWorkflowCall.ref}`;
+  } else if (orgWorkflowCall && config.repository?.startsWith('github:WillBoosterLab/')) {
+    job.uses = `WillBoosterLab/reusable-workflows/.github/workflows/${orgWorkflowCall.workflowName}.yml@${orgWorkflowCall.ref}`;
   }
 
   // Remove redundant parameters

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -218,14 +218,16 @@ type KnownKind = keyof typeof workflows | 'deploy' | 'autofix';
  * left alone. GitHub treats owner/repository names case-insensitively, so the comparison does
  * too, while the workflow path and ref stay case-sensitive.
  */
-function parseOrgReusableWorkflowCall(uses: string | undefined): { workflowName: string; ref: string } | undefined {
-  const match = /^([^/]+)\/([^/]+)\/\.github\/workflows\/([^/@]+?)\.ya?ml@(.+)$/u.exec(uses ?? '');
+function parseOrgReusableWorkflowCall(
+  uses: string | undefined
+): { workflowName: string; extension: string; ref: string } | undefined {
+  const match = /^([^/]+)\/([^/]+)\/\.github\/workflows\/([^/@]+?)\.(ya?ml)@(.+)$/u.exec(uses ?? '');
   if (!match) return undefined;
   const owner = match[1]!.toLowerCase();
   if ((owner !== 'willbooster' && owner !== 'willboosterlab') || match[2]!.toLowerCase() !== 'reusable-workflows') {
     return undefined;
   }
-  return { workflowName: match[3]!, ref: match[4]! };
+  return { workflowName: match[3]!, extension: match[4]!, ref: match[5]! };
 }
 
 export async function generateWorkflows(rootConfig: PackageConfig): Promise<void> {
@@ -748,9 +750,9 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   // Reconstruct from the parsed call so a differently cased owner (GitHub is case-insensitive
   // there) is also normalized to the repository's own organization / mirror.
   if (orgWorkflowCall && config.repository?.startsWith('github:WillBooster/')) {
-    job.uses = `WillBooster/reusable-workflows/.github/workflows/${orgWorkflowCall.workflowName}.yml@${orgWorkflowCall.ref}`;
+    job.uses = `WillBooster/reusable-workflows/.github/workflows/${orgWorkflowCall.workflowName}.${orgWorkflowCall.extension}@${orgWorkflowCall.ref}`;
   } else if (orgWorkflowCall && config.repository?.startsWith('github:WillBoosterLab/')) {
-    job.uses = `WillBoosterLab/reusable-workflows/.github/workflows/${orgWorkflowCall.workflowName}.yml@${orgWorkflowCall.ref}`;
+    job.uses = `WillBoosterLab/reusable-workflows/.github/workflows/${orgWorkflowCall.workflowName}.${orgWorkflowCall.extension}@${orgWorkflowCall.ref}`;
   }
 
   // Remove redundant parameters

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -235,7 +235,7 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
 
     const entries = await fs.promises.readdir(workflowsPath, { withFileTypes: true });
     for (const entry of entries) {
-      if (!entry.isFile() || !isObsoleteGenPrWorkflowFileName(entry.name)) continue;
+      if (!entry.isFile() || !isObsoleteGenPrWorkflow(workflowsPath, entry.name)) continue;
       await promisePool.run(() => fsUtil.removeConfined(path.join(workflowsPath, entry.name)));
     }
     // GitHub accepts both .yml and .yaml workflow files, and a workflow's file name is its public
@@ -245,7 +245,8 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
     // the .yaml twin is left untouched, since merging two workflow definitions is ambiguous.
     const fileNamesByKind = new Map<string, string>();
     for (const entry of entries) {
-      if (!entry.isFile() || !/\.ya?ml$/u.test(entry.name) || isObsoleteGenPrWorkflowFileName(entry.name)) continue;
+      if (!entry.isFile() || !/\.ya?ml$/u.test(entry.name) || isObsoleteGenPrWorkflow(workflowsPath, entry.name))
+        continue;
       const kind = entry.name.replace(/\.ya?ml$/u, '');
       const existingFileName = fileNamesByKind.get(kind);
       if (existingFileName === undefined || existingFileName.endsWith('.yaml')) {
@@ -329,8 +330,32 @@ export function isReusableWorkflowsRepo(repository?: string): boolean {
   return repository?.endsWith('/reusable-workflows') ?? false;
 }
 
-function isObsoleteGenPrWorkflowFileName(fileName: string): boolean {
-  return /^gen-pr(?:-.+)?\.ya?ml$/u.test(fileName);
+/**
+ * The gen-pr workflow family is retired (the reusable gen-pr.yml no longer exists), so wbfy
+ * removes its callers: any `gen-pr*.yml` file, plus a file under another name whose jobs ALL call
+ * the reusable gen-pr workflow. Mixed files keep their other jobs, and unparsable files are only
+ * matched by filename — deleting a whole workflow on a text match would be too aggressive.
+ */
+export function isObsoleteGenPrWorkflow(workflowsPath: string, fileName: string): boolean {
+  if (/^gen-pr(?:-.+)?\.ya?ml$/u.test(fileName)) return true;
+  if (!/\.ya?ml$/u.test(fileName)) return false;
+  let content: string;
+  try {
+    content = fs.readFileSync(path.join(workflowsPath, fileName), 'utf8');
+  } catch {
+    return false;
+  }
+  const genPrCallPattern = /\/reusable-workflows\/\.github\/workflows\/gen-pr\.ya?ml@/u;
+  try {
+    const workflow = yaml.load(content) as Workflow | undefined;
+    if (workflow && typeof workflow === 'object' && workflow.jobs && typeof workflow.jobs === 'object') {
+      const jobs = Object.values(workflow.jobs);
+      return jobs.length > 0 && jobs.every((job) => typeof job?.uses === 'string' && genPrCallPattern.test(job.uses));
+    }
+  } catch {
+    // Fall through to the filename-only decision above.
+  }
+  return false;
 }
 
 async function writeWorkflowYaml(
@@ -618,7 +643,7 @@ function readProductionCustomDomain(rootDirPath: string, workerDirPath: string):
 // The reusable workflows that declare FNOX_AGE_KEY and VERDACCIO_TOKEN under
 // on.workflow_call.secrets (see WillBooster/reusable-workflows). Passing either secret to any
 // other callee is a GitHub error.
-const installCapableReusableWorkflows = new Set(['autofix', 'deploy', 'gen-pr', 'release', 'run-script', 'test']);
+const installCapableReusableWorkflows = new Set(['autofix', 'deploy', 'release', 'run-script', 'test']);
 
 function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   job.with ??= {};

--- a/packages/wbfy/test/genPrWorkflowCleanup.test.ts
+++ b/packages/wbfy/test/genPrWorkflowCleanup.test.ts
@@ -37,6 +37,18 @@ jobs:
   expect(isObsoleteGenPrWorkflow(workflowsPath, 'ai.yml')).toBe(true);
 });
 
+test('detects a caller with differently cased owner/repository (GitHub is case-insensitive there)', () => {
+  writeWorkflow(
+    'cased.yml',
+    `on: issues
+jobs:
+  gen-pr:
+    uses: willbooster/Reusable-Workflows/.github/workflows/gen-pr.yml@main
+`
+  );
+  expect(isObsoleteGenPrWorkflow(workflowsPath, 'cased.yml')).toBe(true);
+});
+
 test('detects a WillBoosterLab mirror caller', () => {
   writeWorkflow(
     'lab.yml',

--- a/packages/wbfy/test/genPrWorkflowCleanup.test.ts
+++ b/packages/wbfy/test/genPrWorkflowCleanup.test.ts
@@ -37,6 +37,30 @@ jobs:
   expect(isObsoleteGenPrWorkflow(workflowsPath, 'ai.yml')).toBe(true);
 });
 
+test('detects a WillBoosterLab mirror caller', () => {
+  writeWorkflow(
+    'lab.yml',
+    `on: issues
+jobs:
+  gen-pr:
+    uses: WillBoosterLab/reusable-workflows/.github/workflows/gen-pr.yml@main
+`
+  );
+  expect(isObsoleteGenPrWorkflow(workflowsPath, 'lab.yml')).toBe(true);
+});
+
+test("keeps a caller of another organization's gen-pr workflow", () => {
+  writeWorkflow(
+    'other-org.yml',
+    `on: issues
+jobs:
+  gen-pr:
+    uses: ExampleOrg/reusable-workflows/.github/workflows/gen-pr.yml@v1
+`
+  );
+  expect(isObsoleteGenPrWorkflow(workflowsPath, 'other-org.yml')).toBe(false);
+});
+
 test('keeps a mixed workflow whose other jobs do not call gen-pr', () => {
   writeWorkflow(
     'mixed.yml',

--- a/packages/wbfy/test/genPrWorkflowCleanup.test.ts
+++ b/packages/wbfy/test/genPrWorkflowCleanup.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, expect, test } from 'vitest';
+
+import { isObsoleteGenPrWorkflow } from '../src/generators/workflow.js';
+
+let workflowsPath: string;
+
+beforeEach(async () => {
+  workflowsPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wbfy-gen-pr-'));
+});
+
+afterEach(async () => {
+  await fs.promises.rm(workflowsPath, { recursive: true, force: true });
+});
+
+function writeWorkflow(fileName: string, content: string): void {
+  fs.writeFileSync(path.join(workflowsPath, fileName), content);
+}
+
+test.each(['gen-pr.yml', 'gen-pr.yaml', 'gen-pr-claude.yml'])('detects %s by filename', (fileName) => {
+  expect(isObsoleteGenPrWorkflow(workflowsPath, fileName)).toBe(true);
+});
+
+test('detects a caller of the reusable gen-pr workflow under another filename', () => {
+  writeWorkflow(
+    'ai.yml',
+    `on: issues
+jobs:
+  gen-pr:
+    uses: WillBooster/reusable-workflows/.github/workflows/gen-pr.yml@main
+    secrets: inherit
+`
+  );
+  expect(isObsoleteGenPrWorkflow(workflowsPath, 'ai.yml')).toBe(true);
+});
+
+test('keeps a mixed workflow whose other jobs do not call gen-pr', () => {
+  writeWorkflow(
+    'mixed.yml',
+    `on: issues
+jobs:
+  gen-pr:
+    uses: WillBooster/reusable-workflows/.github/workflows/gen-pr.yml@main
+  test:
+    uses: WillBooster/reusable-workflows/.github/workflows/test.yml@main
+`
+  );
+  expect(isObsoleteGenPrWorkflow(workflowsPath, 'mixed.yml')).toBe(false);
+});
+
+test('keeps unrelated and unparsable workflows', () => {
+  writeWorkflow(
+    'test.yml',
+    `on: push
+jobs:
+  test:
+    uses: WillBooster/reusable-workflows/.github/workflows/test.yml@main
+`
+  );
+  // The reusable path appears only in a comment of an unparsable file; a text match must not delete it.
+  writeWorkflow('broken.yml', '# WillBooster/reusable-workflows/.github/workflows/gen-pr.yml@main\njobs: [invalid\n');
+  expect(isObsoleteGenPrWorkflow(workflowsPath, 'test.yml')).toBe(false);
+  expect(isObsoleteGenPrWorkflow(workflowsPath, 'broken.yml')).toBe(false);
+  expect(isObsoleteGenPrWorkflow(workflowsPath, 'missing.yml')).toBe(false);
+});

--- a/packages/wbfy/test/wbEnv.test.ts
+++ b/packages/wbfy/test/wbEnv.test.ts
@@ -114,10 +114,13 @@ test('ensureWbEnvDefinitions updates existing legacy mode files only', async () 
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-wbenv-'));
   try {
     fs.writeFileSync(path.join(tempDirPath, '.env'), 'PORT=3000\n');
+    fs.writeFileSync(path.join(tempDirPath, '.env.development'), 'DEBUG=1\n');
     fs.writeFileSync(path.join(tempDirPath, '.env.test'), '');
     const rootConfig = createConfig({ dirPath: tempDirPath, isRoot: true });
     await ensureWbEnvDefinitions(rootConfig, [rootConfig]);
-    expect(fs.readFileSync(path.join(tempDirPath, '.env'), 'utf8')).toBe('PORT=3000\nWB_ENV=development\n');
+    // The shared `.env` loads in EVERY cascade, so wbfy never writes a mode value into it.
+    expect(fs.readFileSync(path.join(tempDirPath, '.env'), 'utf8')).toBe('PORT=3000\n');
+    expect(fs.readFileSync(path.join(tempDirPath, '.env.development'), 'utf8')).toBe('DEBUG=1\nWB_ENV=development\n');
     expect(fs.readFileSync(path.join(tempDirPath, '.env.test'), 'utf8')).toBe('WB_ENV=test\n');
     expect(fs.existsSync(path.join(tempDirPath, '.env.production'))).toBe(false);
     expect(fs.existsSync(path.join(tempDirPath, '.env.staging'))).toBe(false);

--- a/packages/wbfy/test/wbEnv.test.ts
+++ b/packages/wbfy/test/wbEnv.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { parse } from 'smol-toml';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { ensureWbEnvDefinitions, insertWbEnvIntoEnvFile, insertWbEnvIntoFnoxToml } from '../src/generators/wbEnv.js';
 
@@ -122,6 +122,27 @@ test('ensureWbEnvDefinitions updates existing legacy mode files only', async () 
     expect(fs.existsSync(path.join(tempDirPath, '.env.production'))).toBe(false);
     expect(fs.existsSync(path.join(tempDirPath, '.env.staging'))).toBe(false);
   } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('ensureWbEnvDefinitions warns on mismatched WB_ENV in higher-precedence cascade variants', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-wbenv-'));
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    fs.writeFileSync(path.join(tempDirPath, '.env'), 'WB_ENV=development\n');
+    fs.writeFileSync(path.join(tempDirPath, '.env.development'), 'WB_ENV=production\n');
+    fs.writeFileSync(path.join(tempDirPath, '.env.production'), 'WB_ENV=production\n');
+    fs.writeFileSync(path.join(tempDirPath, '.env.production.local'), 'WB_ENV=development\n');
+    const rootConfig = createConfig({ dirPath: tempDirPath, isRoot: true });
+    await ensureWbEnvDefinitions(rootConfig, [rootConfig]);
+    const warnings = warnSpy.mock.calls.map(([message]) => String(message));
+    expect(warnings.some((message) => message.includes('.env.development'))).toBe(true);
+    expect(warnings.some((message) => message.includes('.env.production.local'))).toBe(true);
+    // The canonical files hold correct values and must not be warned about.
+    expect(warnings.some((message) => message.includes('"production"') && message.includes(' .env '))).toBe(false);
+  } finally {
+    warnSpy.mockRestore();
     fs.rmSync(tempDirPath, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

Reworks WB_ENV handling to be "lenient locally, strict on CI, validated everywhere", and retires the gen-pr workflow family (companion PRs: WillBooster/reusable-workflows#454, WillBooster/agentic-workflows#386).

### wb / shared-lib-node
- Locally, an unset `WB_ENV` falls back to the selected cascade mode — `development` by default, `test` for `wb test` (including under explicit env flags via an internal command-level default) — so casual `bun wb ...` invocations work without any env source. The fallback is centralized in `resolveFallbackWbEnv` and also drives `${WB_ENV}` dotenv expansion (with a pristine-reference retry when the expansion itself empties the value).
- On CI, `WB_ENV` must be EXPORTED by the workflow (a committed base default no longer satisfies the check).
- The resolved value must name a standard mode (`development`/`test`/`staging`/`production`), and it must AGREE with the selected mode — forced (`--cascade-env`/`--cascade-node-env`/exported) or auto-selected — so a mode file can no longer silently run one environment's sources labeled as another. `WB_SKIP_ENV_CHECK=1` skips all checks.
- `NEXT_PUBLIC_WB_ENV` is derived from / overridden with `WB_ENV` for Next.js/vinext apps instead of being required.
- Both `wb dotenv` implementations (TypeScript and the published fast path) validate the exported and final effective values after applying sources, honoring a file-defined `WB_SKIP_ENV_CHECK`.

### wbfy
- Deletes retired gen-pr callers: `gen-pr*.yml` files plus files whose jobs ALL call the retired reusable workflow (owner-restricted to WillBooster/WillBoosterLab, case-insensitively; deletions awaited so mandatory filenames regenerate cleanly; `.yml`/`.yaml` extensions preserved).
- Never writes a mode-specific `WB_ENV` into the shared `.env` (mode values go to `.env.<mode>`; the shared file loads in EVERY cascade).
- Warning-only dotenv inspection for every repository flavor: mismatched values in canonical/mode-variant files, `.env.local` overrides, and base-`.env` leakage into unmasked cascades — per key, source-syntax-aware for dynamic values, empty-as-unset, staging opt-in, and run after legacy completion so self-fixed gaps are not warned about.
- Caller normalization (secret injection/removal, deploy permissions, org rewriting) is restricted to WillBooster's own reusable workflows and guards null jobs.

## Breaking changes

- wb exits with an error when `WB_ENV` is not exported on CI (with env sources present), names a non-standard value, or disagrees with the selected mode.
- wbfy no longer writes `WB_ENV=development` into the shared `.env`.

Multi-agent review (Codex / Claude Code / Antigravity) ran for 17 rounds and converged with no remaining findings; all runtime claims were verified by tests or focused reproductions (`bun verify-full` green throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
