### PR TITLE
fix: resolve open wb/wbfy issues (#997, #998, #1000, #1002, #1003, #1004, #1005, #1006)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -173,6 +173,7 @@
         "jsonc-parser": "3.3.1",
         "kill-port": "2.0.1",
         "minimal-promise-pool": "6.0.2",
+        "semver": "7.8.5",
         "yargs": "18.0.0",
       },
       "devDependencies": {
@@ -186,6 +187,7 @@
         "@types/bun": "1.3.14",
         "@types/kill-port": "2.0.3",
         "@types/node": "25.6.0",
+        "@types/semver": "7.7.1",
         "@types/yargs": "17.0.35",
         "@willbooster/oxfmt-config": "1.2.2",
         "@willbooster/oxlint-config": "1.4.8",
@@ -2881,7 +2883,7 @@
 
     "semantic-release": ["semantic-release@25.0.3", "", { "dependencies": { "@semantic-release/commit-analyzer": "^13.0.1", "@semantic-release/error": "^4.0.0", "@semantic-release/github": "^12.0.0", "@semantic-release/npm": "^13.1.1", "@semantic-release/release-notes-generator": "^14.1.0", "aggregate-error": "^5.0.0", "cosmiconfig": "^9.0.0", "debug": "^4.0.0", "env-ci": "^11.0.0", "execa": "^9.0.0", "figures": "^6.0.0", "find-versions": "^6.0.0", "get-stream": "^6.0.0", "git-log-parser": "^1.2.0", "hook-std": "^4.0.0", "hosted-git-info": "^9.0.0", "import-from-esm": "^2.0.0", "lodash-es": "^4.17.21", "marked": "^15.0.0", "marked-terminal": "^7.3.0", "micromatch": "^4.0.2", "p-each-series": "^3.0.0", "p-reduce": "^3.0.0", "read-package-up": "^12.0.0", "resolve-from": "^5.0.0", "semver": "^7.3.2", "signale": "^1.2.1", "yargs": "^18.0.0" }, "bin": { "semantic-release": "bin/semantic-release.js" } }, "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA=="],
 
-    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
 
@@ -3337,6 +3339,8 @@
 
     "@actions/http-client/undici": ["undici@6.27.0", "", {}, "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg=="],
 
+    "@anolilab/multi-semantic-release/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
@@ -3352,6 +3356,8 @@
     "@babel/helper-create-regexp-features-plugin/@babel/core": ["@babel/core@8.0.1", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-compilation-targets": "^8.0.0", "@babel/helpers": "^8.0.0", "@babel/parser": "^8.0.0", "@babel/template": "^8.0.0", "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0", "@types/gensync": "^1.0.5", "convert-source-map": "^2.0.0", "empathic": "^2.0.1", "gensync": "^1.0.0-beta.2", "import-meta-resolve": "^4.2.0", "json5": "^2.2.3", "obug": "^2.1.1", "semver": "^7.7.3" } }, "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw=="],
 
     "@babel/helper-create-regexp-features-plugin/@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@8.0.0", "", { "dependencies": { "@babel/types": "^8.0.0" } }, "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw=="],
+
+    "@babel/helper-create-regexp-features-plugin/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@8.0.0", "", { "dependencies": { "@babel/compat-data": "^8.0.0", "@babel/helper-validator-option": "^8.0.0", "browserslist": "^4.24.0", "lru-cache": "^11.0.0", "semver": "^7.7.3" } }, "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew=="],
 
@@ -3701,6 +3707,8 @@
 
     "@babel/preset-env/@babel/plugin-transform-template-literals": ["@babel/plugin-transform-template-literals@8.0.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^8.0.1" }, "peerDependencies": { "@babel/core": "^8.0.0" } }, "sha512-JXvtj5+BJA9Qv3prDzW2z2DkGTJNmG0BObTdUD03STiu1Jr4fNQkQy3hYZgPL46a2RjcuhwBMYf49BOuJ98gnA=="],
 
+    "@babel/preset-env/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/preset-flow/@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
 
     "@babel/preset-modules/@babel/core": ["@babel/core@8.0.1", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-compilation-targets": "^8.0.0", "@babel/helpers": "^8.0.0", "@babel/parser": "^8.0.0", "@babel/template": "^8.0.0", "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0", "@types/gensync": "^1.0.5", "convert-source-map": "^2.0.0", "empathic": "^2.0.1", "gensync": "^1.0.0-beta.2", "import-meta-resolve": "^4.2.0", "json5": "^2.2.3", "obug": "^2.1.1", "semver": "^7.7.3" } }, "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw=="],
@@ -3743,8 +3751,6 @@
 
     "@jest/types/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "@npmcli/fs/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
-
     "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
@@ -3754,6 +3760,8 @@
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
     "@semantic-release/npm/fs-extra": ["fs-extra@11.3.6", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA=="],
+
+    "@semantic-release/npm/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@semantic-release/release-notes-generator/read-package-up": ["read-package-up@11.0.0", "", { "dependencies": { "find-up-simple": "^1.0.0", "read-pkg": "^9.0.0", "type-fest": "^4.6.0" } }, "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ=="],
 
@@ -3778,8 +3786,6 @@
     "@storybook/core/esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
 
     "@storybook/core/recast": ["recast@0.23.12", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA=="],
-
-    "@storybook/core/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "@storybook/core/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
@@ -3871,6 +3877,8 @@
 
     "@willbooster/wbfy/@willbooster/wb": ["@willbooster/wb@14.1.0", "", { "dependencies": { "chalk": "5.6.2", "dotenv": "17.4.2", "dotenv-expand": "13.0.0", "fastest-levenshtein": "1.0.16", "globby": "16.2.0", "jsonc-parser": "3.3.1", "kill-port": "2.0.1", "minimal-promise-pool": "6.0.2", "yargs": "18.0.0" }, "bin": { "wb": "bin/index.js" } }, "sha512-xlTq73bu3qT83zLO7VP0y5y1uMMZQTrPcNTykpcGGDHz0T8Rp5iAf4veDimylFFl/gsnxUgyHqqZGzDvEamyUg=="],
 
+    "@willbooster/wbfy/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -3959,6 +3967,8 @@
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
 
+    "conventional-changelog-writer/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "copy-concurrently/aproba": ["aproba@1.2.0", "", {}, "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="],
 
     "copy-concurrently/mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
@@ -4032,6 +4042,8 @@
     "gauge/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "gauge/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "global-agent/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "global-prefix/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
@@ -4140,6 +4152,8 @@
     "node-libs-browser/buffer": ["buffer@4.9.2", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4", "isarray": "^1.0.0" } }, "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg=="],
 
     "node-libs-browser/util": ["util@0.11.1", "", { "dependencies": { "inherits": "2.0.3" } }, "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ=="],
+
+    "normalize-package-data/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "npm/@gar/promise-retry": ["@gar/promise-retry@1.0.3", "", {}, "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA=="],
 
@@ -4459,6 +4473,8 @@
 
     "postcss-loader/schema-utils": ["schema-utils@3.3.0", "", { "dependencies": { "@types/json-schema": "^7.0.8", "ajv": "^6.12.5", "ajv-keywords": "^3.5.2" } }, "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg=="],
 
+    "postcss-loader/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "postcss-modules-extract-imports/postcss": ["postcss@7.0.39", "", { "dependencies": { "picocolors": "^0.2.1", "source-map": "^0.6.1" } }, "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA=="],
 
     "postcss-modules-local-by-default/postcss": ["postcss@7.0.39", "", { "dependencies": { "picocolors": "^0.2.1", "source-map": "^0.6.1" } }, "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA=="],
@@ -4507,6 +4523,8 @@
 
     "semantic-release/cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
 
+    "semantic-release/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
@@ -4518,6 +4536,8 @@
     "set-value/extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
     "set-value/is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
+
+    "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "signale/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
@@ -4536,6 +4556,8 @@
     "snapdragon-node/isobject": ["isobject@3.0.1", "", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
 
     "snapdragon-util/kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
+
+    "sort-package-json/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
@@ -4651,6 +4673,8 @@
 
     "@babel/helper-create-regexp-features-plugin/@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/helper-define-polyfill-provider/@babel/helper-compilation-targets/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/helper-define-polyfill-provider/@babel/helper-plugin-utils/@babel/core": ["@babel/core@8.0.1", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-compilation-targets": "^8.0.0", "@babel/helpers": "^8.0.0", "@babel/parser": "^8.0.0", "@babel/template": "^8.0.0", "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0", "@types/gensync": "^1.0.5", "convert-source-map": "^2.0.0", "empathic": "^2.0.1", "gensync": "^1.0.0-beta.2", "import-meta-resolve": "^4.2.0", "json5": "^2.2.3", "obug": "^2.1.1", "semver": "^7.7.3" } }, "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw=="],
 
     "@babel/helper-remap-async-to-generator/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
@@ -4666,6 +4690,8 @@
     "@babel/helper-remap-async-to-generator/@babel/core/@babel/template": ["@babel/template@8.0.0", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ=="],
 
     "@babel/helper-remap-async-to-generator/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/helper-remap-async-to-generator/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/helper-remap-async-to-generator/@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
@@ -4713,6 +4739,8 @@
 
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-bugfix-firefox-class-in-computed-class-key/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-bugfix-safari-class-field-initializer-scope/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-bugfix-safari-class-field-initializer-scope/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -4728,6 +4756,8 @@
     "@babel/plugin-bugfix-safari-class-field-initializer-scope/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-bugfix-safari-class-field-initializer-scope/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-bugfix-safari-class-field-initializer-scope/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -4745,6 +4775,8 @@
 
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -4760,6 +4792,8 @@
     "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/@babel/helper-skip-transparent-expression-wrappers/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
@@ -4781,6 +4815,8 @@
 
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/@babel/helper-skip-transparent-expression-wrappers/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/@babel/helper-skip-transparent-expression-wrappers/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
@@ -4800,6 +4836,8 @@
     "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-proposal-async-generator-functions/@babel/helper-remap-async-to-generator/@babel/helper-wrap-function": ["@babel/helper-wrap-function@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw=="],
 
@@ -4821,6 +4859,8 @@
 
     "@babel/plugin-syntax-jsx/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-syntax-jsx/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-syntax-typescript/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-syntax-typescript/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -4836,6 +4876,8 @@
     "@babel/plugin-syntax-typescript/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-syntax-typescript/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-syntax-typescript/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-syntax-unicode-sets-regex/@babel/helper-create-regexp-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -4855,6 +4897,8 @@
 
     "@babel/plugin-transform-arrow-functions/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-arrow-functions/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-async-generator-functions/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-async-generator-functions/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -4868,6 +4912,8 @@
     "@babel/plugin-transform-async-generator-functions/@babel/core/@babel/template": ["@babel/template@8.0.0", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ=="],
 
     "@babel/plugin-transform-async-generator-functions/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-async-generator-functions/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-async-generator-functions/@babel/traverse/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -4897,6 +4943,8 @@
 
     "@babel/plugin-transform-async-to-generator/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-async-to-generator/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-async-to-generator/@babel/helper-module-imports/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-async-to-generator/@babel/helper-module-imports/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
@@ -4917,6 +4965,8 @@
 
     "@babel/plugin-transform-block-scoped-functions/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-block-scoped-functions/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-block-scoping/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-block-scoping/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -4932,6 +4982,8 @@
     "@babel/plugin-transform-block-scoping/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-block-scoping/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-block-scoping/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-class-properties/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -4949,6 +5001,8 @@
 
     "@babel/plugin-transform-class-properties/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-class-properties/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-class-properties/@babel/helper-create-class-features-plugin/@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@8.0.0", "", { "dependencies": { "@babel/types": "^8.0.0" } }, "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw=="],
 
     "@babel/plugin-transform-class-properties/@babel/helper-create-class-features-plugin/@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ=="],
@@ -4960,6 +5014,8 @@
     "@babel/plugin-transform-class-properties/@babel/helper-create-class-features-plugin/@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw=="],
 
     "@babel/plugin-transform-class-properties/@babel/helper-create-class-features-plugin/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
+
+    "@babel/plugin-transform-class-properties/@babel/helper-create-class-features-plugin/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-class-static-block/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -4977,6 +5033,8 @@
 
     "@babel/plugin-transform-class-static-block/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-class-static-block/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-class-static-block/@babel/helper-create-class-features-plugin/@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@8.0.0", "", { "dependencies": { "@babel/types": "^8.0.0" } }, "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw=="],
 
     "@babel/plugin-transform-class-static-block/@babel/helper-create-class-features-plugin/@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ=="],
@@ -4988,6 +5046,8 @@
     "@babel/plugin-transform-class-static-block/@babel/helper-create-class-features-plugin/@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw=="],
 
     "@babel/plugin-transform-class-static-block/@babel/helper-create-class-features-plugin/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
+
+    "@babel/plugin-transform-class-static-block/@babel/helper-create-class-features-plugin/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-classes/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5001,7 +5061,11 @@
 
     "@babel/plugin-transform-classes/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-classes/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-classes/@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-classes/@babel/helper-compilation-targets/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-classes/@babel/helper-replace-supers/@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ=="],
 
@@ -5033,6 +5097,8 @@
 
     "@babel/plugin-transform-computed-properties/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-computed-properties/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-destructuring/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-destructuring/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5048,6 +5114,8 @@
     "@babel/plugin-transform-destructuring/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-destructuring/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-destructuring/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-dotall-regex/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5065,6 +5133,8 @@
 
     "@babel/plugin-transform-dotall-regex/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-dotall-regex/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-duplicate-keys/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-duplicate-keys/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5080,6 +5150,8 @@
     "@babel/plugin-transform-duplicate-keys/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-duplicate-keys/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-duplicate-keys/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-duplicate-named-capturing-groups-regex/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5097,6 +5169,8 @@
 
     "@babel/plugin-transform-duplicate-named-capturing-groups-regex/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-duplicate-named-capturing-groups-regex/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-dynamic-import/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-dynamic-import/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5112,6 +5186,8 @@
     "@babel/plugin-transform-dynamic-import/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-dynamic-import/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-dynamic-import/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-explicit-resource-management/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5129,6 +5205,8 @@
 
     "@babel/plugin-transform-explicit-resource-management/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-explicit-resource-management/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-exponentiation-operator/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-exponentiation-operator/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5144,6 +5222,8 @@
     "@babel/plugin-transform-exponentiation-operator/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-exponentiation-operator/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-exponentiation-operator/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-export-namespace-from/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5161,6 +5241,8 @@
 
     "@babel/plugin-transform-export-namespace-from/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-export-namespace-from/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-for-of/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-for-of/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5176,6 +5258,8 @@
     "@babel/plugin-transform-for-of/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-for-of/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-for-of/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-for-of/@babel/helper-skip-transparent-expression-wrappers/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
@@ -5195,6 +5279,10 @@
 
     "@babel/plugin-transform-function-name/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-function-name/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "@babel/plugin-transform-function-name/@babel/helper-compilation-targets/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-json-strings/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-json-strings/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5210,6 +5298,8 @@
     "@babel/plugin-transform-json-strings/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-json-strings/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-json-strings/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-literals/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5227,6 +5317,8 @@
 
     "@babel/plugin-transform-literals/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-literals/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-logical-assignment-operators/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-logical-assignment-operators/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5242,6 +5334,8 @@
     "@babel/plugin-transform-logical-assignment-operators/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-logical-assignment-operators/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-logical-assignment-operators/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-member-expression-literals/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5259,6 +5353,8 @@
 
     "@babel/plugin-transform-member-expression-literals/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-member-expression-literals/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-modules-amd/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-modules-amd/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5274,6 +5370,8 @@
     "@babel/plugin-transform-modules-amd/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-modules-amd/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-modules-amd/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-modules-amd/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew=="],
 
@@ -5297,6 +5395,8 @@
 
     "@babel/plugin-transform-modules-commonjs/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-modules-commonjs/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-modules-commonjs/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew=="],
 
     "@babel/plugin-transform-modules-commonjs/@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
@@ -5319,6 +5419,8 @@
 
     "@babel/plugin-transform-modules-systemjs/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-modules-systemjs/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-modules-systemjs/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew=="],
 
     "@babel/plugin-transform-modules-systemjs/@babel/helper-module-transforms/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
@@ -5338,6 +5440,8 @@
     "@babel/plugin-transform-modules-umd/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-modules-umd/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-modules-umd/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-modules-umd/@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew=="],
 
@@ -5361,6 +5465,8 @@
 
     "@babel/plugin-transform-named-capturing-groups-regex/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-named-capturing-groups-regex/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-new-target/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-new-target/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5376,6 +5482,8 @@
     "@babel/plugin-transform-new-target/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-new-target/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-new-target/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-nullish-coalescing-operator/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5393,6 +5501,8 @@
 
     "@babel/plugin-transform-nullish-coalescing-operator/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-nullish-coalescing-operator/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-numeric-separator/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-numeric-separator/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5409,6 +5519,8 @@
 
     "@babel/plugin-transform-numeric-separator/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-numeric-separator/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-object-rest-spread/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-object-rest-spread/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5422,6 +5534,10 @@
     "@babel/plugin-transform-object-rest-spread/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-object-rest-spread/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-object-rest-spread/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "@babel/plugin-transform-object-rest-spread/@babel/helper-compilation-targets/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-object-super/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5438,6 +5554,8 @@
     "@babel/plugin-transform-object-super/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-object-super/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-object-super/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-object-super/@babel/helper-replace-supers/@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ=="],
 
@@ -5461,6 +5579,8 @@
 
     "@babel/plugin-transform-optional-catch-binding/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-optional-catch-binding/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-optional-chaining/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-optional-chaining/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5476,6 +5596,8 @@
     "@babel/plugin-transform-optional-chaining/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-optional-chaining/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-optional-chaining/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-optional-chaining/@babel/helper-skip-transparent-expression-wrappers/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
@@ -5497,6 +5619,8 @@
 
     "@babel/plugin-transform-parameters/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-parameters/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-private-methods/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-private-methods/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5513,6 +5637,8 @@
 
     "@babel/plugin-transform-private-methods/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-private-methods/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-private-methods/@babel/helper-create-class-features-plugin/@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@8.0.0", "", { "dependencies": { "@babel/types": "^8.0.0" } }, "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw=="],
 
     "@babel/plugin-transform-private-methods/@babel/helper-create-class-features-plugin/@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ=="],
@@ -5524,6 +5650,8 @@
     "@babel/plugin-transform-private-methods/@babel/helper-create-class-features-plugin/@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw=="],
 
     "@babel/plugin-transform-private-methods/@babel/helper-create-class-features-plugin/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
+
+    "@babel/plugin-transform-private-methods/@babel/helper-create-class-features-plugin/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-private-property-in-object/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5541,6 +5669,8 @@
 
     "@babel/plugin-transform-private-property-in-object/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-private-property-in-object/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-private-property-in-object/@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
     "@babel/plugin-transform-private-property-in-object/@babel/helper-create-class-features-plugin/@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ=="],
@@ -5552,6 +5682,8 @@
     "@babel/plugin-transform-private-property-in-object/@babel/helper-create-class-features-plugin/@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw=="],
 
     "@babel/plugin-transform-private-property-in-object/@babel/helper-create-class-features-plugin/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
+
+    "@babel/plugin-transform-private-property-in-object/@babel/helper-create-class-features-plugin/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-property-literals/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5569,6 +5701,8 @@
 
     "@babel/plugin-transform-property-literals/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-property-literals/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-react-display-name/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-react-display-name/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5584,6 +5718,8 @@
     "@babel/plugin-transform-react-display-name/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-react-display-name/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-react-display-name/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-react-jsx-development/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5601,6 +5737,8 @@
 
     "@babel/plugin-transform-react-jsx-development/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-react-jsx-development/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-react-jsx/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-react-jsx/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5614,6 +5752,8 @@
     "@babel/plugin-transform-react-jsx/@babel/core/@babel/template": ["@babel/template@8.0.0", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ=="],
 
     "@babel/plugin-transform-react-jsx/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
+
+    "@babel/plugin-transform-react-jsx/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-react-jsx/@babel/helper-module-imports/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
@@ -5637,6 +5777,8 @@
 
     "@babel/plugin-transform-react-pure-annotations/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-react-pure-annotations/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-react-pure-annotations/@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
     "@babel/plugin-transform-regenerator/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
@@ -5655,6 +5797,8 @@
 
     "@babel/plugin-transform-regenerator/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-regenerator/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-regexp-modifiers/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-regexp-modifiers/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5670,6 +5814,8 @@
     "@babel/plugin-transform-regexp-modifiers/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-regexp-modifiers/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-regexp-modifiers/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-reserved-words/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5687,6 +5833,8 @@
 
     "@babel/plugin-transform-reserved-words/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-reserved-words/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-shorthand-properties/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-shorthand-properties/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5703,6 +5851,8 @@
 
     "@babel/plugin-transform-shorthand-properties/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-shorthand-properties/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-spread/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-spread/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5718,6 +5868,8 @@
     "@babel/plugin-transform-spread/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-spread/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-spread/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-spread/@babel/helper-skip-transparent-expression-wrappers/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
@@ -5739,6 +5891,8 @@
 
     "@babel/plugin-transform-sticky-regex/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-sticky-regex/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-typeof-symbol/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-typeof-symbol/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5754,6 +5908,8 @@
     "@babel/plugin-transform-typeof-symbol/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-typeof-symbol/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-typeof-symbol/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-typescript/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5771,6 +5927,8 @@
 
     "@babel/plugin-transform-typescript/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-typescript/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-typescript/@babel/helper-annotate-as-pure/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
     "@babel/plugin-transform-typescript/@babel/helper-create-class-features-plugin/@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@8.0.0", "", { "dependencies": { "@babel/traverse": "^8.0.0", "@babel/types": "^8.0.0" } }, "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ=="],
@@ -5780,6 +5938,8 @@
     "@babel/plugin-transform-typescript/@babel/helper-create-class-features-plugin/@babel/helper-replace-supers": ["@babel/helper-replace-supers@8.0.1", "", { "dependencies": { "@babel/helper-member-expression-to-functions": "^8.0.0", "@babel/helper-optimise-call-expression": "^8.0.0", "@babel/traverse": "^8.0.0" }, "peerDependencies": { "@babel/core": "^8.0.0" } }, "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q=="],
 
     "@babel/plugin-transform-typescript/@babel/helper-create-class-features-plugin/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
+
+    "@babel/plugin-transform-typescript/@babel/helper-create-class-features-plugin/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-typescript/@babel/helper-skip-transparent-expression-wrappers/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
@@ -5801,6 +5961,8 @@
 
     "@babel/plugin-transform-unicode-escapes/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-unicode-escapes/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-unicode-property-regex/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-unicode-property-regex/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5816,6 +5978,8 @@
     "@babel/plugin-transform-unicode-property-regex/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-unicode-property-regex/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-unicode-property-regex/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/plugin-transform-unicode-regex/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5833,6 +5997,8 @@
 
     "@babel/plugin-transform-unicode-regex/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/plugin-transform-unicode-regex/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/plugin-transform-unicode-sets-regex/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/plugin-transform-unicode-sets-regex/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5848,6 +6014,8 @@
     "@babel/plugin-transform-unicode-sets-regex/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/plugin-transform-unicode-sets-regex/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/plugin-transform-unicode-sets-regex/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/preset-env/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
@@ -5877,6 +6045,8 @@
 
     "@babel/preset-modules/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
+    "@babel/preset-modules/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/preset-modules/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 
     "@babel/preset-modules/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
@@ -5897,6 +6067,8 @@
 
     "@babel/preset-react/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
 
+    "@babel/preset-react/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@babel/preset-typescript/@babel/core/@babel/code-frame": ["@babel/code-frame@8.0.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^8.0.0", "js-tokens": "^10.0.0" } }, "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw=="],
 
     "@babel/preset-typescript/@babel/core/@babel/generator": ["@babel/generator@8.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "@babel/types": "^8.0.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g=="],
@@ -5912,6 +6084,8 @@
     "@babel/preset-typescript/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/preset-typescript/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/preset-typescript/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/register/find-cache-dir/pkg-dir": ["pkg-dir@3.0.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw=="],
 
@@ -6161,6 +6335,8 @@
 
     "@storybook/core-common/fork-ts-checker-webpack-plugin/schema-utils": ["schema-utils@2.7.0", "", { "dependencies": { "@types/json-schema": "^7.0.4", "ajv": "^6.12.2", "ajv-keywords": "^3.4.1" } }, "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A=="],
 
+    "@storybook/core-common/fork-ts-checker-webpack-plugin/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@storybook/core/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
     "@storybook/core/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
@@ -6288,6 +6464,8 @@
     "build-ts/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "build-ts/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "build-ts/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "build-ts/@babel/plugin-proposal-decorators/@babel/helper-create-class-features-plugin": ["@babel/helper-create-class-features-plugin@8.0.1", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^8.0.0", "@babel/helper-member-expression-to-functions": "^8.0.0", "@babel/helper-optimise-call-expression": "^8.0.0", "@babel/helper-replace-supers": "^8.0.1", "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0", "@babel/traverse": "^8.0.0", "semver": "^7.7.3" }, "peerDependencies": { "@babel/core": "^8.0.0" } }, "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA=="],
 
@@ -6722,6 +6900,8 @@
     "@babel/helper-define-polyfill-provider/@babel/helper-plugin-utils/@babel/core/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
     "@babel/helper-define-polyfill-provider/@babel/helper-plugin-utils/@babel/core/@babel/types": ["@babel/types@8.0.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.4" } }, "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g=="],
+
+    "@babel/helper-define-polyfill-provider/@babel/helper-plugin-utils/@babel/core/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@babel/helper-remap-async-to-generator/@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.4", "", {}, "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg=="],
 
@@ -7795,6 +7975,8 @@
 
     "build-ts/@babel/plugin-proposal-decorators/@babel/helper-create-class-features-plugin/@babel/traverse": ["@babel/traverse@8.0.4", "", { "dependencies": { "@babel/code-frame": "^8.0.0", "@babel/generator": "^8.0.0", "@babel/helper-globals": "^8.0.0", "@babel/parser": "^8.0.4", "@babel/template": "^8.0.0", "@babel/types": "^8.0.4", "obug": "^2.1.1" } }, "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg=="],
 
+    "build-ts/@babel/plugin-proposal-decorators/@babel/helper-create-class-features-plugin/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "build-ts/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "build-ts/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -8126,6 +8308,8 @@
     "@blitzjs/generator/@babel/preset-env/@babel/plugin-transform-unicode-regex/@babel/helper-create-regexp-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
+
+    "@semantic-release/release-notes-generator/read-package-up/read-pkg/normalize-package-data/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@storybook/addon-essentials/@storybook/addon-docs/@storybook/csf-plugin/unplugin/webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -38,6 +38,7 @@
     "jsonc-parser": "3.3.1",
     "kill-port": "2.0.1",
     "minimal-promise-pool": "6.0.2",
+    "semver": "7.8.5",
     "yargs": "18.0.0"
   },
   "devDependencies": {
@@ -51,6 +52,7 @@
     "@types/bun": "1.3.14",
     "@types/kill-port": "2.0.3",
     "@types/node": "25.6.0",
+    "@types/semver": "7.7.1",
     "@types/yargs": "17.0.35",
     "@willbooster/oxfmt-config": "1.2.2",
     "@willbooster/oxlint-config": "1.4.8",

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -19,8 +19,7 @@ import {
   PRIVATE_REGISTRY_SCOPE,
   isPrivateGitDependency,
   isPrivateRegistryDependency,
-  rangeAdmits,
-  toBaseVersion,
+  materializedVersionSatisfies,
 } from '../utils/privateRegistry.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
@@ -135,17 +134,10 @@ function rewritePrivateGitHubDependenciesForDir(
           );
           continue;
         }
-        // The materialized version is stale when it neither equals the specifier's degraded base
-        // (`wb setup-private-packages` degrades ^/~ to the base version) nor is admitted by the
-        // ^/~ range — setup may legitimately materialize a NEWER admitted version selected by an
-        // exact pin elsewhere in the manifest. Dist-tag specifiers (no x.y.z base, e.g.
-        // `2026-stable`) skip the staleness check.
-        const requestedBaseVersion = toBaseVersion(value);
-        if (
-          requestedBaseVersion !== undefined &&
-          materializedVersion !== requestedBaseVersion &&
-          !rangeAdmits(value, materializedVersion)
-        ) {
+        // The materialized version is stale when the specifier (an exact version or any semver
+        // range `wb setup-private-packages` resolves max-satisfying against the registry) does
+        // not admit it. Dist-tag specifiers (e.g. `2026-stable`) skip the staleness check.
+        if (!materializedVersionSatisfies(value, materializedVersion)) {
           console.error(
             chalk.red(
               `Materialized ${name} is ${materializedVersion} but package.json requires ${value}; rerun \`wb setup-private-packages\`.`

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -190,45 +190,61 @@ function pluginsIncludeNpm(plugins: readonly unknown[]): boolean {
   return plugins.some((plugin) => (Array.isArray(plugin) ? plugin[0] : plugin) === '@semantic-release/npm');
 }
 
-// The JS/YAML config files semantic-release also supports cannot be inspected statically;
-// their presence makes the plugin list 'unknown'.
-const nonJsonReleaseConfigFileNames = [
-  '.releaserc.yaml',
-  '.releaserc.yml',
-  '.releaserc.js',
-  '.releaserc.cjs',
-  '.releaserc.mjs',
-  'release.config.js',
-  'release.config.cjs',
-  'release.config.mjs',
+/**
+ * cosmiconfig 9's default searchPlaces order for module "release" (what semantic-release 25
+ * delegates to), minus the leading package.json entry, which the caller checks first. The FIRST
+ * existing place wins; places whose format JSON.parse cannot read make the effective plugin
+ * list 'unknown'.
+ */
+const semanticReleaseConfigSearchPlaces: { fileName: string; jsonParseable: boolean }[] = [
+  { fileName: '.releaserc', jsonParseable: true },
+  { fileName: '.releaserc.json', jsonParseable: true },
+  { fileName: '.releaserc.yaml', jsonParseable: false },
+  { fileName: '.releaserc.yml', jsonParseable: false },
+  { fileName: '.releaserc.js', jsonParseable: false },
+  { fileName: '.releaserc.ts', jsonParseable: false },
+  { fileName: '.releaserc.mjs', jsonParseable: false },
+  { fileName: '.releaserc.cjs', jsonParseable: false },
+  { fileName: '.config/releaserc', jsonParseable: true },
+  { fileName: '.config/releaserc.json', jsonParseable: true },
+  { fileName: '.config/releaserc.yaml', jsonParseable: false },
+  { fileName: '.config/releaserc.yml', jsonParseable: false },
+  { fileName: '.config/releaserc.js', jsonParseable: false },
+  { fileName: '.config/releaserc.ts', jsonParseable: false },
+  { fileName: '.config/releaserc.mjs', jsonParseable: false },
+  { fileName: '.config/releaserc.cjs', jsonParseable: false },
+  { fileName: 'release.config.js', jsonParseable: false },
+  { fileName: 'release.config.ts', jsonParseable: false },
+  { fileName: 'release.config.mjs', jsonParseable: false },
+  { fileName: 'release.config.cjs', jsonParseable: false },
 ];
 
 function readExplicitSemanticReleasePlugins(
   dirPath: string,
   packageJson: PackageJson | undefined
 ): readonly unknown[] | undefined | 'unknown' {
-  if (nonJsonReleaseConfigFileNames.some((fileName) => fs.existsSync(path.join(dirPath, fileName)))) return 'unknown';
-
-  let config: { plugins?: unknown; extends?: unknown } | undefined;
-  for (const fileName of ['.releaserc', '.releaserc.json']) {
-    const configPath = path.join(dirPath, fileName);
-    if (!fs.existsSync(configPath)) continue;
+  // cosmiconfig searches package.json's `release` key BEFORE any rc/config file; a missing or
+  // unreadable package.json just falls through to the file search places.
+  if (packageJson === undefined) {
     try {
-      config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as typeof config;
+      packageJson = JSON.parse(fs.readFileSync(path.join(dirPath, 'package.json'), 'utf8')) as PackageJson;
     } catch {
-      return 'unknown';
+      packageJson = undefined;
     }
-    break;
   }
-  if (!config) {
-    if (packageJson === undefined) {
+  let config = (packageJson as { release?: { plugins?: unknown; extends?: unknown } } | undefined)?.release;
+  if (config === undefined) {
+    for (const { fileName, jsonParseable } of semanticReleaseConfigSearchPlaces) {
+      const configPath = path.join(dirPath, fileName);
+      if (!fs.existsSync(configPath)) continue;
+      if (!jsonParseable) return 'unknown';
       try {
-        packageJson = JSON.parse(fs.readFileSync(path.join(dirPath, 'package.json'), 'utf8')) as PackageJson;
+        config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as typeof config;
       } catch {
-        return undefined;
+        return 'unknown';
       }
+      break;
     }
-    config = (packageJson as { release?: unknown }).release as typeof config;
   }
   if (!config || typeof config !== 'object') return undefined;
   if (Array.isArray(config.plugins)) return config.plugins;

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -276,9 +276,9 @@ async function prepareNpmCompatibleLayout(
         fs.rmSync(nodeModulesDirPath, { force: true, recursive: true });
       }
       // Resolve and download with lifecycle scripts DISABLED while the release credentials
-      // (VERDACCIO_TOKEN, NPM_TOKEN, GITHUB_TOKEN, fnox-exported secrets, ...) are in the
-      // environment, so repository- or dependency-defined preinstall/postinstall can never read
-      // them — mirroring reusable-workflows' two-step release install (issue #1003).
+      // (VERDACCIO_TOKEN, NPM_TOKEN, GITHUB_TOKEN, FNOX_AGE_KEY, ...) are in the environment,
+      // so repository- or dependency-defined preinstall/postinstall can never read them —
+      // mirroring reusable-workflows' two-step release install (issue #1003).
       const installStatus = await spawnAndWait(activeChild, 'bun', ['install', '--ignore-scripts'], {
         cwd: project.dirPath,
         env: project.env,
@@ -332,7 +332,13 @@ async function prepareNpmCompatibleLayout(
 
 // The credentials the release workflow injects (cf. reusable-workflows' release.yml secrets and
 // npm's own token variables). The release command loads the project with loadEnv: false, so no
-// wb-loader-injected keys exist to scrub beyond these.
+// wb-loader-injected keys exist to scrub beyond these. A denylist (not an allowlist) is
+// deliberate: in the supported entry point — reusable-workflows' release job — these enumerated
+// variables are the ONLY secrets in the ambient environment (fnox secrets stay encrypted because
+// FNOX_AGE_KEY is scrubbed and never exported as plaintext there), while an allowlist would
+// break lifecycle scripts that legitimately read operational variables (PATH, HOME, CI, ...).
+// A local `wb release` inherits whatever the developer's shell already exposes to every
+// `bun install`, which this replay does not widen.
 const credentialEnvVarNames = [
   'VERDACCIO_TOKEN',
   'NPM_TOKEN',

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -74,7 +74,18 @@ export async function release(argv: ReleaseArgv, projectPathForTesting?: string)
   let exitCode = 0;
   let releaseRanSuccessfully = false;
   try {
-    await prepareNpmCompatibleLayout(project, argv, modifiedFiles, activeChild);
+    if (await releasePublishesToNpm(project)) {
+      await prepareNpmCompatibleLayout(project, argv, modifiedFiles, activeChild);
+    } else {
+      // The hoisted reinstall and workspace-range rewrite exist solely so npm (which the
+      // @semantic-release/npm plugin shells out to) can digest the checkout; without that plugin
+      // the release runs directly on the isolated layout (issue #1000).
+      console.info(
+        chalk.cyan(
+          'Skipping the hoisted reinstall because the semantic-release configuration does not include @semantic-release/npm.'
+        )
+      );
+    }
     // A signal may have arrived between children (nothing to forward to at that instant), so it
     // must be checked explicitly before anything publishes.
     if (receivedSignal) {
@@ -155,6 +166,77 @@ async function spawnAndWait(
 }
 
 /**
+ * Whether the release can publish to npm. True unless a plugin list is explicitly configured
+ * (in a JSON-parseable source) and omits `@semantic-release/npm` everywhere in scope — the root
+ * and, for multi-semantic-release monorepos, each workspace package (a package-level plugin list
+ * overrides the root's). semantic-release's DEFAULT plugin list includes the npm plugin, so a
+ * missing plugin list, a non-JSON config file, or an `extends` preset conservatively keeps the
+ * npm preparation.
+ */
+export async function releasePublishesToNpm(project: Pick<Project, 'dirPath' | 'packageJson'>): Promise<boolean> {
+  const rootPlugins = readExplicitSemanticReleasePlugins(project.dirPath, project.packageJson);
+  // Without an explicit root plugin list, semantic-release's default list (npm included) applies.
+  if (!Array.isArray(rootPlugins) || pluginsIncludeNpm(rootPlugins)) return true;
+
+  for (const packageDirPath of await findWorkspacePackageDirs(project)) {
+    const plugins = readExplicitSemanticReleasePlugins(packageDirPath, undefined);
+    // A workspace package without its own plugin list inherits the root's (npm-free) decision.
+    if (plugins === 'unknown' || (Array.isArray(plugins) && pluginsIncludeNpm(plugins))) return true;
+  }
+  return false;
+}
+
+function pluginsIncludeNpm(plugins: readonly unknown[]): boolean {
+  return plugins.some((plugin) => (Array.isArray(plugin) ? plugin[0] : plugin) === '@semantic-release/npm');
+}
+
+// The JS/YAML config files semantic-release also supports cannot be inspected statically;
+// their presence makes the plugin list 'unknown'.
+const nonJsonReleaseConfigFileNames = [
+  '.releaserc.yaml',
+  '.releaserc.yml',
+  '.releaserc.js',
+  '.releaserc.cjs',
+  '.releaserc.mjs',
+  'release.config.js',
+  'release.config.cjs',
+  'release.config.mjs',
+];
+
+function readExplicitSemanticReleasePlugins(
+  dirPath: string,
+  packageJson: PackageJson | undefined
+): readonly unknown[] | undefined | 'unknown' {
+  if (nonJsonReleaseConfigFileNames.some((fileName) => fs.existsSync(path.join(dirPath, fileName)))) return 'unknown';
+
+  let config: { plugins?: unknown; extends?: unknown } | undefined;
+  for (const fileName of ['.releaserc', '.releaserc.json']) {
+    const configPath = path.join(dirPath, fileName);
+    if (!fs.existsSync(configPath)) continue;
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as typeof config;
+    } catch {
+      return 'unknown';
+    }
+    break;
+  }
+  if (!config) {
+    if (packageJson === undefined) {
+      try {
+        packageJson = JSON.parse(fs.readFileSync(path.join(dirPath, 'package.json'), 'utf8')) as PackageJson;
+      } catch {
+        return undefined;
+      }
+    }
+    config = (packageJson as { release?: unknown }).release as typeof config;
+  }
+  if (!config || typeof config !== 'object') return undefined;
+  if (Array.isArray(config.plugins)) return config.plugins;
+  // An `extends` preset may contribute its own plugin list, which cannot be resolved statically.
+  return config.extends === undefined ? undefined : 'unknown';
+}
+
+/**
  * Make the checkout digestible for npm, which semantic-release's npm plugin shells out to for
  * `npm version` / `npm publish`:
  * 1. npm's arborist cannot walk Bun's ISOLATED node_modules layout (the `.bun` symlink farm), so
@@ -187,10 +269,17 @@ async function prepareNpmCompatibleLayout(
         modifiedFiles.set(lockFilePath, fs.existsSync(lockFilePath) ? fs.readFileSync(lockFilePath) : undefined);
       }
       fs.writeFileSync(bunfigPath, hoistedBunfig ?? '', 'utf8');
-      for (const packageDirPath of [project.dirPath, ...(await findWorkspacePackageDirs(project))]) {
-        fs.rmSync(path.join(packageDirPath, 'node_modules'), { force: true, recursive: true });
+      const nodeModulesDirPaths = [project.dirPath, ...(await findWorkspacePackageDirs(project))].map((dirPath) =>
+        path.join(dirPath, 'node_modules')
+      );
+      for (const nodeModulesDirPath of nodeModulesDirPaths) {
+        fs.rmSync(nodeModulesDirPath, { force: true, recursive: true });
       }
-      const installStatus = await spawnAndWait(activeChild, 'bun', ['install'], {
+      // Resolve and download with lifecycle scripts DISABLED while the release credentials
+      // (VERDACCIO_TOKEN, NPM_TOKEN, GITHUB_TOKEN, fnox-exported secrets, ...) are in the
+      // environment, so repository- or dependency-defined preinstall/postinstall can never read
+      // them — mirroring reusable-workflows' two-step release install (issue #1003).
+      const installStatus = await spawnAndWait(activeChild, 'bun', ['install', '--ignore-scripts'], {
         cwd: project.dirPath,
         env: project.env,
         stdio: 'inherit',
@@ -199,6 +288,21 @@ async function prepareNpmCompatibleLayout(
         // Throwing (instead of process.exit, which would skip the caller's finally) lets the
         // restore run before the process terminates.
         throw new Error('bun install failed while preparing the release.');
+      }
+      // Replay the skipped lifecycle scripts in a credential-scrubbed environment. A repeated
+      // `bun install` is a no-op that does not replay them, so node_modules is wiped again;
+      // every package is already in bun's cache from the credentialed step, so this re-link
+      // needs no registry credentials.
+      for (const nodeModulesDirPath of nodeModulesDirPaths) {
+        fs.rmSync(nodeModulesDirPath, { force: true, recursive: true });
+      }
+      const replayStatus = await spawnAndWait(activeChild, 'bun', ['install'], {
+        cwd: project.dirPath,
+        env: buildCredentialFreeEnv(project.env),
+        stdio: 'inherit',
+      });
+      if (replayStatus !== 0) {
+        throw new Error('bun install failed while replaying lifecycle scripts for the release.');
       }
     }
   }
@@ -224,6 +328,33 @@ async function prepareNpmCompatibleLayout(
       fs.writeFileSync(packageJsonPath, rewritten, 'utf8');
     }
   }
+}
+
+// The credentials the release workflow injects (cf. reusable-workflows' release.yml secrets and
+// npm's own token variables). The release command loads the project with loadEnv: false, so no
+// wb-loader-injected keys exist to scrub beyond these.
+const credentialEnvVarNames = [
+  'VERDACCIO_TOKEN',
+  'NPM_TOKEN',
+  'NODE_AUTH_TOKEN',
+  'GITHUB_TOKEN',
+  'GH_TOKEN',
+  'GH_PACKAGES_TOKEN',
+  'GH_PKG_READ_TOKEN',
+  'FNOX_AGE_KEY',
+];
+
+/**
+ * A copy of `env` safe to expose to dependency lifecycle scripts. Credential variables are
+ * EMPTIED rather than deleted so `${VERDACCIO_TOKEN}`-style references in .npmrc keep expanding
+ * to '' instead of crashing the install (the pattern reusable-workflows relies on).
+ */
+export function buildCredentialFreeEnv(env: Record<string, string | undefined>): Record<string, string | undefined> {
+  const scrubbedEnv = { ...env };
+  for (const name of credentialEnvVarNames) {
+    if (name in scrubbedEnv) scrubbedEnv[name] = '';
+  }
+  return scrubbedEnv;
 }
 
 /**
@@ -372,7 +503,7 @@ async function runSemanticRelease(project: Project, argv: ReleaseArgv, activeChi
   });
 }
 
-async function findWorkspacePackageDirs(project: Project): Promise<string[]> {
+async function findWorkspacePackageDirs(project: Pick<Project, 'dirPath' | 'packageJson'>): Promise<string[]> {
   const workspaces = project.packageJson.workspaces;
   const patterns = Array.isArray(workspaces) ? workspaces : (workspaces?.packages ?? []);
   if (patterns.length === 0) return [];

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -10,12 +10,10 @@ import type { PrivateRegistryAuth } from '../utils/privateRegistry.js';
 import {
   PRIVATE_REGISTRY_SCOPE,
   downloadAndExtractRegistryPackage,
-  isExactVersion,
   isPrivateGitDependency,
   isPrivateRegistryDependency,
-  rangeAdmits,
   resolvePrivateRegistryAuth,
-  toBaseVersion,
+  specifierSubset,
 } from '../utils/privateRegistry.js';
 
 interface PrivatePackage {
@@ -40,7 +38,8 @@ const builder = {
 export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, InferredOptionTypes<typeof builder>> = {
   command: 'setup-private-packages',
   describe:
-    'Materialize private dependencies for Docker builds: copy git dependencies and download @willbooster-private/* registry packages (auth via .npmrc / ~/.npmrc locally, or VERDACCIO_TOKEN on CI)',
+    'Materialize private dependencies for Docker builds: copy git dependencies and download @willbooster-private/* registry packages (auth via .npmrc / ~/.npmrc locally, or VERDACCIO_TOKEN on CI). ' +
+    'The Dockerfile must COPY the generated directories (e.g. `COPY @willbooster/ @willbooster/` and `COPY @willbooster-private/ @willbooster-private/`) so the in-image install resolves the rewritten file: paths.',
   builder,
   async handler(argv) {
     const projects = findRootAndSelfProjects(argv, false);
@@ -146,6 +145,9 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     }
 
     await replacePrivateDependencies(projects.root.dirPath, privatePackages);
+    console.info(
+      `Ensure the Dockerfile COPYs ${path.relative(projects.root.dirPath, outDirPath)}/ and ${PRIVATE_REGISTRY_SCOPE}/ into the image before installing dependencies.`
+    );
   },
 };
 
@@ -264,19 +266,16 @@ async function copyGitPackage(rootDirPath: string, privatePackage: PrivatePackag
 }
 
 /**
- * The materialization for `existing` is already selected (its `^`/`~` range degraded to the base
- * version — see downloadAndExtractRegistryPackage), so accept `requested` only when that selected
- * version satisfies it: an exact request must equal it, a `^`/`~` request must admit it, and
- * non-numeric specifiers (dist-tags, git URLs/revisions) must match exactly.
+ * The materialization for `existing` is already selected (a range resolves max-satisfying against
+ * the registry — see downloadAndExtractRegistryPackage), so accept `requested` only when it is
+ * guaranteed satisfied: `existing` must be a subset of it (every possible resolution of `existing`
+ * then satisfies `requested`). Non-range specifiers (dist-tags, git URLs/revisions) must match
+ * exactly.
  */
 function assertNoVersionConflict(existing: PrivatePackage, requested: PrivatePackage, dependentName: string): void {
   if (existing.kind === requested.kind) {
     if (existing.versionSpecifier === requested.versionSpecifier) return;
-    const selectedVersion = toBaseVersion(existing.versionSpecifier);
-    if (selectedVersion !== undefined && requested.versionSpecifier !== undefined) {
-      if (isExactVersion(requested.versionSpecifier) && requested.versionSpecifier === selectedVersion) return;
-      if (rangeAdmits(requested.versionSpecifier, selectedVersion)) return;
-    }
+    if (specifierSubset(existing.versionSpecifier, requested.versionSpecifier)) return;
   }
 
   throw new Error(
@@ -379,26 +378,15 @@ function findPrivateDependencies(
 
 /**
  * A manifest may legitimately request one package from several dependency sections (e.g. an exact
- * devDependencies pin alongside a peerDependencies range). Prefer the exact pin when the other
- * side is a range admitting it (that pin becomes the materialized version); fail loudly when the
- * requirements genuinely diverge.
+ * devDependencies pin alongside a peerDependencies range). Keep the NARROWER requirement — its
+ * max-satisfying resolution satisfies the wider one by definition (an exact pin is the narrowest
+ * range) — and fail loudly when the requirements genuinely diverge.
  */
 function mergeSameManifestRequirement(existing: PrivatePackage, requested: PrivatePackage): PrivatePackage {
   if (existing.kind === requested.kind) {
     if (existing.versionSpecifier === requested.versionSpecifier) return existing;
-    const [exact, other] = isExactVersion(existing.versionSpecifier) ? [existing, requested] : [requested, existing];
-    if (
-      isExactVersion(exact.versionSpecifier) &&
-      other.versionSpecifier !== undefined &&
-      (other.versionSpecifier === exact.versionSpecifier ||
-        rangeAdmits(other.versionSpecifier, exact.versionSpecifier!) ||
-        toBaseVersion(other.versionSpecifier) === exact.versionSpecifier)
-    ) {
-      return exact;
-    }
-    // Two ranges degrading to the same base version select the same materialization.
-    const baseVersion = toBaseVersion(existing.versionSpecifier);
-    if (baseVersion !== undefined && baseVersion === toBaseVersion(requested.versionSpecifier)) return existing;
+    if (specifierSubset(existing.versionSpecifier, requested.versionSpecifier)) return existing;
+    if (specifierSubset(requested.versionSpecifier, existing.versionSpecifier)) return requested;
   }
   throw new Error(
     `Conflicting requirements for ${existing.name} within one manifest: ` +

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -3,6 +3,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import semver from 'semver';
+
 /**
  * Materialization of `@willbooster-private/*` registry (Verdaccio) dependencies for Docker builds:
  * the packages are downloaded on the host (auth via .npmrc / ~/.npmrc locally, or VERDACCIO_TOKEN
@@ -111,9 +113,10 @@ export function parseNpmrc(content: string): Record<string, string> {
 }
 
 /**
- * Download and extract one registry package into `targetDirPath`. The version must be an exact
- * semver (the org pins exact versions via bunfig `exact = true`); `latest` and simple `^`/`~`
- * ranges degrade to the range's base version or the registry's latest dist-tag.
+ * Download and extract one registry package into `targetDirPath`. The specifier may be an exact
+ * semver version (the org's common case via bunfig `exact = true`), any semver range (resolved
+ * max-satisfying against the registry's published versions, matching `npm install`), or a
+ * dist-tag.
  */
 export async function downloadAndExtractRegistryPackage(
   auth: PrivateRegistryAuth,
@@ -157,24 +160,35 @@ async function resolveVersion(
   packageName: string,
   versionSpecifier: string
 ): Promise<string> {
-  // Prerelease and `+build` metadata are both part of valid exact SemVer versions.
-  // toBaseVersion applies the shared anchored SemVer classification: an exact version resolves to
-  // itself and a simple `^`/`~` range degrades to its base version (org repos pin exact versions,
-  // so the range path is a best-effort fallback); anything else resolves as a dist-tag below.
-  const exactVersion = toBaseVersion(versionSpecifier);
-  if (exactVersion) return exactVersion;
+  // Prerelease and `+build` metadata are both part of valid exact SemVer versions, so an exact
+  // specifier resolves to itself without a packument fetch.
+  if (isExactVersion(versionSpecifier)) return versionSpecifier;
 
-  const packument = await fetchRegistryJson<{ 'dist-tags'?: Record<string, string> }>(
-    auth,
-    `${auth.registryUrl}/${encodePackageName(packageName)}`
-  );
-  const distTag = packument['dist-tags']?.[versionSpecifier === '*' ? 'latest' : versionSpecifier];
-  if (!distTag) {
+  const packument = await fetchRegistryJson<Packument>(auth, `${auth.registryUrl}/${encodePackageName(packageName)}`);
+  const version = selectVersionFromPackument(versionSpecifier, packument);
+  if (!version) {
     throw new Error(
-      `Cannot resolve ${packageName}@${versionSpecifier}; use an exact version, a ^/~ range, or a dist-tag.`
+      `Cannot resolve ${packageName}@${versionSpecifier} against ${auth.registryUrl}; use an exact version, a semver range, or a dist-tag.`
     );
   }
-  return distTag;
+  return version;
+}
+
+export interface Packument {
+  'dist-tags'?: Record<string, string>;
+  versions?: Record<string, unknown>;
+}
+
+/**
+ * npm's specifier classification: `*` and dist-tag names resolve via dist-tags (npm resolves `*`
+ * to the `latest` tag), while any other valid semver range resolves to the highest published
+ * version satisfying it, matching `npm install`'s max-satisfying semantics.
+ */
+export function selectVersionFromPackument(versionSpecifier: string, packument: Packument): string | undefined {
+  if (versionSpecifier !== '*' && semver.validRange(versionSpecifier)) {
+    return semver.maxSatisfying(Object.keys(packument.versions ?? {}), versionSpecifier) ?? undefined;
+  }
+  return packument['dist-tags']?.[versionSpecifier === '*' ? 'latest' : versionSpecifier];
 }
 
 async function fetchRegistryJson<T>(auth: PrivateRegistryAuth, url: string): Promise<T> {
@@ -219,53 +233,24 @@ export function isExactVersion(specifier: string | undefined): boolean {
   return !!specifier && exactSemverPattern.test(specifier);
 }
 
-/** The version the specifier resolves to under the degrade-ranges rule, or undefined for tags/git. */
-export function toBaseVersion(specifier: string | undefined): string | undefined {
-  if (!specifier) return;
-  const base = specifier.replace(/^[\^~]/, '');
-  return exactSemverPattern.test(base) ? base : undefined;
+/**
+ * Whether EVERY version `specifier` can resolve to also satisfies `requirement` (exact versions
+ * count as single-version ranges). Conflict checks use this because the actually resolved version
+ * is unknown before the registry is consulted: a subset specifier's max-satisfying resolution is
+ * guaranteed to satisfy the wider requirement. Non-range specifiers (dist-tags, git URLs) are not
+ * comparable and return false — callers accept those only on exact string equality.
+ */
+export function specifierSubset(specifier: string | undefined, requirement: string | undefined): boolean {
+  if (specifier === undefined || requirement === undefined) return false;
+  if (!semver.validRange(specifier) || !semver.validRange(requirement)) return false;
+  return semver.subset(specifier, requirement);
 }
 
 /**
- * Simplified node-semver rules: `^` admits versions not changing the left-most non-zero component
- * (so `^0.1.0` rejects `0.2.0` and `^0.0.3` admits only `0.0.3`), `~` admits same-major.minor
- * >= base. Prerelease identifiers are handled conservatively: any `-` on either side makes this
- * return false, so only an exact string match (checked separately by the callers) is accepted.
+ * Whether the materialized `version` can be the resolution of the registry `specifier`.
+ * Dist-tags (invalid ranges) are not statically checkable and pass.
  */
-export function rangeAdmits(range: string, version: string): boolean {
-  // SemVer build metadata (`+build-1`) is ignored for ordering and may itself contain hyphens,
-  // so strip it BEFORE the prerelease (`-`) check.
-  const rangeBase = range.replace(/^[\^~]/, '').split('+')[0]!;
-  const candidateVersion = version.split('+')[0]!;
-  if (rangeBase.includes('-') || candidateVersion.includes('-')) return false;
-  const baseVersion = parseVersion(rangeBase);
-  const candidate = parseVersion(candidateVersion);
-  if (!baseVersion || !candidate) return false;
-  if (range.startsWith('^')) {
-    if (baseVersion[0] === 0) {
-      if (baseVersion[1] === 0) return compareVersions(candidate, baseVersion) === 0;
-      return candidate[0] === 0 && candidate[1] === baseVersion[1] && compareVersions(candidate, baseVersion) >= 0;
-    }
-    return candidate[0] === baseVersion[0] && compareVersions(candidate, baseVersion) >= 0;
-  }
-  if (range.startsWith('~')) {
-    return (
-      candidate[0] === baseVersion[0] && candidate[1] === baseVersion[1] && compareVersions(candidate, baseVersion) >= 0
-    );
-  }
-  return false;
-}
-
-function parseVersion(version: string): [number, number, number] | undefined {
-  // Anchored: callers strip build metadata and reject prereleases beforehand, so anything beyond
-  // x.y.z marks a non-version (e.g. a numeric-looking dist-tag).
-  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
-  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : undefined;
-}
-
-function compareVersions(a: [number, number, number], b: [number, number, number]): number {
-  for (let index = 0; index < 3; index++) {
-    if (a[index]! !== b[index]!) return a[index]! - b[index]!;
-  }
-  return 0;
+export function materializedVersionSatisfies(specifier: string, version: string): boolean {
+  if (!semver.validRange(specifier)) return true;
+  return semver.satisfies(version, specifier);
 }

--- a/packages/wb/test/privateRegistry.test.ts
+++ b/packages/wb/test/privateRegistry.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { isPrivateRegistryDependency, parseNpmrc } from '../src/utils/privateRegistry.js';
+import {
+  isPrivateRegistryDependency,
+  materializedVersionSatisfies,
+  parseNpmrc,
+  selectVersionFromPackument,
+  specifierSubset,
+} from '../src/utils/privateRegistry.js';
 
 describe('isPrivateRegistryDependency', () => {
   it('accepts registry ranges for the private scope only', () => {
@@ -12,6 +18,75 @@ describe('isPrivateRegistryDependency', () => {
     ).toBe(false);
     expect(isPrivateRegistryDependency('@willbooster-private/agentic-workflows', 'workspace:*')).toBe(false);
     expect(isPrivateRegistryDependency('@willbooster-private/agentic-workflows', 'file:../x')).toBe(false);
+  });
+});
+
+describe('selectVersionFromPackument', () => {
+  const packument = {
+    'dist-tags': { latest: '1.4.0', next: '2.0.0-beta.1' },
+    versions: Object.fromEntries(
+      ['0.9.0', '1.2.3', '1.3.0', '1.4.0', '1.5.0-rc.1', '2.0.0-beta.1'].map((v) => [v, {}])
+    ),
+  };
+
+  it('resolves ranges to the highest satisfying published version', () => {
+    expect(selectVersionFromPackument('^1.2.3', packument)).toBe('1.4.0');
+    expect(selectVersionFromPackument('~1.2.0', packument)).toBe('1.2.3');
+    expect(selectVersionFromPackument('>=0.9.0 <1.4.0', packument)).toBe('1.3.0');
+    expect(selectVersionFromPackument('1.2.x', packument)).toBe('1.2.3');
+  });
+
+  it('excludes prereleases from plain ranges but admits them for same-tuple prerelease ranges', () => {
+    expect(selectVersionFromPackument('^1.4.0', packument)).toBe('1.4.0');
+    expect(selectVersionFromPackument('>=1.5.0-rc.0 <1.5.1', packument)).toBe('1.5.0-rc.1');
+  });
+
+  it('resolves * and dist-tags via dist-tags', () => {
+    expect(selectVersionFromPackument('*', packument)).toBe('1.4.0');
+    expect(selectVersionFromPackument('next', packument)).toBe('2.0.0-beta.1');
+    expect(selectVersionFromPackument('latest', packument)).toBe('1.4.0');
+  });
+
+  it('returns undefined for unsatisfiable ranges and unknown tags', () => {
+    expect(selectVersionFromPackument('^3.0.0', packument)).toBeUndefined();
+    expect(selectVersionFromPackument('unknown-tag', packument)).toBeUndefined();
+    expect(selectVersionFromPackument('^1.0.0', {})).toBeUndefined();
+  });
+});
+
+describe('specifierSubset', () => {
+  it('accepts a specifier whose every resolution satisfies the requirement', () => {
+    expect(specifierSubset('1.2.3', '^1.2.0')).toBe(true);
+    expect(specifierSubset('~1.2.3', '^1.2.0')).toBe(true);
+    expect(specifierSubset('^1.2.0', '>=1.0.0')).toBe(true);
+  });
+
+  it('rejects wider or diverging specifiers', () => {
+    // ^1.2.0 may resolve to e.g. 1.9.0, which does not satisfy the exact 1.2.3 requirement.
+    expect(specifierSubset('^1.2.0', '1.2.3')).toBe(false);
+    expect(specifierSubset('^1.2.0', '~1.2.0')).toBe(false);
+    expect(specifierSubset('^2.0.0', '^1.0.0')).toBe(false);
+  });
+
+  it('rejects non-range specifiers (dist-tags, git URLs)', () => {
+    expect(specifierSubset('latest', '^1.0.0')).toBe(false);
+    expect(specifierSubset('1.2.3', 'some-tag')).toBe(false);
+    expect(specifierSubset('git@github.com:WillBooster/x.git', 'git@github.com:WillBooster/x.git')).toBe(false);
+    expect(specifierSubset(undefined, '^1.0.0')).toBe(false);
+  });
+});
+
+describe('materializedVersionSatisfies', () => {
+  it('checks ranges and exact versions against the materialized version', () => {
+    expect(materializedVersionSatisfies('^1.2.0', '1.4.0')).toBe(true);
+    expect(materializedVersionSatisfies('^1.2.0', '2.0.0')).toBe(false);
+    expect(materializedVersionSatisfies('1.2.3', '1.2.3')).toBe(true);
+    expect(materializedVersionSatisfies('1.2.3', '1.2.4')).toBe(false);
+    expect(materializedVersionSatisfies('1.2.3-beta.1', '1.2.3-beta.1')).toBe(true);
+  });
+
+  it('passes dist-tag specifiers, which are not statically checkable', () => {
+    expect(materializedVersionSatisfies('2026-stable', '1.4.0')).toBe(true);
   });
 });
 

--- a/packages/wb/test/release.test.ts
+++ b/packages/wb/test/release.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
-import { buildHoistedBunfig, restoreWorkspaceRanges, rewriteWorkspaceRanges } from '../src/commands/release.js';
+import type { PackageJson } from 'type-fest';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  buildCredentialFreeEnv,
+  buildHoistedBunfig,
+  releasePublishesToNpm,
+  restoreWorkspaceRanges,
+  rewriteWorkspaceRanges,
+} from '../src/commands/release.js';
 
 describe('buildHoistedBunfig', () => {
   it('switches the isolated linker to hoisted and drops globalStore', () => {
@@ -20,6 +31,131 @@ publicHoistPattern = ["tsx"]
   it('keeps a hoisted bunfig unchanged', () => {
     const bunfig = `[install]\nlinker = "hoisted"\n`;
     expect(buildHoistedBunfig(bunfig)).toBe(bunfig);
+  });
+});
+
+describe('buildCredentialFreeEnv', () => {
+  it('empties credential variables and keeps the rest', () => {
+    const env = {
+      GH_TOKEN: 'gh',
+      GITHUB_TOKEN: 'github',
+      NPM_TOKEN: 'npm',
+      PATH: '/usr/bin',
+      VERDACCIO_TOKEN: 'secret',
+      WB_ENV: 'production',
+    };
+    const scrubbedEnv = buildCredentialFreeEnv(env);
+    // Emptied (not deleted) so `${VERDACCIO_TOKEN}` references in .npmrc expand to ''.
+    expect(scrubbedEnv).toEqual({
+      GH_TOKEN: '',
+      GITHUB_TOKEN: '',
+      NPM_TOKEN: '',
+      PATH: '/usr/bin',
+      VERDACCIO_TOKEN: '',
+      WB_ENV: 'production',
+    });
+    expect(env.VERDACCIO_TOKEN).toBe('secret');
+  });
+});
+
+describe('releasePublishesToNpm', () => {
+  const temporaryDirPaths: string[] = [];
+
+  afterEach(async () => {
+    for (const dirPath of temporaryDirPaths.splice(0)) {
+      await fs.promises.rm(dirPath, { recursive: true, force: true });
+    }
+  });
+
+  async function createProject(files: Record<string, object>): Promise<{ dirPath: string; packageJson: PackageJson }> {
+    const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-release-test-'));
+    temporaryDirPaths.push(dirPath);
+    for (const [relativePath, content] of Object.entries(files)) {
+      const filePath = path.join(dirPath, relativePath);
+      await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.promises.writeFile(filePath, JSON.stringify(content), 'utf8');
+    }
+    const packageJson = JSON.parse(
+      await fs.promises.readFile(path.join(dirPath, 'package.json'), 'utf8')
+    ) as PackageJson;
+    return { dirPath, packageJson };
+  }
+
+  it('keeps the npm preparation when no plugin list is configured (default plugins include npm)', async () => {
+    const project = await createProject({ 'package.json': { name: 'app' } });
+    await expect(releasePublishesToNpm(project)).resolves.toBe(true);
+  });
+
+  it('skips when .releaserc.json explicitly configures plugins without @semantic-release/npm', async () => {
+    const project = await createProject({
+      'package.json': { name: 'app' },
+      '.releaserc.json': {
+        plugins: ['@semantic-release/commit-analyzer', ['@semantic-release/github', { successComment: false }]],
+      },
+    });
+    await expect(releasePublishesToNpm(project)).resolves.toBe(false);
+  });
+
+  it('keeps the npm preparation when the plugin list includes @semantic-release/npm in tuple form', async () => {
+    const project = await createProject({
+      'package.json': { name: 'app' },
+      '.releaserc.json': {
+        plugins: ['@semantic-release/commit-analyzer', ['@semantic-release/npm', { npmPublish: true }]],
+      },
+    });
+    await expect(releasePublishesToNpm(project)).resolves.toBe(true);
+  });
+
+  it('reads the plugin list from package.json#release', async () => {
+    const project = await createProject({
+      'package.json': { name: 'app', release: { plugins: ['@semantic-release/github'] } },
+    });
+    await expect(releasePublishesToNpm(project)).resolves.toBe(false);
+  });
+
+  it('lets an explicit plugin list win over an extends preset', async () => {
+    const project = await createProject({
+      'package.json': { name: 'app' },
+      '.releaserc.json': { extends: 'some-shared-config', plugins: ['@semantic-release/github'] },
+    });
+    // `plugins` is explicit, so it wins over the preset per semantic-release's option merging.
+    await expect(releasePublishesToNpm(project)).resolves.toBe(false);
+  });
+
+  it('keeps the npm preparation for an extends preset without an explicit plugin list', async () => {
+    const project = await createProject({
+      'package.json': { name: 'app' },
+      '.releaserc.json': { extends: 'some-shared-config' },
+    });
+    await expect(releasePublishesToNpm(project)).resolves.toBe(true);
+  });
+
+  it('keeps the npm preparation when a non-JSON configuration file exists', async () => {
+    const project = await createProject({ 'package.json': { name: 'app' } });
+    await fs.promises.writeFile(path.join(project.dirPath, 'release.config.js'), 'module.exports = {};', 'utf8');
+    await expect(releasePublishesToNpm(project)).resolves.toBe(true);
+  });
+
+  it('keeps the npm preparation when a workspace package configures @semantic-release/npm', async () => {
+    const project = await createProject({
+      'package.json': { name: 'root', workspaces: ['packages/*'] },
+      '.releaserc.json': { plugins: ['@semantic-release/github'] },
+      'packages/app/package.json': { name: 'app' },
+      'packages/lib/package.json': { name: 'lib' },
+      'packages/lib/.releaserc.json': { plugins: ['@semantic-release/npm'] },
+    });
+    await expect(releasePublishesToNpm(project)).resolves.toBe(true);
+  });
+
+  it('skips when the root and every workspace package configure npm-free plugins', async () => {
+    const project = await createProject({
+      'package.json': { name: 'root', workspaces: ['packages/*'] },
+      '.releaserc.json': { plugins: ['@semantic-release/github'] },
+      'packages/app/package.json': { name: 'app' },
+      'packages/lib/package.json': { name: 'lib' },
+      'packages/lib/.releaserc.json': { plugins: ['@semantic-release/exec'] },
+    });
+    await expect(releasePublishesToNpm(project)).resolves.toBe(false);
   });
 });
 

--- a/packages/wbfy/src/fixers/typos.ts
+++ b/packages/wbfy/src/fixers/typos.ts
@@ -101,12 +101,16 @@ export function fixTyposInText(content: string): string {
     .replaceAll(/\bie\.(?=\s)/g, 'i.e.');
 }
 
-function fixTyposInCode(content: string): string {
-  return content
-    .replaceAll(/\/\*[\s\S]*?\*\//g, (comment) => fixTyposInText(comment))
-    .replaceAll(/(^|\s)\/\/(.*?)c\.f\./g, '$1//$2cf.')
-    .replaceAll(/(^|\s)\/\/(.*?)eg\./g, '$1//$2e.g.')
-    .replaceAll(/(^|\s)\/\/(.*?)ie\./g, '$1//$2i.e.');
+export function fixTyposInCode(content: string): string {
+  return (
+    content
+      .replaceAll(/\/\*[\s\S]*?\*\//g, (comment) => fixTyposInText(comment))
+      // The word boundary and trailing-whitespace guard keep words merely ending in the
+      // abbreviation letters (e.g. "cookie.", "leg.") intact.
+      .replaceAll(/(^|\s)\/\/(.*?)\bc\.f\.(?=\s|$)/g, '$1//$2cf.')
+      .replaceAll(/(^|\s)\/\/(.*?)\beg\.(?=\s|$)/g, '$1//$2e.g.')
+      .replaceAll(/(^|\s)\/\/(.*?)\bie\.(?=\s|$)/g, '$1//$2i.e.')
+  );
 }
 
 function replaceWithConfig(newContent: string, packageConfig: PackageConfig, propName: 'doc' | 'ts' | 'text'): string {

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
 import { logger } from '../logger.js';
@@ -47,6 +48,9 @@ function generateAgentInstruction(
 ): string {
   const packageManager = 'bun';
   const description = rootConfig.packageJson?.description;
+  const fnoxInstruction = fs.existsSync(path.resolve(rootConfig.dirPath, 'fnox.toml'))
+    ? `\n- Environment variables and secrets are managed in \`fnox.toml\` via mise + fnox; run commands through \`${packageManager} wb ...\` or \`fnox run -- <command>\` instead of expecting \`.env\` files.`
+    : '';
   // WillBooster Railway project identifiers are managed in deploy workflow settings.
   const railwayInstruction = rootConfig.isRailway
     ? '\n- Railway project information is in the deploy workflows under `.github/workflows`.'
@@ -79,7 +83,7 @@ function generateAgentInstruction(
   - Follow the Conventional Commits format (e.g., \`feat:\`, \`fix:\`).${coAuthorInstruction}
   - Always create new commits; avoid \`--amend\`.
 - Use heredoc for multi-line command input (e.g., \`git commit -F -\`, \`gh pr create --body-file -\`).
-- Put temporary files in \`.tmp\`; use \`/tmp\` only for files that must live outside the repo.${railwayInstruction}${playwrightTestServerInstruction}
+- Put temporary files in \`.tmp\`; use \`/tmp\` only for files that must live outside the repo.${fnoxInstruction}${railwayInstruction}${playwrightTestServerInstruction}
 
 ${generateAgentCodingStyle(allConfigs)}
 `
@@ -110,6 +114,8 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
 - Prefer \`undefined\` over \`null\` unless required by APIs or libraries.
 - Build prompts as a single template literal instead of \`join()\` on a pre-computable array of strings.
 - Assume all environment variables are defined; if validation is needed, \`assert\` at startup to fail fast.
+- Assume local tools such as \`git\`, \`gh\`, and \`ghq\` are installed and authenticated.
+- Ensure compatibility only with macOS and Linux; do not include Windows-specific code.
 ${
   allConfigs.some((c) => c.depending.genI18nTs)
     ? `- When adding string literals in React components, register them in the \`i18n\` resource files (e.g., \`i18n/ja-JP.json\`) and reference them via the \`i18n\` utility (e.g., \`i18n.pages.home.title()\` for \`{ "pages": { "home": { "title": "My App" } } }\`).`

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -6,6 +6,7 @@ import { parse } from 'smol-toml';
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
+import { doesContainJava } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
 
 interface BunfigToml {
@@ -178,13 +179,20 @@ export async function generateBunfigToml(config: PackageConfig, linker: BunLinke
   return logger.functionIgnoringException('generateBunfigToml', async () => {
     const filePath = path.resolve(config.dirPath, 'bunfig.toml');
     const existingContent = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
-    const content = newContent(existingContent, linker);
+    const content = newContent(existingContent, linker, config);
     await promisePool.run(() => fsUtil.generateFile(filePath, content));
   });
 }
 
-const newContent = (existingContent: string | undefined, linker: BunLinker): string => {
+const newContent = (existingContent: string | undefined, linker: BunLinker, config: PackageConfig): string => {
   const bunfigToml = parseBunfigToml(existingContent);
+  // Only Java repositories still depend on @willbooster/prettier-config (wbfy installs it with
+  // prettier-plugin-java); everywhere else oxfmt replaced Prettier, so the exclusion is dead
+  // weight in the generated file. The exported list keeps the entry because packageJson.ts's
+  // version age gate matters only where wbfy actually pins the package (i.e. Java repositories).
+  const minimumReleaseAgeExcludes = doesContainJava(config)
+    ? bunMinimumReleaseAgeExcludes
+    : bunMinimumReleaseAgeExcludes.filter((packageName) => packageName !== '@willbooster/prettier-config');
   // No `[run] bun = true`: its node->bun PATH shim leaks into every child process and breaks
   // tools requiring real Node.js (Playwright, wrangler, vinext); any existing setting is dropped.
   return `env = false
@@ -204,7 +212,7 @@ ${
 }
 minimumReleaseAge = ${bunMinimumReleaseAgeSeconds} # 5 days
 minimumReleaseAgeExcludes = [
-${bunMinimumReleaseAgeExcludes.map((packageName) => `    "${packageName}",`).join('\n')}
+${minimumReleaseAgeExcludes.map((packageName) => `    "${packageName}",`).join('\n')}
 ]
 `;
 };

--- a/packages/wbfy/src/generators/idea.ts
+++ b/packages/wbfy/src/generators/idea.ts
@@ -21,6 +21,11 @@ export async function generateIdeaSettings(config: PackageConfig): Promise<void>
       await (doesContainJsOrTs(config) || doesContainJava(config)
         ? promisePool.run(() => fsUtil.generateFile(filePath, getWatcherTasksContent(config)))
         : promisePool.run(() => fs.promises.rm(filePath, { force: true })));
+      // Only Java repositories keep Prettier (via prettier-plugin-java); everywhere else a
+      // leftover prettier.xml is a stale artifact of the pre-oxfmt setup.
+      if (!doesContainJava(config)) {
+        await promisePool.run(() => fs.promises.rm(path.resolve(dirPath, 'prettier.xml'), { force: true }));
+      }
     }
   });
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -790,13 +790,20 @@ async function normalizePackageMetadata(
     jsonObj.name = path.basename(config.dirPath);
   }
 
-  // A monorepo root configured for npm publishing (a semantic-release config with
-  // `@semantic-release/npm` — or one packageConfig cannot inspect statically, such as a JS/YAML
-  // config or an `extends` preset — or an explicit `publishConfig`) must not be forced private:
-  // `@semantic-release/npm` silently
-  // skips private packages, so forcing `private: true` would stop releases without any error
-  // (e.g. WillBoosterLab/llm-proxy publishing @willbooster-private/llm-proxy).
-  if (config.doesContainSubPackageJsons && !config.release.npm && !jsonObj.publishConfig) {
+  // A monorepo root configured for npm publishing (semantic-release with `@semantic-release/npm`
+  // — via an explicit plugin entry, the plugin-less default list, or a config packageConfig
+  // cannot inspect statically such as JS/YAML or an `extends` preset — or an explicit
+  // `publishConfig`) must not be forced private: `@semantic-release/npm` silently skips private
+  // packages, so forcing `private: true` would stop releases without any error (e.g.
+  // WillBoosterLab/llm-proxy publishing @willbooster-private/llm-proxy).
+  if (config.doesContainSubPackageJsons && config.release.npmPublishesRoot) {
+    // Older wbfy forced `private: true` on every monorepo root; when the user has EXPLICITLY
+    // configured `@semantic-release/npm` to publish the root itself, that stale flag silently
+    // suppresses publishing, so migrate it away. Roots relying on the plugin-less default list
+    // keep their `private` value untouched: `private: true` there can be a deliberate opt-out,
+    // which `@semantic-release/npm` honors by defaulting npmPublish to false.
+    delete jsonObj.private;
+  } else if (config.doesContainSubPackageJsons && !config.release.npm && !jsonObj.publishConfig) {
     jsonObj.private = true;
   }
   if (!jsonObj.license) {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -482,10 +482,10 @@ async function applyPackageJsonConventions(
       // declared patterns (workspaces.packages); only extras such as nohoist are dropped.
       // Force `packages/*` only when it actually matches a workspace manifest: an apps/*-only
       // monorepo must not get a never-matching pattern appended to its declaration. A
-      // baseline-active declaration needs no forced pattern at all (the implicit `*/*` already
-      // covers packages/*), and adding one would disable the baseline. The forced pattern is
-      // PREPENDED: Bun evaluates workspace patterns sequentially, so a positive pattern placed
-      // after a user negation would re-include the negated packages.
+      // baseline-seeding declaration needs no forced pattern at all — the seeded baseline
+      // (`*/*` or `**`) already covers packages/*. The forced pattern is PREPENDED: Bun
+      // evaluates workspace patterns sequentially, so a positive pattern placed after a user
+      // negation would re-include the negated packages.
       const forcedPatterns =
         !hasImplicitWorkspaceBaseline(jsonObj.workspaces) &&
         fg.globSync('packages/*/package.json', { cwd: config.dirPath, ignore: ['**/node_modules/**'] }).length > 0

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -786,7 +786,11 @@ async function normalizePackageMetadata(
     jsonObj.name = path.basename(config.dirPath);
   }
 
-  if (config.doesContainSubPackageJsons) {
+  // A monorepo root configured for npm publishing (a `.releaserc.json` with `@semantic-release/npm`
+  // or an explicit `publishConfig`) must not be forced private: `@semantic-release/npm` silently
+  // skips private packages, so forcing `private: true` would stop releases without any error
+  // (e.g. WillBoosterLab/llm-proxy publishing @willbooster-private/llm-proxy).
+  if (config.doesContainSubPackageJsons && !config.release.npm && !jsonObj.publishConfig) {
     jsonObj.private = true;
   }
   if (!jsonObj.license) {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -35,6 +35,7 @@ import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfig
 import {
   getDeclaredWorkspacePatterns,
   getWorkspacePackageJsonPaths,
+  hasDeclaredPackagesStarPattern,
   hasImplicitWorkspaceBaseline,
 } from '../utils/workspaceUtil.js';
 import { bunMinimumReleaseAgeExcludes, bunMinimumReleaseAgeSeconds } from './bunfig.js';
@@ -485,9 +486,12 @@ async function applyPackageJsonConventions(
       // baseline-seeding declaration needs no forced pattern at all — the seeded baseline
       // (`*/*` or `**`) already covers packages/*. The forced pattern is PREPENDED: Bun
       // evaluates workspace patterns sequentially, so a positive pattern placed after a user
-      // negation would re-include the negated packages.
+      // negation would re-include the negated packages. A declaration that already covers
+      // packages/* under normalization (e.g. `./packages/*`) is kept verbatim: forcing a textual
+      // `packages/*` next to it would persist a duplicate equivalent pattern.
       const forcedPatterns =
         !hasImplicitWorkspaceBaseline(jsonObj.workspaces) &&
+        !hasDeclaredPackagesStarPattern(jsonObj.workspaces) &&
         fg.globSync('packages/*/package.json', { cwd: config.dirPath, ignore: ['**/node_modules/**'] }).length > 0
           ? ['packages/*']
           : [];
@@ -786,8 +790,10 @@ async function normalizePackageMetadata(
     jsonObj.name = path.basename(config.dirPath);
   }
 
-  // A monorepo root configured for npm publishing (a `.releaserc.json` with `@semantic-release/npm`
-  // or an explicit `publishConfig`) must not be forced private: `@semantic-release/npm` silently
+  // A monorepo root configured for npm publishing (a semantic-release config with
+  // `@semantic-release/npm` — or one packageConfig cannot inspect statically, such as a JS/YAML
+  // config or an `extends` preset — or an explicit `publishConfig`) must not be forced private:
+  // `@semantic-release/npm` silently
   // skips private packages, so forcing `private: true` would stop releases without any error
   // (e.g. WillBoosterLab/llm-proxy publishing @willbooster-private/llm-proxy).
   if (config.doesContainSubPackageJsons && !config.release.npm && !jsonObj.publishConfig) {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -796,12 +796,15 @@ async function normalizePackageMetadata(
   // `publishConfig`) must not be forced private: `@semantic-release/npm` silently skips private
   // packages, so forcing `private: true` would stop releases without any error (e.g.
   // WillBoosterLab/llm-proxy publishing @willbooster-private/llm-proxy).
-  if (config.doesContainSubPackageJsons && config.release.npmPublishesRoot) {
-    // Older wbfy forced `private: true` on every monorepo root; when the user has EXPLICITLY
-    // configured `@semantic-release/npm` to publish the root itself, that stale flag silently
-    // suppresses publishing, so migrate it away. Roots relying on the plugin-less default list
-    // keep their `private` value untouched: `private: true` there can be a deliberate opt-out,
-    // which `@semantic-release/npm` honors by defaulting npmPublish to false.
+  if (config.doesContainSubPackageJsons && (config.release.npmPublishesRoot || jsonObj.publishConfig)) {
+    // Older wbfy forced `private: true` on every monorepo root (and never added a publishConfig
+    // to one, since it only does that for non-private manifests — so a root-level publishConfig
+    // is user-authored publishing intent); when the user has EXPLICITLY configured
+    // `@semantic-release/npm` to publish the root itself, or declared a `publishConfig`, that
+    // stale flag silently suppresses publishing, so migrate it away. Roots relying on the
+    // plugin-less default list keep their `private` value untouched: `private: true` there can
+    // be a deliberate opt-out, which `@semantic-release/npm` honors by defaulting npmPublish to
+    // false.
     delete jsonObj.private;
   } else if (config.doesContainSubPackageJsons && !config.release.npm && !jsonObj.publishConfig) {
     jsonObj.private = true;

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -141,8 +141,10 @@ function buildRootJsonObj(config: PackageConfig): TsConfigJson {
   settings.exclude = [
     ...new Set([
       ...workspacePatterns.includes.map((workspacePattern) => `${workspacePattern}/test/fixtures`),
-      // Negative workspace patterns (e.g. `!packages/excluded`) opt whole workspace subtrees out
-      // of the monorepo, so their sources must not enter the root type-check project either.
+      // Negative workspace patterns (e.g. `!packages/excluded`) opt workspace subtrees out of the
+      // monorepo, so their sources must not enter the root type-check project either. A negation
+      // whose directory is an ancestor of a workspace yields package-owned subpath entries
+      // instead of the whole subtree (see getWorkspaceDirPatterns).
       ...workspacePatterns.excludes,
       ...(settings.exclude ?? []),
     ]),

--- a/packages/wbfy/src/generators/vscodeSettings.ts
+++ b/packages/wbfy/src/generators/vscodeSettings.ts
@@ -7,7 +7,11 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { sortKeys } from '../utils/objectUtil.js';
+import { doesContainJava } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
+
+const prettierVscodeExtension = 'esbenp.prettier-vscode';
+const oxcVscodeExtension = 'oxc.oxc-vscode';
 
 const excludeFilePatterns = [
   '**/.git/objects/**',
@@ -49,6 +53,12 @@ export async function generateVscodeSettings(config: PackageConfig): Promise<voi
     if ('editor.formatOnSave' in settings) {
       delete settings['editor.formatOnSave'];
     }
+    // Only Java repositories keep Prettier (via prettier-plugin-java); everywhere else the
+    // formatter is oxfmt, so a leftover prettier-vscode formatter setting (including per-language
+    // overrides) must follow the migration to the oxc extension.
+    if (!doesContainJava(config)) {
+      replacePrettierVscodeValues(settings);
+    }
     sortKeys(settings as Record<string, unknown>);
     // Skip the write when nothing changes semantically, so JSONC comments and formatting in an
     // already-clean settings.json survive wbfy runs.
@@ -56,6 +66,44 @@ export async function generateVscodeSettings(config: PackageConfig): Promise<voi
     const newContent = JSON.stringify(settings, undefined, 2);
     await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
   });
+}
+
+/**
+ * Replaces a stale prettier-vscode recommendation in an existing .vscode/extensions.json with the
+ * oxc extension (Java repositories keep Prettier, so theirs is left untouched). The file is never
+ * created when absent.
+ */
+export async function fixVscodeExtensions(config: PackageConfig): Promise<void> {
+  return logger.functionIgnoringException('fixVscodeExtensions', async () => {
+    if (doesContainJava(config)) return;
+    const filePath = path.resolve(config.dirPath, '.vscode', 'extensions.json');
+    const existingContent = await fsUtil.readFileIfExists(filePath);
+    if (existingContent === undefined) return;
+    const parsed = jsoncUtil.parseObjectIgnoringError<{ recommendations?: unknown }>(existingContent);
+    if (!parsed || !Array.isArray(parsed.recommendations) || !parsed.recommendations.includes(prettierVscodeExtension))
+      return;
+    const recommendations = [
+      ...new Set(
+        parsed.recommendations.map((extension: unknown) =>
+          extension === prettierVscodeExtension ? oxcVscodeExtension : extension
+        )
+      ),
+    ];
+    const newContent = JSON.stringify({ ...parsed, recommendations }, undefined, 2);
+    await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
+  });
+}
+
+// Values only (e.g. `editor.defaultFormatter` and its per-language `[typescript]` overrides):
+// keys never carry the extension identifier.
+function replacePrettierVscodeValues(node: object): void {
+  for (const [key, value] of Object.entries(node)) {
+    if (value === prettierVscodeExtension) {
+      (node as Record<string, unknown>)[key] = oxcVscodeExtension;
+    } else if (value && typeof value === 'object') {
+      replacePrettierVscodeValues(value);
+    }
+  }
 }
 
 function excludeSetting(excludeFilePattern: string): object {

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -178,9 +178,14 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
   }
 
   const wbEnvComment =
+    '# CI sets WB_ENV as a process env var, which wins over fnox when loaded through wb; bare fnox run/export uses the fnox value, so pass -P <profile>.';
+  // An earlier wbfy wrote a comment overstating the precedence (bare `fnox run/export` lets the
+  // fnox value win over an inherited process env var); rewrite it in place so target repositories
+  // converge on the corrected wording instead of keeping the stale claim forever.
+  const outdatedWbEnvComment =
     '# CI sets WB_ENV as a process env var, which wins over fnox; these defaults only fill it locally.';
   const keyNames = needsNextPublic ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
-  let updatedContent = content;
+  let updatedContent = content.replace(outdatedWbEnvComment, wbEnvComment);
   for (const mode of wbEnvModes) {
     // The staging mode is optional: complete it only when the repository already declares the profile.
     if (mode === 'staging' && !settings.profiles?.staging) continue;

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -179,13 +179,14 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
 
   const wbEnvComment =
     '# CI sets WB_ENV as a process env var, which wins over fnox when loaded through wb; bare fnox run/export uses the fnox value, so pass -P <profile>.';
-  // An earlier wbfy wrote a comment overstating the precedence (bare `fnox run/export` lets the
-  // fnox value win over an inherited process env var); rewrite it in place so target repositories
-  // converge on the corrected wording instead of keeping the stale claim forever.
-  const outdatedWbEnvComment =
-    '# CI sets WB_ENV as a process env var, which wins over fnox; these defaults only fill it locally.';
+  // Earlier wbfy versions wrote a comment overstating the precedence (bare `fnox run/export` lets
+  // the fnox value win over an inherited process env var), in several wording variants (with or
+  // without a trailing period); rewrite any of them in place so target repositories converge on
+  // the corrected wording instead of keeping the stale claim forever.
+  const outdatedWbEnvCommentPattern =
+    /^# CI sets WB_ENV as a process env var, which wins over fnox;(?! when loaded through wb).*$/mu;
   const keyNames = needsNextPublic ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
-  let updatedContent = content.replace(outdatedWbEnvComment, wbEnvComment);
+  let updatedContent = content.replace(outdatedWbEnvCommentPattern, wbEnvComment);
   for (const mode of wbEnvModes) {
     // The staging mode is optional: complete it only when the repository already declares the profile.
     if (mode === 'staging' && !settings.profiles?.staging) continue;

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -38,7 +38,7 @@ import { generateReleaserc } from './generators/releaserc.js';
 import { generateRenovateJson } from './generators/renovateJson.js';
 import { installAgentSkills } from './generators/skills.js';
 import { generateTsconfig } from './generators/tsconfig.js';
-import { generateVscodeSettings } from './generators/vscodeSettings.js';
+import { fixVscodeExtensions, generateVscodeSettings } from './generators/vscodeSettings.js';
 import { ensureWbEnvDefinitions } from './generators/wbEnv.js';
 import { generateWorkflows, isReusableWorkflowsRepo } from './generators/workflow.js';
 import { generateMiseToml, minimumBunVersion } from './generators/miseToml.js';
@@ -311,6 +311,9 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
       promises.push(generateLintstagedrc(config));
       if (config.doesContainVscodeSettingsJson && config.doesContainPackageJson) {
         promises.push(generateVscodeSettings(config));
+      }
+      if (config.doesContainPackageJson) {
+        promises.push(fixVscodeExtensions(config));
       }
       if (config.doesContainTypeScript || config.doesContainTypeScriptInPackages) {
         promises.push(generateTsconfig(config));

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -125,19 +125,40 @@ export async function getPackageConfig(
     }
 
     let releaseBranches: string[] = [];
-    let releasePlugins: string[] = [];
+    let releasePlugins: (string | object)[] = [];
+    // JS/YAML semantic-release configs and `extends` presets cannot be inspected statically
+    // (mirrors readExplicitSemanticReleasePlugins in wb's release.ts). Treating their plugin
+    // list as unknown keeps `release.npm` conservatively true, so applyPackageJsonConventions
+    // never forces `private: true` on a monorepo that actually publishes to npm.
+    let releasePluginsAreUnknown = [
+      '.releaserc.yaml',
+      '.releaserc.yml',
+      '.releaserc.js',
+      '.releaserc.cjs',
+      '.releaserc.mjs',
+      'release.config.js',
+      'release.config.cjs',
+      'release.config.mjs',
+    ].some((fileName) => fs.existsSync(path.resolve(dirPath, fileName)));
     try {
-      const releasercJsonPath = path.resolve(dirPath, '.releaserc.json');
-      const json = JSON.parse(await fsp.readFile(releasercJsonPath, 'utf8')) as
-        | {
-            branches: string[];
-            plugins?: string[][];
-          }
-        | undefined;
-      releaseBranches = json?.branches ?? [];
-      releasePlugins = json?.plugins?.flat() ?? [];
+      type ReleaseConfig = { branches?: string[]; plugins?: (string | object)[][]; extends?: unknown } | undefined;
+      let releaseConfig: ReleaseConfig;
+      for (const fileName of ['.releaserc', '.releaserc.json']) {
+        const releasercPath = path.resolve(dirPath, fileName);
+        if (!fs.existsSync(releasercPath)) continue;
+        // `.releaserc` may also hold YAML; a JSON.parse failure lands in the catch below and
+        // marks the plugin list unknown instead of silently reporting "no plugins".
+        releaseConfig = JSON.parse(await fsp.readFile(releasercPath, 'utf8')) as ReleaseConfig;
+        break;
+      }
+      releaseConfig ??= (packageJson as { release?: ReleaseConfig }).release;
+      releaseBranches = releaseConfig?.branches ?? [];
+      releasePlugins = releaseConfig?.plugins?.flat() ?? [];
+      if (releaseConfig && !Array.isArray(releaseConfig.plugins) && releaseConfig.extends !== undefined) {
+        releasePluginsAreUnknown = true;
+      }
     } catch {
-      // do nothing
+      releasePluginsAreUnknown = true;
     }
 
     // The caller may classify explicitly (index.ts passes false for every discovered workspace,
@@ -260,7 +281,8 @@ export async function getPackageConfig(
         semanticRelease: !!(
           devDependencies['semantic-release'] ||
           releaseBranches.length > 0 ||
-          releasePlugins.length > 0
+          releasePlugins.length > 0 ||
+          releasePluginsAreUnknown
         ),
         storybook: !!devDependencies['@storybook/react'],
         tauri:
@@ -276,7 +298,7 @@ export async function getPackageConfig(
       release: {
         branches: releaseBranches,
         github: releasePlugins.includes('@semantic-release/github'),
-        npm: releasePlugins.includes('@semantic-release/npm'),
+        npm: releasePlugins.includes('@semantic-release/npm') || releasePluginsAreUnknown,
       },
       miseTasks: await readMiseTasks(dirPath),
       packageJson,

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -110,6 +110,34 @@ const wbfyJsonSchema = z.object({
     .optional(),
 });
 
+/**
+ * cosmiconfig 9's default searchPlaces order for module "release" (what semantic-release 25
+ * delegates to), minus the leading package.json entry, which the caller checks first. Places
+ * whose format JSON.parse cannot read are statically uninspectable.
+ */
+const semanticReleaseConfigSearchPlaces: { fileName: string; jsonParseable: boolean }[] = [
+  { fileName: '.releaserc', jsonParseable: true },
+  { fileName: '.releaserc.json', jsonParseable: true },
+  { fileName: '.releaserc.yaml', jsonParseable: false },
+  { fileName: '.releaserc.yml', jsonParseable: false },
+  { fileName: '.releaserc.js', jsonParseable: false },
+  { fileName: '.releaserc.ts', jsonParseable: false },
+  { fileName: '.releaserc.mjs', jsonParseable: false },
+  { fileName: '.releaserc.cjs', jsonParseable: false },
+  { fileName: '.config/releaserc', jsonParseable: true },
+  { fileName: '.config/releaserc.json', jsonParseable: true },
+  { fileName: '.config/releaserc.yaml', jsonParseable: false },
+  { fileName: '.config/releaserc.yml', jsonParseable: false },
+  { fileName: '.config/releaserc.js', jsonParseable: false },
+  { fileName: '.config/releaserc.ts', jsonParseable: false },
+  { fileName: '.config/releaserc.mjs', jsonParseable: false },
+  { fileName: '.config/releaserc.cjs', jsonParseable: false },
+  { fileName: 'release.config.js', jsonParseable: false },
+  { fileName: 'release.config.ts', jsonParseable: false },
+  { fileName: 'release.config.mjs', jsonParseable: false },
+  { fileName: 'release.config.cjs', jsonParseable: false },
+];
+
 export async function getPackageConfig(
   dirPath: string,
   options?: { isRoot?: boolean }
@@ -133,35 +161,46 @@ export async function getPackageConfig(
     let releasePlugins: string[] = [];
     let releasePluginsAreExplicit = false;
     let releaseNpmPluginPublishesRoot = false;
-    // JS/YAML semantic-release configs and `extends` presets cannot be inspected statically
-    // (mirrors readExplicitSemanticReleasePlugins in wb's release.ts). Treating their plugin
-    // list as unknown keeps `release.npm` conservatively true, so applyPackageJsonConventions
-    // never forces `private: true` on a monorepo that actually publishes to npm.
-    let releasePluginsAreUnknown = [
-      '.releaserc.yaml',
-      '.releaserc.yml',
-      '.releaserc.js',
-      '.releaserc.cjs',
-      '.releaserc.mjs',
-      'release.config.js',
-      'release.config.cjs',
-      'release.config.mjs',
-    ].some((fileName) => fs.existsSync(path.resolve(dirPath, fileName)));
+    // The FIRST existing search place wins (cosmiconfig short-circuits), so a JS/YAML/TS config
+    // or an `extends` preset makes the effective plugin list statically uninspectable (mirrors
+    // readExplicitSemanticReleasePlugins in wb's release.ts). Treating it as unknown keeps
+    // `release.npm` conservatively true, so applyPackageJsonConventions never forces
+    // `private: true` on a monorepo that actually publishes to npm.
+    let releasePluginsAreUnknown = false;
     try {
       type ReleaseConfig =
-        | { branches?: string[]; plugins?: (string | [string, Record<string, unknown>])[]; extends?: unknown }
+        | {
+            branches?: unknown;
+            plugins?: (string | [string, Record<string, unknown>])[];
+            extends?: unknown;
+          }
         | undefined;
-      let releaseConfig: ReleaseConfig;
-      for (const fileName of ['.releaserc', '.releaserc.json']) {
-        const releasercPath = path.resolve(dirPath, fileName);
-        if (!fs.existsSync(releasercPath)) continue;
-        // `.releaserc` may also hold YAML; a JSON.parse failure lands in the catch below and
-        // marks the plugin list unknown instead of silently reporting "no plugins".
-        releaseConfig = JSON.parse(await fsp.readFile(releasercPath, 'utf8')) as ReleaseConfig;
-        break;
+      // cosmiconfig searches package.json's `release` key BEFORE any rc/config file
+      // (semantic-release 25 delegates to cosmiconfig 9's default searchPlaces).
+      let releaseConfig = (packageJson as { release?: ReleaseConfig }).release;
+      if (releaseConfig === undefined) {
+        for (const { fileName, jsonParseable } of semanticReleaseConfigSearchPlaces) {
+          const releasercPath = path.resolve(dirPath, fileName);
+          if (!fs.existsSync(releasercPath)) continue;
+          if (!jsonParseable) {
+            releasePluginsAreUnknown = true;
+            break;
+          }
+          // `.releaserc` and `.config/releaserc` may also hold YAML; a JSON.parse failure lands
+          // in the catch below and marks the plugin list unknown instead of silently reporting
+          // "no plugins".
+          releaseConfig = JSON.parse(await fsp.readFile(releasercPath, 'utf8')) as ReleaseConfig;
+          break;
+        }
       }
-      releaseConfig ??= (packageJson as { release?: ReleaseConfig }).release;
-      releaseBranches = releaseConfig?.branches ?? [];
+      // semantic-release accepts a scalar branch or branch objects ({ name, prerelease, ... });
+      // normalize to plain branch names for consumers such as the workflow generator.
+      const rawBranches = releaseConfig?.branches;
+      releaseBranches = (Array.isArray(rawBranches) ? rawBranches : rawBranches === undefined ? [] : [rawBranches])
+        .map((branch: unknown) =>
+          typeof branch === 'string' ? branch : (branch as { name?: unknown } | undefined)?.name
+        )
+        .filter((branchName): branchName is string => typeof branchName === 'string');
       if (Array.isArray(releaseConfig?.plugins)) {
         releasePluginsAreExplicit = true;
         for (const pluginEntry of releaseConfig.plugins) {
@@ -169,11 +208,14 @@ export async function getPackageConfig(
           if (typeof pluginName !== 'string') continue;
           releasePlugins.push(pluginName);
           if (pluginName !== '@semantic-release/npm') continue;
-          // With pkgRoot the plugin publishes another manifest, and npmPublish: false disables
-          // publishing entirely; only the remaining shape proves the ROOT itself is published.
+          // With pkgRoot the plugin publishes another manifest (it resolves pkgRoot against the
+          // repo root, so `.` and `./` both mean the root itself), and npmPublish: false
+          // disables publishing entirely; only the remaining shape proves the ROOT is published.
+          const pkgRoot = pluginOptions?.pkgRoot;
           const publishesRoot =
             pluginOptions?.npmPublish !== false &&
-            (pluginOptions?.pkgRoot === undefined || pluginOptions.pkgRoot === '.');
+            (pkgRoot === undefined ||
+              (typeof pkgRoot === 'string' && path.resolve(dirPath, pkgRoot) === path.resolve(dirPath)));
           releaseNpmPluginPublishesRoot ||= publishesRoot;
         }
       } else if (releaseConfig && releaseConfig.extends !== undefined) {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -86,6 +86,11 @@ export interface PackageConfig {
     branches: string[];
     github: boolean;
     npm: boolean;
+    /**
+     * An explicit `@semantic-release/npm` plugin entry publishes the root manifest itself
+     * (no pkgRoot redirection and npmPublish not disabled).
+     */
+    npmPublishesRoot: boolean;
   };
   miseTasks: Record<string, string>;
   packageJson?: PackageJson;
@@ -125,7 +130,9 @@ export async function getPackageConfig(
     }
 
     let releaseBranches: string[] = [];
-    let releasePlugins: (string | object)[] = [];
+    let releasePlugins: string[] = [];
+    let releasePluginsAreExplicit = false;
+    let releaseNpmPluginPublishesRoot = false;
     // JS/YAML semantic-release configs and `extends` presets cannot be inspected statically
     // (mirrors readExplicitSemanticReleasePlugins in wb's release.ts). Treating their plugin
     // list as unknown keeps `release.npm` conservatively true, so applyPackageJsonConventions
@@ -141,7 +148,9 @@ export async function getPackageConfig(
       'release.config.mjs',
     ].some((fileName) => fs.existsSync(path.resolve(dirPath, fileName)));
     try {
-      type ReleaseConfig = { branches?: string[]; plugins?: (string | object)[][]; extends?: unknown } | undefined;
+      type ReleaseConfig =
+        | { branches?: string[]; plugins?: (string | [string, Record<string, unknown>])[]; extends?: unknown }
+        | undefined;
       let releaseConfig: ReleaseConfig;
       for (const fileName of ['.releaserc', '.releaserc.json']) {
         const releasercPath = path.resolve(dirPath, fileName);
@@ -153,13 +162,35 @@ export async function getPackageConfig(
       }
       releaseConfig ??= (packageJson as { release?: ReleaseConfig }).release;
       releaseBranches = releaseConfig?.branches ?? [];
-      releasePlugins = releaseConfig?.plugins?.flat() ?? [];
-      if (releaseConfig && !Array.isArray(releaseConfig.plugins) && releaseConfig.extends !== undefined) {
+      if (Array.isArray(releaseConfig?.plugins)) {
+        releasePluginsAreExplicit = true;
+        for (const pluginEntry of releaseConfig.plugins) {
+          const [pluginName, pluginOptions] = Array.isArray(pluginEntry) ? pluginEntry : [pluginEntry, undefined];
+          if (typeof pluginName !== 'string') continue;
+          releasePlugins.push(pluginName);
+          if (pluginName !== '@semantic-release/npm') continue;
+          // With pkgRoot the plugin publishes another manifest, and npmPublish: false disables
+          // publishing entirely; only the remaining shape proves the ROOT itself is published.
+          const publishesRoot =
+            pluginOptions?.npmPublish !== false &&
+            (pluginOptions?.pkgRoot === undefined || pluginOptions.pkgRoot === '.');
+          releaseNpmPluginPublishesRoot ||= publishesRoot;
+        }
+      } else if (releaseConfig && releaseConfig.extends !== undefined) {
         releasePluginsAreUnknown = true;
       }
     } catch {
       releasePluginsAreUnknown = true;
     }
+    // Without an explicit plugin list, semantic-release's default list applies, which includes
+    // @semantic-release/npm and @semantic-release/github (mirrors releasePublishesToNpm in wb's
+    // release.ts).
+    const usesSemanticRelease = !!(
+      devDependencies['semantic-release'] ||
+      releaseBranches.length > 0 ||
+      releasePlugins.length > 0 ||
+      releasePluginsAreUnknown
+    );
 
     // The caller may classify explicitly (index.ts passes false for every discovered workspace,
     // including non-packages/* layouts such as apps/*); the heuristic classifies the CLI entry
@@ -278,12 +309,7 @@ export async function getPackageConfig(
         prisma: !!dependencies['@prisma/client'] || !!devDependencies.prisma,
         pyright: !!devDependencies.pyright,
         reactNative: !!dependencies['react-native'],
-        semanticRelease: !!(
-          devDependencies['semantic-release'] ||
-          releaseBranches.length > 0 ||
-          releasePlugins.length > 0 ||
-          releasePluginsAreUnknown
-        ),
+        semanticRelease: usesSemanticRelease,
         storybook: !!devDependencies['@storybook/react'],
         tauri:
           !!dependencies['@tauri-apps/api'] ||
@@ -297,8 +323,13 @@ export async function getPackageConfig(
       },
       release: {
         branches: releaseBranches,
-        github: releasePlugins.includes('@semantic-release/github'),
-        npm: releasePlugins.includes('@semantic-release/npm') || releasePluginsAreUnknown,
+        github: releasePluginsAreExplicit
+          ? releasePlugins.includes('@semantic-release/github') || releasePluginsAreUnknown
+          : usesSemanticRelease,
+        npm: releasePluginsAreExplicit
+          ? releasePlugins.includes('@semantic-release/npm') || releasePluginsAreUnknown
+          : usesSemanticRelease,
+        npmPublishesRoot: releaseNpmPluginPublishesRoot,
       },
       miseTasks: await readMiseTasks(dirPath),
       packageJson,

--- a/packages/wbfy/src/utils/globUtil.ts
+++ b/packages/wbfy/src/utils/globUtil.ts
@@ -1,6 +1,9 @@
 export const globIgnore = [
   '**/node_modules/**',
   '**/.antigravitycli/**',
+  // The org-standard temporary directory; stale copies under it (e.g. review scratch dirs) must
+  // not influence language detection.
+  '**/.tmp/**',
   '**/.venv/**',
   '**/test-fixtures/**',
   '**/test/fixtures/**',

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
 import fg from 'fast-glob';
@@ -105,22 +106,29 @@ export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): WorkspaceD
 /**
  * tsconfig exclude entries for one negation. Pattern-shaped when the negation excludes exactly
  * what it matches (stable output); per-directory otherwise: a directory that is a workspace
- * despite the negation is not excluded at all, and neither is a descendant of a workspace
- * directory — negating a non-package directory is a no-op for Bun, and the enclosing workspace
- * stays active (e.g. `['apps/**', '!apps/**', 'apps/web']` re-includes apps/web, whose src must
- * keep type-checking; a tsconfig exclude would override the include). A directory that is an
+ * despite the negation is not excluded at all, and neither is a PLAIN (package.json-less)
+ * descendant of a workspace directory — negating a non-package directory is a no-op for Bun,
+ * and the enclosing workspace stays active (e.g. `['apps/**', '!apps/**', 'apps/web']`
+ * re-includes apps/web, whose src must keep type-checking; a tsconfig exclude would override
+ * the include). A descendant with its own manifest that the negation keeps out of the workspace
+ * set is an excluded nested package and stays excluded. A directory that is an
  * ancestor of a workspace directory gets only its package-owned subpaths excluded, because Bun
  * excludes only the package AT that directory while keeping descendant workspaces (#1004).
  */
 function toExcludeEntries(negationBody: string, workspaceDirPaths: Set<string>, rootDirPath: string): string[] {
   const isWorkspaceAncestor = (dirPath: string): boolean =>
     [...workspaceDirPaths].some((workspaceDirPath) => workspaceDirPath.startsWith(`${dirPath}/`));
-  const isWorkspaceDescendant = (dirPath: string): boolean =>
-    [...workspaceDirPaths].some((workspaceDirPath) => dirPath.startsWith(`${workspaceDirPath}/`));
+  // Only PLAIN directories (no package.json of their own) are protected by the enclosing
+  // workspace: a matched directory that carries its own manifest yet is absent from the final
+  // workspace set is an excluded nested package, and its exclusion must survive.
+  const isProtectedWorkspaceDescendant = (dirPath: string): boolean =>
+    [...workspaceDirPaths].some((workspaceDirPath) => dirPath.startsWith(`${workspaceDirPath}/`)) &&
+    !fs.existsSync(path.join(rootDirPath, dirPath, 'package.json'));
   const matchedDirPaths = getMatchedDirPaths(negationBody, rootDirPath);
   if (
     !matchedDirPaths.some(
-      (dirPath) => workspaceDirPaths.has(dirPath) || isWorkspaceAncestor(dirPath) || isWorkspaceDescendant(dirPath)
+      (dirPath) =>
+        workspaceDirPaths.has(dirPath) || isWorkspaceAncestor(dirPath) || isProtectedWorkspaceDescendant(dirPath)
     )
   ) {
     return toTsconfigCompatibleDirPatterns(negationBody, rootDirPath);
@@ -129,7 +137,7 @@ function toExcludeEntries(negationBody: string, workspaceDirPaths: Set<string>, 
     // The descendant check precedes the ancestor one: a directory inside one workspace but above
     // a nested one (e.g. apps/web/plugins between workspaces apps/web and apps/web/plugins/x)
     // still belongs to the enclosing active workspace, so nothing of it may be excluded.
-    if (workspaceDirPaths.has(dirPath) || isWorkspaceDescendant(dirPath)) return [];
+    if (workspaceDirPaths.has(dirPath) || isProtectedWorkspaceDescendant(dirPath)) return [];
     if (isWorkspaceAncestor(dirPath)) {
       return [`${dirPath}/*.config.ts`, `${dirPath}/scripts`, `${dirPath}/src`, `${dirPath}/test`];
     }
@@ -285,7 +293,13 @@ function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
 export function hasDeclaredPackagesStarPattern(workspaces: PackageJson['workspaces']): boolean {
   return getMeaningfulDeclaredWorkspacePatterns(workspaces).some(
     (workspacePattern) =>
-      !workspacePattern.startsWith('!') && normalizeWorkspacePatternBody(workspacePattern) === 'packages/*'
+      !workspacePattern.startsWith('!') &&
+      // A `..`-traversing or absolute spelling (e.g. `x/../packages/*`) is discarded by
+      // getSanitizedWorkspacePatterns, so it must not count as covering packages/* — that would
+      // suppress the fallback AND lose the pattern, leaving no discovered workspaces.
+      !path.posix.isAbsolute(workspacePattern) &&
+      !workspacePattern.split('/').includes('..') &&
+      normalizeWorkspacePatternBody(workspacePattern) === 'packages/*'
   );
 }
 

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -24,34 +24,16 @@ export function getWorkspaceSubDirPaths(rootLike: WorkspaceRootLike): string[] {
 }
 
 /**
- * Every workspace package.json path (relative to the monorepo root), including manifests without
- * a `name` field — wbfy names those later, so dependency scans must not skip them.
+ * Every workspace package.json path (relative to the monorepo root, sorted), including manifests
+ * without a `name` field — wbfy names those later, so dependency scans must not skip them.
+ * Resolution mimics Bun's sequential pattern evaluation; see resolveWorkspacePackageJsonPaths.
  */
 export function getWorkspacePackageJsonPaths(rootConfig: WorkspaceRootLike): string[] {
-  // Expand all patterns in one glob call so Bun-supported negative patterns (e.g.
-  // `!packages/excluded`) actually exclude their matches. Known limitation (#1005): Bun evaluates
-  // patterns sequentially (a positive pattern after a negation re-includes its matches), while
-  // fast-glob treats negations as order-independent global ignores; declarations relying on
-  // positional re-inclusion do not occur in WillBooster repositories and are unsupported.
-  // Do not apply globIgnore here: workspace membership is defined solely by the declared
-  // patterns, and source-scanning ignores such as `build` or `dist` would hide legitimately
-  // named workspace directories.
-  const packageJsonGlobs = getSanitizedWorkspacePatterns(rootConfig).map((workspacePattern) =>
-    workspacePattern.startsWith('!')
-      ? `!${path.posix.join(workspacePattern.slice(1), 'package.json')}`
-      : path.posix.join(workspacePattern, 'package.json')
-  );
-  // followSymbolicLinks: false — a workspace symlink pointing outside the repository must not be
-  // treated as a workspace directory (removeNodeModules would delete through it).
-  return fg.globSync(packageJsonGlobs, {
-    cwd: rootConfig.dirPath,
-    followSymbolicLinks: false,
-    ignore: ['**/node_modules/**'],
-  });
+  return resolveWorkspacePackageJsonPaths(getSanitizedWorkspacePatterns(rootConfig), rootConfig.dirPath);
 }
 
 export interface WorkspaceDirPatterns {
-  /** Directory subtrees matched by negative workspace patterns, for tsconfig `exclude` entries. */
+  /** Directory subtrees (or package-owned subpaths) matched by effective negations, for tsconfig `exclude` entries. */
   excludes: string[];
   /** Positive directory patterns (or concrete directories for Bun-only glob syntax). */
   includes: string[];
@@ -64,10 +46,12 @@ export interface WorkspaceDirPatterns {
  * workspace package is added or removed. Every returned pattern is valid tsconfig glob syntax.
  * A pattern can match a sibling directory without a package.json (not a workspace to Bun); that
  * is deliberate, mirroring the long-standing `packages/*` entries' behavior in favor of stable
- * generated output. Known limitation (#1004): a negation whose directory is an ANCESTOR of
- * another workspace (e.g. `["apps/**", "!apps"]`) excludes the whole subtree here, although Bun
- * excludes only the package at that directory; such nested workspace layouts do not occur in
- * WillBooster repositories.
+ * generated output. Negations follow Bun's sequential semantics (see
+ * resolveWorkspacePackageJsonPaths): a negation stays pattern-shaped while it excludes exactly
+ * what it matches, but is concretized per matched directory when a matched directory ends up a
+ * workspace anyway (re-included by a later positive, a pinned concrete positive, or a seeded
+ * baseline; #1005) or is an ancestor of a workspace directory, where Bun excludes only the
+ * package AT that directory, so only its package-owned subpaths are excluded (#1004).
  */
 export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): WorkspaceDirPatterns {
   // Unlike discovery, generated output must not contain a never-matching `packages/*` fallback:
@@ -75,31 +59,89 @@ export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): WorkspaceD
   // applyPackageJsonConventions, which forces `packages/*` only when a manifest actually matches.
   const hasPackagesLayout =
     rootLike.doesContainSubPackageJsons &&
-    // Mirror applyPackageJsonConventions' baseline gate too: with the implicit `*/*` baseline
-    // active, `packages/*` entries would be dead globs subsumed by the `*/*` ones.
+    // Mirror applyPackageJsonConventions' baseline gate too: with an implicit baseline seeded,
+    // `packages/*` entries would be dead globs subsumed by the baseline-derived ones.
     !hasImplicitWorkspaceBaseline(rootLike.packageJson?.workspaces) &&
     fg.globSync('packages/*/package.json', {
       cwd: rootLike.dirPath,
       followSymbolicLinks: false,
       ignore: ['**/node_modules/**'],
     }).length > 0;
-  const excludes = new Set<string>();
-  const includes = new Set<string>();
-  for (const workspacePattern of getSanitizedWorkspacePatterns({
+  const workspacePatterns = getSanitizedWorkspacePatterns({
     ...rootLike,
     doesContainSubPackageJsons: hasPackagesLayout,
-  })) {
+  });
+  const workspaceDirPaths = new Set(
+    resolveWorkspacePackageJsonPaths(workspacePatterns, rootLike.dirPath).map((packageJsonPath) =>
+      path.posix.dirname(packageJsonPath)
+    )
+  );
+  const includes = new Set<string>();
+  const negationBodies: string[] = [];
+  for (const workspacePattern of workspacePatterns) {
     const isNegative = workspacePattern.startsWith('!');
-    // Normalization collapses `//` and strips trailing slashes so template-literal consumers
-    // (e.g. `${pattern}/src/**/*`) never emit doubled separators for patterns like `apps/*/`.
-    const patternBody = path.posix
-      .normalize(isNegative ? workspacePattern.slice(1) : workspacePattern)
-      .replace(/\/+$/u, '');
-    for (const dirPattern of toTsconfigCompatibleDirPatterns(patternBody, rootLike.dirPath)) {
-      (isNegative ? excludes : includes).add(dirPattern);
+    const patternBody = normalizeWorkspacePatternBody(isNegative ? workspacePattern.slice(1) : workspacePattern);
+    if (isNegative) {
+      // A seeding negation makes Bun link baseline-matched directories, so the baseline must
+      // enter the generated include patterns even when every declared pattern is a negation.
+      const baselineGlob = getSeededBaselineGlob(patternBody);
+      if (baselineGlob !== undefined) includes.add(baselineGlob);
+      negationBodies.push(patternBody);
+    } else {
+      for (const dirPattern of toTsconfigCompatibleDirPatterns(patternBody, rootLike.dirPath)) {
+        includes.add(dirPattern);
+      }
+    }
+  }
+  const excludes = new Set<string>();
+  for (const negationBody of negationBodies) {
+    for (const excludeEntry of toExcludeEntries(negationBody, workspaceDirPaths, rootLike.dirPath)) {
+      excludes.add(excludeEntry);
     }
   }
   return { excludes: [...excludes].toSorted(), includes: [...includes].toSorted() };
+}
+
+/**
+ * tsconfig exclude entries for one negation. Pattern-shaped when the negation excludes exactly
+ * what it matches (stable output); per-directory otherwise: a directory that is a workspace
+ * despite the negation is not excluded at all, and a directory that is an ancestor of a workspace
+ * directory gets only its package-owned subpaths excluded, because Bun excludes only the package
+ * AT that directory while keeping descendant workspaces (#1004).
+ */
+function toExcludeEntries(negationBody: string, workspaceDirPaths: Set<string>, rootDirPath: string): string[] {
+  const isWorkspaceAncestor = (dirPath: string): boolean =>
+    [...workspaceDirPaths].some((workspaceDirPath) => workspaceDirPath.startsWith(`${dirPath}/`));
+  const matchedDirPaths = getMatchedDirPaths(negationBody, rootDirPath);
+  if (!matchedDirPaths.some((dirPath) => workspaceDirPaths.has(dirPath) || isWorkspaceAncestor(dirPath))) {
+    return toTsconfigCompatibleDirPatterns(negationBody, rootDirPath);
+  }
+  return matchedDirPaths.flatMap((dirPath) => {
+    if (workspaceDirPaths.has(dirPath)) return [];
+    if (isWorkspaceAncestor(dirPath)) {
+      return [`${dirPath}/*.config.ts`, `${dirPath}/scripts`, `${dirPath}/src`, `${dirPath}/test`];
+    }
+    return [dirPath];
+  });
+}
+
+/**
+ * Directories a negation matches. The manifest-based glob complements onlyDirectories because
+ * fast-glob's `dir/**` does not return `dir` itself as a directory, while both Bun and the
+ * manifest glob treat `**` as zero or more segments (`apps/**` covers the package at apps).
+ */
+function getMatchedDirPaths(negationBody: string, rootDirPath: string): string[] {
+  const globOptions = { cwd: rootDirPath, followSymbolicLinks: false, ignore: ['**/node_modules/**'] };
+  return [
+    ...new Set([
+      ...fg.globSync(negationBody, { ...globOptions, onlyDirectories: true }),
+      ...fg
+        .globSync(path.posix.join(negationBody, 'package.json'), globOptions)
+        .map((packageJsonPath) => path.posix.dirname(packageJsonPath))
+        // A zero-segment `**` match reaches the root itself, which is never a workspace.
+        .filter((dirPath) => dirPath !== '.'),
+    ]),
+  ].toSorted();
 }
 
 /**
@@ -118,23 +160,105 @@ function toTsconfigCompatibleDirPatterns(patternBody: string, rootDirPath: strin
 }
 
 /**
+ * Resolves workspace patterns to package.json paths mimicking Bun's SEQUENTIAL evaluation,
+ * derived empirically with Bun 1.3.14 (fixture repos observed via `bun install --lockfile-only`;
+ * #1004/#1005):
+ * 1. Patterns are evaluated in declaration order into an accumulating set: a positive glob
+ *    pattern adds every package.json it matches; a negation deletes its matches from the set
+ *    accumulated SO FAR, so a later positive re-adds them (`["!apps/excluded", "apps/*"]` links
+ *    apps/excluded, while `["apps/*", "!apps/excluded"]` does not).
+ * 2. A negation whose normalized body has EXACTLY two segments, whose last segment is a star-run
+ *    (`*`, `**`, `***`, …), and whose first segment is NOT itself a star-run first seeds the
+ *    implicit baseline into the set, then deletes its own matches: a `**` last segment seeds
+ *    `**` (packages at any depth), any other star-run seeds `*\/*` (depth 2 only). Seeding
+ *    happens even alongside positive patterns (`["apps/*", "!other/*"]` links every depth-2
+ *    package outside other/). No other negation shape seeds: `!*`, `!**`, `!*\/*`, `!*\/**`,
+ *    `!**\/*`, `!a/b/*`, `!a/b/**`, `!dir`, `!dir/?`, and `!dir/*x` each link nothing on their
+ *    own.
+ * 3. A non-glob positive pattern PINS its directory: it stays a workspace regardless of where a
+ *    matching negation appears (`["other/x", "!other/x"]` and `["!other/x", "other/x"]` both
+ *    link other/x).
+ * 4. `**` matches zero or more path segments (`["apps/**"]` links the package at apps itself, and
+ *    `!apps/**` deletes it), matching fast-glob's file-glob semantics.
+ * Do not apply globIgnore here: workspace membership is defined solely by the declared patterns,
+ * and source-scanning ignores such as `build` or `dist` would hide legitimately named workspace
+ * directories.
+ */
+function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], rootDirPath: string): string[] {
+  // followSymbolicLinks: false — a workspace symlink pointing outside the repository must not be
+  // treated as a workspace directory (removeNodeModules would delete through it).
+  const globManifestPaths = (pattern: string): string[] =>
+    fg
+      .globSync(path.posix.join(pattern, 'package.json'), {
+        cwd: rootDirPath,
+        followSymbolicLinks: false,
+        ignore: ['**/node_modules/**'],
+      })
+      // A zero-segment `**` match reaches the root's own manifest, but Bun never treats the
+      // monorepo root as its own workspace.
+      .filter((packageJsonPath) => packageJsonPath !== 'package.json');
+  const accumulatedPaths = new Set<string>();
+  const pinnedPaths = new Set<string>();
+  for (const workspacePattern of workspacePatterns) {
+    const isNegative = workspacePattern.startsWith('!');
+    const patternBody = normalizeWorkspacePatternBody(isNegative ? workspacePattern.slice(1) : workspacePattern);
+    if (isNegative) {
+      const baselineGlob = getSeededBaselineGlob(patternBody);
+      if (baselineGlob !== undefined) {
+        for (const packageJsonPath of globManifestPaths(baselineGlob)) accumulatedPaths.add(packageJsonPath);
+      }
+      for (const packageJsonPath of globManifestPaths(patternBody)) accumulatedPaths.delete(packageJsonPath);
+    } else {
+      for (const packageJsonPath of globManifestPaths(patternBody)) {
+        (fg.isDynamicPattern(patternBody) ? accumulatedPaths : pinnedPaths).add(packageJsonPath);
+      }
+    }
+  }
+  return [...new Set([...accumulatedPaths, ...pinnedPaths])].toSorted();
+}
+
+/** The implicit baseline glob a negation seeds under Bun's rule 2 above, or undefined if none. */
+function getSeededBaselineGlob(negationBody: string): string | undefined {
+  const segments = negationBody.split('/');
+  if (segments.length !== 2) return undefined;
+  const [firstSegment, lastSegment] = segments as [string, string];
+  if (!/^\*+$/u.test(lastSegment) || /^\*+$/u.test(firstSegment)) return undefined;
+  return lastSegment === '**' ? '**' : '*/*';
+}
+
+/**
+ * Collapses `//`, resolves `./`, and strips trailing slashes, mirroring Bun's path handling.
+ * A pure star-run segment of three or more stars behaves like `*` under Bun (`!other/***`
+ * matches other/x) but not under fast-glob, so canonicalize it to `*`.
+ */
+function normalizeWorkspacePatternBody(patternBody: string): string {
+  return path.posix
+    .normalize(patternBody)
+    .replace(/\/+$/u, '')
+    .split('/')
+    .map((segment) => (/^\*{3,}$/u.test(segment) ? '*' : segment))
+    .join('/');
+}
+
+/**
  * Declared workspace patterns (negative ones included) that stay inside the repository: absolute
  * or `..`-traversing patterns would make consumers such as removeNodeModules operate on another
- * repository's files.
+ * repository's files. Declaration order and duplicates are preserved — Bun evaluates the
+ * patterns sequentially, so position matters.
  */
 function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
+  const declaredPatterns = getMeaningfulDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces);
   // applyPackageJsonConventions forces `packages/*` into a monorepo's workspaces when a
   // packages/*/package.json actually matches, but it may not have written the root package.json
-  // yet, so mirror that normalization here. Discovery callers pass the fallback unconditionally
-  // for monorepos — a never-matching pattern contributes no paths there — while pattern-shaped
-  // callers (getWorkspaceDirPatterns) gate it on an actual match.
-  const workspacePatterns = [
-    ...new Set([
-      ...(hasImplicitWorkspaceBaseline(rootLike.packageJson?.workspaces) ? ['*/*'] : []),
-      ...getMeaningfulDeclaredWorkspacePatterns(rootLike.packageJson?.workspaces),
-      ...(rootLike.doesContainSubPackageJsons ? ['packages/*'] : []),
-    ]),
-  ];
+  // yet, so mirror that normalization here — PREPENDED like there, because a positive pattern
+  // placed after a user negation would re-include the negated packages under Bun's sequential
+  // evaluation. Discovery callers pass the fallback unconditionally for monorepos — a
+  // never-matching pattern contributes no paths there — while pattern-shaped callers
+  // (getWorkspaceDirPatterns) gate it on an actual match.
+  const workspacePatterns =
+    rootLike.doesContainSubPackageJsons && !declaredPatterns.includes('packages/*')
+      ? ['packages/*', ...declaredPatterns]
+      : declaredPatterns;
   return workspacePatterns.filter((workspacePattern) => {
     const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
     return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
@@ -142,24 +266,18 @@ function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
 }
 
 /**
- * Whether Bun applies its implicit `*\/*` workspace baseline: the declaration (ignoring no-op
- * patterns) contains ONLY negative patterns AND at least one of them ends in a standalone
- * star-run segment (`*`, `**`, `***`, ...). Measured with Bun 1.3.14: those forms consistently
- * seed the baseline, while concrete or mixed-literal last segments (`!apps/excluded`,
- * `!apps/*d`, `??`) link ZERO workspaces. `?`, brace, and character-class last segments behaved
- * inconsistently across fixtures (sometimes dropping even unrelated sibling workspaces), so they
- * are conservatively treated as not seeding; see #1005.
+ * Whether the declaration seeds Bun's implicit workspace baseline: it contains at least one
+ * negation of the seeding shape (see resolveWorkspacePackageJsonPaths rule 2). Measured with Bun
+ * 1.3.14, seeding is per-negation and happens even alongside positive patterns; concrete or
+ * mixed-literal last segments (`!apps/excluded`, `!apps/*d`) never seed, and `?`, brace, and
+ * character-class last segments behaved inconsistently across fixtures (sometimes dropping even
+ * unrelated sibling workspaces), so they are conservatively treated as not seeding; see #1005.
  */
 export function hasImplicitWorkspaceBaseline(workspaces: PackageJson['workspaces']): boolean {
-  const workspacePatterns = getMeaningfulDeclaredWorkspacePatterns(workspaces);
-  return (
-    workspacePatterns.length > 0 &&
-    workspacePatterns.every((workspacePattern) => workspacePattern.startsWith('!')) &&
-    workspacePatterns.some((workspacePattern) => {
-      // Normalize first: Bun ignores trailing slashes, so `!apps/*/` seeds the baseline too.
-      const lastSegment = path.posix.normalize(workspacePattern.slice(1)).replace(/\/+$/u, '').split('/').at(-1);
-      return lastSegment !== undefined && /^\*+$/u.test(lastSegment);
-    })
+  return getMeaningfulDeclaredWorkspacePatterns(workspaces).some(
+    (workspacePattern) =>
+      workspacePattern.startsWith('!') &&
+      getSeededBaselineGlob(normalizeWorkspacePatternBody(workspacePattern.slice(1))) !== undefined
   );
 }
 
@@ -181,7 +299,7 @@ export function getMeaningfulDeclaredWorkspacePatterns(workspaces: PackageJson['
       const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
       // Normalize so spellings like `./`, `./.`, and `!./` are recognized as the same no-ops
       // (path.posix.normalize('') === '.', so the empty pattern is covered too).
-      return path.posix.normalize(patternBody).replace(/\/+$/u, '') !== '.';
+      return normalizeWorkspacePatternBody(patternBody) !== '.';
     });
 }
 

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -105,19 +105,31 @@ export function getWorkspaceDirPatterns(rootLike: WorkspaceRootLike): WorkspaceD
 /**
  * tsconfig exclude entries for one negation. Pattern-shaped when the negation excludes exactly
  * what it matches (stable output); per-directory otherwise: a directory that is a workspace
- * despite the negation is not excluded at all, and a directory that is an ancestor of a workspace
- * directory gets only its package-owned subpaths excluded, because Bun excludes only the package
- * AT that directory while keeping descendant workspaces (#1004).
+ * despite the negation is not excluded at all, and neither is a descendant of a workspace
+ * directory — negating a non-package directory is a no-op for Bun, and the enclosing workspace
+ * stays active (e.g. `['apps/**', '!apps/**', 'apps/web']` re-includes apps/web, whose src must
+ * keep type-checking; a tsconfig exclude would override the include). A directory that is an
+ * ancestor of a workspace directory gets only its package-owned subpaths excluded, because Bun
+ * excludes only the package AT that directory while keeping descendant workspaces (#1004).
  */
 function toExcludeEntries(negationBody: string, workspaceDirPaths: Set<string>, rootDirPath: string): string[] {
   const isWorkspaceAncestor = (dirPath: string): boolean =>
     [...workspaceDirPaths].some((workspaceDirPath) => workspaceDirPath.startsWith(`${dirPath}/`));
+  const isWorkspaceDescendant = (dirPath: string): boolean =>
+    [...workspaceDirPaths].some((workspaceDirPath) => dirPath.startsWith(`${workspaceDirPath}/`));
   const matchedDirPaths = getMatchedDirPaths(negationBody, rootDirPath);
-  if (!matchedDirPaths.some((dirPath) => workspaceDirPaths.has(dirPath) || isWorkspaceAncestor(dirPath))) {
+  if (
+    !matchedDirPaths.some(
+      (dirPath) => workspaceDirPaths.has(dirPath) || isWorkspaceAncestor(dirPath) || isWorkspaceDescendant(dirPath)
+    )
+  ) {
     return toTsconfigCompatibleDirPatterns(negationBody, rootDirPath);
   }
   return matchedDirPaths.flatMap((dirPath) => {
-    if (workspaceDirPaths.has(dirPath)) return [];
+    // The descendant check precedes the ancestor one: a directory inside one workspace but above
+    // a nested one (e.g. apps/web/plugins between workspaces apps/web and apps/web/plugins/x)
+    // still belongs to the enclosing active workspace, so nothing of it may be excluded.
+    if (workspaceDirPaths.has(dirPath) || isWorkspaceDescendant(dirPath)) return [];
     if (isWorkspaceAncestor(dirPath)) {
       return [`${dirPath}/*.config.ts`, `${dirPath}/scripts`, `${dirPath}/src`, `${dirPath}/test`];
     }

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -256,13 +256,25 @@ function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
   // never-matching pattern contributes no paths there — while pattern-shaped callers
   // (getWorkspaceDirPatterns) gate it on an actual match.
   const workspacePatterns =
-    rootLike.doesContainSubPackageJsons && !declaredPatterns.includes('packages/*')
+    rootLike.doesContainSubPackageJsons && !hasDeclaredPackagesStarPattern(rootLike.packageJson?.workspaces)
       ? ['packages/*', ...declaredPatterns]
       : declaredPatterns;
   return workspacePatterns.filter((workspacePattern) => {
     const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
     return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
   });
+}
+
+/**
+ * Whether a declared positive pattern already covers `packages/*` under path normalization
+ * (e.g. `./packages/*` or a trailing-slash spelling): forcing a textual `packages/*` next to
+ * such a spelling would persist duplicate equivalent patterns and re-scan the same directories.
+ */
+export function hasDeclaredPackagesStarPattern(workspaces: PackageJson['workspaces']): boolean {
+  return getMeaningfulDeclaredWorkspacePatterns(workspaces).some(
+    (workspacePattern) =>
+      !workspacePattern.startsWith('!') && normalizeWorkspacePatternBody(workspacePattern) === 'packages/*'
+  );
 }
 
 /**

--- a/packages/wbfy/test/packageConfig.test.ts
+++ b/packages/wbfy/test/packageConfig.test.ts
@@ -50,6 +50,29 @@ test('detects a nested Tauri application from a parent package', async () => {
   }
 });
 
+test('detects @semantic-release/npm in both string and tuple plugin forms', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-package-config-'));
+  try {
+    // The packages/root layout keeps getPackageConfig from looking up a GitHub repository.
+    const packageDirPath = path.join(tempDirPath, 'packages', 'root');
+    fs.mkdirSync(packageDirPath, { recursive: true });
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), '{}');
+    fs.writeFileSync(path.join(packageDirPath, 'package.json'), '{}');
+    fs.writeFileSync(
+      path.join(packageDirPath, '.releaserc.json'),
+      JSON.stringify({
+        branches: ['main'],
+        plugins: ['@semantic-release/commit-analyzer', ['@semantic-release/npm', { pkgRoot: '.' }]],
+      })
+    );
+    const config = await getPackageConfig(packageDirPath);
+    expect(config?.release.npm).toBe(true);
+    expect(config?.depending.semanticRelease).toBe(true);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 async function detectTauri(setup: { packageJson?: object; srcTauriFileName?: string }): Promise<boolean> {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-package-config-'));
   try {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1726,6 +1726,20 @@ test('does not force private on a monorepo root with a publishConfig', async () 
   expect(packageJson.private).toBeUndefined();
 });
 
+test('removes stale private from a monorepo root with a publishConfig', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      name: 'published-monorepo',
+      private: true,
+      workspaces: ['packages/*'],
+      publishConfig: { registry: 'https://npm.example.com' },
+    },
+    { isRoot: true, doesContainSubPackageJsons: true }
+  );
+
+  expect(packageJson.private).toBeUndefined();
+});
+
 async function generatePackageJsonFrom(
   initialPackageJson: Record<string, unknown>,
   configOverrides: Parameters<typeof createConfig>[0] = {},

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -11,6 +11,7 @@ import { createConfig } from './testConfig.js';
 interface GeneratedPackageJson {
   dependencies?: Record<string, string | undefined>;
   devDependencies?: Record<string, string | undefined>;
+  private?: boolean;
   scripts?: Record<string, string | undefined>;
   trustedDependencies?: string[];
 }
@@ -1674,6 +1675,35 @@ test('does not trust @chakra-ui/react for @chakra-ui/cli v2', async () => {
   );
 
   expect(packageJson.trustedDependencies).toBeUndefined();
+});
+
+test('keeps a plain monorepo root private', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    { name: 'monorepo', workspaces: ['packages/*'] },
+    { isRoot: true, doesContainSubPackageJsons: true }
+  );
+
+  expect(packageJson.private).toBe(true);
+});
+
+// @semantic-release/npm silently skips private packages, so forcing `private: true` on a
+// publishing monorepo root (e.g. WillBoosterLab/llm-proxy) would stop releases without any error.
+test('does not force private on a monorepo root released via @semantic-release/npm', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    { name: '@willbooster-private/llm-proxy', private: false, workspaces: ['packages/*'] },
+    { isRoot: true, doesContainSubPackageJsons: true, release: { branches: ['main'], github: true, npm: true } }
+  );
+
+  expect(packageJson.private).toBe(false);
+});
+
+test('does not force private on a monorepo root with a publishConfig', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    { name: 'published-monorepo', workspaces: ['packages/*'], publishConfig: { registry: 'https://npm.example.com' } },
+    { isRoot: true, doesContainSubPackageJsons: true }
+  );
+
+  expect(packageJson.private).toBeUndefined();
 });
 
 async function generatePackageJsonFrom(

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1691,10 +1691,30 @@ test('keeps a plain monorepo root private', async () => {
 test('does not force private on a monorepo root released via @semantic-release/npm', async () => {
   const packageJson = await generatePackageJsonFrom(
     { name: '@willbooster-private/llm-proxy', private: false, workspaces: ['packages/*'] },
-    { isRoot: true, doesContainSubPackageJsons: true, release: { branches: ['main'], github: true, npm: true } }
+    {
+      isRoot: true,
+      doesContainSubPackageJsons: true,
+      release: { branches: ['main'], github: true, npm: true, npmPublishesRoot: false },
+    }
   );
 
   expect(packageJson.private).toBe(false);
+});
+
+// Older wbfy forced `private: true` on every monorepo root; when the user explicitly configured
+// `@semantic-release/npm` to publish the root itself, the stale flag silently suppresses
+// publishing, so the generator must migrate it away on upgrade.
+test('removes stale private from a monorepo root explicitly publishing itself via @semantic-release/npm', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    { name: '@willbooster-private/llm-proxy', private: true, workspaces: ['packages/*'] },
+    {
+      isRoot: true,
+      doesContainSubPackageJsons: true,
+      release: { branches: ['main'], github: true, npm: true, npmPublishesRoot: true },
+    }
+  );
+
+  expect(packageJson.private).toBeUndefined();
 });
 
 test('does not force private on a monorepo root with a publishConfig', async () => {

--- a/packages/wbfy/test/prettierMigration.test.ts
+++ b/packages/wbfy/test/prettierMigration.test.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { generateBunfigToml } from '../src/generators/bunfig.js';
+import { generateIdeaSettings } from '../src/generators/idea.js';
+import { fixVscodeExtensions, generateVscodeSettings } from '../src/generators/vscodeSettings.js';
+import { promisePool } from '../src/utils/promisePool.js';
+
+import { createConfig } from './testConfig.js';
+
+test('rewrites prettier-vscode formatter values (including per-language overrides) to the oxc extension', async () => {
+  await withTempDir(async (tempDirPath) => {
+    const settingsPath = path.join(tempDirPath, '.vscode', 'settings.json');
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        'editor.defaultFormatter': 'esbenp.prettier-vscode',
+        '[typescript]': { 'editor.defaultFormatter': 'esbenp.prettier-vscode' },
+      })
+    );
+    await generateVscodeSettings(createConfig({ dirPath: tempDirPath }));
+    await promisePool.promiseAll();
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+    expect(settings['editor.defaultFormatter']).toBe('oxc.oxc-vscode');
+    expect(settings['[typescript]']).toEqual({ 'editor.defaultFormatter': 'oxc.oxc-vscode' });
+  });
+});
+
+test('keeps prettier-vscode formatter values in Java repositories', async () => {
+  await withTempDir(async (tempDirPath) => {
+    const settingsPath = path.join(tempDirPath, '.vscode', 'settings.json');
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ 'editor.defaultFormatter': 'esbenp.prettier-vscode' }));
+    await generateVscodeSettings(createConfig({ dirPath: tempDirPath, doesContainJava: true }));
+    await promisePool.promiseAll();
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+    expect(settings['editor.defaultFormatter']).toBe('esbenp.prettier-vscode');
+  });
+});
+
+test('replaces a prettier-vscode recommendation with the oxc extension and dedupes', async () => {
+  await withTempDir(async (tempDirPath) => {
+    const extensionsPath = path.join(tempDirPath, '.vscode', 'extensions.json');
+    fs.mkdirSync(path.dirname(extensionsPath), { recursive: true });
+    fs.writeFileSync(
+      extensionsPath,
+      JSON.stringify({ recommendations: ['esbenp.prettier-vscode', 'oxc.oxc-vscode', 'dbaeumer.vscode-eslint'] })
+    );
+    await fixVscodeExtensions(createConfig({ dirPath: tempDirPath }));
+    await promisePool.promiseAll();
+    const extensions = JSON.parse(fs.readFileSync(extensionsPath, 'utf8')) as { recommendations: string[] };
+    expect(extensions.recommendations).toEqual(['oxc.oxc-vscode', 'dbaeumer.vscode-eslint']);
+  });
+});
+
+test('does not create .vscode/extensions.json and leaves Java repositories untouched', async () => {
+  await withTempDir(async (tempDirPath) => {
+    await fixVscodeExtensions(createConfig({ dirPath: tempDirPath }));
+    await promisePool.promiseAll();
+    expect(fs.existsSync(path.join(tempDirPath, '.vscode', 'extensions.json'))).toBe(false);
+
+    const extensionsPath = path.join(tempDirPath, '.vscode', 'extensions.json');
+    fs.mkdirSync(path.dirname(extensionsPath), { recursive: true });
+    const content = JSON.stringify({ recommendations: ['esbenp.prettier-vscode'] });
+    fs.writeFileSync(extensionsPath, content);
+    await fixVscodeExtensions(createConfig({ dirPath: tempDirPath, doesContainJava: true }));
+    await promisePool.promiseAll();
+    expect(fs.readFileSync(extensionsPath, 'utf8')).toBe(content);
+  });
+});
+
+test('deletes .idea/prettier.xml except in Java repositories', async () => {
+  await withTempDir(async (tempDirPath) => {
+    const prettierXmlPath = path.join(tempDirPath, '.idea', 'prettier.xml');
+    fs.mkdirSync(path.dirname(prettierXmlPath), { recursive: true });
+    fs.writeFileSync(prettierXmlPath, '<project />');
+    await generateIdeaSettings(createConfig({ dirPath: tempDirPath, doesContainJava: true }));
+    await promisePool.promiseAll();
+    expect(fs.existsSync(prettierXmlPath)).toBe(true);
+
+    await generateIdeaSettings(createConfig({ dirPath: tempDirPath }));
+    await promisePool.promiseAll();
+    expect(fs.existsSync(prettierXmlPath)).toBe(false);
+  });
+});
+
+test('omits @willbooster/prettier-config from bunfig excludes except in Java repositories', async () => {
+  await withTempDir(async (tempDirPath) => {
+    await generateBunfigToml(createConfig({ dirPath: tempDirPath }));
+    await promisePool.promiseAll();
+    const bunfigPath = path.join(tempDirPath, 'bunfig.toml');
+    expect(fs.readFileSync(bunfigPath, 'utf8')).not.toContain('@willbooster/prettier-config');
+
+    await generateBunfigToml(createConfig({ dirPath: tempDirPath, doesContainJava: true }));
+    await promisePool.promiseAll();
+    expect(fs.readFileSync(bunfigPath, 'utf8')).toContain('@willbooster/prettier-config');
+  });
+});
+
+async function withTempDir(testBody: (tempDirPath: string) => Promise<void>): Promise<void> {
+  const tempDirPath = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-prettier-migration-')));
+  try {
+    await testBody(tempDirPath);
+  } finally {
+    fs.rmSync(tempDirPath, { force: true, recursive: true });
+  }
+}

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -61,6 +61,7 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
       branches: [],
       github: false,
       npm: false,
+      npmPublishesRoot: false,
     },
     miseTasks: {},
     packageJson: {},

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -142,6 +142,45 @@ test('merges settings from a tsconfig with a UTF-8 BOM instead of skipping it', 
   expect(compilerOptions.paths).toEqual({ 'undici-types': ['./node_modules/undici-types/index.d.ts'] });
 });
 
+test('keeps a nested workspace in the root project when its ancestor package is negated', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-tsconfig-'));
+  try {
+    // Bun 1.3.14 links only apps/web here (the package AT apps is negated), so the root tsconfig
+    // must exclude apps' own sources without dropping apps/web/src (#1004).
+    const workspaces = ['apps/**', '!apps'];
+    fs.writeFileSync(
+      path.join(tempDirPath, 'package.json'),
+      JSON.stringify({ name: 'root', private: true, workspaces })
+    );
+    for (const workspaceDirName of ['apps', 'apps/web']) {
+      const workspaceDirPath = path.join(tempDirPath, workspaceDirName);
+      fs.mkdirSync(path.join(workspaceDirPath, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(workspaceDirPath, 'package.json'), JSON.stringify({}));
+      fs.writeFileSync(path.join(workspaceDirPath, 'src', 'index.ts'), 'export {};\n');
+    }
+    const config = createConfig({
+      dirPath: tempDirPath,
+      isRoot: true,
+      doesContainSubPackageJsons: true,
+      doesContainTypeScript: true,
+      packageJson: { name: 'root', workspaces },
+    });
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    const tsconfig = JSON.parse(fs.readFileSync(path.join(tempDirPath, 'tsconfig.json'), 'utf8')) as {
+      exclude?: string[];
+      include?: string[];
+    };
+    expect(tsconfig.include).toContain('apps/**/src/**/*');
+    expect(tsconfig.exclude).not.toContain('apps');
+    for (const excludeEntry of ['apps/*.config.ts', 'apps/scripts', 'apps/src', 'apps/test']) {
+      expect(tsconfig.exclude).toContain(excludeEntry);
+    }
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('keeps a commented Next tsconfig byte-identical when no cleanup is needed', async () => {
   const commentedContent = `{
   "compilerOptions": {

--- a/packages/wbfy/test/typos.test.ts
+++ b/packages/wbfy/test/typos.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+
+import { fixTyposInCode, fixTyposInText } from '../src/fixers/typos.js';
+
+test('fixTyposInText normalizes abbreviation typos without touching regular words', () => {
+  expect(fixTyposInText('eg. one, ie. two, c.f. three')).toBe('e.g. one, i.e. two, cf. three');
+  expect(fixTyposInText('the cookie. crumbles')).toBe('the cookie. crumbles');
+  expect(fixTyposInText('my leg. hurts')).toBe('my leg. hurts');
+});
+
+test('line-comment typo fixes keep words merely ending in the abbreviation letters intact', () => {
+  // Regression: "// ... cookie." used to become "// ... cooki.e." because the pattern
+  // lacked a word boundary (observed in agent-challenges src/db/schema.ts).
+  expect(fixTyposInCode('// stores the session cookie.\n')).toBe('// stores the session cookie.\n');
+  expect(fixTyposInCode('// the left leg. moves\n')).toBe('// the left leg. moves\n');
+  expect(fixTyposInCode('// values, eg. one\n')).toBe('// values, e.g. one\n');
+  expect(fixTyposInCode('// values, ie. one\n')).toBe('// values, i.e. one\n');
+  expect(fixTyposInCode('/* block eg. one */')).toBe('/* block e.g. one */');
+});

--- a/packages/wbfy/test/wbEnv.test.ts
+++ b/packages/wbfy/test/wbEnv.test.ts
@@ -89,6 +89,20 @@ test('does not duplicate the explanatory comment when only NEXT_PUBLIC_WB_ENV is
   expect(settings.secrets?.NEXT_PUBLIC_WB_ENV).toEqual({ default: 'development' });
 });
 
+test('rewrites the outdated precedence comment written by earlier wbfy versions', () => {
+  const withOutdatedComment = (insertWbEnvIntoFnoxToml(fnoxTomlWithoutWbEnv, false) ?? '').replace(
+    /# CI sets WB_ENV.*$/mu,
+    '# CI sets WB_ENV as a process env var, which wins over fnox; these defaults only fill it locally.'
+  );
+  const migrated = insertWbEnvIntoFnoxToml(withOutdatedComment, false) ?? '';
+  expect(migrated).not.toContain('these defaults only fill it locally');
+  expect(migrated).toContain('bare fnox run/export uses the fnox value, so pass -P <profile>');
+  expect(migrated.split('# CI sets WB_ENV').length - 1).toBe(1);
+  // The migration is a pure rewrite: values stay untouched and a second pass is a no-op.
+  expect(parse(migrated)).toEqual(parse(withOutdatedComment));
+  expect(insertWbEnvIntoFnoxToml(migrated, false)).toBe(migrated);
+});
+
 test('refuses to edit an unparsable fnox.toml', () => {
   expect(insertWbEnvIntoFnoxToml('[secrets\nbroken', false)).toBeUndefined();
 });

--- a/packages/wbfy/test/wbEnv.test.ts
+++ b/packages/wbfy/test/wbEnv.test.ts
@@ -103,6 +103,23 @@ test('rewrites the outdated precedence comment written by earlier wbfy versions'
   expect(insertWbEnvIntoFnoxToml(migrated, false)).toBe(migrated);
 });
 
+test('rewrites the outdated precedence comment variant without a trailing period, keeping following lines', () => {
+  // Some repositories (e.g. ai-growbench, ai-game-builder) carry a period-less variant, optionally
+  // followed by an unrelated explanatory line that must survive the migration.
+  const withOutdatedVariant = (insertWbEnvIntoFnoxToml(fnoxTomlWithoutWbEnv, false) ?? '').replace(
+    /# CI sets WB_ENV.*$/mu,
+    "# CI sets WB_ENV as a process env var, which wins over fnox; these defaults only fill it locally\n# (wb's required-keys check treats every .env.example key, including WB_ENV, as required)."
+  );
+  const migrated = insertWbEnvIntoFnoxToml(withOutdatedVariant, false) ?? '';
+  expect(migrated).not.toContain('these defaults only fill it locally');
+  expect(migrated).toContain('bare fnox run/export uses the fnox value, so pass -P <profile>');
+  expect(migrated).toContain(
+    "# (wb's required-keys check treats every .env.example key, including WB_ENV, as required)."
+  );
+  expect(migrated.split('# CI sets WB_ENV').length - 1).toBe(1);
+  expect(insertWbEnvIntoFnoxToml(migrated, false)).toBe(migrated);
+});
+
 test('refuses to edit an unparsable fnox.toml', () => {
   expect(insertWbEnvIntoFnoxToml('[secrets\nbroken', false)).toBeUndefined();
 });

--- a/packages/wbfy/test/workspaceDiscovery.test.ts
+++ b/packages/wbfy/test/workspaceDiscovery.test.ts
@@ -257,6 +257,113 @@ test('ignores empty workspace patterns as Bun does', () => {
   }
 });
 
+test('resolves workspace patterns sequentially like Bun (positional re-inclusion and pinning)', () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    for (const workspaceDirName of ['apps/web', 'apps/excluded', 'other/x', 'tools/cli']) {
+      const workspaceDirPath = path.join(tempDirPath, workspaceDirName);
+      fs.mkdirSync(workspaceDirPath, { recursive: true });
+      fs.writeFileSync(path.join(workspaceDirPath, 'package.json'), JSON.stringify({}));
+    }
+    const resolve = (workspaces: string[]): string[] => {
+      fs.writeFileSync(path.join(tempDirPath, 'package.json'), JSON.stringify({ name: 'root', workspaces }));
+      return getWorkspaceSubDirPaths({
+        dirPath: tempDirPath,
+        doesContainSubPackageJsons: false,
+        packageJson: { workspaces },
+      }).map((subDirPath) => path.relative(tempDirPath, subDirPath).replaceAll('\\', '/'));
+    };
+    // Expectations recorded from Bun 1.3.14 (`bun install --lockfile-only` on identical fixtures).
+    // A later positive re-includes an earlier negation's matches.
+    expect(resolve(['!apps/excluded', 'apps/*'])).toEqual(['apps/excluded', 'apps/web']);
+    expect(resolve(['apps/*', '!apps/excluded'])).toEqual(['apps/web']);
+    // A non-glob positive pins its workspace regardless of negation position.
+    expect(resolve(['apps/*', '!apps/excluded', 'apps/excluded'])).toEqual(['apps/excluded', 'apps/web']);
+    expect(resolve(['other/x', '!other/x'])).toEqual(['other/x']);
+    // A two-segment star-run negation seeds the implicit baseline even alongside positives:
+    // `!other/*` seeds `*/*`, re-adding the previously negated apps/excluded.
+    expect(resolve(['apps/*', '!apps/excluded', '!other/*'])).toEqual(['apps/excluded', 'apps/web', 'tools/cli']);
+    expect(resolve(['apps/*', '!other/*', '!apps/excluded'])).toEqual(['apps/web', 'tools/cli']);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('seeds the any-depth ** baseline for a two-segment globstar negation', () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    for (const workspaceDirName of ['apps', 'apps/web', 'solo', 'deep/a/b']) {
+      const workspaceDirPath = path.join(tempDirPath, workspaceDirName);
+      fs.mkdirSync(workspaceDirPath, { recursive: true });
+      fs.writeFileSync(path.join(workspaceDirPath, 'package.json'), JSON.stringify({}));
+    }
+    const workspaces = ['!apps/**'];
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), JSON.stringify({ name: 'root', workspaces }));
+    const rootLike = { dirPath: tempDirPath, doesContainSubPackageJsons: false, packageJson: { workspaces } };
+    // Bun 1.3.14: `!apps/**` seeds `**` (packages at any depth) and deletes the apps subtree
+    // including the package AT apps (`**` matches zero segments).
+    expect(getWorkspaceSubDirPaths(rootLike)).toEqual([
+      path.join(tempDirPath, 'deep', 'a', 'b'),
+      path.join(tempDirPath, 'solo'),
+    ]);
+    expect(getWorkspaceDirPatterns(rootLike)).toEqual({ excludes: ['apps/**'], includes: ['**'] });
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('drops or concretizes negations that later patterns re-cover in dir patterns', () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    for (const workspaceDirName of ['apps/web', 'apps/excluded', 'tools/cli']) {
+      const workspaceDirPath = path.join(tempDirPath, workspaceDirName);
+      fs.mkdirSync(workspaceDirPath, { recursive: true });
+      fs.writeFileSync(path.join(workspaceDirPath, 'package.json'), JSON.stringify({}));
+    }
+    const patternsFor = (workspaces: string[]): ReturnType<typeof getWorkspaceDirPatterns> => {
+      fs.writeFileSync(path.join(tempDirPath, 'package.json'), JSON.stringify({ name: 'root', workspaces }));
+      return getWorkspaceDirPatterns({
+        dirPath: tempDirPath,
+        doesContainSubPackageJsons: false,
+        packageJson: { workspaces },
+      });
+    };
+    // The later positive re-includes apps/excluded, so no exclude entry may remain for it.
+    expect(patternsFor(['!apps/excluded', 'apps/*'])).toEqual({ excludes: [], includes: ['apps/*'] });
+    // Only the matches a later positive does NOT re-add stay excluded (concretized per directory).
+    expect(patternsFor(['apps/*', '!apps/*', 'apps/web'])).toEqual({
+      excludes: ['apps/excluded'],
+      includes: ['*/*', 'apps/*', 'apps/web'],
+    });
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('excludes only package-owned subpaths for a negated ancestor of a workspace', () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
+  try {
+    for (const workspaceDirName of ['apps', 'apps/web']) {
+      const workspaceDirPath = path.join(tempDirPath, workspaceDirName);
+      fs.mkdirSync(path.join(workspaceDirPath, 'src'), { recursive: true });
+      fs.writeFileSync(path.join(workspaceDirPath, 'package.json'), JSON.stringify({}));
+      fs.writeFileSync(path.join(workspaceDirPath, 'src', 'index.ts'), 'export {};\n');
+    }
+    const workspaces = ['apps/**', '!apps'];
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), JSON.stringify({ name: 'root', workspaces }));
+    const rootLike = { dirPath: tempDirPath, doesContainSubPackageJsons: false, packageJson: { workspaces } };
+    // Bun 1.3.14 excludes only the package AT apps while keeping apps/web, so the whole apps
+    // subtree must not be excluded (#1004).
+    expect(getWorkspaceSubDirPaths(rootLike)).toEqual([path.join(tempDirPath, 'apps', 'web')]);
+    expect(getWorkspaceDirPatterns(rootLike)).toEqual({
+      excludes: ['apps/*.config.ts', 'apps/scripts', 'apps/src', 'apps/test'],
+      includes: ['apps/**'],
+    });
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('ignores workspace patterns escaping the repository', () => {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-workspaces-'));
   try {


### PR DESCRIPTION
Closes #997, #998, #1000, #1002, #1003, #1004, #1005, #1006

## Customer Summary

- `wb release` no longer exposes npm/Verdaccio credentials to package lifecycle scripts, and skips its clean reinstall entirely for repos that publish only to GitHub (no `@semantic-release/npm`).
- `wb setup-private-packages` now resolves full semver ranges (e.g. `^1.2.3`) against the registry instead of degrading to base versions, and documents the Dockerfile `COPY` requirement.
- `wbfy` no longer forces `private: true` on monorepo roots that are configured for npm publishing (fixes the llm-proxy regression), writes a correct WB_ENV precedence comment into fnox.toml (and repairs existing stale comments in all their variants), and fully cleans up Prettier leftovers (VS Code/IDEA settings, bunfig excludes) when migrating a repo to oxfmt.
- `wbfy` now resolves Bun workspace patterns exactly like Bun 1.3.14, so generated root tsconfig references and typo-fixing cover the right directories in monorepos with negated or overlapping workspace globs.
- Generated agent instructions (AGENTS.md/CLAUDE.md/GEMINI.md/.cursor rules) now cover fnox-managed repos and current org conventions.

## Technical Summary

### wb
- **#1003**: the hoisted clean reinstall runs `bun install --ignore-scripts` under the credentialed env, then replays lifecycle scripts via a second cache-hit install with a credential-free env (denylisted vars emptied so `${VERDACCIO_TOKEN}` references expand to `''`).
- **#1000**: the reinstall (and workspace-range rewrite) is skipped when the resolved semantic-release plugin lists contain no `@semantic-release/npm`; config discovery mirrors cosmiconfig search semantics (`.releaserc`, `.releaserc.{json,yaml,yml,js,cjs,mjs}`, `release.config.*`, `package.json#release`, default plugin list when no config), with conservative fallbacks that keep the reinstall whenever the config is implicit, non-JSON, or unreadable.
- **#998**: `wb setup-private-packages` resolves ranges via `semver.maxSatisfying` against the registry packument; conflict checks use `semver.subset`.
- **#999** was already fixed on main by #991 (closed with a comment, no changes here).

### wbfy
- **#997**: the WB_ENV precedence comment inserted into fnox.toml no longer overstates process-env precedence for bare `fnox run/export`; all stale comment variants are migrated in place.
- **#1002**: monorepo roots configured for npm publishing (semantic-release config with `@semantic-release/npm` — including the default plugin set — or an existing `publishConfig`) no longer get `private: true` forced; a stale forced `private: true` is migrated back off such roots.
- **#1006**: Prettier→oxfmt migration also rewrites `esbenp.prettier-vscode` to `oxc.oxc-vscode` in `.vscode/settings.json`/`extensions.json`, deletes `.idea/prettier.xml`, and drops `@willbooster/prettier-config` from the generated bunfig `minimumReleaseAgeExcludes` (all kept for Java repos, which retain Prettier).
- **#1004/#1005**: workspace patterns are resolved sequentially exactly like Bun 1.3.14 (order-sensitive negations, baseline re-seeding by trailing star-run negations, non-glob pin immunity, zero-segment `**`), verified with a differential harness against ~75 real `bun install` fixture runs; a negated ancestor of a workspace no longer excludes the whole subtree from the generated root tsconfig / fixTypos, while true workspace-descendant directories stay excluded.
- Language detection ignores `.tmp` directories (glob ignore fix), and the comment typo fixer keeps words ending in abbreviation letters intact (word-boundary fix, e.g. no more rewriting identifiers that merely end in a known abbreviation).
- Generated agent instructions refreshed for fnox repos and org conventions.

## Why

- These were all the remaining open issues (except the Renovate dashboard); fixing them in one pass keeps wb/wbfy behavior consistent with current Bun, semantic-release, and org tooling (fnox, oxfmt).
- Bun-compatible workspace resolution was derived empirically and locked in with a differential fixture harness to avoid regressing on edge cases Bun actually exhibits.

## Testing

- `bun verify` (tsc + oxlint, all packages)
- `bun wb test` full suite: wb 167, wbfy 181, shared-lib-node 46 (+ others) — all pass
- Multi-round review converged; all review threads resolved; CI green on the latest commit.
