### PR TITLE
fix: share Bun-exact workspace resolver so wb release matches bun install

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -101,6 +101,7 @@
         "@types/yargs": "17.0.35",
         "dotenv": "17.4.2",
         "dotenv-expand": "13.0.0",
+        "fast-glob": "3.3.3",
       },
       "devDependencies": {
         "@tsconfig/bun": "1.0.10",
@@ -168,6 +169,7 @@
         "chalk": "5.6.2",
         "dotenv": "17.4.2",
         "dotenv-expand": "13.0.0",
+        "fast-glob": "3.3.3",
         "fastest-levenshtein": "1.0.16",
         "globby": "16.2.0",
         "jsonc-parser": "3.3.1",

--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -44,7 +44,8 @@
   "dependencies": {
     "@types/yargs": "17.0.35",
     "dotenv": "17.4.2",
-    "dotenv-expand": "13.0.0"
+    "dotenv-expand": "13.0.0",
+    "fast-glob": "3.3.3"
   },
   "devDependencies": {
     "@tsconfig/bun": "1.0.10",

--- a/packages/shared-lib-node/src/bunWorkspaces.ts
+++ b/packages/shared-lib-node/src/bunWorkspaces.ts
@@ -59,6 +59,36 @@ export function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], ro
   // so keep only manifests whose real path stays inside the repository's real root. Scanning each
   // pattern separately (no cross-pattern caching) is deliberate: declarations hold a handful of
   // patterns, so a cache would complicate this shared code without measurable gain.
+  const globManifestPaths = (pattern: string): string[] => {
+    // Bun links dot-directory packages only through fully static patterns: with Bun 1.3.14,
+    // `.hidden/x` pins the package while `.hidden/*`, `.*/*`, and `**` all link nothing under
+    // .hidden — even when the dotted segment itself is literal — so any dynamic pattern must
+    // drop matches containing a dot-led segment (fast-glob's `dot: false` only covers segments
+    // a wildcard matches).
+    const excludesDotSegments = fg.isDynamicPattern(pattern);
+    const globOptions = { cwd: rootDirPath, followSymbolicLinks: false, ignore: ['**/node_modules/**'] };
+    // fast-glob 3.3.3 returns no matches for file globs with a lone-`?` segment (e.g.
+    // `packages/?/package.json`), although micromatch matches them and Bun 1.3.14 links such
+    // workspaces; for `?`-carrying patterns only (a directory glob for e.g. `**` would scan every
+    // directory in the repository), globbing the directories (where `?` works) and checking their
+    // manifests complements the manifest glob, which stays necessary for `**`'s zero-segment
+    // matches — `dir/**` does not return dir itself as a directory.
+    const manifestPaths = new Set(fg.globSync(path.posix.join(pattern, 'package.json'), globOptions));
+    if (pattern.includes('?')) {
+      for (const dirPath of fg.globSync(pattern, { ...globOptions, onlyDirectories: true })) {
+        const packageJsonPath = path.posix.join(dirPath, 'package.json');
+        if (fs.existsSync(path.join(rootDirPath, packageJsonPath))) manifestPaths.add(packageJsonPath);
+      }
+    }
+    // A zero-segment `**` match reaches the root's own manifest, but Bun never treats the
+    // monorepo root as its own workspace.
+    return [...manifestPaths].filter(
+      (packageJsonPath) =>
+        packageJsonPath !== 'package.json' &&
+        (!excludesDotSegments || !packageJsonPath.split('/').some((segment) => segment.startsWith('.'))) &&
+        isInsideRealRoot(packageJsonPath)
+    );
+  };
   let realRootDirPath: string | undefined;
   const isInsideRealRoot = (packageJsonPath: string): boolean => {
     try {
@@ -71,35 +101,6 @@ export function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], ro
       // A manifest that vanished between the glob and the realpath call is not a workspace.
       return false;
     }
-  };
-  const globManifestPaths = (pattern: string): string[] => {
-    // Bun links dot-directory packages only through fully static patterns: with Bun 1.3.14,
-    // `.hidden/x` pins the package while `.hidden/*`, `.*/*`, and `**` all link nothing under
-    // .hidden — even when the dotted segment itself is literal — so any dynamic pattern must
-    // drop matches containing a dot-led segment (fast-glob's `dot: false` only covers segments
-    // a wildcard matches).
-    const excludesDotSegments = fg.isDynamicPattern(pattern);
-    const globOptions = { cwd: rootDirPath, followSymbolicLinks: false, ignore: ['**/node_modules/**'] };
-    // fast-glob 3.3.3 returns no matches for file globs with a lone-`?` segment (e.g.
-    // `packages/?/package.json`), although micromatch matches them and Bun 1.3.14 links such
-    // workspaces; globbing the directories (where `?` works) and checking their manifests
-    // complements it. The manifest glob stays necessary for `**`'s zero-segment matches —
-    // `dir/**` does not return dir itself as a directory.
-    const manifestPaths = new Set([
-      ...fg.globSync(path.posix.join(pattern, 'package.json'), globOptions),
-      ...fg
-        .globSync(pattern, { ...globOptions, onlyDirectories: true })
-        .map((dirPath) => path.posix.join(dirPath, 'package.json'))
-        .filter((packageJsonPath) => fs.existsSync(path.join(rootDirPath, packageJsonPath))),
-    ]);
-    // A zero-segment `**` match reaches the root's own manifest, but Bun never treats the
-    // monorepo root as its own workspace.
-    return [...manifestPaths].filter(
-      (packageJsonPath) =>
-        packageJsonPath !== 'package.json' &&
-        (!excludesDotSegments || !packageJsonPath.split('/').some((segment) => segment.startsWith('.'))) &&
-        isInsideRealRoot(packageJsonPath)
-    );
   };
   const accumulatedPaths = new Set<string>();
   const pinnedPaths = new Set<string>();

--- a/packages/shared-lib-node/src/bunWorkspaces.ts
+++ b/packages/shared-lib-node/src/bunWorkspaces.ts
@@ -1,0 +1,160 @@
+import path from 'node:path';
+
+import fg from 'fast-glob';
+
+/** The `workspaces` field of a root package.json: the array form or Yarn v1's object form. */
+export type WorkspacesDeclaration = string[] | { packages?: string[] } | undefined;
+
+/**
+ * Every workspace package.json path (relative to the monorepo root, sorted) that Bun would link
+ * for the given root package.json `workspaces` declaration. Canonicalizes the declared patterns
+ * (see getMeaningfulDeclaredWorkspacePatterns), drops patterns escaping the repository (see
+ * isInRepositoryWorkspacePattern), and resolves the rest with Bun's sequential semantics (see
+ * resolveWorkspacePackageJsonPaths).
+ */
+export function resolveBunWorkspacePackageJsonPaths(workspaces: WorkspacesDeclaration, rootDirPath: string): string[] {
+  return resolveWorkspacePackageJsonPaths(
+    getMeaningfulDeclaredWorkspacePatterns(workspaces).filter((workspacePattern) =>
+      isInRepositoryWorkspacePattern(workspacePattern)
+    ),
+    rootDirPath
+  );
+}
+
+/**
+ * Resolves workspace patterns to package.json paths mimicking Bun's SEQUENTIAL evaluation,
+ * derived empirically with Bun 1.3.14 (fixture repos observed via `bun install --lockfile-only`;
+ * WillBooster/shared#1004 / WillBooster/shared#1005):
+ * 1. Patterns are evaluated in declaration order into an accumulating set: a positive glob
+ *    pattern adds every package.json it matches; a negation deletes its matches from the set
+ *    accumulated SO FAR, so a later positive re-adds them (`["!apps/excluded", "apps/*"]` links
+ *    apps/excluded, while `["apps/*", "!apps/excluded"]` does not).
+ * 2. A negation whose normalized body has EXACTLY two segments, whose last segment is a star-run
+ *    (`*`, `**`, `***`, …), and whose first segment is NOT itself a star-run first seeds the
+ *    implicit baseline into the set, then deletes its own matches: a `**` last segment seeds
+ *    `**` (packages at any depth), any other star-run seeds `*\/*` (depth 2 only). Seeding
+ *    happens even alongside positive patterns (`["apps/*", "!other/*"]` links every depth-2
+ *    package outside other/). No other negation shape seeds: `!*`, `!**`, `!*\/*`, `!*\/**`,
+ *    `!**\/*`, `!a/b/*`, `!a/b/**`, `!dir`, `!dir/?`, and `!dir/*x` each link nothing on their
+ *    own.
+ * 3. A non-glob positive pattern PINS its directory: it stays a workspace regardless of where a
+ *    matching negation appears (`["other/x", "!other/x"]` and `["!other/x", "other/x"]` both
+ *    link other/x).
+ * 4. `**` matches zero or more path segments (`["apps/**"]` links the package at apps itself, and
+ *    `!apps/**` deletes it), matching fast-glob's file-glob semantics.
+ * Do not apply globIgnore here: workspace membership is defined solely by the declared patterns,
+ * and source-scanning ignores such as `build` or `dist` would hide legitimately named workspace
+ * directories.
+ */
+export function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], rootDirPath: string): string[] {
+  // followSymbolicLinks: false — a workspace symlink pointing outside the repository must not be
+  // treated as a workspace directory (consumers such as node_modules cleanup would operate
+  // through it).
+  const globManifestPaths = (pattern: string): string[] =>
+    fg
+      .globSync(path.posix.join(pattern, 'package.json'), {
+        cwd: rootDirPath,
+        followSymbolicLinks: false,
+        ignore: ['**/node_modules/**'],
+      })
+      // A zero-segment `**` match reaches the root's own manifest, but Bun never treats the
+      // monorepo root as its own workspace.
+      .filter((packageJsonPath) => packageJsonPath !== 'package.json');
+  const accumulatedPaths = new Set<string>();
+  const pinnedPaths = new Set<string>();
+  for (const workspacePattern of workspacePatterns) {
+    const isNegative = workspacePattern.startsWith('!');
+    const patternBody = normalizeWorkspacePatternBody(isNegative ? workspacePattern.slice(1) : workspacePattern);
+    if (isNegative) {
+      const baselineGlob = getSeededBaselineGlob(patternBody);
+      if (baselineGlob !== undefined) {
+        for (const packageJsonPath of globManifestPaths(baselineGlob)) accumulatedPaths.add(packageJsonPath);
+      }
+      for (const packageJsonPath of globManifestPaths(patternBody)) accumulatedPaths.delete(packageJsonPath);
+    } else {
+      for (const packageJsonPath of globManifestPaths(patternBody)) {
+        (fg.isDynamicPattern(patternBody) ? accumulatedPaths : pinnedPaths).add(packageJsonPath);
+      }
+    }
+  }
+  return [...new Set([...accumulatedPaths, ...pinnedPaths])].toSorted();
+}
+
+/**
+ * Whether the declaration seeds Bun's implicit workspace baseline: it contains at least one
+ * negation of the seeding shape (see resolveWorkspacePackageJsonPaths rule 2). Measured with Bun
+ * 1.3.14, seeding is per-negation and happens even alongside positive patterns; concrete or
+ * mixed-literal last segments (`!apps/excluded`, `!apps/*d`) never seed, and `?`, brace, and
+ * character-class last segments behaved inconsistently across fixtures (sometimes dropping even
+ * unrelated sibling workspaces), so they are conservatively treated as not seeding; see
+ * WillBooster/shared#1005.
+ */
+export function hasImplicitWorkspaceBaseline(workspaces: WorkspacesDeclaration): boolean {
+  return getMeaningfulDeclaredWorkspacePatterns(workspaces).some(
+    (workspacePattern) =>
+      workspacePattern.startsWith('!') &&
+      getSeededBaselineGlob(normalizeWorkspacePatternBody(workspacePattern.slice(1))) !== undefined
+  );
+}
+
+/** The implicit baseline glob a negation seeds under Bun's rule 2 above, or undefined if none. */
+export function getSeededBaselineGlob(negationBody: string): string | undefined {
+  const segments = negationBody.split('/');
+  if (segments.length !== 2) return undefined;
+  const [firstSegment, lastSegment] = segments as [string, string];
+  if (!/^\*+$/u.test(lastSegment) || /^\*+$/u.test(firstSegment)) return undefined;
+  return lastSegment === '**' ? '**' : '*/*';
+}
+
+/**
+ * Collapses `//`, resolves `./`, and strips trailing slashes, mirroring Bun's path handling.
+ * A pure star-run segment of three or more stars behaves like `*` under Bun (`!other/***`
+ * matches other/x) but not under fast-glob, so canonicalize it to `*`.
+ */
+export function normalizeWorkspacePatternBody(patternBody: string): string {
+  return path.posix
+    .normalize(patternBody)
+    .replace(/\/+$/u, '')
+    .split('/')
+    .map((segment) => (/^\*{3,}$/u.test(segment) ? '*' : segment))
+    .join('/');
+}
+
+/**
+ * Whether a declared workspace pattern (negative ones included) stays inside the repository:
+ * absolute or `..`-traversing patterns would make consumers such as node_modules cleanup operate
+ * on another repository's files.
+ */
+export function isInRepositoryWorkspacePattern(workspacePattern: string): boolean {
+  const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
+  return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
+}
+
+/**
+ * Declared workspace patterns without Bun's no-op ones (`""`, a lone `"!"`, and `"."`), which Bun
+ * ignores entirely — a lone `"!"` must not activate the negative-only implicit baseline, and `""`
+ * must not make the repository root itself a discovered workspace. Declaration order and
+ * duplicates are preserved — Bun evaluates the patterns sequentially, so position matters.
+ */
+export function getMeaningfulDeclaredWorkspacePatterns(workspaces: WorkspacesDeclaration): string[] {
+  return getDeclaredWorkspacePatterns(workspaces)
+    .map((workspacePattern) => {
+      // Bun applies leading-bang PARITY (verified with Bun 1.3.14): `!!p` is the positive `p`
+      // and `!!!p` the negation `!p`, so canonicalize to at most one bang.
+      const bangCount = /^!*/u.exec(workspacePattern)![0].length;
+      const patternBody = workspacePattern.slice(bangCount);
+      return bangCount % 2 === 1 ? `!${patternBody}` : patternBody;
+    })
+    .filter((workspacePattern) => {
+      const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
+      // Normalize so spellings like `./`, `./.`, and `!./` are recognized as the same no-ops
+      // (path.posix.normalize('') === '.', so the empty pattern is covered too).
+      return normalizeWorkspacePatternBody(patternBody) !== '.';
+    });
+}
+
+/** Workspace patterns from either the array form or Yarn v1's `{ packages: […] }` object form. */
+export function getDeclaredWorkspacePatterns(workspaces: WorkspacesDeclaration): string[] {
+  if (Array.isArray(workspaces)) return workspaces;
+  return Array.isArray(workspaces?.packages) ? workspaces.packages : [];
+}

--- a/packages/shared-lib-node/src/bunWorkspaces.ts
+++ b/packages/shared-lib-node/src/bunWorkspaces.ts
@@ -66,7 +66,7 @@ export function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], ro
       const relativePath = path.relative(realRootDirPath, fs.realpathSync(path.join(rootDirPath, packageJsonPath)));
       // Compare whole segments, not a `..` prefix: a directory literally named e.g. `..pkg` is
       // inside the root, while a plain startsWith('..') would misread it as parent traversal.
-      return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
+      return relativePath !== '..' && !relativePath.startsWith('../') && !path.isAbsolute(relativePath);
     } catch {
       // A manifest that vanished between the glob and the realpath call is not a workspace.
       return false;

--- a/packages/shared-lib-node/src/bunWorkspaces.ts
+++ b/packages/shared-lib-node/src/bunWorkspaces.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
 import fg from 'fast-glob';
@@ -47,9 +48,25 @@ export function resolveBunWorkspacePackageJsonPaths(workspaces: WorkspacesDeclar
  * directories.
  */
 export function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], rootDirPath: string): string[] {
-  // followSymbolicLinks: false — a workspace symlink pointing outside the repository must not be
-  // treated as a workspace directory (consumers such as node_modules cleanup would operate
-  // through it).
+  // followSymbolicLinks: false stops GLOB traversal through symlinks, but a non-glob pattern
+  // naming a symlinked directory (e.g. `linked` with `linked -> ../other-repo`) still matches —
+  // fast-glob resolves static patterns with direct fs checks, and Bun does link such a workspace.
+  // Deliberately diverge from Bun there: consumers such as node_modules cleanup and manifest
+  // rewriting would otherwise delete and rewrite files in ANOTHER repository through the symlink,
+  // so keep only manifests whose real path stays inside the repository's real root. Scanning each
+  // pattern separately (no cross-pattern caching) is deliberate: declarations hold a handful of
+  // patterns, so a cache would complicate this shared code without measurable gain.
+  let realRootDirPath: string | undefined;
+  const isInsideRealRoot = (packageJsonPath: string): boolean => {
+    try {
+      realRootDirPath ??= fs.realpathSync(rootDirPath);
+      const relativePath = path.relative(realRootDirPath, fs.realpathSync(path.join(rootDirPath, packageJsonPath)));
+      return !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+    } catch {
+      // A manifest that vanished between the glob and the realpath call is not a workspace.
+      return false;
+    }
+  };
   const globManifestPaths = (pattern: string): string[] =>
     fg
       .globSync(path.posix.join(pattern, 'package.json'), {
@@ -59,7 +76,7 @@ export function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], ro
       })
       // A zero-segment `**` match reaches the root's own manifest, but Bun never treats the
       // monorepo root as its own workspace.
-      .filter((packageJsonPath) => packageJsonPath !== 'package.json');
+      .filter((packageJsonPath) => packageJsonPath !== 'package.json' && isInsideRealRoot(packageJsonPath));
   const accumulatedPaths = new Set<string>();
   const pinnedPaths = new Set<string>();
   for (const workspacePattern of workspacePatterns) {

--- a/packages/shared-lib-node/src/bunWorkspaces.ts
+++ b/packages/shared-lib-node/src/bunWorkspaces.ts
@@ -79,21 +79,26 @@ export function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], ro
     // drop matches containing a dot-led segment (fast-glob's `dot: false` only covers segments
     // a wildcard matches).
     const excludesDotSegments = fg.isDynamicPattern(pattern);
-    return (
-      fg
-        .globSync(path.posix.join(pattern, 'package.json'), {
-          cwd: rootDirPath,
-          followSymbolicLinks: false,
-          ignore: ['**/node_modules/**'],
-        })
-        // A zero-segment `**` match reaches the root's own manifest, but Bun never treats the
-        // monorepo root as its own workspace.
-        .filter(
-          (packageJsonPath) =>
-            packageJsonPath !== 'package.json' &&
-            (!excludesDotSegments || !packageJsonPath.split('/').some((segment) => segment.startsWith('.'))) &&
-            isInsideRealRoot(packageJsonPath)
-        )
+    const globOptions = { cwd: rootDirPath, followSymbolicLinks: false, ignore: ['**/node_modules/**'] };
+    // fast-glob 3.3.3 returns no matches for file globs with a lone-`?` segment (e.g.
+    // `packages/?/package.json`), although micromatch matches them and Bun 1.3.14 links such
+    // workspaces; globbing the directories (where `?` works) and checking their manifests
+    // complements it. The manifest glob stays necessary for `**`'s zero-segment matches —
+    // `dir/**` does not return dir itself as a directory.
+    const manifestPaths = new Set([
+      ...fg.globSync(path.posix.join(pattern, 'package.json'), globOptions),
+      ...fg
+        .globSync(pattern, { ...globOptions, onlyDirectories: true })
+        .map((dirPath) => path.posix.join(dirPath, 'package.json'))
+        .filter((packageJsonPath) => fs.existsSync(path.join(rootDirPath, packageJsonPath))),
+    ]);
+    // A zero-segment `**` match reaches the root's own manifest, but Bun never treats the
+    // monorepo root as its own workspace.
+    return [...manifestPaths].filter(
+      (packageJsonPath) =>
+        packageJsonPath !== 'package.json' &&
+        (!excludesDotSegments || !packageJsonPath.split('/').some((segment) => segment.startsWith('.'))) &&
+        isInsideRealRoot(packageJsonPath)
     );
   };
   const accumulatedPaths = new Set<string>();

--- a/packages/shared-lib-node/src/bunWorkspaces.ts
+++ b/packages/shared-lib-node/src/bunWorkspaces.ts
@@ -114,8 +114,9 @@ export function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], ro
       }
       for (const packageJsonPath of globManifestPaths(patternBody)) accumulatedPaths.delete(packageJsonPath);
     } else {
+      const targetPaths = fg.isDynamicPattern(patternBody) ? accumulatedPaths : pinnedPaths;
       for (const packageJsonPath of globManifestPaths(patternBody)) {
-        (fg.isDynamicPattern(patternBody) ? accumulatedPaths : pinnedPaths).add(packageJsonPath);
+        targetPaths.add(packageJsonPath);
       }
     }
   }

--- a/packages/shared-lib-node/src/bunWorkspaces.ts
+++ b/packages/shared-lib-node/src/bunWorkspaces.ts
@@ -61,7 +61,9 @@ export function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], ro
     try {
       realRootDirPath ??= fs.realpathSync(rootDirPath);
       const relativePath = path.relative(realRootDirPath, fs.realpathSync(path.join(rootDirPath, packageJsonPath)));
-      return !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+      // Compare whole segments, not a `..` prefix: a directory literally named e.g. `..pkg` is
+      // inside the root, while a plain startsWith('..') would misread it as parent traversal.
+      return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
     } catch {
       // A manifest that vanished between the glob and the realpath call is not a workspace.
       return false;
@@ -114,39 +116,6 @@ export function hasImplicitWorkspaceBaseline(workspaces: WorkspacesDeclaration):
   );
 }
 
-/** The implicit baseline glob a negation seeds under Bun's rule 2 above, or undefined if none. */
-export function getSeededBaselineGlob(negationBody: string): string | undefined {
-  const segments = negationBody.split('/');
-  if (segments.length !== 2) return undefined;
-  const [firstSegment, lastSegment] = segments as [string, string];
-  if (!/^\*+$/u.test(lastSegment) || /^\*+$/u.test(firstSegment)) return undefined;
-  return lastSegment === '**' ? '**' : '*/*';
-}
-
-/**
- * Collapses `//`, resolves `./`, and strips trailing slashes, mirroring Bun's path handling.
- * A pure star-run segment of three or more stars behaves like `*` under Bun (`!other/***`
- * matches other/x) but not under fast-glob, so canonicalize it to `*`.
- */
-export function normalizeWorkspacePatternBody(patternBody: string): string {
-  return path.posix
-    .normalize(patternBody)
-    .replace(/\/+$/u, '')
-    .split('/')
-    .map((segment) => (/^\*{3,}$/u.test(segment) ? '*' : segment))
-    .join('/');
-}
-
-/**
- * Whether a declared workspace pattern (negative ones included) stays inside the repository:
- * absolute or `..`-traversing patterns would make consumers such as node_modules cleanup operate
- * on another repository's files.
- */
-export function isInRepositoryWorkspacePattern(workspacePattern: string): boolean {
-  const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
-  return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
-}
-
 /**
  * Declared workspace patterns without Bun's no-op ones (`""`, a lone `"!"`, and `"."`), which Bun
  * ignores entirely — a lone `"!"` must not activate the negative-only implicit baseline, and `""`
@@ -170,8 +139,41 @@ export function getMeaningfulDeclaredWorkspacePatterns(workspaces: WorkspacesDec
     });
 }
 
+/**
+ * Collapses `//`, resolves `./`, and strips trailing slashes, mirroring Bun's path handling.
+ * A pure star-run segment of three or more stars behaves like `*` under Bun (`!other/***`
+ * matches other/x) but not under fast-glob, so canonicalize it to `*`.
+ */
+export function normalizeWorkspacePatternBody(patternBody: string): string {
+  return path.posix
+    .normalize(patternBody)
+    .replace(/\/+$/u, '')
+    .split('/')
+    .map((segment) => (/^\*{3,}$/u.test(segment) ? '*' : segment))
+    .join('/');
+}
+
+/** The implicit baseline glob a negation seeds under Bun's rule 2 above, or undefined if none. */
+export function getSeededBaselineGlob(negationBody: string): string | undefined {
+  const segments = negationBody.split('/');
+  if (segments.length !== 2) return undefined;
+  const [firstSegment, lastSegment] = segments as [string, string];
+  if (!/^\*+$/u.test(lastSegment) || /^\*+$/u.test(firstSegment)) return undefined;
+  return lastSegment === '**' ? '**' : '*/*';
+}
+
 /** Workspace patterns from either the array form or Yarn v1's `{ packages: […] }` object form. */
 export function getDeclaredWorkspacePatterns(workspaces: WorkspacesDeclaration): string[] {
   if (Array.isArray(workspaces)) return workspaces;
   return Array.isArray(workspaces?.packages) ? workspaces.packages : [];
+}
+
+/**
+ * Whether a declared workspace pattern (negative ones included) stays inside the repository:
+ * absolute or `..`-traversing patterns would make consumers such as node_modules cleanup operate
+ * on another repository's files.
+ */
+export function isInRepositoryWorkspacePattern(workspacePattern: string): boolean {
+  const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
+  return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
 }

--- a/packages/shared-lib-node/src/bunWorkspaces.ts
+++ b/packages/shared-lib-node/src/bunWorkspaces.ts
@@ -36,8 +36,11 @@ export function resolveBunWorkspacePackageJsonPaths(workspaces: WorkspacesDeclar
  *    `**` (packages at any depth), any other star-run seeds `*\/*` (depth 2 only). Seeding
  *    happens even alongside positive patterns (`["apps/*", "!other/*"]` links every depth-2
  *    package outside other/). No other negation shape seeds: `!*`, `!**`, `!*\/*`, `!*\/**`,
- *    `!**\/*`, `!a/b/*`, `!a/b/**`, `!dir`, `!dir/?`, and `!dir/*x` each link nothing on their
- *    own.
+ *    `!**\/*`, `!a/b/*`, `!a/b/**`, `!dir`, and `!dir/*x` each link nothing on their own.
+ *    `?`, brace, and character-class last segments behave ERRATICALLY (`["!other/?"]` links
+ *    packages/a yet not the equally baseline-shaped other/yy, `["!other/??"]` links nothing, and
+ *    `["!?/?"]` links the very other/x it matches), so no consistent rule can model them; they
+ *    are deliberately treated as not seeding — see hasImplicitWorkspaceBaseline and #1005.
  * 3. A non-glob positive pattern PINS its directory: it stays a workspace regardless of where a
  *    matching negation appears (`["other/x", "!other/x"]` and `["!other/x", "other/x"]` both
  *    link other/x).
@@ -69,16 +72,30 @@ export function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], ro
       return false;
     }
   };
-  const globManifestPaths = (pattern: string): string[] =>
-    fg
-      .globSync(path.posix.join(pattern, 'package.json'), {
-        cwd: rootDirPath,
-        followSymbolicLinks: false,
-        ignore: ['**/node_modules/**'],
-      })
-      // A zero-segment `**` match reaches the root's own manifest, but Bun never treats the
-      // monorepo root as its own workspace.
-      .filter((packageJsonPath) => packageJsonPath !== 'package.json' && isInsideRealRoot(packageJsonPath));
+  const globManifestPaths = (pattern: string): string[] => {
+    // Bun links dot-directory packages only through fully static patterns: with Bun 1.3.14,
+    // `.hidden/x` pins the package while `.hidden/*`, `.*/*`, and `**` all link nothing under
+    // .hidden — even when the dotted segment itself is literal — so any dynamic pattern must
+    // drop matches containing a dot-led segment (fast-glob's `dot: false` only covers segments
+    // a wildcard matches).
+    const excludesDotSegments = fg.isDynamicPattern(pattern);
+    return (
+      fg
+        .globSync(path.posix.join(pattern, 'package.json'), {
+          cwd: rootDirPath,
+          followSymbolicLinks: false,
+          ignore: ['**/node_modules/**'],
+        })
+        // A zero-segment `**` match reaches the root's own manifest, but Bun never treats the
+        // monorepo root as its own workspace.
+        .filter(
+          (packageJsonPath) =>
+            packageJsonPath !== 'package.json' &&
+            (!excludesDotSegments || !packageJsonPath.split('/').some((segment) => segment.startsWith('.'))) &&
+            isInsideRealRoot(packageJsonPath)
+        )
+    );
+  };
   const accumulatedPaths = new Set<string>();
   const pinnedPaths = new Set<string>();
   for (const workspacePattern of workspacePatterns) {

--- a/packages/shared-lib-node/src/index.ts
+++ b/packages/shared-lib-node/src/index.ts
@@ -1,4 +1,15 @@
 export {
+  getDeclaredWorkspacePatterns,
+  getMeaningfulDeclaredWorkspacePatterns,
+  getSeededBaselineGlob,
+  hasImplicitWorkspaceBaseline,
+  isInRepositoryWorkspacePattern,
+  normalizeWorkspacePatternBody,
+  resolveBunWorkspacePackageJsonPaths,
+  resolveWorkspacePackageJsonPaths,
+} from './bunWorkspaces.js';
+export type { WorkspacesDeclaration } from './bunWorkspaces.js';
+export {
   hasProjectFnoxConfig,
   readEnvironmentVariables,
   readAndApplyEnvironmentVariables,

--- a/packages/shared-lib-node/test/bunWorkspaces.test.ts
+++ b/packages/shared-lib-node/test/bunWorkspaces.test.ts
@@ -1,0 +1,107 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import {
+  getMeaningfulDeclaredWorkspacePatterns,
+  hasImplicitWorkspaceBaseline,
+  resolveBunWorkspacePackageJsonPaths,
+} from '../src/bunWorkspaces.js';
+
+/** Creates a temp monorepo whose given directories each contain a package.json. */
+function withPackageDirs(packageDirPaths: string[], testBody: (rootDirPath: string) => void): void {
+  const rootDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bun-workspaces-'));
+  try {
+    fs.writeFileSync(path.join(rootDirPath, 'package.json'), JSON.stringify({ name: 'root' }));
+    for (const packageDirPath of packageDirPaths) {
+      fs.mkdirSync(path.join(rootDirPath, packageDirPath), { recursive: true });
+      fs.writeFileSync(path.join(rootDirPath, packageDirPath, 'package.json'), JSON.stringify({}));
+    }
+    testBody(rootDirPath);
+  } finally {
+    fs.rmSync(rootDirPath, { recursive: true, force: true });
+  }
+}
+
+test('evaluates patterns sequentially: a later positive re-adds what an earlier negation removed', () => {
+  withPackageDirs(['apps/web', 'apps/excluded'], (rootDirPath) => {
+    expect(resolveBunWorkspacePackageJsonPaths(['apps/*', '!apps/excluded'], rootDirPath)).toEqual([
+      'apps/web/package.json',
+    ]);
+    expect(resolveBunWorkspacePackageJsonPaths(['!apps/excluded', 'apps/*'], rootDirPath)).toEqual([
+      'apps/excluded/package.json',
+      'apps/web/package.json',
+    ]);
+  });
+});
+
+test('a non-glob positive pattern pins its directory regardless of negation order (issue #1008)', () => {
+  withPackageDirs(['packages/a', 'packages/lib'], (rootDirPath) => {
+    for (const workspaces of [
+      ['packages/*', 'packages/lib', '!packages/lib'],
+      ['packages/*', '!packages/lib', 'packages/lib'],
+      ['packages/lib', '!packages/lib'],
+    ]) {
+      expect(resolveBunWorkspacePackageJsonPaths(workspaces, rootDirPath), workspaces.join(',')).toContain(
+        'packages/lib/package.json'
+      );
+    }
+  });
+});
+
+test('a two-segment star-run negation seeds the implicit baseline before deleting its matches', () => {
+  withPackageDirs(['apps/web', 'other/x', 'deep/nested/pkg'], (rootDirPath) => {
+    // `!other/*` seeds `*/*` (depth 2 only), then removes other/x.
+    expect(resolveBunWorkspacePackageJsonPaths(['!other/*'], rootDirPath)).toEqual(['apps/web/package.json']);
+    // `!other/**` seeds `**` (any depth), then removes other/x.
+    expect(resolveBunWorkspacePackageJsonPaths(['!other/**'], rootDirPath)).toEqual([
+      'apps/web/package.json',
+      'deep/nested/pkg/package.json',
+    ]);
+    // Seeding also happens alongside positive patterns.
+    expect(resolveBunWorkspacePackageJsonPaths(['deep/nested/pkg', '!other/*'], rootDirPath)).toEqual([
+      'apps/web/package.json',
+      'deep/nested/pkg/package.json',
+    ]);
+    // Non-seeding negation shapes link nothing on their own.
+    for (const workspaces of [['!*'], ['!**'], ['!*/*'], ['!apps/excluded'], ['!apps/*d'], ['!a/b/*']]) {
+      expect(resolveBunWorkspacePackageJsonPaths(workspaces, rootDirPath), workspaces.join(',')).toEqual([]);
+    }
+  });
+});
+
+test('`**` matches zero segments but never turns the monorepo root into a workspace', () => {
+  withPackageDirs(['apps'], (rootDirPath) => {
+    expect(resolveBunWorkspacePackageJsonPaths(['apps/**'], rootDirPath)).toEqual(['apps/package.json']);
+    expect(resolveBunWorkspacePackageJsonPaths(['**'], rootDirPath)).toEqual(['apps/package.json']);
+  });
+});
+
+test('drops no-op patterns, applies bang parity, and ignores repository-escaping patterns', () => {
+  expect(getMeaningfulDeclaredWorkspacePatterns(['', '!', '.', './', 'apps/*', '!!a', '!!!b'])).toEqual([
+    'apps/*',
+    'a',
+    '!b',
+  ]);
+  expect(getMeaningfulDeclaredWorkspacePatterns({ packages: ['packages/*'] })).toEqual(['packages/*']);
+  expect(getMeaningfulDeclaredWorkspacePatterns(undefined)).toEqual([]);
+  withPackageDirs(['apps/web'], (rootDirPath) => {
+    expect(resolveBunWorkspacePackageJsonPaths(['/abs/*', '../outside/*', 'apps/*'], rootDirPath)).toEqual([
+      'apps/web/package.json',
+    ]);
+  });
+});
+
+test('detects the implicit workspace baseline only for seeding negation shapes', () => {
+  expect(hasImplicitWorkspaceBaseline(['!other/*'])).toBe(true);
+  expect(hasImplicitWorkspaceBaseline(['apps/*', '!other/**'])).toBe(true);
+  expect(hasImplicitWorkspaceBaseline(['!other/***'])).toBe(true);
+  expect(hasImplicitWorkspaceBaseline(['apps/*'])).toBe(false);
+  expect(hasImplicitWorkspaceBaseline(['!*'])).toBe(false);
+  expect(hasImplicitWorkspaceBaseline(['!**/*'])).toBe(false);
+  expect(hasImplicitWorkspaceBaseline(['!apps/excluded'])).toBe(false);
+  expect(hasImplicitWorkspaceBaseline(['!'])).toBe(false);
+  expect(hasImplicitWorkspaceBaseline(undefined)).toBe(false);
+});

--- a/packages/shared-lib-node/test/bunWorkspaces.test.ts
+++ b/packages/shared-lib-node/test/bunWorkspaces.test.ts
@@ -94,6 +94,18 @@ test('drops no-op patterns, applies bang parity, and ignores repository-escaping
   });
 });
 
+test('matches lone-`?` segments like Bun despite fast-glob returning no file matches for them', () => {
+  withPackageDirs(['packages/a', 'packages/b', 'packages/long'], (rootDirPath) => {
+    // Bun 1.3.14 links packages/a and packages/b for `packages/?`; fast-glob 3.3.3 returns [] for
+    // the file glob `packages/?/package.json`, so the resolver complements it with a directory
+    // glob.
+    expect(resolveBunWorkspacePackageJsonPaths(['packages/?'], rootDirPath)).toEqual([
+      'packages/a/package.json',
+      'packages/b/package.json',
+    ]);
+  });
+});
+
 test('links dot-directory packages only through fully static patterns, like Bun', () => {
   withPackageDirs(['.hidden/x', 'packages/a'], (rootDirPath) => {
     // Bun 1.3.14 links nothing under .hidden for these dynamic patterns, even with a literal

--- a/packages/shared-lib-node/test/bunWorkspaces.test.ts
+++ b/packages/shared-lib-node/test/bunWorkspaces.test.ts
@@ -94,6 +94,28 @@ test('drops no-op patterns, applies bang parity, and ignores repository-escaping
   });
 });
 
+test('drops a workspace whose symlink escapes the repository but keeps internal symlinks', () => {
+  const outerDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bun-workspaces-symlink-'));
+  try {
+    const rootDirPath = path.join(outerDirPath, 'repo');
+    fs.mkdirSync(path.join(rootDirPath, 'real-pkg'), { recursive: true });
+    fs.mkdirSync(path.join(outerDirPath, 'outside'));
+    fs.writeFileSync(path.join(rootDirPath, 'package.json'), JSON.stringify({ name: 'root' }));
+    fs.writeFileSync(path.join(rootDirPath, 'real-pkg', 'package.json'), JSON.stringify({}));
+    fs.writeFileSync(path.join(outerDirPath, 'outside', 'package.json'), JSON.stringify({}));
+    // Bun links both, but the resolver must keep only the internal one: consumers (node_modules
+    // cleanup, manifest rewriting) would otherwise operate on another repository via the symlink.
+    fs.symlinkSync(path.join('..', 'outside'), path.join(rootDirPath, 'escaping'));
+    fs.symlinkSync('real-pkg', path.join(rootDirPath, 'internal'));
+    expect(resolveBunWorkspacePackageJsonPaths(['escaping', 'internal', 'real-pkg'], rootDirPath)).toEqual([
+      'internal/package.json',
+      'real-pkg/package.json',
+    ]);
+  } finally {
+    fs.rmSync(outerDirPath, { recursive: true, force: true });
+  }
+});
+
 test('detects the implicit workspace baseline only for seeding negation shapes', () => {
   expect(hasImplicitWorkspaceBaseline(['!other/*'])).toBe(true);
   expect(hasImplicitWorkspaceBaseline(['apps/*', '!other/**'])).toBe(true);

--- a/packages/shared-lib-node/test/bunWorkspaces.test.ts
+++ b/packages/shared-lib-node/test/bunWorkspaces.test.ts
@@ -10,21 +10,6 @@ import {
   resolveBunWorkspacePackageJsonPaths,
 } from '../src/bunWorkspaces.js';
 
-/** Creates a temp monorepo whose given directories each contain a package.json. */
-function withPackageDirs(packageDirPaths: string[], testBody: (rootDirPath: string) => void): void {
-  const rootDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bun-workspaces-'));
-  try {
-    fs.writeFileSync(path.join(rootDirPath, 'package.json'), JSON.stringify({ name: 'root' }));
-    for (const packageDirPath of packageDirPaths) {
-      fs.mkdirSync(path.join(rootDirPath, packageDirPath), { recursive: true });
-      fs.writeFileSync(path.join(rootDirPath, packageDirPath, 'package.json'), JSON.stringify({}));
-    }
-    testBody(rootDirPath);
-  } finally {
-    fs.rmSync(rootDirPath, { recursive: true, force: true });
-  }
-}
-
 test('evaluates patterns sequentially: a later positive re-adds what an earlier negation removed', () => {
   withPackageDirs(['apps/web', 'apps/excluded'], (rootDirPath) => {
     expect(resolveBunWorkspacePackageJsonPaths(['apps/*', '!apps/excluded'], rootDirPath)).toEqual([
@@ -156,3 +141,18 @@ test('detects the implicit workspace baseline only for seeding negation shapes',
   expect(hasImplicitWorkspaceBaseline(['!'])).toBe(false);
   expect(hasImplicitWorkspaceBaseline(undefined)).toBe(false);
 });
+
+/** Creates a temp monorepo whose given directories each contain a package.json. */
+function withPackageDirs(packageDirPaths: string[], testBody: (rootDirPath: string) => void): void {
+  const rootDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bun-workspaces-'));
+  try {
+    fs.writeFileSync(path.join(rootDirPath, 'package.json'), JSON.stringify({ name: 'root' }));
+    for (const packageDirPath of packageDirPaths) {
+      fs.mkdirSync(path.join(rootDirPath, packageDirPath), { recursive: true });
+      fs.writeFileSync(path.join(rootDirPath, packageDirPath, 'package.json'), JSON.stringify({}));
+    }
+    testBody(rootDirPath);
+  } finally {
+    fs.rmSync(rootDirPath, { recursive: true, force: true });
+  }
+}

--- a/packages/shared-lib-node/test/bunWorkspaces.test.ts
+++ b/packages/shared-lib-node/test/bunWorkspaces.test.ts
@@ -94,6 +94,12 @@ test('drops no-op patterns, applies bang parity, and ignores repository-escaping
   });
 });
 
+test('keeps a workspace directory whose name merely starts with ".." inside the repository', () => {
+  withPackageDirs(['..pkg'], (rootDirPath) => {
+    expect(resolveBunWorkspacePackageJsonPaths(['..pkg'], rootDirPath)).toEqual(['..pkg/package.json']);
+  });
+});
+
 test('drops a workspace whose symlink escapes the repository but keeps internal symlinks', () => {
   const outerDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bun-workspaces-symlink-'));
   try {

--- a/packages/shared-lib-node/test/bunWorkspaces.test.ts
+++ b/packages/shared-lib-node/test/bunWorkspaces.test.ts
@@ -94,6 +94,17 @@ test('drops no-op patterns, applies bang parity, and ignores repository-escaping
   });
 });
 
+test('links dot-directory packages only through fully static patterns, like Bun', () => {
+  withPackageDirs(['.hidden/x', 'packages/a'], (rootDirPath) => {
+    // Bun 1.3.14 links nothing under .hidden for these dynamic patterns, even with a literal
+    // dotted segment, but pins the fully static `.hidden/x`.
+    expect(resolveBunWorkspacePackageJsonPaths(['.hidden/*'], rootDirPath)).toEqual([]);
+    expect(resolveBunWorkspacePackageJsonPaths(['.*/*'], rootDirPath)).toEqual([]);
+    expect(resolveBunWorkspacePackageJsonPaths(['**'], rootDirPath)).toEqual(['packages/a/package.json']);
+    expect(resolveBunWorkspacePackageJsonPaths(['.hidden/x'], rootDirPath)).toEqual(['.hidden/x/package.json']);
+  });
+});
+
 test('keeps a workspace directory whose name merely starts with ".." inside the repository', () => {
   withPackageDirs(['..pkg'], (rootDirPath) => {
     expect(resolveBunWorkspacePackageJsonPaths(['..pkg'], rootDirPath)).toEqual(['..pkg/package.json']);

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -33,6 +33,7 @@
     "chalk": "5.6.2",
     "dotenv": "17.4.2",
     "dotenv-expand": "13.0.0",
+    "fast-glob": "3.3.3",
     "fastest-levenshtein": "1.0.16",
     "globby": "16.2.0",
     "jsonc-parser": "3.3.1",

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -3,11 +3,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import chalk from 'chalk';
-import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
 import type { ArgumentsCamelCase, Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
-import { treeKill } from '@willbooster/shared-lib-node/src';
+import { resolveBunWorkspacePackageJsonPaths, treeKill } from '@willbooster/shared-lib-node/src';
 
 import type { Project } from '../project.js';
 import { findRootAndSelfProjects } from '../project.js';
@@ -178,7 +177,7 @@ export async function releasePublishesToNpm(project: Pick<Project, 'dirPath' | '
   // Without an explicit root plugin list, semantic-release's default list (npm included) applies.
   if (!Array.isArray(rootPlugins) || pluginsIncludeNpm(rootPlugins)) return true;
 
-  for (const packageDirPath of await findWorkspacePackageDirs(project)) {
+  for (const packageDirPath of findWorkspacePackageDirs(project)) {
     const plugins = readExplicitSemanticReleasePlugins(packageDirPath, undefined);
     // A workspace package without its own plugin list inherits the root's (npm-free) decision.
     if (plugins === 'unknown' || (Array.isArray(plugins) && pluginsIncludeNpm(plugins))) return true;
@@ -285,7 +284,7 @@ async function prepareNpmCompatibleLayout(
         modifiedFiles.set(lockFilePath, fs.existsSync(lockFilePath) ? fs.readFileSync(lockFilePath) : undefined);
       }
       fs.writeFileSync(bunfigPath, hoistedBunfig ?? '', 'utf8');
-      const nodeModulesDirPaths = [project.dirPath, ...(await findWorkspacePackageDirs(project))].map((dirPath) =>
+      const nodeModulesDirPaths = [project.dirPath, ...findWorkspacePackageDirs(project)].map((dirPath) =>
         path.join(dirPath, 'node_modules')
       );
       for (const nodeModulesDirPath of nodeModulesDirPaths) {
@@ -323,7 +322,7 @@ async function prepareNpmCompatibleLayout(
     }
   }
 
-  const workspacePackageDirs = await findWorkspacePackageDirs(project);
+  const workspacePackageDirs = findWorkspacePackageDirs(project);
   for (const packageJsonPath of [
     project.packageJsonPath,
     ...workspacePackageDirs.map((dirPath) => path.join(dirPath, 'package.json')),
@@ -525,11 +524,14 @@ async function runSemanticRelease(project: Project, argv: ReleaseArgv, activeChi
   });
 }
 
-async function findWorkspacePackageDirs(project: Pick<Project, 'dirPath' | 'packageJson'>): Promise<string[]> {
-  const workspaces = project.packageJson.workspaces;
-  const patterns = Array.isArray(workspaces) ? workspaces : (workspaces?.packages ?? []);
-  if (patterns.length === 0) return [];
-
-  const dirPaths = await globby(patterns, { cwd: project.dirPath, onlyDirectories: true });
-  return dirPaths.map((dirPath) => path.join(project.dirPath, dirPath));
+/**
+ * The absolute directory of every workspace Bun would link, resolved with the shared Bun-exact
+ * resolver so exotic patterns (pinned positives after a matching negation, baseline-seeding
+ * negations, …) match `bun install`'s view — globby's negation/baseline semantics diverge
+ * (issue #1008).
+ */
+function findWorkspacePackageDirs(project: Pick<Project, 'dirPath' | 'packageJson'>): string[] {
+  return resolveBunWorkspacePackageJsonPaths(project.packageJson.workspaces, project.dirPath).map((packageJsonPath) =>
+    path.join(project.dirPath, path.posix.dirname(packageJsonPath))
+  );
 }

--- a/packages/wb/src/commands/release.ts
+++ b/packages/wb/src/commands/release.ts
@@ -6,10 +6,10 @@ import chalk from 'chalk';
 import type { PackageJson } from 'type-fest';
 import type { ArgumentsCamelCase, Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
-import { resolveBunWorkspacePackageJsonPaths, treeKill } from '@willbooster/shared-lib-node/src';
+import { treeKill } from '@willbooster/shared-lib-node/src';
 
 import type { Project } from '../project.js';
-import { findRootAndSelfProjects } from '../project.js';
+import { findRootAndSelfProjects, findWorkspacePackageDirs } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { prependNodeModulesBinToPath } from '../utils/binPath.js';
 import { isCI } from '../utils/ci.js';
@@ -172,12 +172,14 @@ async function spawnAndWait(
  * missing plugin list, a non-JSON config file, or an `extends` preset conservatively keeps the
  * npm preparation.
  */
-export async function releasePublishesToNpm(project: Pick<Project, 'dirPath' | 'packageJson'>): Promise<boolean> {
+export async function releasePublishesToNpm(
+  project: Pick<Project, 'dirPath' | 'packageJson' | 'usesBunPackageManager'>
+): Promise<boolean> {
   const rootPlugins = readExplicitSemanticReleasePlugins(project.dirPath, project.packageJson);
   // Without an explicit root plugin list, semantic-release's default list (npm included) applies.
   if (!Array.isArray(rootPlugins) || pluginsIncludeNpm(rootPlugins)) return true;
 
-  for (const packageDirPath of findWorkspacePackageDirs(project)) {
+  for (const packageDirPath of await findWorkspacePackageDirs(project)) {
     const plugins = readExplicitSemanticReleasePlugins(packageDirPath, undefined);
     // A workspace package without its own plugin list inherits the root's (npm-free) decision.
     if (plugins === 'unknown' || (Array.isArray(plugins) && pluginsIncludeNpm(plugins))) return true;
@@ -284,7 +286,7 @@ async function prepareNpmCompatibleLayout(
         modifiedFiles.set(lockFilePath, fs.existsSync(lockFilePath) ? fs.readFileSync(lockFilePath) : undefined);
       }
       fs.writeFileSync(bunfigPath, hoistedBunfig ?? '', 'utf8');
-      const nodeModulesDirPaths = [project.dirPath, ...findWorkspacePackageDirs(project)].map((dirPath) =>
+      const nodeModulesDirPaths = [project.dirPath, ...(await findWorkspacePackageDirs(project))].map((dirPath) =>
         path.join(dirPath, 'node_modules')
       );
       for (const nodeModulesDirPath of nodeModulesDirPaths) {
@@ -322,7 +324,7 @@ async function prepareNpmCompatibleLayout(
     }
   }
 
-  const workspacePackageDirs = findWorkspacePackageDirs(project);
+  const workspacePackageDirs = await findWorkspacePackageDirs(project);
   for (const packageJsonPath of [
     project.packageJsonPath,
     ...workspacePackageDirs.map((dirPath) => path.join(dirPath, 'package.json')),
@@ -522,16 +524,4 @@ async function runSemanticRelease(project: Project, argv: ReleaseArgv, activeChi
     env,
     stdio: 'inherit',
   });
-}
-
-/**
- * The absolute directory of every workspace Bun would link, resolved with the shared Bun-exact
- * resolver so exotic patterns (pinned positives after a matching negation, baseline-seeding
- * negations, …) match `bun install`'s view — globby's negation/baseline semantics diverge
- * (issue #1008).
- */
-function findWorkspacePackageDirs(project: Pick<Project, 'dirPath' | 'packageJson'>): string[] {
-  return resolveBunWorkspacePackageJsonPaths(project.packageJson.workspaces, project.dirPath).map((packageJsonPath) =>
-    path.join(project.dirPath, path.posix.dirname(packageJsonPath))
-  );
 }

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -563,10 +563,13 @@ export async function findWorkspacePackageDirs(
   const manifestPatterns = patterns.map((pattern) =>
     pattern.startsWith('!') ? `!${pattern.slice(1)}/package.json` : `${pattern}/package.json`
   );
-  const manifestPaths = await globby(manifestPatterns, { cwd: project.dirPath });
+  const manifestPaths = await globby(manifestPatterns, { cwd: project.dirPath, ignore: ['**/node_modules/**'] });
   const realRootDirPath = fs.realpathSync(project.dirPath);
-  return manifestPaths
+  const workspaceDirPaths = manifestPaths
+    // A `**` pattern reaches the root's own manifest and installed packages, but neither is a
+    // workspace to Yarn (which never descends into node_modules).
     .filter((manifestPath) => {
+      if (manifestPath === 'package.json') return false;
       try {
         const relativePath = path.relative(realRootDirPath, fs.realpathSync(path.join(project.dirPath, manifestPath)));
         return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
@@ -575,6 +578,6 @@ export async function findWorkspacePackageDirs(
         return false;
       }
     })
-    .map((manifestPath) => path.join(project.dirPath, path.posix.dirname(manifestPath)))
-    .toSorted();
+    .map((manifestPath) => path.join(project.dirPath, path.posix.dirname(manifestPath)));
+  return [...new Set(workspaceDirPaths)].toSorted();
 }

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -592,7 +592,7 @@ export async function findWorkspacePackageDirs(
       if (manifestPath === 'package.json') return false;
       try {
         const relativePath = path.relative(realRootDirPath, fs.realpathSync(path.join(project.dirPath, manifestPath)));
-        return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
+        return relativePath !== '..' && !relativePath.startsWith('../') && !path.isAbsolute(relativePath);
       } catch {
         // The manifest vanished between the glob and the realpath call: not a workspace.
         return false;

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -574,21 +574,22 @@ export async function findWorkspacePackageDirs(
     ignore: ['**/node_modules/**'],
   };
   // fast-glob (globby's engine) returns no matches for file globs with a lone-`?` segment (e.g.
-  // `packages/?/package.json`) although Yarn links such workspaces; globbing the directories
-  // (where `?` works) and checking their manifests complements it.
+  // `packages/?/package.json`) although Yarn links such workspaces; for `?`-carrying patterns
+  // only (a directory glob for e.g. `**` would scan every directory in the repository), globbing
+  // the directories (where `?` works) and checking their manifests complements the manifest glob.
   const globbedManifestPaths = await globby(
     positivePatterns.map((pattern) => path.posix.join(pattern, 'package.json')),
     globbyOptions
   );
-  const globbedDirPaths = await globby(positivePatterns, { ...globbyOptions, onlyDirectories: true });
-  const manifestPaths = [
-    ...new Set([
-      ...globbedManifestPaths,
-      ...globbedDirPaths
-        .map((dirPath) => path.posix.join(dirPath, 'package.json'))
-        .filter((manifestPath) => fs.existsSync(path.join(project.dirPath, manifestPath))),
-    ]),
-  ];
+  const manifestPathSet = new Set(globbedManifestPaths);
+  const questionMarkPatterns = positivePatterns.filter((pattern) => pattern.includes('?'));
+  if (questionMarkPatterns.length > 0) {
+    for (const dirPath of await globby(questionMarkPatterns, { ...globbyOptions, onlyDirectories: true })) {
+      const manifestPath = path.posix.join(dirPath, 'package.json');
+      if (fs.existsSync(path.join(project.dirPath, manifestPath))) manifestPathSet.add(manifestPath);
+    }
+  }
+  const manifestPaths = [...manifestPathSet];
   const realRootDirPath = fs.realpathSync(project.dirPath);
   const workspaceDirPaths = manifestPaths
     // A `**` pattern reaches the root's own manifest and installed packages, but neither is a

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -565,10 +565,25 @@ export async function findWorkspacePackageDirs(
     (pattern) => !pattern.startsWith('!')
   );
   if (positivePatterns.length === 0) return [];
-  const manifestPaths = await globby(
+  // expandDirectories: false — globby would otherwise expand a literal directory pattern to its
+  // CHILDREN, turning e.g. `packages` into matches for every packages/* subdirectory.
+  const globbyOptions = { cwd: project.dirPath, expandDirectories: false, ignore: ['**/node_modules/**'] };
+  // fast-glob (globby's engine) returns no matches for file globs with a lone-`?` segment (e.g.
+  // `packages/?/package.json`) although Yarn links such workspaces; globbing the directories
+  // (where `?` works) and checking their manifests complements it.
+  const globbedManifestPaths = await globby(
     positivePatterns.map((pattern) => `${pattern}/package.json`),
-    { cwd: project.dirPath, ignore: ['**/node_modules/**'] }
+    globbyOptions
   );
+  const globbedDirPaths = await globby(positivePatterns, { ...globbyOptions, onlyDirectories: true });
+  const manifestPaths = [
+    ...new Set([
+      ...globbedManifestPaths,
+      ...globbedDirPaths
+        .map((dirPath) => path.posix.join(dirPath, 'package.json'))
+        .filter((manifestPath) => fs.existsSync(path.join(project.dirPath, manifestPath))),
+    ]),
+  ];
   const realRootDirPath = fs.realpathSync(project.dirPath);
   const workspaceDirPaths = manifestPaths
     // A `**` pattern reaches the root's own manifest and installed packages, but neither is a

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import type { EnvReaderOptions } from '@willbooster/shared-lib-node/src';
 import {
+  getDeclaredWorkspacePatterns,
   readEnvironmentVariables,
   resolveBunWorkspacePackageJsonPaths,
   resolveFallbackWbEnv,
@@ -10,6 +11,7 @@ import {
 } from '@willbooster/shared-lib-node/src';
 import { memoizeOne } from 'at-decorators';
 import chalk from 'chalk';
+import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
 
 import { prependNodeModulesBinToPath } from './utils/binPath.js';
@@ -488,7 +490,7 @@ export async function findDescendantProjects(
     ...rootAndSelfProjects,
     descendants:
       rootAndSelfProjects.root === rootAndSelfProjects.self
-        ? getAllDescendantProjects(argv, rootAndSelfProjects.root, loadEnv)
+        ? await getAllDescendantProjects(argv, rootAndSelfProjects.root, loadEnv)
         : [rootAndSelfProjects.self],
   };
 }
@@ -521,17 +523,58 @@ function testFileContent(filePath: string, pattern: RegExp): boolean {
 }
 
 /**
- * The root project followed by one Project per workspace Bun would link, discovered with the
- * shared Bun-exact resolver so every wb command sees the same workspaces as `bun install`
- * (negations, Yarn v1's object form, pinned positives, and baseline-seeding negations included;
- * issue #1008).
+ * The root project followed by one Project per workspace directory the target repository's
+ * package manager would link (issue #1008): Bun repos use the shared Bun-exact resolver
+ * (negations, pinned positives, and baseline-seeding negations included), while Yarn repos keep
+ * glob semantics — Bun-only rules such as the implicit baseline would invent workspaces Yarn
+ * never links.
  */
-function getAllDescendantProjects(argv: EnvReaderOptions, rootProject: Project, loadEnv: boolean): Project[] {
-  return [
-    rootProject,
-    ...resolveBunWorkspacePackageJsonPaths(rootProject.packageJson.workspaces, rootProject.dirPath).map(
-      (packageJsonPath) =>
-        new Project(path.join(rootProject.dirPath, path.posix.dirname(packageJsonPath)), argv, loadEnv)
-    ),
-  ];
+async function getAllDescendantProjects(
+  argv: EnvReaderOptions,
+  rootProject: Project,
+  loadEnv: boolean
+): Promise<Project[]> {
+  const workspaceDirPaths = await findWorkspacePackageDirs(rootProject);
+  return [rootProject, ...workspaceDirPaths.map((workspaceDirPath) => new Project(workspaceDirPath, argv, loadEnv))];
+}
+
+/**
+ * The absolute directory of every workspace the target repository's package manager would link,
+ * matching the manager the way getAllDescendantProjects describes. Exported for wb release, whose
+ * plugin inspection, node_modules cleanup, and manifest rewriting must see the same workspace set.
+ */
+export async function findWorkspacePackageDirs(
+  project: Pick<Project, 'dirPath' | 'packageJson' | 'usesBunPackageManager'>
+): Promise<string[]> {
+  if (project.usesBunPackageManager) {
+    return resolveBunWorkspacePackageJsonPaths(project.packageJson.workspaces, project.dirPath).map((packageJsonPath) =>
+      path.join(project.dirPath, path.posix.dirname(packageJsonPath))
+    );
+  }
+  // Yarn v1 resolves the declared patterns (array or `{ packages: […] }` form) as plain globs and
+  // links only directories carrying a package.json, so glob for the manifests themselves —
+  // globby's `onlyDirectories` would return a literal directory pattern's CHILDREN instead of the
+  // directory. Without any positive pattern nothing can match (globby would instead return
+  // everything a lone negation does not exclude). The realpath containment mirrors
+  // resolveWorkspacePackageJsonPaths: a workspace symlink escaping the repository must not let
+  // consumers touch another checkout.
+  const patterns = getDeclaredWorkspacePatterns(project.packageJson.workspaces);
+  if (!patterns.some((pattern) => !pattern.startsWith('!'))) return [];
+  const manifestPatterns = patterns.map((pattern) =>
+    pattern.startsWith('!') ? `!${pattern.slice(1)}/package.json` : `${pattern}/package.json`
+  );
+  const manifestPaths = await globby(manifestPatterns, { cwd: project.dirPath });
+  const realRootDirPath = fs.realpathSync(project.dirPath);
+  return manifestPaths
+    .filter((manifestPath) => {
+      try {
+        const relativePath = path.relative(realRootDirPath, fs.realpathSync(path.join(project.dirPath, manifestPath)));
+        return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
+      } catch {
+        // The manifest vanished between the glob and the realpath call: not a workspace.
+        return false;
+      }
+    })
+    .map((manifestPath) => path.join(project.dirPath, path.posix.dirname(manifestPath)))
+    .toSorted();
 }

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -567,12 +567,17 @@ export async function findWorkspacePackageDirs(
   if (positivePatterns.length === 0) return [];
   // expandDirectories: false — globby would otherwise expand a literal directory pattern to its
   // CHILDREN, turning e.g. `packages` into matches for every packages/* subdirectory.
-  const globbyOptions = { cwd: project.dirPath, expandDirectories: false, ignore: ['**/node_modules/**'] };
+  const globbyOptions = {
+    cwd: project.dirPath,
+    expandDirectories: false,
+    followSymbolicLinks: false,
+    ignore: ['**/node_modules/**'],
+  };
   // fast-glob (globby's engine) returns no matches for file globs with a lone-`?` segment (e.g.
   // `packages/?/package.json`) although Yarn links such workspaces; globbing the directories
   // (where `?` works) and checking their manifests complements it.
   const globbedManifestPaths = await globby(
-    positivePatterns.map((pattern) => `${pattern}/package.json`),
+    positivePatterns.map((pattern) => path.posix.join(pattern, 'package.json')),
     globbyOptions
   );
   const globbedDirPaths = await globby(positivePatterns, { ...globbyOptions, onlyDirectories: true });

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import type { EnvReaderOptions } from '@willbooster/shared-lib-node/src';
 import {
   getDeclaredWorkspacePatterns,
+  isInRepositoryWorkspacePattern,
   readEnvironmentVariables,
   resolveBunWorkspacePackageJsonPaths,
   resolveFallbackWbEnv,
@@ -562,7 +563,7 @@ export async function findWorkspacePackageDirs(
   // containment mirrors resolveWorkspacePackageJsonPaths: a workspace symlink escaping the
   // repository must not let consumers touch another checkout.
   const positivePatterns = getDeclaredWorkspacePatterns(project.packageJson.workspaces).filter(
-    (pattern) => !pattern.startsWith('!')
+    (pattern) => !pattern.startsWith('!') && isInRepositoryWorkspacePattern(pattern)
   );
   if (positivePatterns.length === 0) return [];
   // expandDirectories: false — globby would otherwise expand a literal directory pattern to its

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -551,19 +551,24 @@ export async function findWorkspacePackageDirs(
       path.join(project.dirPath, path.posix.dirname(packageJsonPath))
     );
   }
-  // Yarn v1 resolves the declared patterns (array or `{ packages: […] }` form) as plain globs and
-  // links only directories carrying a package.json, so glob for the manifests themselves —
-  // globby's `onlyDirectories` would return a literal directory pattern's CHILDREN instead of the
-  // directory. Without any positive pattern nothing can match (globby would instead return
-  // everything a lone negation does not exclude). The realpath containment mirrors
-  // resolveWorkspacePackageJsonPaths: a workspace symlink escaping the repository must not let
-  // consumers touch another checkout.
-  const patterns = getDeclaredWorkspacePatterns(project.packageJson.workspaces);
-  if (!patterns.some((pattern) => !pattern.startsWith('!'))) return [];
-  const manifestPatterns = patterns.map((pattern) =>
-    pattern.startsWith('!') ? `!${pattern.slice(1)}/package.json` : `${pattern}/package.json`
+  // Yarn 1.22.22 resolves each declared pattern (array or `{ packages: […] }` form) independently
+  // and unions the results, so a leading-`!` pattern is not an exclusion — `["packages/*",
+  // "!packages/a"]` still links packages/a. Yarn additionally ignores manifests missing a name or
+  // version ("Missing version in workspace …, ignoring."), but that is deliberately NOT mirrored:
+  // wb's descendant discovery exists to run commands (lint, test, typecheck, …) in sub-packages,
+  // and version-less private packages must stay discovered — the long-standing behavior wb's
+  // monorepo fixtures encode. Glob for the manifests themselves: globby's `onlyDirectories`
+  // would return a literal directory pattern's CHILDREN instead of the directory. The realpath
+  // containment mirrors resolveWorkspacePackageJsonPaths: a workspace symlink escaping the
+  // repository must not let consumers touch another checkout.
+  const positivePatterns = getDeclaredWorkspacePatterns(project.packageJson.workspaces).filter(
+    (pattern) => !pattern.startsWith('!')
   );
-  const manifestPaths = await globby(manifestPatterns, { cwd: project.dirPath, ignore: ['**/node_modules/**'] });
+  if (positivePatterns.length === 0) return [];
+  const manifestPaths = await globby(
+    positivePatterns.map((pattern) => `${pattern}/package.json`),
+    { cwd: project.dirPath, ignore: ['**/node_modules/**'] }
+  );
   const realRootDirPath = fs.realpathSync(project.dirPath);
   const workspaceDirPaths = manifestPaths
     // A `**` pattern reaches the root's own manifest and installed packages, but neither is a

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -4,12 +4,12 @@ import path from 'node:path';
 import type { EnvReaderOptions } from '@willbooster/shared-lib-node/src';
 import {
   readEnvironmentVariables,
+  resolveBunWorkspacePackageJsonPaths,
   resolveFallbackWbEnv,
   shouldSuppressEnvironmentOutput,
 } from '@willbooster/shared-lib-node/src';
 import { memoizeOne } from 'at-decorators';
 import chalk from 'chalk';
-import { globby } from 'globby';
 import type { PackageJson } from 'type-fest';
 
 import { prependNodeModulesBinToPath } from './utils/binPath.js';
@@ -488,7 +488,7 @@ export async function findDescendantProjects(
     ...rootAndSelfProjects,
     descendants:
       rootAndSelfProjects.root === rootAndSelfProjects.self
-        ? await getAllDescendantProjects(argv, rootAndSelfProjects.root, loadEnv)
+        ? getAllDescendantProjects(argv, rootAndSelfProjects.root, loadEnv)
         : [rootAndSelfProjects.self],
   };
 }
@@ -520,30 +520,18 @@ function testFileContent(filePath: string, pattern: RegExp): boolean {
   }
 }
 
-async function getAllDescendantProjects(
-  argv: EnvReaderOptions,
-  rootProject: Project,
-  loadEnv: boolean
-): Promise<Project[]> {
-  const projects = [rootProject];
-
-  const workspace = rootProject.packageJson.workspaces;
-  if (!Array.isArray(workspace)) return projects;
-
-  const globPattern: string[] = [];
-  const packageDirs: string[] = [];
-  for (const workspacePath of workspace.map((ws: string) => path.join(rootProject.dirPath, ws))) {
-    if (fs.existsSync(workspacePath)) {
-      packageDirs.push(workspacePath);
-    } else {
-      globPattern.push(workspacePath);
-    }
-  }
-  packageDirs.push(...(await globby(globPattern, { dot: true, onlyDirectories: true })));
-  for (const subPackageDirPath of packageDirs) {
-    if (!fs.existsSync(path.join(subPackageDirPath, 'package.json'))) continue;
-
-    projects.push(new Project(subPackageDirPath, argv, loadEnv));
-  }
-  return projects;
+/**
+ * The root project followed by one Project per workspace Bun would link, discovered with the
+ * shared Bun-exact resolver so every wb command sees the same workspaces as `bun install`
+ * (negations, Yarn v1's object form, pinned positives, and baseline-seeding negations included;
+ * issue #1008).
+ */
+function getAllDescendantProjects(argv: EnvReaderOptions, rootProject: Project, loadEnv: boolean): Project[] {
+  return [
+    rootProject,
+    ...resolveBunWorkspacePackageJsonPaths(rootProject.packageJson.workspaces, rootProject.dirPath).map(
+      (packageJsonPath) =>
+        new Project(path.join(rootProject.dirPath, path.posix.dirname(packageJsonPath)), argv, loadEnv)
+    ),
+  ];
 }

--- a/packages/wb/test/project.test.ts
+++ b/packages/wb/test/project.test.ts
@@ -52,6 +52,10 @@ describe('project', () => {
       await expect(findWorkspacePackageDirs({ dirPath, packageJson, usesBunPackageManager: false })).resolves.toEqual([
         path.join(dirPath, 'packages', 'a'),
       ]);
+      // Yarn also links lone-`?` patterns, which fast-glob's file globs cannot match on their own.
+      await expect(
+        findWorkspacePackageDirs({ dirPath, packageJson: { workspaces: ['packages/?'] }, usesBunPackageManager: false })
+      ).resolves.toEqual([path.join(dirPath, 'packages', 'a')]);
     } finally {
       await fs.promises.rm(dirPath, { recursive: true, force: true });
     }

--- a/packages/wb/test/project.test.ts
+++ b/packages/wb/test/project.test.ts
@@ -1,10 +1,16 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import childProcess from 'node:child_process';
 
 import { describe, expect, it } from 'vitest';
 
-import { findDescendantProjects, findSelfProject, getAbsoluteFileDatabaseUrlPath } from '../src/project.js';
+import {
+  findDescendantProjects,
+  findSelfProject,
+  findWorkspacePackageDirs,
+  getAbsoluteFileDatabaseUrlPath,
+} from '../src/project.js';
 
 import { initializeProjectDirectory, tempDir } from './shared.js';
 
@@ -25,6 +31,28 @@ describe('project', () => {
     },
     5 * 60 * 1000
   );
+
+  it('excludes the root manifest and node_modules from Yarn workspace discovery', async () => {
+    const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-yarn-workspaces-'));
+    try {
+      for (const [relativePath, content] of [
+        ['package.json', { name: 'root', workspaces: ['**'] }],
+        ['packages/a/package.json', { name: 'a' }],
+        ['node_modules/dep/package.json', { name: 'dep' }],
+      ] as const) {
+        await fs.promises.mkdir(path.join(dirPath, path.dirname(relativePath)), { recursive: true });
+        await fs.promises.writeFile(path.join(dirPath, relativePath), JSON.stringify(content), 'utf8');
+      }
+      const packageJson = JSON.parse(await fs.promises.readFile(path.join(dirPath, 'package.json'), 'utf8')) as {
+        workspaces: string[];
+      };
+      await expect(findWorkspacePackageDirs({ dirPath, packageJson, usesBunPackageManager: false })).resolves.toEqual([
+        path.join(dirPath, 'packages', 'a'),
+      ]);
+    } finally {
+      await fs.promises.rm(dirPath, { recursive: true, force: true });
+    }
+  });
 
   it('detects bun from a mise.toml tool pin', async () => {
     // wbfy migrates .tool-versions into mise.toml, so the tool-manifest signal must survive

--- a/packages/wb/test/project.test.ts
+++ b/packages/wb/test/project.test.ts
@@ -32,13 +32,16 @@ describe('project', () => {
     5 * 60 * 1000
   );
 
-  it('excludes the root manifest and node_modules from Yarn workspace discovery', async () => {
+  it('mirrors Yarn v1 workspace discovery: unions patterns and ignores the root manifest and node_modules', async () => {
     const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-yarn-workspaces-'));
     try {
       for (const [relativePath, content] of [
-        ['package.json', { name: 'root', workspaces: ['**'] }],
-        ['packages/a/package.json', { name: 'a' }],
-        ['node_modules/dep/package.json', { name: 'dep' }],
+        // Yarn 1.22.22 resolves each pattern independently and unions the results, so the
+        // `!packages/a` "negation" is not an exclusion, and `**` must reach neither the root
+        // manifest nor node_modules.
+        ['package.json', { name: 'root', workspaces: ['**', '!packages/a'] }],
+        ['packages/a/package.json', { name: 'a', version: '1.0.0' }],
+        ['node_modules/dep/package.json', { name: 'dep', version: '1.0.0' }],
       ] as const) {
         await fs.promises.mkdir(path.join(dirPath, path.dirname(relativePath)), { recursive: true });
         await fs.promises.writeFile(path.join(dirPath, relativePath), JSON.stringify(content), 'utf8');

--- a/packages/wb/test/release.test.ts
+++ b/packages/wb/test/release.test.ts
@@ -147,6 +147,40 @@ describe('releasePublishesToNpm', () => {
     await expect(releasePublishesToNpm(project)).resolves.toBe(true);
   });
 
+  it('sees a pinned workspace (positive kept despite a matching negation) like Bun does', async () => {
+    // globby dropped the pinned packages/lib entirely (issue #1008); Bun keeps it, so its
+    // npm-configuring .releaserc.json must trigger the npm preparation.
+    const project = await createProject({
+      'package.json': { name: 'root', workspaces: ['packages/lib', '!packages/lib'] },
+      '.releaserc.json': { plugins: ['@semantic-release/github'] },
+      'packages/lib/package.json': { name: 'lib' },
+      'packages/lib/.releaserc.json': { plugins: ['@semantic-release/npm'] },
+    });
+    await expect(releasePublishesToNpm(project)).resolves.toBe(true);
+  });
+
+  it('sees workspaces linked by a baseline-seeding negation like Bun does', async () => {
+    // `!other/*` seeds Bun's implicit `*/*` baseline, so packages/lib is a workspace even though
+    // no positive pattern is declared (issue #1008).
+    const project = await createProject({
+      'package.json': { name: 'root', workspaces: ['!other/*'] },
+      '.releaserc.json': { plugins: ['@semantic-release/github'] },
+      'other/x/package.json': { name: 'x' },
+      'other/x/.releaserc.json': { plugins: ['@semantic-release/npm'] },
+      'packages/lib/package.json': { name: 'lib' },
+      'packages/lib/.releaserc.json': { plugins: ['@semantic-release/npm'] },
+    });
+    await expect(releasePublishesToNpm(project)).resolves.toBe(true);
+    // …and the negated other/x alone must NOT trigger it: it is not a workspace to Bun.
+    const negatedOnlyProject = await createProject({
+      'package.json': { name: 'root', workspaces: ['!other/*'] },
+      '.releaserc.json': { plugins: ['@semantic-release/github'] },
+      'other/x/package.json': { name: 'x' },
+      'other/x/.releaserc.json': { plugins: ['@semantic-release/npm'] },
+    });
+    await expect(releasePublishesToNpm(negatedOnlyProject)).resolves.toBe(false);
+  });
+
   it('skips when the root and every workspace package configure npm-free plugins', async () => {
     const project = await createProject({
       'package.json': { name: 'root', workspaces: ['packages/*'] },

--- a/packages/wb/test/release.test.ts
+++ b/packages/wb/test/release.test.ts
@@ -67,7 +67,10 @@ describe('releasePublishesToNpm', () => {
     }
   });
 
-  async function createProject(files: Record<string, object>): Promise<{ dirPath: string; packageJson: PackageJson }> {
+  async function createProject(
+    files: Record<string, object>,
+    usesBunPackageManager = true
+  ): Promise<{ dirPath: string; packageJson: PackageJson; usesBunPackageManager: boolean }> {
     const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-release-test-'));
     temporaryDirPaths.push(dirPath);
     for (const [relativePath, content] of Object.entries(files)) {
@@ -78,7 +81,7 @@ describe('releasePublishesToNpm', () => {
     const packageJson = JSON.parse(
       await fs.promises.readFile(path.join(dirPath, 'package.json'), 'utf8')
     ) as PackageJson;
-    return { dirPath, packageJson };
+    return { dirPath, packageJson, usesBunPackageManager };
   }
 
   it('keeps the npm preparation when no plugin list is configured (default plugins include npm)', async () => {
@@ -179,6 +182,20 @@ describe('releasePublishesToNpm', () => {
       'other/x/.releaserc.json': { plugins: ['@semantic-release/npm'] },
     });
     await expect(releasePublishesToNpm(negatedOnlyProject)).resolves.toBe(false);
+  });
+
+  it('does not apply Bun-only baseline seeding to a Yarn project', async () => {
+    // Yarn v1 links no workspaces for `["!other/*"]`, so packages/lib's npm plugin must not count.
+    const project = await createProject(
+      {
+        'package.json': { name: 'root', workspaces: ['!other/*'] },
+        '.releaserc.json': { plugins: ['@semantic-release/github'] },
+        'packages/lib/package.json': { name: 'lib' },
+        'packages/lib/.releaserc.json': { plugins: ['@semantic-release/npm'] },
+      },
+      false
+    );
+    await expect(releasePublishesToNpm(project)).resolves.toBe(false);
   });
 
   it('skips when the root and every workspace package configure npm-free plugins', async () => {

--- a/packages/wbfy/src/utils/workspaceUtil.ts
+++ b/packages/wbfy/src/utils/workspaceUtil.ts
@@ -1,10 +1,26 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import {
+  getMeaningfulDeclaredWorkspacePatterns,
+  getSeededBaselineGlob,
+  hasImplicitWorkspaceBaseline,
+  isInRepositoryWorkspacePattern,
+  normalizeWorkspacePatternBody,
+  resolveWorkspacePackageJsonPaths,
+} from '@willbooster/shared-lib-node/src';
 import fg from 'fast-glob';
 import type { PackageJson } from 'type-fest';
 
 import type { PackageConfig } from '../packageConfig.js';
+
+// The Bun-exact resolution primitives live in @willbooster/shared-lib-node (src/bunWorkspaces.ts)
+// so wb's release code shares them; re-export the ones wbfy modules and tests consume.
+export {
+  getDeclaredWorkspacePatterns,
+  getMeaningfulDeclaredWorkspacePatterns,
+  hasImplicitWorkspaceBaseline,
+} from '@willbooster/shared-lib-node/src';
 
 /** The subset of PackageConfig that workspace discovery needs, so it can run before configs exist. */
 export type WorkspaceRootLike = Pick<PackageConfig, 'dirPath' | 'doesContainSubPackageJsons' | 'packageJson'>;
@@ -180,87 +196,6 @@ function toTsconfigCompatibleDirPatterns(patternBody: string, rootDirPath: strin
 }
 
 /**
- * Resolves workspace patterns to package.json paths mimicking Bun's SEQUENTIAL evaluation,
- * derived empirically with Bun 1.3.14 (fixture repos observed via `bun install --lockfile-only`;
- * #1004/#1005):
- * 1. Patterns are evaluated in declaration order into an accumulating set: a positive glob
- *    pattern adds every package.json it matches; a negation deletes its matches from the set
- *    accumulated SO FAR, so a later positive re-adds them (`["!apps/excluded", "apps/*"]` links
- *    apps/excluded, while `["apps/*", "!apps/excluded"]` does not).
- * 2. A negation whose normalized body has EXACTLY two segments, whose last segment is a star-run
- *    (`*`, `**`, `***`, …), and whose first segment is NOT itself a star-run first seeds the
- *    implicit baseline into the set, then deletes its own matches: a `**` last segment seeds
- *    `**` (packages at any depth), any other star-run seeds `*\/*` (depth 2 only). Seeding
- *    happens even alongside positive patterns (`["apps/*", "!other/*"]` links every depth-2
- *    package outside other/). No other negation shape seeds: `!*`, `!**`, `!*\/*`, `!*\/**`,
- *    `!**\/*`, `!a/b/*`, `!a/b/**`, `!dir`, `!dir/?`, and `!dir/*x` each link nothing on their
- *    own.
- * 3. A non-glob positive pattern PINS its directory: it stays a workspace regardless of where a
- *    matching negation appears (`["other/x", "!other/x"]` and `["!other/x", "other/x"]` both
- *    link other/x).
- * 4. `**` matches zero or more path segments (`["apps/**"]` links the package at apps itself, and
- *    `!apps/**` deletes it), matching fast-glob's file-glob semantics.
- * Do not apply globIgnore here: workspace membership is defined solely by the declared patterns,
- * and source-scanning ignores such as `build` or `dist` would hide legitimately named workspace
- * directories.
- */
-function resolveWorkspacePackageJsonPaths(workspacePatterns: string[], rootDirPath: string): string[] {
-  // followSymbolicLinks: false — a workspace symlink pointing outside the repository must not be
-  // treated as a workspace directory (removeNodeModules would delete through it).
-  const globManifestPaths = (pattern: string): string[] =>
-    fg
-      .globSync(path.posix.join(pattern, 'package.json'), {
-        cwd: rootDirPath,
-        followSymbolicLinks: false,
-        ignore: ['**/node_modules/**'],
-      })
-      // A zero-segment `**` match reaches the root's own manifest, but Bun never treats the
-      // monorepo root as its own workspace.
-      .filter((packageJsonPath) => packageJsonPath !== 'package.json');
-  const accumulatedPaths = new Set<string>();
-  const pinnedPaths = new Set<string>();
-  for (const workspacePattern of workspacePatterns) {
-    const isNegative = workspacePattern.startsWith('!');
-    const patternBody = normalizeWorkspacePatternBody(isNegative ? workspacePattern.slice(1) : workspacePattern);
-    if (isNegative) {
-      const baselineGlob = getSeededBaselineGlob(patternBody);
-      if (baselineGlob !== undefined) {
-        for (const packageJsonPath of globManifestPaths(baselineGlob)) accumulatedPaths.add(packageJsonPath);
-      }
-      for (const packageJsonPath of globManifestPaths(patternBody)) accumulatedPaths.delete(packageJsonPath);
-    } else {
-      for (const packageJsonPath of globManifestPaths(patternBody)) {
-        (fg.isDynamicPattern(patternBody) ? accumulatedPaths : pinnedPaths).add(packageJsonPath);
-      }
-    }
-  }
-  return [...new Set([...accumulatedPaths, ...pinnedPaths])].toSorted();
-}
-
-/** The implicit baseline glob a negation seeds under Bun's rule 2 above, or undefined if none. */
-function getSeededBaselineGlob(negationBody: string): string | undefined {
-  const segments = negationBody.split('/');
-  if (segments.length !== 2) return undefined;
-  const [firstSegment, lastSegment] = segments as [string, string];
-  if (!/^\*+$/u.test(lastSegment) || /^\*+$/u.test(firstSegment)) return undefined;
-  return lastSegment === '**' ? '**' : '*/*';
-}
-
-/**
- * Collapses `//`, resolves `./`, and strips trailing slashes, mirroring Bun's path handling.
- * A pure star-run segment of three or more stars behaves like `*` under Bun (`!other/***`
- * matches other/x) but not under fast-glob, so canonicalize it to `*`.
- */
-function normalizeWorkspacePatternBody(patternBody: string): string {
-  return path.posix
-    .normalize(patternBody)
-    .replace(/\/+$/u, '')
-    .split('/')
-    .map((segment) => (/^\*{3,}$/u.test(segment) ? '*' : segment))
-    .join('/');
-}
-
-/**
  * Declared workspace patterns (negative ones included) that stay inside the repository: absolute
  * or `..`-traversing patterns would make consumers such as removeNodeModules operate on another
  * repository's files. Declaration order and duplicates are preserved — Bun evaluates the
@@ -279,10 +214,7 @@ function getSanitizedWorkspacePatterns(rootLike: WorkspaceRootLike): string[] {
     rootLike.doesContainSubPackageJsons && !hasDeclaredPackagesStarPattern(rootLike.packageJson?.workspaces)
       ? ['packages/*', ...declaredPatterns]
       : declaredPatterns;
-  return workspacePatterns.filter((workspacePattern) => {
-    const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
-    return !path.posix.isAbsolute(patternBody) && !patternBody.split('/').includes('..');
-  });
+  return workspacePatterns.filter((workspacePattern) => isInRepositoryWorkspacePattern(workspacePattern));
 }
 
 /**
@@ -297,52 +229,7 @@ export function hasDeclaredPackagesStarPattern(workspaces: PackageJson['workspac
       // A `..`-traversing or absolute spelling (e.g. `x/../packages/*`) is discarded by
       // getSanitizedWorkspacePatterns, so it must not count as covering packages/* — that would
       // suppress the fallback AND lose the pattern, leaving no discovered workspaces.
-      !path.posix.isAbsolute(workspacePattern) &&
-      !workspacePattern.split('/').includes('..') &&
+      isInRepositoryWorkspacePattern(workspacePattern) &&
       normalizeWorkspacePatternBody(workspacePattern) === 'packages/*'
   );
-}
-
-/**
- * Whether the declaration seeds Bun's implicit workspace baseline: it contains at least one
- * negation of the seeding shape (see resolveWorkspacePackageJsonPaths rule 2). Measured with Bun
- * 1.3.14, seeding is per-negation and happens even alongside positive patterns; concrete or
- * mixed-literal last segments (`!apps/excluded`, `!apps/*d`) never seed, and `?`, brace, and
- * character-class last segments behaved inconsistently across fixtures (sometimes dropping even
- * unrelated sibling workspaces), so they are conservatively treated as not seeding; see #1005.
- */
-export function hasImplicitWorkspaceBaseline(workspaces: PackageJson['workspaces']): boolean {
-  return getMeaningfulDeclaredWorkspacePatterns(workspaces).some(
-    (workspacePattern) =>
-      workspacePattern.startsWith('!') &&
-      getSeededBaselineGlob(normalizeWorkspacePatternBody(workspacePattern.slice(1))) !== undefined
-  );
-}
-
-/**
- * Declared workspace patterns without Bun's no-op ones (`""`, a lone `"!"`, and `"."`), which Bun
- * ignores entirely — a lone `"!"` must not activate the negative-only implicit baseline, and `""`
- * must not make the repository root itself a discovered workspace.
- */
-export function getMeaningfulDeclaredWorkspacePatterns(workspaces: PackageJson['workspaces']): string[] {
-  return getDeclaredWorkspacePatterns(workspaces)
-    .map((workspacePattern) => {
-      // Bun applies leading-bang PARITY (verified with Bun 1.3.14): `!!p` is the positive `p`
-      // and `!!!p` the negation `!p`, so canonicalize to at most one bang.
-      const bangCount = /^!*/u.exec(workspacePattern)![0].length;
-      const patternBody = workspacePattern.slice(bangCount);
-      return bangCount % 2 === 1 ? `!${patternBody}` : patternBody;
-    })
-    .filter((workspacePattern) => {
-      const patternBody = workspacePattern.startsWith('!') ? workspacePattern.slice(1) : workspacePattern;
-      // Normalize so spellings like `./`, `./.`, and `!./` are recognized as the same no-ops
-      // (path.posix.normalize('') === '.', so the empty pattern is covered too).
-      return normalizeWorkspacePatternBody(patternBody) !== '.';
-    });
-}
-
-/** Workspace patterns from either the array form or Yarn v1's `{ packages: […] }` object form. */
-export function getDeclaredWorkspacePatterns(workspaces: PackageJson['workspaces']): string[] {
-  if (Array.isArray(workspaces)) return workspaces;
-  return Array.isArray(workspaces?.packages) ? workspaces.packages : [];
 }


### PR DESCRIPTION
Closes #1008

## Customer Summary

- `wb release` now sees exactly the workspaces `bun install` links, so releases no longer miss a workspace's npm publish configuration or skip its cleanup when the root `workspaces` field uses unusual patterns (negations, pinned entries, `?` wildcards, dot directories).
- All other `wb` commands (test, lint, typecheck, start, setup, …) now discover the same workspace set as the repository's package manager: Bun-exact for Bun repositories, Yarn-v1-compatible for Yarn repositories.
- Workspace symlinks pointing outside the repository can no longer cause release preparation to delete or rewrite files in another checkout.
- No migration needed; repositories with plain `packages/*` layouts behave exactly as before.

## Technical Summary

- Extracted wbfy's empirically derived Bun 1.3.14 workspace resolver into `@willbooster/shared-lib-node` (`src/bunWorkspaces.ts`): sequential pattern evaluation, pinned concrete positives, baseline-seeding negations, bang parity, no-op pattern filtering, and the full rule documentation. wbfy's `workspaceUtil.ts` now imports/re-exports these primitives without behavior change.
- `wb`'s `findWorkspacePackageDirs` (project.ts) gates on `usesBunPackageManager`: Bun repos use `resolveBunWorkspacePackageJsonPaths`; Yarn repos mirror Yarn 1.22.22 (per-pattern union, negations are not exclusions, node_modules and the root manifest excluded). `wb release` (plugin inspection, node_modules cleanup, `workspace:` rewriting/restoration) uses the same discovery.
- Hardened the resolver beyond the extraction: realpath containment rejects workspaces whose symlinks escape the repository; dynamic patterns drop dot-led segments (matching Bun); a directory-glob complement covers fast-glob 3.3.3's inability to match lone-`?` file globs; `..`-prefixed directory names are no longer misread as traversal.
- Added `fast-glob` to shared-lib-node's dependencies and wb's dependencies (kept external in wb's bundle, following the existing dotenv pattern for `@willbooster/shared-lib-node/src` imports).

## Why

- `wb release` resolved workspaces by passing `workspaces` patterns to globby, whose negation/baseline semantics diverge from Bun's (e.g. `["packages/lib", "!packages/lib"]`: Bun keeps the pinned workspace, globby drops it), so `releasePublishesToNpm` could miss `@semantic-release/npm` configs and `prepareNpmCompatibleLayout` could skip manifests (issue #1008).
- Sharing wbfy's Bun-exact resolver (instead of duplicating it) keeps one empirically validated implementation for both tools.

## Testing

- `bun verify` at the repository root (type checking + linting).
- `bun wb test` in packages/shared-lib-node (56 tests), packages/wb (171 tests), and packages/wbfy (186 tests, unchanged).
- New dedicated resolver tests in `packages/shared-lib-node/test/bunWorkspaces.test.ts`; release tests cover pinned positives, baseline-seeding negations, and the Yarn gate; project tests cover Yarn union/node_modules/root exclusion.
- Empirical fixtures verified against Bun 1.3.14 (`bun install --lockfile-only`) and Yarn 1.22.22 (`yarn install` / `yarn workspaces info`).

## Notes

- Bun's `?`/brace/character-class negation shapes behave erratically (documented in the resolver with observed counterexamples), so they are deliberately treated as not seeding the implicit baseline.
- The resolver deliberately diverges from Bun for repository-escaping symlinked workspaces (Bun links them; wb/wbfy must never operate outside the repository).
