### PR TITLE
fix(wbfy): make convertYarnCommandsToBun quote-aware instead of regex-only

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -213,12 +213,35 @@ async function updateScripts(
 
 function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
   for (const [key, value] of Object.entries(scripts)) {
-    if (typeof value !== 'string') continue;
+    if (typeof value !== 'string' || !value.includes('yarn')) continue;
     // Fresh repos still require standalone `yarn install`; only remove legacy install prefixes before another command.
-    if (!value.includes('git clone')) {
-      scripts[key] = value.replaceAll(/yarn\s*(?:install\s*)?&&\s*/gu, '');
-    }
+    // Heredoc bodies are data, not commands; skip such scripts instead of modeling heredocs.
+    if (value.includes('git clone') || value.includes('<<')) continue;
+    scripts[key] = removeLegacyYarnInstallPrefixes(value);
   }
+}
+
+/**
+ * Removes each `yarn && ` / `yarn install && ` prefix that precedes another command. The scan is
+ * quote- and command-position-aware (sharing convertYarnInvocationsToBun's tokenizer walk), so
+ * quoted data such as `echo 'yarn install && deploy now'` stays untouched.
+ */
+function removeLegacyYarnInstallPrefixes(script: string): string {
+  const removalRanges: [number, number][] = [];
+  forEachCommandPositionToken(tokenizeShellCommand(script), (token, index, tokens) => {
+    if (token.text !== 'yarn') return;
+    const next = tokens[index + 1];
+    const separatorToken = next?.text === 'install' ? tokens[index + 2] : next;
+    if (separatorToken?.text !== '&&') return;
+    let end = separatorToken.end;
+    while (end < script.length && /\s/u.test(script[end] ?? '')) end++;
+    removalRanges.push([token.start, end]);
+  });
+  let result = script;
+  for (const [start, end] of removalRanges.toReversed()) {
+    result = result.slice(0, start) + result.slice(end);
+  }
+  return result;
 }
 
 function updatePostinstallScript(
@@ -384,28 +407,30 @@ function convertYarnCommandsToBun(
   // has no such concept, so the invocation must be routed to the defining workspace explicitly.
   // Resolved lazily: most scripts have no colon invocations.
   let colonScriptOwners: Map<string, ColonScriptOwner | undefined> | undefined;
+  // Returns the `bun run ...` runner prefix to put before the (raw) script-name token, or
+  // undefined to keep the yarn form.
   const resolveColonScriptInvocation = (scriptName: string, prefix: string): string | undefined => {
-    if (typeof scripts[scriptName] === 'string') return `bun run ${scriptName}`;
+    if (typeof scripts[scriptName] === 'string') return 'bun run';
     colonScriptOwners ??= collectColonScriptOwners(rootConfig);
     const owner = colonScriptOwners.get(scriptName);
     const fallback = (): string | undefined =>
       // A missing or ambiguous leading-colon script cannot run locally either, so its yarn form
       // is kept (undefined) to surface in review; other unresolved colon names keep the plain
       // conversion (e.g. `cd sub && yarn build:sub` targeting a non-workspace directory).
-      scriptName.startsWith(':') ? undefined : `bun run ${scriptName}`;
+      scriptName.startsWith(':') ? undefined : 'bun run';
     if (!owner) return fallback();
     // Bun's --filter never matches the workspace root, and its path filters resolve against the
     // invoking cwd (both verified on Bun 1.3.14), so the root package and unnamed workspaces are
     // addressed with --cwd relative to the invoking package instead.
     if (owner.packageName && owner.dirPath !== path.resolve(rootConfig.dirPath)) {
-      return `bun run --filter ${owner.packageName} ${scriptName}`;
+      return `bun run --filter ${owner.packageName}`;
     }
     // A `cd` BEFORE this invocation would make the package-relative --cwd resolve from the wrong
     // directory at runtime, so such invocations fall back instead of getting a silently broken
     // route; a cd after the invocation cannot affect it and must not prevent the conversion.
     if (prefixMayChangeWorkingDirectory(prefix)) return fallback();
     const relativeDirPath = path.relative(config.dirPath, owner.dirPath) || '.';
-    return `bun run --cwd '${relativeDirPath.replaceAll("'", String.raw`'\''`)}' ${scriptName}`;
+    return `bun run --cwd '${relativeDirPath.replaceAll("'", String.raw`'\''`)}'`;
   };
   // Managed repositories are Bun projects and wbfy deletes Yarn's configuration, so any leftover
   // yarn invocation in package scripts (e.g. postinstall) would fail on machines without Yarn.
@@ -418,11 +443,13 @@ function convertYarnCommandsToBun(
 /**
  * Rewrites the actual `yarn ...` command invocations in a script to their bun equivalents.
  *
- * The scan is quote-aware in both directions (reusing removeBunRuntimeFlag's shell tokenizer
- * instead of bare regexes): `yarn` inside a quoted token (e.g. `echo 'yarn build:cache'`) is data
- * and stays untouched, while a quoted argument token (e.g. `yarn ':build-cache'`) is unquoted
- * before colon-owner resolution. Anything unconvertible keeps its yarn form verbatim to surface
- * during review instead of being mis-rewritten.
+ * The scan is quote- and command-position-aware (reusing removeBunRuntimeFlag's shell tokenizer
+ * walk instead of bare regexes): `yarn` appearing as data — inside a quoted token (e.g.
+ * `echo 'yarn build:cache'`) or as an argument of another command (e.g. `git commit -m yarn`) —
+ * stays untouched, while a quoted argument token (e.g. `yarn ':build-cache'`) is decoded before
+ * colon-owner resolution and re-emitted verbatim so its shell semantics never change. Anything
+ * unconvertible keeps its yarn form verbatim to surface during review instead of being
+ * mis-rewritten.
  */
 function convertYarnInvocationsToBun(
   script: string,
@@ -430,13 +457,10 @@ function convertYarnInvocationsToBun(
 ): string {
   // Heredoc bodies are data, not commands; skip such scripts instead of modeling heredocs.
   if (script.includes('<<')) return script;
-  const tokens = tokenizeShellCommand(script);
   const replacements: ShellReplacement[] = [];
-  for (const [index, token] of tokens.entries()) {
-    // Only a bare unquoted `yarn` word starts an invocation; a quoted occurrence is data.
-    if (token.text !== 'yarn') continue;
-    // A `yarn` token consumed by a previous invocation's rewrite is not an invocation of its own.
-    if (token.start < (replacements.at(-1)?.end ?? 0)) continue;
+  forEachCommandPositionToken(tokenizeShellCommand(script), (token, index, tokens) => {
+    // Only a bare unquoted `yarn` word at command position starts an invocation.
+    if (token.text !== 'yarn') return;
     const remainingTokens = tokens.slice(index + 1);
     const terminatorIndex = remainingTokens.findIndex((argToken) => isShellSeparator(argToken.text));
     const args = terminatorIndex === -1 ? remainingTokens : remainingTokens.slice(0, terminatorIndex);
@@ -448,11 +472,11 @@ function convertYarnInvocationsToBun(
       if (terminatorText === undefined || /^(?:&&|\|{1,2}|;|\n)/u.test(terminatorText)) {
         replacements.push({ start: token.start, end: token.end, text: 'bun install' });
       }
-      continue;
+      return;
     }
     const replacement = convertSingleYarnInvocation(token, args, script, resolveColonScriptInvocation);
     if (replacement) replacements.push(replacement);
-  }
+  });
   let result = script;
   for (const { start, end, text } of replacements.toReversed()) {
     result = result.slice(0, start) + text + result.slice(end);
@@ -466,6 +490,19 @@ interface ShellReplacement {
   text: string;
 }
 
+// `yarn workspaces foreach` flags that neither restrict which workspaces are selected nor
+// suppress execution, so `bun run --filter '*'` preserves their fan-out. Anything else (--since,
+// --from, --include, --exclude, --no-private, --dry-run, ...) changes the selection or effect and
+// keeps the yarn form to surface during review.
+const selectionNeutralForeachFlags = new Set([
+  '--all',
+  '--interlaced',
+  '--parallel',
+  '--topological',
+  '--topological-dev',
+  '--verbose',
+]);
+
 /**
  * Converts one `yarn <args...>` invocation (args already cut at the next command separator) into
  * the text replacing it, or undefined to keep the yarn form untouched.
@@ -476,10 +513,15 @@ function convertSingleYarnInvocation(
   script: string,
   resolveColonScriptInvocation: (scriptName: string, prefix: string) => string | undefined
 ): ShellReplacement | undefined {
+  // Decoded (literal) argument values drive the matching, while emitted rewrites always reuse the
+  // raw token text (rawArg) so quoting and expansion semantics survive the conversion unchanged
+  // (e.g. `yarn 'build:$target'` keeps its single quotes). A shell-ambiguous token decodes to
+  // undefined, which keeps the invocation in its yarn form.
   const argText = (argIndex: number): string | undefined => {
     const arg = args[argIndex];
-    return arg && unquoteShellToken(arg.text);
+    return arg && decodeSimpleShellWord(arg.text);
   };
+  const rawArg = (argIndex: number): string => args[argIndex]?.text ?? '';
   const replaceThroughArg = (argIndex: number, text: string): ShellReplacement => ({
     start: yarnToken.start,
     end: (args[argIndex] as ShellToken).end,
@@ -487,11 +529,23 @@ function convertSingleYarnInvocation(
   });
   const first = argText(0);
   const second = argText(1);
-  // `yarn workspaces foreach [flags] run <script>` fans a script out to every workspace.
+  // `yarn workspaces foreach <selection-neutral flags> run <script>` fans a script out to every
+  // workspace; a selection-restricting or execution-suppressing flag keeps the yarn form.
   if (first === 'workspaces' && second === 'foreach') {
-    const runIndex = args.findIndex((arg, index) => index >= 2 && unquoteShellToken(arg.text) === 'run');
+    let runIndex = -1;
+    for (let index = 2; index < args.length; index++) {
+      const flag = argText(index);
+      if (flag === 'run') {
+        runIndex = index;
+        break;
+      }
+      if (flag === undefined || !(selectionNeutralForeachFlags.has(flag) || /^-[Aiptv]+$/u.test(flag)))
+        return undefined;
+    }
     const scriptName = runIndex === -1 ? undefined : argText(runIndex + 1);
-    return scriptName === undefined ? undefined : replaceThroughArg(runIndex + 1, `bun run --filter '*' ${scriptName}`);
+    return scriptName === undefined || scriptName.startsWith('-')
+      ? undefined
+      : replaceThroughArg(runIndex + 1, `bun run --filter '*' ${rawArg(runIndex + 1)}`);
   }
   if (first === 'dlx') return replaceThroughArg(0, 'bunx');
   if (first === 'workspace') {
@@ -504,36 +558,55 @@ function convertSingleYarnInvocation(
       command !== undefined &&
       /^[\w.:/-]+$/u.test(command) &&
       (hasRun || !yarnBuiltinSubcommands.has(command))
-      ? replaceThroughArg(commandIndex, `bun run --filter ${second} ${command}`)
+      ? replaceThroughArg(commandIndex, `bun run --filter ${rawArg(1)} ${rawArg(commandIndex)}`)
       : undefined;
   }
-  // A colon-containing script name (after optional `run`) needs workspace-global resolution. The
-  // name may contain any non-metacharacter (e.g. `build:@scope`), not just \w./:-. Only a leading
-  // `-` (a yarn flag) is excluded: Yarn's global lookup has no first-character restriction, so
-  // names like `.build:cache` must resolve too.
-  const scriptNameIndex = first === 'run' ? 1 : 0;
+  // A colon-containing script name (after `run` and its flags, if any) needs workspace-global
+  // resolution. The name may contain any non-metacharacter (e.g. `build:@scope`), not just
+  // \w./:-. Only a leading `-` (a yarn flag) is excluded: Yarn's global lookup has no
+  // first-character restriction, so names like `.build:cache` must resolve too.
+  let scriptNameIndex = 0;
+  if (first === 'run') {
+    scriptNameIndex = 1;
+    while (argText(scriptNameIndex)?.startsWith('-')) scriptNameIndex++;
+  }
   const scriptName = argText(scriptNameIndex);
-  if (
-    scriptName !== undefined &&
-    !scriptName.startsWith('-') &&
-    scriptName.includes(':') &&
-    /^[^\s;&|<>()'"`]+$/u.test(scriptName)
-  ) {
-    const replacement = resolveColonScriptInvocation(scriptName, script.slice(0, yarnToken.start));
-    return replacement === undefined ? undefined : replaceThroughArg(scriptNameIndex, replacement);
+  if (scriptName !== undefined && scriptName.includes(':') && /^[^\s;&|<>()'"`]+$/u.test(scriptName)) {
+    const runnerPrefix = resolveColonScriptInvocation(scriptName, script.slice(0, yarnToken.start));
+    if (runnerPrefix === undefined) return undefined;
+    // With flags between `run` and the target (e.g. `yarn run --inspect-brk build:remote`), only
+    // a plain local `bun run` provably keeps their meaning; where flags would have to travel into
+    // a --filter/--cwd route, the yarn form is kept to surface in review.
+    if (scriptNameIndex > 1) {
+      return runnerPrefix === 'bun run' ? replaceThroughArg(0, 'bun run') : undefined;
+    }
+    return replaceThroughArg(scriptNameIndex, `${runnerPrefix} ${rawArg(scriptNameIndex)}`);
   }
   if (first === 'run') {
-    // An unresolvable `yarn run :name` keeps its yarn form (the colon rule above already
+    // An unresolvable `yarn run [flags] :name` keeps its yarn form (the colon rule above already
     // converted every resolvable one); otherwise `bun run` accepts the same flags and target.
-    return scriptName?.startsWith(':') ? undefined : replaceThroughArg(0, 'bun run');
+    return scriptName?.startsWith(':') || args[scriptNameIndex]?.text.startsWith(':')
+      ? undefined
+      : replaceThroughArg(0, 'bun run');
   }
   if (first === 'install') return replaceThroughArg(0, 'bun install');
   // A bare `yarn <name>` invokes the package script; Yarn built-ins, flag forms
   // (e.g. `yarn --cwd ...`), and still-unconverted `:` global scripts have no direct Bun
   // equivalent and are intentionally left untouched to surface during review.
   return first !== undefined && /^(?![-.:])[\w.:/-]+$/u.test(first) && !yarnBuiltinSubcommands.has(first)
-    ? replaceThroughArg(0, `bun run ${first}`)
+    ? replaceThroughArg(0, `bun run ${rawArg(0)}`)
     : undefined;
+}
+
+/**
+ * The literal value of a shell word that is either fully unquoted or wholly wrapped in one simple
+ * quote pair, or undefined for anything shell-ambiguous (embedded or mixed quotes, backslashes,
+ * expansions inside double quotes), whose invocation must then stay in its yarn form.
+ */
+function decodeSimpleShellWord(text: string): string | undefined {
+  if (!/['"\\]/u.test(text)) return text;
+  const quoted = /^'([^'\\]*)'$/u.exec(text) ?? /^"([^"'\\$`]*)"$/u.exec(text);
+  return quoted?.[1];
 }
 
 /**
@@ -597,26 +670,14 @@ function removeBunRuntimeFlag(script: string, scriptNames: ReadonlySet<string>):
   // A quote-aware scan (not a bare regex) so quoted literals (`echo "bun --bun ..."`), executables
   // merely ending in `bun` (`my-bun`), quoted targets with spaces, and Bun runtime flags between
   // `--bun` and the script file are all classified correctly.
-  const tokens = tokenizeShellCommand(script);
   const removalRanges: [number, number][] = [];
-  let atCommandPosition = true;
-  for (const [index, token] of tokens.entries()) {
-    if (isShellSeparator(token.text)) {
-      atCommandPosition = true;
-      continue;
-    }
-    if (!atCommandPosition) continue;
-    const tokenText = unquoteShellToken(token.text);
-    // `KEY=VALUE` prefixes and shell prefix words (`exec`, `env`, `command`, `!`) keep the next
-    // token in command position.
-    if (/^[A-Za-z_]\w*=/u.test(tokenText) || ['exec', 'env', 'command', '!'].includes(tokenText)) continue;
-    atCommandPosition = false;
-    if (tokenText !== 'bun') continue;
+  forEachCommandPositionToken(tokenizeShellCommand(script), (token, index, tokens) => {
+    if (unquoteShellToken(token.text) !== 'bun') return;
     const flagToken = tokens[index + 1];
-    if (!flagToken || unquoteShellToken(flagToken.text) !== '--bun') continue;
-    if (shouldKeepBunRuntimeFlag(tokens.slice(index + 2), scriptNames)) continue;
+    if (!flagToken || unquoteShellToken(flagToken.text) !== '--bun') return;
+    if (shouldKeepBunRuntimeFlag(tokens.slice(index + 2), scriptNames)) return;
     removalRanges.push([flagToken.start, flagToken.end]);
-  }
+  });
 
   let result = script;
   for (const [start, end] of removalRanges.toReversed()) {
@@ -668,6 +729,34 @@ interface ShellToken {
   end: number;
 }
 
+// Prefix words that run the command that follows them, so the next token stays in command
+// position. cross-env is included because `cross-env KEY=VALUE <command> ...` is the common
+// pre-Bun way to set environment variables portably in package scripts.
+const commandPositionTransparentWords = new Set(['!', 'command', 'cross-env', 'env', 'exec']);
+
+/**
+ * Invokes the callback for every token in shell command position. Separators start a new command;
+ * `KEY=VALUE` prefixes and transparent prefix words (`exec`, `env`, ...) keep the next token in
+ * command position.
+ */
+function forEachCommandPositionToken(
+  tokens: readonly ShellToken[],
+  callback: (token: ShellToken, index: number, tokens: readonly ShellToken[]) => void
+): void {
+  let atCommandPosition = true;
+  for (const [index, token] of tokens.entries()) {
+    if (isShellSeparator(token.text)) {
+      atCommandPosition = true;
+      continue;
+    }
+    if (!atCommandPosition) continue;
+    const tokenText = unquoteShellToken(token.text);
+    if (/^[A-Za-z_]\w*=/u.test(tokenText) || commandPositionTransparentWords.has(tokenText)) continue;
+    atCommandPosition = false;
+    callback(token, index, tokens);
+  }
+}
+
 function tokenizeShellCommand(script: string): ShellToken[] {
   const tokens: ShellToken[] = [];
   let index = 0;
@@ -685,6 +774,16 @@ function tokenizeShellCommand(script: string): ShellToken[] {
       index = end;
       continue;
     }
+    // An unquoted redirection operator ends the preceding word even without whitespace
+    // (`yarn build>log` redirects `yarn build`), so it forms its own token; heredocs (`<<`) never
+    // reach this tokenizer — every caller skips scripts containing them.
+    if (char === '<' || char === '>') {
+      let end = index + 1;
+      while (end < script.length && (script[end] === '<' || script[end] === '>')) end++;
+      tokens.push({ text: script.slice(index, end), start: index, end });
+      index = end;
+      continue;
+    }
     let end = index;
     let quote: string | undefined;
     while (end < script.length) {
@@ -696,7 +795,7 @@ function tokenizeShellCommand(script: string): ShellToken[] {
         quote = current;
       } else if (current === '\\') {
         end++;
-      } else if (/\s/u.test(current) || isShellSeparator(current)) {
+      } else if (/\s/u.test(current) || isShellSeparator(current) || current === '<' || current === '>') {
         break;
       }
       end++;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -729,10 +729,28 @@ function shouldKeepBunRuntimeFlag(followingTokens: ShellToken[], scriptNames: Re
   return !nodeBasedTools.has(first);
 }
 
-// Prefix words that run the command that follows them, so the next token stays in command
-// position. cross-env is included because `cross-env KEY=VALUE <command> ...` is the common
-// pre-Bun way to set environment variables portably in package scripts.
-const commandPositionTransparentWords = new Set(['!', 'command', 'cross-env', 'env', 'exec']);
+// Words after which the next token is still in command position: prefix words that run the
+// command following them (cross-env is included because `cross-env KEY=VALUE <command> ...` is
+// the common pre-Bun way to set environment variables portably in package scripts), shell
+// keywords introducing a compound command's body (`if cmd`, `then cmd`, ...), and the `{ ... }`
+// grouping braces.
+const commandPositionTransparentWords = new Set([
+  '!',
+  'command',
+  'cross-env',
+  'env',
+  'exec',
+  'time',
+  'if',
+  'elif',
+  'then',
+  'else',
+  'while',
+  'until',
+  'do',
+  '{',
+  '}',
+]);
 
 /**
  * Invokes the callback for every token in shell command position. Separators start a new command;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -396,6 +396,18 @@ const yarnBuiltinSubcommands = new Set([
   'workspaces',
 ]);
 
+interface ShellToken {
+  text: string;
+  start: number;
+  end: number;
+}
+
+interface ShellReplacement {
+  start: number;
+  end: number;
+  text: string;
+}
+
 function convertYarnCommandsToBun(
   scripts: PackageJson.Scripts,
   config: PackageConfig,
@@ -482,12 +494,6 @@ function convertYarnInvocationsToBun(
     result = result.slice(0, start) + text + result.slice(end);
   }
   return result;
-}
-
-interface ShellReplacement {
-  start: number;
-  end: number;
-  text: string;
 }
 
 // `yarn workspaces foreach` flags that neither restrict which workspaces are selected nor
@@ -721,12 +727,6 @@ function shouldKeepBunRuntimeFlag(followingTokens: ShellToken[], scriptNames: Re
     return second === undefined || /[./$]/u.test(second) || !scriptNames.has(second);
   }
   return !nodeBasedTools.has(first);
-}
-
-interface ShellToken {
-  text: string;
-  start: number;
-  end: number;
 }
 
 // Prefix words that run the command that follows them, so the next token stays in command

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -231,7 +231,8 @@ function removeLegacyYarnInstallPrefixes(script: string): string {
   forEachCommandPositionToken(tokenizeShellCommand(script), (token, index, tokens) => {
     if (token.text !== 'yarn') return;
     const next = tokens[index + 1];
-    const separatorToken = next?.text === 'install' ? tokens[index + 2] : next;
+    // decodeSimpleShellWord: shell quoting makes `yarn 'install'` equivalent to `yarn install`.
+    const separatorToken = next && decodeSimpleShellWord(next.text) === 'install' ? tokens[index + 2] : next;
     if (separatorToken?.text !== '&&') return;
     let end = separatorToken.end;
     while (end < script.length && /\s/u.test(script[end] ?? '')) end++;
@@ -496,18 +497,13 @@ function convertYarnInvocationsToBun(
   return result;
 }
 
-// `yarn workspaces foreach` flags that neither restrict which workspaces are selected nor
-// suppress execution, so `bun run --filter '*'` preserves their fan-out. Anything else (--since,
-// --from, --include, --exclude, --no-private, --dry-run, ...) changes the selection or effect and
-// keeps the yarn form to surface during review.
-const selectionNeutralForeachFlags = new Set([
-  '--all',
-  '--interlaced',
-  '--parallel',
-  '--topological',
-  '--topological-dev',
-  '--verbose',
-]);
+// `yarn workspaces foreach` flags under which `bun run --filter '*'` (which runs every workspace
+// respecting dependency order) is an accepted equivalent of the fan-out. Anything else keeps the
+// yarn form to surface during review: selection flags (--since, --from, --include, ...) restrict
+// the workspaces, --dry-run suppresses execution, and parallelism flags (--parallel,
+// --interlaced, --jobs) start dependent scripts concurrently — under Bun's dependency-ordered
+// concurrency a long-running dependency would block its dependents forever.
+const selectionNeutralForeachFlags = new Set(['--all', '--topological', '--topological-dev', '--verbose']);
 
 /**
  * Converts one `yarn <args...>` invocation (args already cut at the next command separator) into
@@ -545,8 +541,7 @@ function convertSingleYarnInvocation(
         runIndex = index;
         break;
       }
-      if (flag === undefined || !(selectionNeutralForeachFlags.has(flag) || /^-[Aiptv]+$/u.test(flag)))
-        return undefined;
+      if (flag === undefined || !(selectionNeutralForeachFlags.has(flag) || /^-[Atv]+$/u.test(flag))) return undefined;
     }
     const scriptName = runIndex === -1 ? undefined : argText(runIndex + 1);
     return scriptName === undefined || scriptName.startsWith('-')
@@ -590,8 +585,11 @@ function convertSingleYarnInvocation(
   }
   if (first === 'run') {
     // An unresolvable `yarn run [flags] :name` keeps its yarn form (the colon rule above already
-    // converted every resolvable one); otherwise `bun run` accepts the same flags and target.
-    return scriptName?.startsWith(':') || args[scriptNameIndex]?.text.startsWith(':')
+    // converted every resolvable one), and so does an undecodable (dynamic or ambiguous) target:
+    // its expanded name could need Yarn's global routing. Otherwise `bun run` accepts the same
+    // flags and target.
+    const target = args[scriptNameIndex];
+    return target && (scriptName === undefined || scriptName.startsWith(':') || target.text.startsWith(':'))
       ? undefined
       : replaceThroughArg(0, 'bun run');
   }
@@ -606,11 +604,14 @@ function convertSingleYarnInvocation(
 
 /**
  * The literal value of a shell word that is either fully unquoted or wholly wrapped in one simple
- * quote pair, or undefined for anything shell-ambiguous (embedded or mixed quotes, backslashes,
- * expansions inside double quotes), whose invocation must then stay in its yarn form.
+ * quote pair, or undefined for anything shell-dynamic or ambiguous (unquoted expansions and
+ * globs, embedded or mixed quotes, backslashes, expansions inside double quotes), whose
+ * invocation must then stay in its yarn form.
  */
 function decodeSimpleShellWord(text: string): string | undefined {
-  if (!/['"\\]/u.test(text)) return text;
+  // An unquoted `$var`, backtick, glob, or brace expansion resolves at runtime, so its literal
+  // spelling must not drive script-name matching or colon-owner routing.
+  if (!/['"\\]/u.test(text)) return /[$`*?[\]{}]|^~/u.test(text) ? undefined : text;
   const quoted = /^'([^'\\]*)'$/u.exec(text) ?? /^"([^"'\\$`]*)"$/u.exec(text);
   return quoted?.[1];
 }
@@ -762,12 +763,25 @@ function forEachCommandPositionToken(
   callback: (token: ShellToken, index: number, tokens: readonly ShellToken[]) => void
 ): void {
   let atCommandPosition = true;
+  let redirectionOperandFollows = false;
   for (const [index, token] of tokens.entries()) {
     if (isShellSeparator(token.text)) {
       atCommandPosition = true;
+      redirectionOperandFollows = false;
+      continue;
+    }
+    if (redirectionOperandFollows) {
+      redirectionOperandFollows = false;
       continue;
     }
     if (!atCommandPosition) continue;
+    // A redirection may precede the command (`>out.log yarn build`, `2>err.log yarn build`); the
+    // operator and its operand (and a detached file-descriptor digit) leave the position intact.
+    if (/^[<>]+$/u.test(token.text)) {
+      redirectionOperandFollows = true;
+      continue;
+    }
+    if (/^\d+$/u.test(token.text) && /^[<>]/u.test(tokens[index + 1]?.text ?? '')) continue;
     const tokenText = unquoteShellToken(token.text);
     if (/^[A-Za-z_]\w*=/u.test(tokenText) || commandPositionTransparentWords.has(tokenText)) continue;
     atCommandPosition = false;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -565,6 +565,9 @@ function convertSingleYarnInvocation(
   // workspace; a selection-restricting or execution-suppressing flag keeps the yarn form.
   if (first === 'workspaces' && second === 'foreach') {
     let runIndex = -1;
+    // `--filter '*'` widens the fan-out to every workspace, so an explicit --all/-A selection is
+    // required: an unflagged foreach is either scoped (Yarn <4.1) or an error (Yarn >=4.1).
+    let selectsAllWorkspaces = false;
     for (let index = 2; index < logicalArgs.length; index++) {
       const flag = argText(index);
       if (flag === 'run') {
@@ -572,8 +575,11 @@ function convertSingleYarnInvocation(
         break;
       }
       if (flag === undefined || !(selectionNeutralForeachFlags.has(flag) || /^-[Atv]+$/u.test(flag))) return undefined;
+      if (flag === '--all' || (flag.startsWith('-') && !flag.startsWith('--') && flag.includes('A'))) {
+        selectsAllWorkspaces = true;
+      }
     }
-    const scriptName = runIndex === -1 ? undefined : argText(runIndex + 1);
+    const scriptName = runIndex === -1 || !selectsAllWorkspaces ? undefined : argText(runIndex + 1);
     return scriptName === undefined || scriptName.startsWith('-')
       ? undefined
       : replaceThroughArg(runIndex + 1, `bun run --filter '*' ${rawArg(runIndex + 1)}`);
@@ -599,7 +605,11 @@ function convertSingleYarnInvocation(
   let scriptNameIndex = 0;
   if (first === 'run') {
     scriptNameIndex = 1;
-    while (argText(scriptNameIndex)?.startsWith('-')) scriptNameIndex++;
+    while (argText(scriptNameIndex)?.startsWith('-')) {
+      // `--require <path>` is the one `yarn run` flag taking a separate value; its value must not
+      // be mistaken for the script name (`--require=<path>` needs no special casing).
+      scriptNameIndex += argText(scriptNameIndex) === '--require' ? 2 : 1;
+    }
   }
   const scriptName = argText(scriptNameIndex);
   if (scriptName !== undefined && scriptName.includes(':') && /^[^\s;&|<>()'"`]+$/u.test(scriptName)) {
@@ -788,9 +798,29 @@ const commandPositionTransparentWords = new Set([
   '}',
 ]);
 
-/** Whether the token stream contains an unquoted heredoc or herestring operator (`<<`, `<<<`). */
+/**
+ * Whether the token stream contains an unquoted heredoc or herestring operator (`<<`, `<<<`).
+ * `<<` inside an arithmetic context (`echo $((1 << 2))`) is a left shift, not a heredoc.
+ */
 function containsHeredocOperator(tokens: readonly ShellToken[]): boolean {
-  return tokens.some((token) => /^&?[<>]/u.test(token.text) && token.text.includes('<<'));
+  let inArithmetic = false;
+  const outerArithmeticStates: boolean[] = [];
+  for (const token of tokens) {
+    if (isShellSeparator(token.text)) {
+      for (let charIndex = 0; charIndex < token.text.length; charIndex++) {
+        const char = token.text[charIndex];
+        if (char === '(') {
+          outerArithmeticStates.push(inArithmetic);
+          if (charIndex > 0) inArithmetic = true;
+        } else if (char === ')') {
+          inArithmetic = outerArithmeticStates.pop() ?? false;
+        }
+      }
+      continue;
+    }
+    if (!inArithmetic && /^&?[<>]/u.test(token.text) && token.text.includes('<<')) return true;
+  }
+  return false;
 }
 
 /**
@@ -807,16 +837,27 @@ function forEachCommandPositionToken(
   // `((` opens an arithmetic context: nothing inside is a command (`echo $((yarn && 1))`).
   let inArithmetic = false;
   let previousSeparatorChar: string | undefined;
+  // The word before a `(` decides whether an empty `()` pair is a function definition
+  // (`build_all() { ... }`) or an empty command substitution (`echo $() yarn`).
+  let lastWordToken: ShellToken | undefined;
+  // `function f { ... }` declares f without parentheses: the name is consumed, and the `{` body
+  // that follows is in command position.
+  let functionNameFollows = false;
   // `$(...)` (and a subshell) opens a nested command context; on `)` the OUTER state must be
   // restored, or `echo $(date) yarn build` would treat the outer argument `yarn` as a command.
-  const outerStates: { atCommandPosition: boolean; inArithmetic: boolean }[] = [];
+  const outerStates: { atCommandPosition: boolean; inArithmetic: boolean; functionCandidate: boolean }[] = [];
   for (const [index, token] of tokens.entries()) {
     if (isShellSeparator(token.text)) {
       // Separator tokens are ASCII, so index-based iteration is safe.
       for (let charIndex = 0; charIndex < token.text.length; charIndex++) {
         const char = token.text[charIndex] ?? '';
         if (char === '(') {
-          outerStates.push({ atCommandPosition, inArithmetic });
+          outerStates.push({
+            atCommandPosition,
+            inArithmetic,
+            // A word ending in `$` opens a substitution, never a function definition.
+            functionCandidate: lastWordToken !== undefined && !lastWordToken.text.endsWith('$'),
+          });
           // Only an ADJACENT `((` (one token, since separator tokens are same-char runs) is
           // arithmetic; a spaced `( (` is a nested subshell.
           if (charIndex > 0) inArithmetic = true;
@@ -824,11 +865,16 @@ function forEachCommandPositionToken(
         } else if (char === ')') {
           const outerState = outerStates.pop();
           inArithmetic = outerState?.inArithmetic ?? false;
-          // An empty `()` pair is a function definition: its body follows in command position,
-          // and its yarn invocations really run when the function is called.
-          atCommandPosition = previousSeparatorChar === '(' ? true : (outerState?.atCommandPosition ?? true);
+          // An empty `()` pair after a plain word is a function definition: its body follows in
+          // command position, and its yarn invocations really run when the function is called.
+          atCommandPosition =
+            previousSeparatorChar === '(' && outerState?.functionCandidate
+              ? true
+              : (outerState?.atCommandPosition ?? true);
         } else {
           atCommandPosition = true;
+          lastWordToken = undefined;
+          functionNameFollows = false;
         }
         previousSeparatorChar = char;
       }
@@ -836,12 +882,22 @@ function forEachCommandPositionToken(
       continue;
     }
     previousSeparatorChar = undefined;
+    lastWordToken = token;
     if (inArithmetic) continue;
+    if (functionNameFollows) {
+      // The declared function name is not a command; the `{` body follows in command position.
+      functionNameFollows = false;
+      continue;
+    }
     if (redirectionOperandFollows) {
       redirectionOperandFollows = false;
       continue;
     }
     if (!atCommandPosition) continue;
+    if (token.text === 'function') {
+      functionNameFollows = true;
+      continue;
+    }
     // A redirection may precede the command (`>out.log yarn build`, `2>&1 yarn build`); the
     // operator (with its operand, unless a `>&1`-style duplication makes it self-contained) and
     // an ADJACENT file-descriptor digit (`2>` splits into two tokens; a detached `2 >out` is not

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -215,8 +215,7 @@ function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
   for (const [key, value] of Object.entries(scripts)) {
     if (typeof value !== 'string' || !value.includes('yarn')) continue;
     // Fresh repos still require standalone `yarn install`; only remove legacy install prefixes before another command.
-    // Heredoc bodies are data, not commands; skip such scripts instead of modeling heredocs.
-    if (value.includes('git clone') || value.includes('<<')) continue;
+    if (value.includes('git clone')) continue;
     scripts[key] = removeLegacyYarnInstallPrefixes(value);
   }
 }
@@ -227,8 +226,10 @@ function removeLegacyInstallCommands(scripts: PackageJson.Scripts): void {
  * quoted data such as `echo 'yarn install && deploy now'` stays untouched.
  */
 function removeLegacyYarnInstallPrefixes(script: string): string {
+  const tokens = tokenizeShellCommand(script);
+  if (containsHeredocOperator(tokens)) return script;
   const removalRanges: [number, number][] = [];
-  forEachCommandPositionToken(tokenizeShellCommand(script), (token, index, tokens) => {
+  forEachCommandPositionToken(tokens, (token, index) => {
     if (token.text !== 'yarn') return;
     const next = tokens[index + 1];
     // decodeSimpleShellWord: shell quoting makes `yarn 'install'` equivalent to `yarn install`.
@@ -463,15 +464,22 @@ function convertYarnCommandsToBun(
  * colon-owner resolution and re-emitted verbatim so its shell semantics never change. Anything
  * unconvertible keeps its yarn form verbatim to surface during review instead of being
  * mis-rewritten.
+ *
+ * Substitutions nested inside double quotes or backticks (`echo "$(yarn compile)"`) and quoted
+ * script names containing whitespace (`yarn 'build docs'`) are deliberately NOT modeled: they
+ * only produce conservative misses that keep the yarn form and surface during review (like the
+ * regex-based predecessor), and covering them would require a full shell parser.
  */
 function convertYarnInvocationsToBun(
   script: string,
   resolveColonScriptInvocation: (scriptName: string, prefix: string) => string | undefined
 ): string {
-  // Heredoc bodies are data, not commands; skip such scripts instead of modeling heredocs.
-  if (script.includes('<<')) return script;
+  const tokens = tokenizeShellCommand(script);
+  // Heredoc bodies are data, not commands; skip such scripts instead of modeling heredocs. Only
+  // a real unquoted operator counts — `echo '<<' && yarn compile` still converts.
+  if (containsHeredocOperator(tokens)) return script;
   const replacements: ShellReplacement[] = [];
-  forEachCommandPositionToken(tokenizeShellCommand(script), (token, index, tokens) => {
+  forEachCommandPositionToken(tokens, (token, index) => {
     // Only a bare unquoted `yarn` word at command position starts an invocation.
     if (token.text !== 'yarn') return;
     const remainingTokens = tokens.slice(index + 1);
@@ -521,9 +529,9 @@ function convertSingleYarnInvocation(
   const logicalArgs: { token: ShellToken; rawIndex: number }[] = [];
   for (let index = 0; index < args.length; index++) {
     const token = args[index] as ShellToken;
-    if (/^[<>]/u.test(token.text)) {
-      // A plain operator consumes its operand; a `>&1`-style duplication is self-contained.
-      if (/^[<>]+$/u.test(token.text)) index++;
+    if (/^&?[<>]/u.test(token.text)) {
+      // The operator consumes its operand unless a `>&1`-style duplication is self-contained.
+      if (!/&(?:\d+|-)$/u.test(token.text)) index++;
       continue;
     }
     if (
@@ -548,7 +556,7 @@ function convertSingleYarnInvocation(
     const arg = logicalArgs[argIndex] as { token: ShellToken; rawIndex: number };
     // A redirection inside the replaced span would be deleted by the rewrite, so such an
     // invocation keeps its yarn form to surface in review.
-    if (args.slice(0, arg.rawIndex).some((argToken) => /^[<>]/u.test(argToken.text))) return undefined;
+    if (args.slice(0, arg.rawIndex).some((argToken) => /^&?[<>]/u.test(argToken.text))) return undefined;
     return { start: yarnToken.start, end: arg.token.end, text };
   };
   const first = argText(0);
@@ -694,13 +702,14 @@ function removeBunRuntimeFlagFromScripts(scripts: PackageJson.Scripts): void {
 }
 
 function removeBunRuntimeFlag(script: string, scriptNames: ReadonlySet<string>): string {
+  const tokens = tokenizeShellCommand(script);
   // Heredoc bodies are data, not commands; skip such scripts instead of modeling heredocs.
-  if (script.includes('<<')) return script;
+  if (containsHeredocOperator(tokens)) return script;
   // A quote-aware scan (not a bare regex) so quoted literals (`echo "bun --bun ..."`), executables
   // merely ending in `bun` (`my-bun`), quoted targets with spaces, and Bun runtime flags between
   // `--bun` and the script file are all classified correctly.
   const removalRanges: [number, number][] = [];
-  forEachCommandPositionToken(tokenizeShellCommand(script), (token, index, tokens) => {
+  forEachCommandPositionToken(tokens, (token, index) => {
     if (unquoteShellToken(token.text) !== 'bun') return;
     const flagToken = tokens[index + 1];
     if (!flagToken || unquoteShellToken(flagToken.text) !== '--bun') return;
@@ -779,6 +788,11 @@ const commandPositionTransparentWords = new Set([
   '}',
 ]);
 
+/** Whether the token stream contains an unquoted heredoc or herestring operator (`<<`, `<<<`). */
+function containsHeredocOperator(tokens: readonly ShellToken[]): boolean {
+  return tokens.some((token) => /^&?[<>]/u.test(token.text) && token.text.includes('<<'));
+}
+
 /**
  * Invokes the callback for every token in shell command position. Separators start a new command;
  * `KEY=VALUE` prefixes and transparent prefix words (`exec`, `env`, ...) keep the next token in
@@ -790,24 +804,37 @@ function forEachCommandPositionToken(
 ): void {
   let atCommandPosition = true;
   let redirectionOperandFollows = false;
-  // `$(...)` (and a subshell) opens a nested command context; on `)` the OUTER position must be
+  // `((` opens an arithmetic context: nothing inside is a command (`echo $((yarn && 1))`).
+  let inArithmetic = false;
+  let previousSeparatorChar: string | undefined;
+  // `$(...)` (and a subshell) opens a nested command context; on `)` the OUTER state must be
   // restored, or `echo $(date) yarn build` would treat the outer argument `yarn` as a command.
-  const outerCommandPositions: boolean[] = [];
+  const outerStates: { atCommandPosition: boolean; inArithmetic: boolean }[] = [];
   for (const [index, token] of tokens.entries()) {
     if (isShellSeparator(token.text)) {
-      for (const char of token.text) {
+      for (const [charIndex, char] of [...token.text].entries()) {
         if (char === '(') {
-          outerCommandPositions.push(atCommandPosition);
+          outerStates.push({ atCommandPosition, inArithmetic });
+          // Only an ADJACENT `((` (one token, since separator tokens are same-char runs) is
+          // arithmetic; a spaced `( (` is a nested subshell.
+          if (charIndex > 0) inArithmetic = true;
           atCommandPosition = true;
         } else if (char === ')') {
-          atCommandPosition = outerCommandPositions.pop() ?? true;
+          const outerState = outerStates.pop();
+          inArithmetic = outerState?.inArithmetic ?? false;
+          // An empty `()` pair is a function definition: its body follows in command position,
+          // and its yarn invocations really run when the function is called.
+          atCommandPosition = previousSeparatorChar === '(' ? true : (outerState?.atCommandPosition ?? true);
         } else {
           atCommandPosition = true;
         }
+        previousSeparatorChar = char;
       }
       redirectionOperandFollows = false;
       continue;
     }
+    previousSeparatorChar = undefined;
+    if (inArithmetic) continue;
     if (redirectionOperandFollows) {
       redirectionOperandFollows = false;
       continue;
@@ -817,8 +844,8 @@ function forEachCommandPositionToken(
     // operator (with its operand, unless a `>&1`-style duplication makes it self-contained) and
     // an ADJACENT file-descriptor digit (`2>` splits into two tokens; a detached `2 >out` is not
     // a descriptor) leave the position intact.
-    if (/^[<>]/u.test(token.text)) {
-      redirectionOperandFollows = /^[<>]+$/u.test(token.text);
+    if (/^&?[<>]/u.test(token.text)) {
+      redirectionOperandFollows = !/&(?:\d+|-)$/u.test(token.text);
       continue;
     }
     if (
@@ -828,14 +855,15 @@ function forEachCommandPositionToken(
     ) {
       continue;
     }
-    const tokenText = unquoteShellToken(token.text);
-    if (/^[A-Za-z_]\w*=/u.test(tokenText) || commandPositionTransparentWords.has(tokenText)) continue;
+    // The raw token text drives the assignment and keyword checks: shell quoting turns them into
+    // ordinary command words (`"FOO=bar" yarn build` runs the command `FOO=bar`).
+    if (/^[A-Za-z_]\w*=/u.test(token.text) || commandPositionTransparentWords.has(token.text)) continue;
     // At command position a `-`-leading token can only be an option of a preceding transparent
     // wrapper (`env -i yarn build`); a real command never starts with `-`. Only known valueless
     // options stay transparent — an unmodeled option may consume the next word as its value
     // (`env -u yarn build`), so discovery for this command stops conservatively instead.
-    if (tokenText.startsWith('-')) {
-      if (!valuelessWrapperOptions.has(tokenText)) atCommandPosition = false;
+    if (token.text.startsWith('-')) {
+      if (!valuelessWrapperOptions.has(token.text)) atCommandPosition = false;
       continue;
     }
     atCommandPosition = false;
@@ -869,15 +897,19 @@ function tokenizeShellCommand(script: string): ShellToken[] {
       continue;
     }
     // An unquoted redirection operator ends the preceding word even without whitespace
-    // (`yarn build>log` redirects `yarn build`), so it forms its own token; heredocs (`<<`) never
-    // reach this tokenizer — every caller skips scripts containing them. A duplication suffix
-    // (`>&1`, `2>&1`, `>&-`) belongs to the operator token, or its `&` would read as a separator.
-    if (char === '<' || char === '>') {
-      let end = index + 1;
+    // (`yarn build>log` redirects `yarn build`), so it forms its own token; heredoc-containing
+    // token streams are rejected by every caller before interpretation. Compound forms — the
+    // `&>file` both-streams shorthand, the `>|` clobber operator, and `>&`/`>&1`-style
+    // duplications — belong to the operator token, or their `&`/`|` would read as a separator.
+    if (char === '<' || char === '>' || (char === '&' && /^[<>]$/u.test(script[index + 1] ?? ''))) {
+      let end = char === '&' ? index + 1 : index;
       while (end < script.length && (script[end] === '<' || script[end] === '>')) end++;
-      if (script[end] === '&' && /^[\d-]$/u.test(script[end + 1] ?? '')) {
-        end += 2;
-        while (end < script.length && /\d/u.test(script[end] ?? '')) end++;
+      if (script[end] === '&') {
+        end++;
+        if (script[end] === '-') end++;
+        else while (end < script.length && /\d/u.test(script[end] ?? '')) end++;
+      } else if (script[end] === '|') {
+        end++;
       }
       tokens.push({ text: script.slice(index, end), start: index, end });
       index = end;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -384,20 +384,15 @@ function convertYarnCommandsToBun(
   // has no such concept, so the invocation must be routed to the defining workspace explicitly.
   // Resolved lazily: most scripts have no colon invocations.
   let colonScriptOwners: Map<string, ColonScriptOwner | undefined> | undefined;
-  const convertColonScriptInvocation = (
-    match: string,
-    scriptName: string,
-    offset: number,
-    currentScript: string
-  ): string => {
+  const resolveColonScriptInvocation = (scriptName: string, prefix: string): string | undefined => {
     if (typeof scripts[scriptName] === 'string') return `bun run ${scriptName}`;
     colonScriptOwners ??= collectColonScriptOwners(rootConfig);
     const owner = colonScriptOwners.get(scriptName);
-    const fallback = (): string =>
+    const fallback = (): string | undefined =>
       // A missing or ambiguous leading-colon script cannot run locally either, so its yarn form
-      // is kept to surface in review; other unresolved colon names keep the plain conversion
-      // (e.g. `cd sub && yarn build:sub` targeting a non-workspace directory).
-      scriptName.startsWith(':') ? match : `bun run ${scriptName}`;
+      // is kept (undefined) to surface in review; other unresolved colon names keep the plain
+      // conversion (e.g. `cd sub && yarn build:sub` targeting a non-workspace directory).
+      scriptName.startsWith(':') ? undefined : `bun run ${scriptName}`;
     if (!owner) return fallback();
     // Bun's --filter never matches the workspace root, and its path filters resolve against the
     // invoking cwd (both verified on Bun 1.3.14), so the root package and unnamed workspaces are
@@ -408,7 +403,7 @@ function convertYarnCommandsToBun(
     // A `cd` BEFORE this invocation would make the package-relative --cwd resolve from the wrong
     // directory at runtime, so such invocations fall back instead of getting a silently broken
     // route; a cd after the invocation cannot affect it and must not prevent the conversion.
-    if (prefixMayChangeWorkingDirectory(currentScript.slice(0, offset))) return fallback();
+    if (prefixMayChangeWorkingDirectory(prefix)) return fallback();
     const relativeDirPath = path.relative(config.dirPath, owner.dirPath) || '.';
     return `bun run --cwd '${relativeDirPath.replaceAll("'", String.raw`'\''`)}' ${scriptName}`;
   };
@@ -416,37 +411,129 @@ function convertYarnCommandsToBun(
   // yarn invocation in package scripts (e.g. postinstall) would fail on machines without Yarn.
   for (const [key, value] of Object.entries(scripts)) {
     if (typeof value !== 'string' || !/\byarn\b/u.test(value)) continue;
-    scripts[key] = value
-      .replaceAll(
-        /yarn workspaces foreach\b[^&|;]*?\brun\s+(\S+)/gu,
-        (_, scriptName: string) => `bun run --filter '*' ${scriptName}`
-      )
-      .replaceAll(/\byarn\s+dlx\b/gu, 'bunx')
-      .replaceAll(
-        /\byarn\s+workspace\s+(\S+)\s+(run\s+)?([\w.:/-]+)/gu,
-        (match, packageName: string, run: string | undefined, command: string) =>
-          // Without an explicit `run`, a built-in like `yarn workspace pkg add -D x` is a Yarn CLI
-          // action, not a script; Bun's --filter only executes package scripts.
-          run || !yarnBuiltinSubcommands.has(command) ? `bun run --filter ${packageName} ${command}` : match
-      )
-      // The token may contain any non-metacharacter (e.g. `build:@scope`), not just \w./:-,
-      // so the whole shell word is captured and the colon requirement is a lookahead. Only a
-      // leading `-` (a yarn flag) is excluded: Yarn's global lookup has no first-character
-      // restriction, so names like `.build:cache` must resolve too.
-      .replaceAll(/\byarn\s+(?:run\s+)?(?!-)((?=[^\s:;&|<>()'"`]*:)[^\s;&|<>()'"`]+)/gu, convertColonScriptInvocation)
-      // The `(?!\s+:)` guard keeps an unresolvable `yarn run :name` in its yarn form (the colon
-      // rule above already converted every resolvable one).
-      .replaceAll(/\byarn\s+run\b(?!\s+:)/gu, 'bun run')
-      .replaceAll(/\byarn\s+install\b/gu, 'bun install')
-      // A bare `yarn <name>` invokes the package script; Yarn built-ins, flag forms
-      // (e.g. `yarn --cwd ...`), and still-unconverted `:` global scripts have no direct Bun
-      // equivalent and are intentionally left untouched to surface during review.
-      .replaceAll(/\byarn\s+(?![-.:])([\w.:/-]+)/gu, (match, scriptName: string) =>
-        yarnBuiltinSubcommands.has(scriptName) ? match : `bun run ${scriptName}`
-      )
-      // A bare `yarn` (at the end or before a command separator) is an install.
-      .replaceAll(/\byarn\b(?=\s*(?:$|&&|\|\||[;|]))/gu, 'bun install');
+    scripts[key] = convertYarnInvocationsToBun(value, resolveColonScriptInvocation);
   }
+}
+
+/**
+ * Rewrites the actual `yarn ...` command invocations in a script to their bun equivalents.
+ *
+ * The scan is quote-aware in both directions (reusing removeBunRuntimeFlag's shell tokenizer
+ * instead of bare regexes): `yarn` inside a quoted token (e.g. `echo 'yarn build:cache'`) is data
+ * and stays untouched, while a quoted argument token (e.g. `yarn ':build-cache'`) is unquoted
+ * before colon-owner resolution. Anything unconvertible keeps its yarn form verbatim to surface
+ * during review instead of being mis-rewritten.
+ */
+function convertYarnInvocationsToBun(
+  script: string,
+  resolveColonScriptInvocation: (scriptName: string, prefix: string) => string | undefined
+): string {
+  // Heredoc bodies are data, not commands; skip such scripts instead of modeling heredocs.
+  if (script.includes('<<')) return script;
+  const tokens = tokenizeShellCommand(script);
+  const replacements: ShellReplacement[] = [];
+  for (const [index, token] of tokens.entries()) {
+    // Only a bare unquoted `yarn` word starts an invocation; a quoted occurrence is data.
+    if (token.text !== 'yarn') continue;
+    // A `yarn` token consumed by a previous invocation's rewrite is not an invocation of its own.
+    if (token.start < (replacements.at(-1)?.end ?? 0)) continue;
+    const remainingTokens = tokens.slice(index + 1);
+    const terminatorIndex = remainingTokens.findIndex((argToken) => isShellSeparator(argToken.text));
+    const args = terminatorIndex === -1 ? remainingTokens : remainingTokens.slice(0, terminatorIndex);
+    if (args.length === 0) {
+      // A bare `yarn` (at the end or before a command separator) is an install. A control
+      // operator that does not simply chain commands (a backgrounding `&`, a subshell
+      // parenthesis) keeps the yarn form to surface in review.
+      const terminatorText = terminatorIndex === -1 ? undefined : remainingTokens[terminatorIndex]?.text;
+      if (terminatorText === undefined || /^(?:&&|\|{1,2}|;|\n)/u.test(terminatorText)) {
+        replacements.push({ start: token.start, end: token.end, text: 'bun install' });
+      }
+      continue;
+    }
+    const replacement = convertSingleYarnInvocation(token, args, script, resolveColonScriptInvocation);
+    if (replacement) replacements.push(replacement);
+  }
+  let result = script;
+  for (const { start, end, text } of replacements.toReversed()) {
+    result = result.slice(0, start) + text + result.slice(end);
+  }
+  return result;
+}
+
+interface ShellReplacement {
+  start: number;
+  end: number;
+  text: string;
+}
+
+/**
+ * Converts one `yarn <args...>` invocation (args already cut at the next command separator) into
+ * the text replacing it, or undefined to keep the yarn form untouched.
+ */
+function convertSingleYarnInvocation(
+  yarnToken: ShellToken,
+  args: readonly ShellToken[],
+  script: string,
+  resolveColonScriptInvocation: (scriptName: string, prefix: string) => string | undefined
+): ShellReplacement | undefined {
+  const argText = (argIndex: number): string | undefined => {
+    const arg = args[argIndex];
+    return arg && unquoteShellToken(arg.text);
+  };
+  const replaceThroughArg = (argIndex: number, text: string): ShellReplacement => ({
+    start: yarnToken.start,
+    end: (args[argIndex] as ShellToken).end,
+    text,
+  });
+  const first = argText(0);
+  const second = argText(1);
+  // `yarn workspaces foreach [flags] run <script>` fans a script out to every workspace.
+  if (first === 'workspaces' && second === 'foreach') {
+    const runIndex = args.findIndex((arg, index) => index >= 2 && unquoteShellToken(arg.text) === 'run');
+    const scriptName = runIndex === -1 ? undefined : argText(runIndex + 1);
+    return scriptName === undefined ? undefined : replaceThroughArg(runIndex + 1, `bun run --filter '*' ${scriptName}`);
+  }
+  if (first === 'dlx') return replaceThroughArg(0, 'bunx');
+  if (first === 'workspace') {
+    const hasRun = argText(2) === 'run';
+    const commandIndex = hasRun ? 3 : 2;
+    const command = argText(commandIndex);
+    // Without an explicit `run`, a built-in like `yarn workspace pkg add -D x` is a Yarn CLI
+    // action, not a script; Bun's --filter only executes package scripts.
+    return second !== undefined &&
+      command !== undefined &&
+      /^[\w.:/-]+$/u.test(command) &&
+      (hasRun || !yarnBuiltinSubcommands.has(command))
+      ? replaceThroughArg(commandIndex, `bun run --filter ${second} ${command}`)
+      : undefined;
+  }
+  // A colon-containing script name (after optional `run`) needs workspace-global resolution. The
+  // name may contain any non-metacharacter (e.g. `build:@scope`), not just \w./:-. Only a leading
+  // `-` (a yarn flag) is excluded: Yarn's global lookup has no first-character restriction, so
+  // names like `.build:cache` must resolve too.
+  const scriptNameIndex = first === 'run' ? 1 : 0;
+  const scriptName = argText(scriptNameIndex);
+  if (
+    scriptName !== undefined &&
+    !scriptName.startsWith('-') &&
+    scriptName.includes(':') &&
+    /^[^\s;&|<>()'"`]+$/u.test(scriptName)
+  ) {
+    const replacement = resolveColonScriptInvocation(scriptName, script.slice(0, yarnToken.start));
+    return replacement === undefined ? undefined : replaceThroughArg(scriptNameIndex, replacement);
+  }
+  if (first === 'run') {
+    // An unresolvable `yarn run :name` keeps its yarn form (the colon rule above already
+    // converted every resolvable one); otherwise `bun run` accepts the same flags and target.
+    return scriptName?.startsWith(':') ? undefined : replaceThroughArg(0, 'bun run');
+  }
+  if (first === 'install') return replaceThroughArg(0, 'bun install');
+  // A bare `yarn <name>` invokes the package script; Yarn built-ins, flag forms
+  // (e.g. `yarn --cwd ...`), and still-unconverted `:` global scripts have no direct Bun
+  // equivalent and are intentionally left untouched to surface during review.
+  return first !== undefined && /^(?![-.:])[\w.:/-]+$/u.test(first) && !yarnBuiltinSubcommands.has(first)
+    ? replaceThroughArg(0, `bun run ${first}`)
+    : undefined;
 }
 
 /**

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -812,7 +812,9 @@ function forEachCommandPositionToken(
   const outerStates: { atCommandPosition: boolean; inArithmetic: boolean }[] = [];
   for (const [index, token] of tokens.entries()) {
     if (isShellSeparator(token.text)) {
-      for (const [charIndex, char] of [...token.text].entries()) {
+      // Separator tokens are ASCII, so index-based iteration is safe.
+      for (let charIndex = 0; charIndex < token.text.length; charIndex++) {
+        const char = token.text[charIndex] ?? '';
         if (char === '(') {
           outerStates.push({ atCommandPosition, inArithmetic });
           // Only an ADJACENT `((` (one token, since separator tokens are same-char runs) is

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -515,27 +515,49 @@ function convertSingleYarnInvocation(
   script: string,
   resolveColonScriptInvocation: (scriptName: string, prefix: string) => string | undefined
 ): ShellReplacement | undefined {
+  // Redirections may appear anywhere in a simple command without affecting which strings the
+  // command receives (`yarn run >out.log build:cache` passes `run build:cache`), so the rules
+  // below operate on the logical (non-redirection) arguments only.
+  const logicalArgs: { token: ShellToken; rawIndex: number }[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const token = args[index] as ShellToken;
+    if (/^[<>]/u.test(token.text)) {
+      // A plain operator consumes its operand; a `>&1`-style duplication is self-contained.
+      if (/^[<>]+$/u.test(token.text)) index++;
+      continue;
+    }
+    if (
+      /^\d+$/u.test(token.text) &&
+      args[index + 1]?.start === token.end &&
+      /^[<>]/u.test(args[index + 1]?.text ?? '')
+    ) {
+      continue;
+    }
+    logicalArgs.push({ token, rawIndex: index });
+  }
   // Decoded (literal) argument values drive the matching, while emitted rewrites always reuse the
   // raw token text (rawArg) so quoting and expansion semantics survive the conversion unchanged
   // (e.g. `yarn 'build:$target'` keeps its single quotes). A shell-ambiguous token decodes to
   // undefined, which keeps the invocation in its yarn form.
   const argText = (argIndex: number): string | undefined => {
-    const arg = args[argIndex];
-    return arg && decodeSimpleShellWord(arg.text);
+    const arg = logicalArgs[argIndex];
+    return arg && decodeSimpleShellWord(arg.token.text);
   };
-  const rawArg = (argIndex: number): string => args[argIndex]?.text ?? '';
-  const replaceThroughArg = (argIndex: number, text: string): ShellReplacement => ({
-    start: yarnToken.start,
-    end: (args[argIndex] as ShellToken).end,
-    text,
-  });
+  const rawArg = (argIndex: number): string => logicalArgs[argIndex]?.token.text ?? '';
+  const replaceThroughArg = (argIndex: number, text: string): ShellReplacement | undefined => {
+    const arg = logicalArgs[argIndex] as { token: ShellToken; rawIndex: number };
+    // A redirection inside the replaced span would be deleted by the rewrite, so such an
+    // invocation keeps its yarn form to surface in review.
+    if (args.slice(0, arg.rawIndex).some((argToken) => /^[<>]/u.test(argToken.text))) return undefined;
+    return { start: yarnToken.start, end: arg.token.end, text };
+  };
   const first = argText(0);
   const second = argText(1);
   // `yarn workspaces foreach <selection-neutral flags> run <script>` fans a script out to every
   // workspace; a selection-restricting or execution-suppressing flag keeps the yarn form.
   if (first === 'workspaces' && second === 'foreach') {
     let runIndex = -1;
-    for (let index = 2; index < args.length; index++) {
+    for (let index = 2; index < logicalArgs.length; index++) {
       const flag = argText(index);
       if (flag === 'run') {
         runIndex = index;
@@ -588,8 +610,8 @@ function convertSingleYarnInvocation(
     // converted every resolvable one), and so does an undecodable (dynamic or ambiguous) target:
     // its expanded name could need Yarn's global routing. Otherwise `bun run` accepts the same
     // flags and target.
-    const target = args[scriptNameIndex];
-    return target && (scriptName === undefined || scriptName.startsWith(':') || target.text.startsWith(':'))
+    const target = logicalArgs[scriptNameIndex];
+    return target && (scriptName === undefined || scriptName.startsWith(':') || target.token.text.startsWith(':'))
       ? undefined
       : replaceThroughArg(0, 'bun run');
   }
@@ -775,15 +797,26 @@ function forEachCommandPositionToken(
       continue;
     }
     if (!atCommandPosition) continue;
-    // A redirection may precede the command (`>out.log yarn build`, `2>err.log yarn build`); the
-    // operator and its operand (and a detached file-descriptor digit) leave the position intact.
-    if (/^[<>]+$/u.test(token.text)) {
-      redirectionOperandFollows = true;
+    // A redirection may precede the command (`>out.log yarn build`, `2>&1 yarn build`); the
+    // operator (with its operand, unless a `>&1`-style duplication makes it self-contained) and
+    // an ADJACENT file-descriptor digit (`2>` splits into two tokens; a detached `2 >out` is not
+    // a descriptor) leave the position intact.
+    if (/^[<>]/u.test(token.text)) {
+      redirectionOperandFollows = /^[<>]+$/u.test(token.text);
       continue;
     }
-    if (/^\d+$/u.test(token.text) && /^[<>]/u.test(tokens[index + 1]?.text ?? '')) continue;
+    if (
+      /^\d+$/u.test(token.text) &&
+      tokens[index + 1]?.start === token.end &&
+      /^[<>]/u.test(tokens[index + 1]?.text ?? '')
+    ) {
+      continue;
+    }
     const tokenText = unquoteShellToken(token.text);
     if (/^[A-Za-z_]\w*=/u.test(tokenText) || commandPositionTransparentWords.has(tokenText)) continue;
+    // At command position a `-`-leading token can only be an option of a preceding transparent
+    // wrapper (`env -i yarn build`); a real command never starts with `-`.
+    if (tokenText.startsWith('-')) continue;
     atCommandPosition = false;
     callback(token, index, tokens);
   }
@@ -808,10 +841,15 @@ function tokenizeShellCommand(script: string): ShellToken[] {
     }
     // An unquoted redirection operator ends the preceding word even without whitespace
     // (`yarn build>log` redirects `yarn build`), so it forms its own token; heredocs (`<<`) never
-    // reach this tokenizer — every caller skips scripts containing them.
+    // reach this tokenizer — every caller skips scripts containing them. A duplication suffix
+    // (`>&1`, `2>&1`, `>&-`) belongs to the operator token, or its `&` would read as a separator.
     if (char === '<' || char === '>') {
       let end = index + 1;
       while (end < script.length && (script[end] === '<' || script[end] === '>')) end++;
+      if (script[end] === '&' && /^[\d-]$/u.test(script[end + 1] ?? '')) {
+        end += 2;
+        while (end < script.length && /\d/u.test(script[end] ?? '')) end++;
+      }
       tokens.push({ text: script.slice(index, end), start: index, end });
       index = end;
       continue;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -757,6 +757,10 @@ function shouldKeepBunRuntimeFlag(followingTokens: ShellToken[], scriptNames: Re
 // the common pre-Bun way to set environment variables portably in package scripts), shell
 // keywords introducing a compound command's body (`if cmd`, `then cmd`, ...), and the `{ ... }`
 // grouping braces.
+// Options of the transparent wrapper words below that never consume a following argument
+// (`env -i`/`--ignore-environment`, `command -p`, `time -p`).
+const valuelessWrapperOptions = new Set(['-i', '-p', '--ignore-environment']);
+
 const commandPositionTransparentWords = new Set([
   '!',
   'command',
@@ -786,9 +790,21 @@ function forEachCommandPositionToken(
 ): void {
   let atCommandPosition = true;
   let redirectionOperandFollows = false;
+  // `$(...)` (and a subshell) opens a nested command context; on `)` the OUTER position must be
+  // restored, or `echo $(date) yarn build` would treat the outer argument `yarn` as a command.
+  const outerCommandPositions: boolean[] = [];
   for (const [index, token] of tokens.entries()) {
     if (isShellSeparator(token.text)) {
-      atCommandPosition = true;
+      for (const char of token.text) {
+        if (char === '(') {
+          outerCommandPositions.push(atCommandPosition);
+          atCommandPosition = true;
+        } else if (char === ')') {
+          atCommandPosition = outerCommandPositions.pop() ?? true;
+        } else {
+          atCommandPosition = true;
+        }
+      }
       redirectionOperandFollows = false;
       continue;
     }
@@ -815,8 +831,13 @@ function forEachCommandPositionToken(
     const tokenText = unquoteShellToken(token.text);
     if (/^[A-Za-z_]\w*=/u.test(tokenText) || commandPositionTransparentWords.has(tokenText)) continue;
     // At command position a `-`-leading token can only be an option of a preceding transparent
-    // wrapper (`env -i yarn build`); a real command never starts with `-`.
-    if (tokenText.startsWith('-')) continue;
+    // wrapper (`env -i yarn build`); a real command never starts with `-`. Only known valueless
+    // options stay transparent — an unmodeled option may consume the next word as its value
+    // (`env -u yarn build`), so discovery for this command stops conservatively instead.
+    if (tokenText.startsWith('-')) {
+      if (!valuelessWrapperOptions.has(tokenText)) atCommandPosition = false;
+      continue;
+    }
     atCommandPosition = false;
     callback(token, index, tokens);
   }
@@ -836,6 +857,14 @@ function tokenizeShellCommand(script: string): ShellToken[] {
       let end = index + 1;
       while (end < script.length && script[end] === char) end++;
       tokens.push({ text: script.slice(index, end), start: index, end });
+      index = end;
+      continue;
+    }
+    // An unquoted `#` starting a word begins a comment: the shell ignores it through the next
+    // newline, so no tokens (in particular no separators) may come out of it.
+    if (char === '#') {
+      let end = index + 1;
+      while (end < script.length && script[end] !== '\n') end++;
       index = end;
       continue;
     }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -834,37 +834,66 @@ function forEachCommandPositionToken(
 ): void {
   let atCommandPosition = true;
   let redirectionOperandFollows = false;
-  // `((` opens an arithmetic context: nothing inside is a command (`echo $((yarn && 1))`).
-  let inArithmetic = false;
+  // A muted paren context contains data, not commands: `((` arithmetic (`echo $((yarn && 1))`)
+  // and array literals (`args=(yarn compile)`).
+  let inDataParens = false;
   let previousSeparatorChar: string | undefined;
   // The word before a `(` decides whether an empty `()` pair is a function definition
-  // (`build_all() { ... }`) or an empty command substitution (`echo $() yarn`).
+  // (`build_all() { ... }`) or an empty command substitution (`echo $() yarn`), and whether the
+  // parens hold an array literal.
   let lastWordToken: ShellToken | undefined;
   // `function f { ... }` declares f without parentheses: the name is consumed, and the `{` body
   // that follows is in command position.
   let functionNameFollows = false;
+  // Between `case <subject> in` (or after `;;`) and the pattern's closing `)`, words are patterns
+  // and a leading `(` is a delimiter, not a subshell.
+  let caseContext: 'none' | 'awaitingIn' | 'pattern' | 'body' = 'none';
   // `$(...)` (and a subshell) opens a nested command context; on `)` the OUTER state must be
   // restored, or `echo $(date) yarn build` would treat the outer argument `yarn` as a command.
-  const outerStates: { atCommandPosition: boolean; inArithmetic: boolean; functionCandidate: boolean }[] = [];
+  const outerStates: { atCommandPosition: boolean; inDataParens: boolean; functionCandidate: boolean }[] = [];
   for (const [index, token] of tokens.entries()) {
     if (isShellSeparator(token.text)) {
+      if (caseContext === 'body' && token.text.startsWith(';;')) {
+        caseContext = 'pattern';
+        redirectionOperandFollows = false;
+        previousSeparatorChar = undefined;
+        continue;
+      }
       // Separator tokens are ASCII, so index-based iteration is safe.
       for (let charIndex = 0; charIndex < token.text.length; charIndex++) {
         const char = token.text[charIndex] ?? '';
+        if (caseContext === 'awaitingIn' || caseContext === 'pattern') {
+          // Inside a pattern, `(` and `|` delimit alternatives and `)` starts the branch body.
+          if (caseContext === 'pattern' && char === ')') {
+            caseContext = 'body';
+            atCommandPosition = true;
+          }
+          previousSeparatorChar = char;
+          continue;
+        }
         if (char === '(') {
           outerStates.push({
             atCommandPosition,
-            inArithmetic,
+            inDataParens,
             // A word ending in `$` opens a substitution, never a function definition.
             functionCandidate: lastWordToken !== undefined && !lastWordToken.text.endsWith('$'),
           });
           // Only an ADJACENT `((` (one token, since separator tokens are same-char runs) is
-          // arithmetic; a spaced `( (` is a nested subshell.
-          if (charIndex > 0) inArithmetic = true;
+          // arithmetic, and an ADJACENT `name=(` opens an array literal; a spaced `( (` is a
+          // nested subshell.
+          if (
+            charIndex > 0 ||
+            (lastWordToken !== undefined &&
+              lastWordToken.text.endsWith('=') &&
+              lastWordToken.end === token.start &&
+              /^[A-Za-z_][+\w]*=$/u.test(lastWordToken.text))
+          ) {
+            inDataParens = true;
+          }
           atCommandPosition = true;
         } else if (char === ')') {
           const outerState = outerStates.pop();
-          inArithmetic = outerState?.inArithmetic ?? false;
+          inDataParens = outerState?.inDataParens ?? false;
           // An empty `()` pair after a plain word is a function definition: its body follows in
           // command position, and its yarn invocations really run when the function is called.
           atCommandPosition =
@@ -883,7 +912,16 @@ function forEachCommandPositionToken(
     }
     previousSeparatorChar = undefined;
     lastWordToken = token;
-    if (inArithmetic) continue;
+    if (caseContext === 'awaitingIn') {
+      if (token.text === 'in') caseContext = 'pattern';
+      continue;
+    }
+    if (caseContext === 'pattern') {
+      // A branch-less `esac` (e.g. right after `;;`) ends the case statement.
+      if (token.text === 'esac') caseContext = 'none';
+      continue;
+    }
+    if (inDataParens) continue;
     if (functionNameFollows) {
       // The declared function name is not a command; the `{` body follows in command position.
       functionNameFollows = false;
@@ -896,6 +934,15 @@ function forEachCommandPositionToken(
     if (!atCommandPosition) continue;
     if (token.text === 'function') {
       functionNameFollows = true;
+      continue;
+    }
+    if (token.text === 'case') {
+      caseContext = 'awaitingIn';
+      continue;
+    }
+    if (caseContext === 'body' && token.text === 'esac') {
+      caseContext = 'none';
+      atCommandPosition = false;
       continue;
     }
     // A redirection may precede the command (`>out.log yarn build`, `2>&1 yarn build`); the

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1503,6 +1503,8 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       dollar: "yarn 'build:$target'",
       dynamic: 'yarn build:$target && yarn run "build:$target"',
       arith: 'echo $((yarn && 1))',
+      'array-lit': 'args=(yarn compile); echo done',
+      'case-pat': 'case "$r" in (yarn) yarn compile;; esac',
       clobber: 'echo hi >| yarn && yarn compile',
       commented: 'echo ready # note; yarn compile',
       'env-opt': 'env -i yarn compile && 2>&1 yarn compile',
@@ -1545,6 +1547,7 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     // after a command substitution, inside an arithmetic expansion, as a redirection operand, as
     // a quoted command word's argument, or inside a comment is data, not a command.
     arith: 'echo $((yarn && 1))',
+    'array-lit': 'args=(yarn compile); echo done',
     commented: 'echo ready # note; yarn compile',
     'quoted-assign': '"FOO=bar" yarn compile',
     'empty-subst': 'echo $() yarn && echo deploy',
@@ -1577,6 +1580,8 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     'func-def': 'build_all() { bun run compile; }; build_all',
     'func-kw': 'function f { bun run compile; }; f',
     'in-subst': 'echo $(bun run compile)',
+    // `case` patterns (parenthesized or not) are data, while the branch bodies convert.
+    'case-pat': 'case "$r" in (yarn) bun run compile;; esac',
     // `<<` inside an arithmetic expansion is a left shift, not a heredoc.
     shift: 'echo $((1 << 2)) && bun run compile',
     // Only a real unquoted heredoc operator suppresses conversion, not quoted `<<` data.

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1500,12 +1500,19 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     scripts: {
       'clean-all': 'yarn workspaces foreach --all exec rimraf dist',
       'deps-up': 'yarn up -R typescript',
+      dollar: "yarn 'build:$target'",
       'fan-out': 'yarn workspaces foreach --all run build',
       'gen:sub': 'cd sub && yarn build:sub',
       hint: "echo 'run yarn build before deploying'",
+      'install-note': "echo 'yarn install && deploy now'",
+      mention: 'git commit -m yarn && echo yarn build',
       publish2: 'yarn npm publish --tolerate-republish',
+      redirect: 'yarn build>out.log',
+      'setup-all': 'yarn install && yarn compile',
+      'since-build': 'yarn workspaces foreach --since run build',
       'ws-add': 'yarn workspace components add -D react',
       'ws-run': 'yarn workspace components run gen',
+      wrapped: 'cross-env NODE_ENV=production yarn build',
     },
   });
 
@@ -1515,12 +1522,22 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     'deps-up': 'yarn up -R typescript',
     publish2: 'yarn npm publish --tolerate-republish',
     'ws-add': 'yarn workspace components add -D react',
-    // `yarn` inside a quoted token is data, not a command, so it stays untouched.
+    // `yarn` inside a quoted token or in argument position is data, not a command.
     hint: "echo 'run yarn build before deploying'",
-    // Script invocations are converted.
+    'install-note': "echo 'yarn install && deploy now'",
+    mention: 'git commit -m yarn && echo yarn build',
+    // A selection-restricting foreach flag keeps the yarn form: --filter '*' would widen it.
+    'since-build': 'yarn workspaces foreach --since run build',
+    // Script invocations are converted; quoted arguments are re-emitted verbatim so quoting and
+    // expansion semantics never change.
+    dollar: "bun run 'build:$target'",
     'fan-out': "bun run --filter '*' build",
     'gen:sub': 'cd sub && bun run build:sub',
+    redirect: 'bun run build>out.log',
+    // The legacy `yarn install && ` prefix is removed before conversion.
+    'setup-all': 'bun run compile',
     'ws-run': 'bun run --filter components gen',
+    wrapped: 'cross-env NODE_ENV=production bun run build',
   });
 });
 
@@ -1534,7 +1551,9 @@ test('routes yarn colon global scripts to the workspace defining them', async ()
         'cache-all': 'yarn build:cache',
         dot: 'yarn .build:cache',
         echoed: 'echo \'yarn build:cache\' && node warn.js "prefer yarn :build-caches"',
+        flagged: 'yarn run --inspect-brk build:cache',
         local: 'yarn :local-cache',
+        'local-flag': 'yarn run --silent :local-cache',
         missing: 'yarn :unknown-script && yarn run :unknown-script',
         quoted: `yarn ':build-caches' && yarn run ":build-caches"`,
         'test/ci-setup': 'build-ts run scripts/rename.ts && yarn :build-caches && sh scripts/install.sh',
@@ -1570,12 +1589,18 @@ test('routes yarn colon global scripts to the workspace defining them', async ()
     // `yarn ...` inside a quoted token is data, not a command; rewriting it would change the
     // script's output (or worse, inject a --filter route into a string literal).
     echoed: 'echo \'yarn build:cache\' && node warn.js "prefer yarn :build-caches"',
+    // Flags between `run` and a target routed to ANOTHER workspace keep the yarn form: their
+    // placement inside a --filter route is unmodeled.
+    flagged: 'yarn run --inspect-brk build:cache',
     // A colon script defined in the invoking package stays a local bun run.
     local: 'bun run :local-cache',
+    // Flags before a locally-defined target survive a plain `bun run` conversion.
+    'local-flag': 'bun run --silent :local-cache',
     // A leading-colon script no workspace defines keeps its yarn form to surface in review.
     missing: 'yarn :unknown-script && yarn run :unknown-script',
-    // A quoted script-name token is unquoted before colon-owner resolution.
-    quoted: 'bun run --filter @judge/server :build-caches && bun run --filter @judge/server :build-caches',
+    // A quoted script-name token is unquoted before colon-owner resolution, and re-emitted with
+    // its original quoting so shell semantics never change.
+    quoted: `bun run --filter @judge/server ':build-caches' && bun run --filter @judge/server ":build-caches"`,
     // A colon script defined in another workspace is routed there: bun has no global scripts.
     'test/ci-setup':
       'build-ts run scripts/rename.ts && bun run --filter @judge/server :build-caches && sh scripts/install.sh',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1502,6 +1502,7 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       'deps-up': 'yarn up -R typescript',
       dollar: "yarn 'build:$target'",
       dynamic: 'yarn build:$target && yarn run "build:$target"',
+      'env-opt': 'env -i yarn compile && 2>&1 yarn compile',
       'fan-out': 'yarn workspaces foreach --all run build',
       'gen:sub': 'cd sub && yarn build:sub',
       guarded: 'if [ -f .env ]; then yarn compile; fi && { yarn compile; }',
@@ -1545,6 +1546,8 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     'gen:sub': 'cd sub && bun run build:sub',
     // Shell keywords and grouping braces keep the following word in command position.
     guarded: 'if [ -f .env ]; then bun run compile; fi && { bun run compile; }',
+    // Wrapper options and file-descriptor duplications before the command are stepped over.
+    'env-opt': 'env -i bun run compile && 2>&1 bun run compile',
     redirect: 'bun run build>out.log',
     // A redirection before the command leaves it in command position.
     'redirect-first': '>build.log bun run compile',
@@ -1567,6 +1570,7 @@ test('routes yarn colon global scripts to the workspace defining them', async ()
         dot: 'yarn .build:cache',
         echoed: 'echo \'yarn build:cache\' && node warn.js "prefer yarn :build-caches"',
         flagged: 'yarn run --inspect-brk build:cache',
+        'redir-target': 'yarn run >out.log build:cache',
         local: 'yarn :local-cache',
         'local-flag': 'yarn run --silent :local-cache',
         missing: 'yarn :unknown-script && yarn run :unknown-script',
@@ -1613,6 +1617,9 @@ test('routes yarn colon global scripts to the workspace defining them', async ()
     'local-flag': 'bun run --silent :local-cache',
     // A leading-colon script no workspace defines keeps its yarn form to surface in review.
     missing: 'yarn :unknown-script && yarn run :unknown-script',
+    // A redirection between `run` and a routed target would be swallowed by the rewrite, so the
+    // invocation keeps its yarn form.
+    'redir-target': 'yarn run >out.log build:cache',
     // A quoted script-name token is unquoted before colon-owner resolution, and re-emitted with
     // its original quoting so shell semantics never change.
     quoted: `bun run --filter @judge/server ':build-caches' && bun run --filter @judge/server ":build-caches"`,

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1500,7 +1500,9 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     scripts: {
       'clean-all': 'yarn workspaces foreach --all exec rimraf dist',
       'deps-up': 'yarn up -R typescript',
+      'fan-out': 'yarn workspaces foreach --all run build',
       'gen:sub': 'cd sub && yarn build:sub',
+      hint: "echo 'run yarn build before deploying'",
       publish2: 'yarn npm publish --tolerate-republish',
       'ws-add': 'yarn workspace components add -D react',
       'ws-run': 'yarn workspace components run gen',
@@ -1513,7 +1515,10 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     'deps-up': 'yarn up -R typescript',
     publish2: 'yarn npm publish --tolerate-republish',
     'ws-add': 'yarn workspace components add -D react',
+    // `yarn` inside a quoted token is data, not a command, so it stays untouched.
+    hint: "echo 'run yarn build before deploying'",
     // Script invocations are converted.
+    'fan-out': "bun run --filter '*' build",
     'gen:sub': 'cd sub && bun run build:sub',
     'ws-run': 'bun run --filter components gen',
   });
@@ -1528,8 +1533,10 @@ test('routes yarn colon global scripts to the workspace defining them', async ()
         at: 'yarn build:@scope',
         'cache-all': 'yarn build:cache',
         dot: 'yarn .build:cache',
+        echoed: 'echo \'yarn build:cache\' && node warn.js "prefer yarn :build-caches"',
         local: 'yarn :local-cache',
         missing: 'yarn :unknown-script && yarn run :unknown-script',
+        quoted: `yarn ':build-caches' && yarn run ":build-caches"`,
         'test/ci-setup': 'build-ts run scripts/rename.ts && yarn :build-caches && sh scripts/install.sh',
         tools: 'yarn :tool-cache',
       },
@@ -1560,10 +1567,15 @@ test('routes yarn colon global scripts to the workspace defining them', async ()
     'cache-all': 'bun run --filter @judge/server build:cache',
     // Yarn's lookup has no first-character restriction, so dot-prefixed names resolve too.
     dot: 'bun run --filter @judge/server .build:cache',
+    // `yarn ...` inside a quoted token is data, not a command; rewriting it would change the
+    // script's output (or worse, inject a --filter route into a string literal).
+    echoed: 'echo \'yarn build:cache\' && node warn.js "prefer yarn :build-caches"',
     // A colon script defined in the invoking package stays a local bun run.
     local: 'bun run :local-cache',
     // A leading-colon script no workspace defines keeps its yarn form to surface in review.
     missing: 'yarn :unknown-script && yarn run :unknown-script',
+    // A quoted script-name token is unquoted before colon-owner resolution.
+    quoted: 'bun run --filter @judge/server :build-caches && bun run --filter @judge/server :build-caches',
     // A colon script defined in another workspace is routed there: bun has no global scripts.
     'test/ci-setup':
       'build-ts run scripts/rename.ts && bun run --filter @judge/server :build-caches && sh scripts/install.sh',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1502,7 +1502,11 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       'deps-up': 'yarn up -R typescript',
       dollar: "yarn 'build:$target'",
       dynamic: 'yarn build:$target && yarn run "build:$target"',
+      commented: 'echo ready # note; yarn compile',
       'env-opt': 'env -i yarn compile && 2>&1 yarn compile',
+      'env-unset': 'env -u yarn compile && time -f yarn compile',
+      'in-subst': 'echo $(yarn compile)',
+      subst: 'echo $(date) yarn compile',
       'fan-out': 'yarn workspaces foreach --all run build',
       'gen:sub': 'cd sub && yarn build:sub',
       guarded: 'if [ -f .env ]; then yarn compile; fi && { yarn compile; }',
@@ -1528,10 +1532,14 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     'deps-up': 'yarn up -R typescript',
     publish2: 'yarn npm publish --tolerate-republish',
     'ws-add': 'yarn workspace components add -D react',
-    // `yarn` inside a quoted token or in argument position is data, not a command.
+    // `yarn` inside a quoted token, in argument position, after a value-taking wrapper option,
+    // after a command substitution, or inside a comment is data, not a command.
+    commented: 'echo ready # note; yarn compile',
+    'env-unset': 'env -u yarn compile && time -f yarn compile',
     hint: "echo 'run yarn build before deploying'",
     'install-note': "echo 'yarn install && deploy now'",
     mention: 'git commit -m yarn && echo yarn build',
+    subst: 'echo $(date) yarn compile',
     // An unquoted expansion is dynamic: its runtime value could need Yarn's global routing.
     dynamic: 'yarn build:$target && yarn run "build:$target"',
     // A parallelism foreach flag keeps the yarn form: Bun's dependency-ordered concurrency could
@@ -1548,6 +1556,8 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     guarded: 'if [ -f .env ]; then bun run compile; fi && { bun run compile; }',
     // Wrapper options and file-descriptor duplications before the command are stepped over.
     'env-opt': 'env -i bun run compile && 2>&1 bun run compile',
+    // A yarn invocation inside a command substitution really runs.
+    'in-subst': 'echo $(bun run compile)',
     redirect: 'bun run build>out.log',
     // A redirection before the command leaves it in command position.
     'redirect-first': '>build.log bun run compile',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1503,6 +1503,7 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       dollar: "yarn 'build:$target'",
       'fan-out': 'yarn workspaces foreach --all run build',
       'gen:sub': 'cd sub && yarn build:sub',
+      guarded: 'if [ -f .env ]; then yarn compile; fi && { yarn compile; }',
       hint: "echo 'run yarn build before deploying'",
       'install-note': "echo 'yarn install && deploy now'",
       mention: 'git commit -m yarn && echo yarn build',
@@ -1533,6 +1534,8 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     dollar: "bun run 'build:$target'",
     'fan-out': "bun run --filter '*' build",
     'gen:sub': 'cd sub && bun run build:sub',
+    // Shell keywords and grouping braces keep the following word in command position.
+    guarded: 'if [ -f .env ]; then bun run compile; fi && { bun run compile; }',
     redirect: 'bun run build>out.log',
     // The legacy `yarn install && ` prefix is removed before conversion.
     'setup-all': 'bun run compile',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1509,8 +1509,12 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       'func-def': 'build_all() { yarn compile; }; build_all',
       'quoted-assign': '"FOO=bar" yarn compile',
       'quoted-heredoc': "echo '<<' && yarn compile",
+      'empty-subst': 'echo $() yarn && echo deploy',
       'env-unset': 'env -u yarn compile && time -f yarn compile',
+      'foreach-bare': 'yarn workspaces foreach run build',
+      'func-kw': 'function f { yarn compile; }; f',
       'in-subst': 'echo $(yarn compile)',
+      shift: 'echo $((1 << 2)) && yarn compile',
       subst: 'echo $(date) yarn compile',
       'fan-out': 'yarn workspaces foreach --all run build',
       'gen:sub': 'cd sub && yarn build:sub',
@@ -1543,11 +1547,14 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     arith: 'echo $((yarn && 1))',
     commented: 'echo ready # note; yarn compile',
     'quoted-assign': '"FOO=bar" yarn compile',
+    'empty-subst': 'echo $() yarn && echo deploy',
     'env-unset': 'env -u yarn compile && time -f yarn compile',
     hint: "echo 'run yarn build before deploying'",
     'install-note': "echo 'yarn install && deploy now'",
     mention: 'git commit -m yarn && echo yarn build',
     subst: 'echo $(date) yarn compile',
+    // Without an explicit --all/-A selection, `--filter '*'` would widen the fan-out.
+    'foreach-bare': 'yarn workspaces foreach run build',
     // An unquoted expansion is dynamic: its runtime value could need Yarn's global routing.
     dynamic: 'yarn build:$target && yarn run "build:$target"',
     // A parallelism foreach flag keeps the yarn form: Bun's dependency-ordered concurrency could
@@ -1568,7 +1575,10 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     // `>|` operand stays data while the chained invocation after it converts.
     clobber: 'echo hi >| yarn && bun run compile',
     'func-def': 'build_all() { bun run compile; }; build_all',
+    'func-kw': 'function f { bun run compile; }; f',
     'in-subst': 'echo $(bun run compile)',
+    // `<<` inside an arithmetic expansion is a left shift, not a heredoc.
+    shift: 'echo $((1 << 2)) && bun run compile',
     // Only a real unquoted heredoc operator suppresses conversion, not quoted `<<` data.
     'quoted-heredoc': "echo '<<' && bun run compile",
     redirect: 'bun run build>out.log',
@@ -1594,6 +1604,7 @@ test('routes yarn colon global scripts to the workspace defining them', async ()
         echoed: 'echo \'yarn build:cache\' && node warn.js "prefer yarn :build-caches"',
         flagged: 'yarn run --inspect-brk build:cache',
         'redir-target': 'yarn run >out.log build:cache',
+        'require-flag': 'yarn run --require ./hook.cjs build:cache',
         local: 'yarn :local-cache',
         'local-flag': 'yarn run --silent :local-cache',
         missing: 'yarn :unknown-script && yarn run :unknown-script',
@@ -1643,6 +1654,8 @@ test('routes yarn colon global scripts to the workspace defining them', async ()
     // A redirection between `run` and a routed target would be swallowed by the rewrite, so the
     // invocation keeps its yarn form.
     'redir-target': 'yarn run >out.log build:cache',
+    // The value consumed by `--require` is not the target; the routed target keeps the yarn form.
+    'require-flag': 'yarn run --require ./hook.cjs build:cache',
     // A quoted script-name token is unquoted before colon-owner resolution, and re-emitted with
     // its original quoting so shell semantics never change.
     quoted: `bun run --filter @judge/server ':build-caches' && bun run --filter @judge/server ":build-caches"`,

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1501,14 +1501,18 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       'clean-all': 'yarn workspaces foreach --all exec rimraf dist',
       'deps-up': 'yarn up -R typescript',
       dollar: "yarn 'build:$target'",
+      dynamic: 'yarn build:$target && yarn run "build:$target"',
       'fan-out': 'yarn workspaces foreach --all run build',
       'gen:sub': 'cd sub && yarn build:sub',
       guarded: 'if [ -f .env ]; then yarn compile; fi && { yarn compile; }',
       hint: "echo 'run yarn build before deploying'",
       'install-note': "echo 'yarn install && deploy now'",
       mention: 'git commit -m yarn && echo yarn build',
+      'parallel-dev': 'yarn workspaces foreach --all --parallel run dev',
       publish2: 'yarn npm publish --tolerate-republish',
+      'quoted-install': "yarn 'install' && yarn compile",
       redirect: 'yarn build>out.log',
+      'redirect-first': '>build.log yarn compile',
       'setup-all': 'yarn install && yarn compile',
       'since-build': 'yarn workspaces foreach --since run build',
       'ws-add': 'yarn workspace components add -D react',
@@ -1527,6 +1531,11 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     hint: "echo 'run yarn build before deploying'",
     'install-note': "echo 'yarn install && deploy now'",
     mention: 'git commit -m yarn && echo yarn build',
+    // An unquoted expansion is dynamic: its runtime value could need Yarn's global routing.
+    dynamic: 'yarn build:$target && yarn run "build:$target"',
+    // A parallelism foreach flag keeps the yarn form: Bun's dependency-ordered concurrency could
+    // block dependent long-running scripts forever.
+    'parallel-dev': 'yarn workspaces foreach --all --parallel run dev',
     // A selection-restricting foreach flag keeps the yarn form: --filter '*' would widen it.
     'since-build': 'yarn workspaces foreach --since run build',
     // Script invocations are converted; quoted arguments are re-emitted verbatim so quoting and
@@ -1537,7 +1546,10 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     // Shell keywords and grouping braces keep the following word in command position.
     guarded: 'if [ -f .env ]; then bun run compile; fi && { bun run compile; }',
     redirect: 'bun run build>out.log',
-    // The legacy `yarn install && ` prefix is removed before conversion.
+    // A redirection before the command leaves it in command position.
+    'redirect-first': '>build.log bun run compile',
+    // The legacy `yarn install && ` prefix is removed before conversion, quoted or not.
+    'quoted-install': 'bun run compile',
     'setup-all': 'bun run compile',
     'ws-run': 'bun run --filter components gen',
     wrapped: 'cross-env NODE_ENV=production bun run build',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1502,8 +1502,13 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       'deps-up': 'yarn up -R typescript',
       dollar: "yarn 'build:$target'",
       dynamic: 'yarn build:$target && yarn run "build:$target"',
+      arith: 'echo $((yarn && 1))',
+      clobber: 'echo hi >| yarn && yarn compile',
       commented: 'echo ready # note; yarn compile',
       'env-opt': 'env -i yarn compile && 2>&1 yarn compile',
+      'func-def': 'build_all() { yarn compile; }; build_all',
+      'quoted-assign': '"FOO=bar" yarn compile',
+      'quoted-heredoc': "echo '<<' && yarn compile",
       'env-unset': 'env -u yarn compile && time -f yarn compile',
       'in-subst': 'echo $(yarn compile)',
       subst: 'echo $(date) yarn compile',
@@ -1533,8 +1538,11 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     publish2: 'yarn npm publish --tolerate-republish',
     'ws-add': 'yarn workspace components add -D react',
     // `yarn` inside a quoted token, in argument position, after a value-taking wrapper option,
-    // after a command substitution, or inside a comment is data, not a command.
+    // after a command substitution, inside an arithmetic expansion, as a redirection operand, as
+    // a quoted command word's argument, or inside a comment is data, not a command.
+    arith: 'echo $((yarn && 1))',
     commented: 'echo ready # note; yarn compile',
+    'quoted-assign': '"FOO=bar" yarn compile',
     'env-unset': 'env -u yarn compile && time -f yarn compile',
     hint: "echo 'run yarn build before deploying'",
     'install-note': "echo 'yarn install && deploy now'",
@@ -1556,8 +1564,13 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     guarded: 'if [ -f .env ]; then bun run compile; fi && { bun run compile; }',
     // Wrapper options and file-descriptor duplications before the command are stepped over.
     'env-opt': 'env -i bun run compile && 2>&1 bun run compile',
-    // A yarn invocation inside a command substitution really runs.
+    // A yarn invocation inside a command substitution or a function body really runs, and a
+    // `>|` operand stays data while the chained invocation after it converts.
+    clobber: 'echo hi >| yarn && bun run compile',
+    'func-def': 'build_all() { bun run compile; }; build_all',
     'in-subst': 'echo $(bun run compile)',
+    // Only a real unquoted heredoc operator suppresses conversion, not quoted `<<` data.
+    'quoted-heredoc': "echo '<<' && bun run compile",
     redirect: 'bun run build>out.log',
     // A redirection before the command leaves it in command position.
     'redirect-first': '>build.log bun run compile',


### PR DESCRIPTION
## Summary

`convertYarnCommandsToBun` rewrote `yarn ...` invocations in package scripts with plain `String.replaceAll` regexes, which was quote-unaware in both directions:

- A valid invocation with a quoted script name, e.g. `yarn ':build-cache'`, was not matched and survived as a yarn invocation after wbfy removed Yarn.
- `yarn ...` text inside quoted data, e.g. `echo 'yarn build:cache'`, was rewritten even though it is a string literal (and with colon-global routing it could even gain a `--filter`/`--cwd` prefix).

This PR drives the conversion from the quote-aware shell tokenizer added for `--bun` stripping in #1015 (`tokenizeShellCommand` / `isShellSeparator` / `unquoteShellToken`), instead of adding a second ad-hoc parser:

- Only a bare unquoted `yarn` token starts an invocation; `yarn` inside quoted tokens is data and stays untouched.
- Argument tokens are unquoted before matching, so `yarn ':build-cache'` and `yarn run ":build-cache"` now resolve through colon-owner routing (from #1016), which is preserved unchanged.
- Each regex rule was translated into an explicit token rule (`workspaces foreach ... run`, `dlx`, `workspace <pkg> [run] <cmd>`, colon-global scripts, `run`, `install`, bare script names, bare `yarn` install), keeping the same rule order and conservative fallbacks: anything unconvertible keeps its yarn form verbatim to surface during review instead of being mis-rewritten.
- Heredoc-containing scripts are skipped like in `removeBunRuntimeFlag` (heredoc bodies are data).

## Tests

- New cases: quoted colon script names are unquoted and routed; `echo 'yarn build:cache'` / quoted literals stay untouched; `yarn workspaces foreach --all run build` fan-out.
- All existing wbfy tests (colon-script resolution etc.) pass unchanged: 210 passed.
- `bun verify` passes.

Closes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)
