### PR TITLE
fix(wbfy): tokenize &> redirects and execute substitutions in data contexts

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -847,10 +847,16 @@ function forEachCommandPositionToken(
   let functionNameFollows = false;
   // Between `case <subject> in` (or after `;;`) and the pattern's closing `)`, words are patterns
   // and a leading `(` is a delimiter, not a subshell.
-  let caseContext: 'none' | 'awaitingIn' | 'pattern' | 'body' = 'none';
+  type CaseContext = 'none' | 'awaitingIn' | 'pattern' | 'body';
+  let caseContext: CaseContext = 'none';
   // `$(...)` (and a subshell) opens a nested command context; on `)` the OUTER state must be
   // restored, or `echo $(date) yarn build` would treat the outer argument `yarn` as a command.
-  const outerStates: { atCommandPosition: boolean; inDataParens: boolean; functionCandidate: boolean }[] = [];
+  const outerStates: {
+    atCommandPosition: boolean;
+    inDataParens: boolean;
+    functionCandidate: boolean;
+    caseContext: CaseContext;
+  }[] = [];
   for (const [index, token] of tokens.entries()) {
     if (isShellSeparator(token.text)) {
       if (caseContext === 'body' && token.text.startsWith(';;')) {
@@ -862,7 +868,14 @@ function forEachCommandPositionToken(
       // Separator tokens are ASCII, so index-based iteration is safe.
       for (let charIndex = 0; charIndex < token.text.length; charIndex++) {
         const char = token.text[charIndex] ?? '';
-        if (caseContext === 'awaitingIn' || caseContext === 'pattern') {
+        // An ADJACENT `$(` opens a command substitution, whose content EXECUTES even where the
+        // surrounding context is data (a case subject/pattern, an array literal).
+        const opensSubstitution =
+          char === '(' &&
+          lastWordToken !== undefined &&
+          lastWordToken.text.endsWith('$') &&
+          lastWordToken.end === token.start + charIndex;
+        if ((caseContext === 'awaitingIn' || caseContext === 'pattern') && !opensSubstitution) {
           // Inside a pattern, `(` and `|` delimit alternatives and `)` starts the branch body.
           if (caseContext === 'pattern' && char === ')') {
             caseContext = 'body';
@@ -877,6 +890,7 @@ function forEachCommandPositionToken(
             inDataParens,
             // A word ending in `$` opens a substitution, never a function definition.
             functionCandidate: lastWordToken !== undefined && !lastWordToken.text.endsWith('$'),
+            caseContext,
           });
           // Only an ADJACENT `((` (one token, since separator tokens are same-char runs) is
           // arithmetic, and an ADJACENT `name=(` opens an array literal; a spaced `( (` is a
@@ -885,15 +899,19 @@ function forEachCommandPositionToken(
             charIndex > 0 ||
             (lastWordToken !== undefined &&
               lastWordToken.text.endsWith('=') &&
-              lastWordToken.end === token.start &&
+              lastWordToken.end === token.start + charIndex &&
               /^[A-Za-z_][+\w]*=$/u.test(lastWordToken.text))
           ) {
             inDataParens = true;
+          } else if (opensSubstitution) {
+            inDataParens = false;
           }
+          caseContext = 'none';
           atCommandPosition = true;
         } else if (char === ')') {
           const outerState = outerStates.pop();
           inDataParens = outerState?.inDataParens ?? false;
+          caseContext = outerState?.caseContext ?? 'none';
           // An empty `()` pair after a plain word is a function definition: its body follows in
           // command position, and its yarn invocations really run when the function is called.
           atCommandPosition =
@@ -986,7 +1004,9 @@ function tokenizeShellCommand(script: string): ShellToken[] {
       index++;
       continue;
     }
-    if (isShellSeparator(char)) {
+    // `&<` / `&>` starts a compound redirection, so the redirect branch below must win over the
+    // separator branch: isShellSeparator('&') is true.
+    if (isShellSeparator(char) && !(char === '&' && /^[<>]$/u.test(script[index + 1] ?? ''))) {
       let end = index + 1;
       while (end < script.length && script[end] === char) end++;
       tokens.push({ text: script.slice(index, end), start: index, end });

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1502,9 +1502,12 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       'deps-up': 'yarn up -R typescript',
       dollar: "yarn 'build:$target'",
       dynamic: 'yarn build:$target && yarn run "build:$target"',
+      'amp-redirect': 'node report.js &>logs/yarn.log yarn compile',
       arith: 'echo $((yarn && 1))',
       'array-lit': 'args=(yarn compile); echo done',
+      'array-subst': 'args=($(yarn list-args))',
       'case-pat': 'case "$r" in (yarn) yarn compile;; esac',
+      'case-subst': 'case $(yarn kind) in x) echo matched;; esac',
       clobber: 'echo hi >| yarn && yarn compile',
       commented: 'echo ready # note; yarn compile',
       'env-opt': 'env -i yarn compile && 2>&1 yarn compile',
@@ -1546,6 +1549,7 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     // `yarn` inside a quoted token, in argument position, after a value-taking wrapper option,
     // after a command substitution, inside an arithmetic expansion, as a redirection operand, as
     // a quoted command word's argument, or inside a comment is data, not a command.
+    'amp-redirect': 'node report.js &>logs/yarn.log yarn compile',
     arith: 'echo $((yarn && 1))',
     'array-lit': 'args=(yarn compile); echo done',
     commented: 'echo ready # note; yarn compile',
@@ -1582,6 +1586,9 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     'in-subst': 'echo $(bun run compile)',
     // `case` patterns (parenthesized or not) are data, while the branch bodies convert.
     'case-pat': 'case "$r" in (yarn) bun run compile;; esac',
+    // A `$(...)` substitution EXECUTES even inside data contexts (case subjects, array literals).
+    'array-subst': 'args=($(bun run list-args))',
+    'case-subst': 'case $(bun run kind) in x) echo matched;; esac',
     // `<<` inside an arithmetic expansion is a left shift, not a heredoc.
     shift: 'echo $((1 << 2)) && bun run compile',
     // Only a real unquoted heredoc operator suppresses conversion, not quoted `<<` data.


### PR DESCRIPTION
## Summary

Follow-up to #1019: the last review round's two fixes landed after the PR was merged, so they ship here.

- The compound `&>`/`&<` redirect branch in `tokenizeShellCommand` was dead code: `isShellSeparator('&')` is true, so the separator branch consumed the `&` first and `cmd &>out.log yarn build` wrongly treated the data argument `yarn` as a command (found by the Claude Code reviewer, reproduced via tokenization: `cmd | & | > | out.log | yarn | build`). The redirect branch now wins for `&<`/`&>`.
- `$(...)` command substitutions execute even where the surrounding context is data — a `case` subject/pattern or an array literal — so the command-position walk now re-enables scanning inside an adjacent `$(` and restores the outer data context on `)` (found by the Codex reviewer): `case $(yarn kind) in ...` and `args=($(yarn list-args))` convert again while patterns/literals stay data.

New test cases: `amp-redirect`, `array-subst`, `case-subst`.

## Tests

- `cd packages/wbfy && bun wb test`: 210 passed.
- `bun verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
