### PR TITLE
fix: reuse installed private packages without registry auth, add ponharu age keys, harden yarn scan

### DIFF
--- a/packages/wb/README.md
+++ b/packages/wb/README.md
@@ -27,8 +27,10 @@ Commands:
                                 ignored.
   wb setup-private-packages     Materialize private git and registry
                                 dependencies for Docker builds (installed
-                                registry packages are reused; only missing
-                                ones are downloaded)
+                                registry packages satisfying an exact version
+                                or semver range are reused; dist-tag
+                                specifiers and missing packages are
+                                downloaded)
   wb start [args..]             Start app
   wb test [targets...]          Test project. If you pass no arguments, it will
                                 run all tests.

--- a/packages/wb/README.md
+++ b/packages/wb/README.md
@@ -25,7 +25,10 @@ Commands:
   wb retry [command] [args...]  Retry the given command until it succeeds
   wb setup                      Setup development environment. .env files are
                                 ignored.
-  wb setup-private-packages     Copy private git dependencies for Docker builds
+  wb setup-private-packages     Materialize private git and registry
+                                dependencies for Docker builds (installed
+                                registry packages are reused; only missing
+                                ones are downloaded)
   wb start [args..]             Start app
   wb test [targets...]          Test project. If you pass no arguments, it will
                                 run all tests.

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -28,6 +28,8 @@ interface PrivatePackage {
   sourceDirPath: string | undefined;
   targetDirPath: string;
   versionSpecifier: string | undefined;
+  /** The materialized version once an installed copy is selected or a download is extracted. */
+  resolvedVersion: string | undefined;
 }
 
 const dependencyKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
@@ -63,6 +65,18 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       // registry step recursively deletes registryOutDirPath, which would destroy the git
       // packages copied into an equal or NESTED directory moments earlier.
       console.error(chalk.red(`--out-dir must not overlap the ${PRIVATE_REGISTRY_SCOPE} registry output directory.`));
+      process.exit(1);
+    }
+    const stagingDirPath = path.join(projects.root.dirPath, '.tmp', 'wb-private-registry-staging');
+    if (pathsOverlap(outDirPath, path.join(projects.root.dirPath, 'node_modules'))) {
+      // The recursive delete of outDirPath would destroy the installed sources the copies read.
+      console.error(chalk.red('--out-dir must not overlap node_modules.'));
+      process.exit(1);
+    }
+    if (pathsOverlap(outDirPath, stagingDirPath)) {
+      // The registry step recreates the staging directory, silently discarding anything copied
+      // into an equal or nested --out-dir moments earlier.
+      console.error(chalk.red(`--out-dir must not overlap the staging directory (${stagingDirPath}).`));
       process.exit(1);
     }
     if (path.relative(projects.root.dirPath, outDirPath) !== '@willbooster') {
@@ -115,7 +129,6 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     if (registryPackages.length > 0) {
       // Download into a staging directory and swap it in only after every download succeeded, so
       // a failing registry/token/extraction cannot destroy the last usable materialization.
-      const stagingDirPath = path.join(projects.root.dirPath, '.tmp', 'wb-private-registry-staging');
       const toStagedPath = (targetDirPath: string): string =>
         path.join(stagingDirPath, path.relative(registryOutDirPath, targetDirPath));
       await fs.promises.rm(stagingDirPath, { recursive: true, force: true });
@@ -135,6 +148,10 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
               privatePackage.name,
               privatePackage.versionSpecifier ?? 'latest',
               toStagedPath(privatePackage.targetDirPath)
+            );
+            privatePackage.resolvedVersion = readInstalledVersion(
+              toStagedPath(privatePackage.targetDirPath),
+              privatePackage.name
             );
             console.info(
               `Downloaded ${privatePackage.name} to ${path.relative(projects.root.dirPath, privatePackage.targetDirPath)}`
@@ -189,10 +206,13 @@ async function collectPrivatePackages(
     if (!privatePackage) continue;
     if (privatePackages.has(privatePackage.name)) continue;
 
-    privatePackage.sourceDirPath =
-      privatePackage.kind === 'git'
-        ? findInstalledPackageDir(rootDirPath, privatePackage.name)
-        : findInstalledRegistryPackageDir(rootDirPath, privatePackage);
+    if (privatePackage.kind === 'git') {
+      privatePackage.sourceDirPath = findInstalledPackageDir(rootDirPath, privatePackage.name);
+    } else {
+      const installed = findInstalledRegistryPackage(rootDirPath, privatePackage);
+      privatePackage.sourceDirPath = installed?.dirPath;
+      privatePackage.resolvedVersion = installed?.version;
+    }
     // Nested private dependencies of an installed package are discoverable right away; registry
     // packages without a usable installed copy are inspected after download instead
     // (collectNestedPrivatePackages).
@@ -201,11 +221,23 @@ async function collectPrivatePackages(
         const packageJson = await readPackageJson(packageJsonPath);
         for (const nested of findPrivateDependencies(packageJson, outDirPath, registryOutDirPath)) {
           const queued = queuedPackages.get(nested.name);
-          if (queued) {
-            assertNoVersionConflict(queued, nested, privatePackage.name);
-          } else {
+          if (!queued) {
             queuedPackages.set(nested.name, nested);
             packagesToProcess.push(nested);
+            continue;
+          }
+          if (privatePackages.has(nested.name)) {
+            // Already materialized (or selected): the requirement must admit that selection.
+            assertNoVersionConflict(queued, nested, privatePackage.name);
+          } else {
+            // Still queued: keep the NARROWER compatible requirement so discovery order cannot
+            // turn compatible constraints (e.g. `^1.0.0` and `1.2.3`) into a spurious conflict.
+            const narrower = narrowerCompatibleRequirement(queued, nested);
+            if (narrower === undefined) {
+              assertNoVersionConflict(queued, nested, privatePackage.name);
+            } else {
+              queued.versionSpecifier = narrower.versionSpecifier;
+            }
           }
         }
       }
@@ -253,7 +285,9 @@ async function collectNestedPrivatePackages(
         nested.sourceDirPath = findInstalledPackageDir(rootDirPath, nested.name);
         await copyInstalledPackage(rootDirPath, nested, nested.targetDirPath);
       } else {
-        nested.sourceDirPath = findInstalledRegistryPackageDir(rootDirPath, nested);
+        const installed = findInstalledRegistryPackage(rootDirPath, nested);
+        nested.sourceDirPath = installed?.dirPath;
+        nested.resolvedVersion = installed?.version;
         if (nested.sourceDirPath) {
           await copyInstalledPackage(rootDirPath, nested, toStagedPath(nested.targetDirPath));
         } else {
@@ -263,6 +297,7 @@ async function collectNestedPrivatePackages(
             nested.versionSpecifier ?? 'latest',
             toStagedPath(nested.targetDirPath)
           );
+          nested.resolvedVersion = readInstalledVersion(toStagedPath(nested.targetDirPath), nested.name);
           console.info(`Downloaded ${nested.name} (nested dependency) to ${nested.targetDirPath}`);
         }
       }
@@ -347,6 +382,16 @@ function assertNoVersionConflict(existing: PrivatePackage, requested: PrivatePac
   if (existing.kind === requested.kind) {
     if (existing.versionSpecifier === requested.versionSpecifier) return;
     if (specifierSubset(existing.versionSpecifier, requested.versionSpecifier)) return;
+    // Once the concrete materialized version is known (installed copy or extracted download), a
+    // requirement it satisfies is compatible even when the original specifiers are not subsets
+    // (e.g. `^1.0.0` resolved to 1.2.3 also satisfies a later exact `1.2.3`).
+    if (
+      existing.resolvedVersion !== undefined &&
+      requested.versionSpecifier !== undefined &&
+      installedVersionSatisfies(requested.versionSpecifier, existing.resolvedVersion)
+    ) {
+      return;
+    }
   }
 
   throw new Error(
@@ -414,32 +459,37 @@ function findInstalledPackageDir(rootDirPath: string, packageName: string): stri
  * deliberately receive no Verdaccio token) reuse it instead of downloading. Returns undefined
  * (falling back to a download) when no unambiguously correct installed copy exists.
  */
-function findInstalledRegistryPackageDir(rootDirPath: string, privatePackage: PrivatePackage): string | undefined {
+function findInstalledRegistryPackage(
+  rootDirPath: string,
+  privatePackage: PrivatePackage
+): { dirPath: string; version: string } | undefined {
   const specifier = privatePackage.versionSpecifier ?? 'latest';
   const relativeDirPath = path.join('node_modules', ...privatePackage.name.split('/'));
-  const addCandidate = (candidateDirPaths: Set<string>, dirPath: string): void => {
+  const addCandidate = (candidates: Map<string, string>, dirPath: string): void => {
     const version = readInstalledVersion(dirPath, privatePackage.name);
-    if (version && installedVersionSatisfies(specifier, version)) candidateDirPaths.add(fs.realpathSync(dirPath));
+    if (version && installedVersionSatisfies(specifier, version)) candidates.set(fs.realpathSync(dirPath), version);
   };
   // A root-level installation is THE lockfile resolution for the root dependency; the .bun store
   // is consulted only for transitive-only packages, where multiple satisfying resolutions may
   // coexist and picking one arbitrarily could materialize the wrong content.
-  const directCandidateDirPaths = new Set<string>();
-  addCandidate(directCandidateDirPaths, path.join(rootDirPath, relativeDirPath));
-  if (directCandidateDirPaths.size === 1) return [...directCandidateDirPaths][0];
+  const directCandidates = new Map<string, string>();
+  addCandidate(directCandidates, path.join(rootDirPath, relativeDirPath));
+  if (directCandidates.size === 1) return toSingleCandidate(directCandidates);
 
-  const storeCandidateDirPaths = new Set<string>();
+  const storeCandidates = new Map<string, string>();
   try {
     for (const dirent of fs.readdirSync(path.join(rootDirPath, 'node_modules', '.bun'), { withFileTypes: true })) {
-      addCandidate(
-        storeCandidateDirPaths,
-        path.join(rootDirPath, 'node_modules', '.bun', dirent.name, relativeDirPath)
-      );
+      addCandidate(storeCandidates, path.join(rootDirPath, 'node_modules', '.bun', dirent.name, relativeDirPath));
     }
   } catch {
     // No .bun store (hoisted install); fall back to downloading.
   }
-  return storeCandidateDirPaths.size === 1 ? [...storeCandidateDirPaths][0] : undefined;
+  return toSingleCandidate(storeCandidates);
+}
+
+function toSingleCandidate(candidates: Map<string, string>): { dirPath: string; version: string } | undefined {
+  const [entry] = candidates;
+  return candidates.size === 1 && entry ? { dirPath: entry[0], version: entry[1] } : undefined;
 }
 
 function readInstalledVersion(dirPath: string, packageName: string): string | undefined {
@@ -480,6 +530,7 @@ function findPrivateDependencies(
         name,
         kind: isGit ? 'git' : 'registry',
         sourceDirPath: undefined,
+        resolvedVersion: undefined,
         targetDirPath: path.join(isGit ? outDirPath : registryOutDirPath, unscopedName),
         // The full git specifier is preserved so divergent URLs/revisions (#abc vs #def) are
         // detected as conflicts instead of silently collapsing into one copied package.
@@ -499,15 +550,27 @@ function findPrivateDependencies(
  * range) — and fail loudly when the requirements genuinely diverge.
  */
 function mergeSameManifestRequirement(existing: PrivatePackage, requested: PrivatePackage): PrivatePackage {
-  if (existing.kind === requested.kind) {
-    if (existing.versionSpecifier === requested.versionSpecifier) return existing;
-    if (specifierSubset(existing.versionSpecifier, requested.versionSpecifier)) return existing;
-    if (specifierSubset(requested.versionSpecifier, existing.versionSpecifier)) return requested;
-  }
+  const narrower = narrowerCompatibleRequirement(existing, requested);
+  if (narrower) return narrower;
   throw new Error(
     `Conflicting requirements for ${existing.name} within one manifest: ` +
       `${existing.versionSpecifier ?? existing.kind} vs ${requested.versionSpecifier ?? requested.kind}.`
   );
+}
+
+/**
+ * The requirement whose max-satisfying resolution is guaranteed to satisfy the other (an exact
+ * pin is the narrowest range), or undefined when neither subsumes the other.
+ */
+function narrowerCompatibleRequirement(
+  existing: PrivatePackage,
+  requested: PrivatePackage
+): PrivatePackage | undefined {
+  if (existing.kind !== requested.kind) return undefined;
+  if (existing.versionSpecifier === requested.versionSpecifier) return existing;
+  if (specifierSubset(existing.versionSpecifier, requested.versionSpecifier)) return existing;
+  if (specifierSubset(requested.versionSpecifier, existing.versionSpecifier)) return requested;
+  return undefined;
 }
 
 async function replacePrivateDependencies(

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -214,6 +214,10 @@ async function collectPrivatePackages(
       privatePackage.sourceDirPath = installed?.dirPath;
       privatePackage.resolvedVersion = installed?.version;
     }
+    // Selected BEFORE the deep scan: a manifest inside the package may refer back to the package
+    // itself, and that requirement must be validated against the selection (assertNoVersionConflict
+    // below), never narrow the already-selected specifier.
+    privatePackages.set(privatePackage.name, privatePackage);
     // Nested private dependencies of an installed package are discoverable right away; registry
     // packages without a usable installed copy are inspected after download instead
     // (collectNestedPrivatePackages).
@@ -243,7 +247,6 @@ async function collectPrivatePackages(
         }
       }
     }
-    privatePackages.set(privatePackage.name, privatePackage);
   }
 
   return privatePackages;

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -55,15 +55,29 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       process.exit(1);
     }
 
-    // Every containment/overlap check below compares canonicalized paths: a symlink component
-    // (e.g. `escape -> node_modules`) would otherwise smuggle the recursive deletes past the
-    // lexical guards and destroy the symlink's target.
+    // Output paths are recursively DELETED before being recreated, so none of them may contain a
+    // symlink component: a symlink (e.g. `escape -> node_modules`, or `@willbooster-private`
+    // itself linking elsewhere) would either smuggle the delete past the lexical overlap guards
+    // or destroy the symlink's target. Rejecting canonical/lexical mismatches keeps every
+    // destructive operation on the intended lexical location.
     const rootDirPath = canonicalizePath(projects.root.dirPath);
-    const outDirPath = canonicalizePath(path.resolve(rootDirPath, argv.outDir));
+    const resolveOutputDirPath = (relativeOrAbsolutePath: string, label: string): string => {
+      const lexicalPath = path.resolve(rootDirPath, relativeOrAbsolutePath);
+      const canonicalPath = canonicalizePath(lexicalPath);
+      if (canonicalPath !== lexicalPath) {
+        console.error(chalk.red(`${label} must not contain symlinks (${lexicalPath} resolves to ${canonicalPath}).`));
+        process.exit(1);
+      }
+      return lexicalPath;
+    };
+    const outDirPath = resolveOutputDirPath(argv.outDir, '--out-dir');
     assertSubdirectory(rootDirPath, outDirPath);
     // Registry packages always materialize at the repository root: `wb optimizeForDockerBuild`
     // resolves them from `<root>/@willbooster-private` regardless of `--out-dir`.
-    const registryOutDirPath = canonicalizePath(path.join(rootDirPath, PRIVATE_REGISTRY_SCOPE));
+    const registryOutDirPath = resolveOutputDirPath(
+      PRIVATE_REGISTRY_SCOPE,
+      `The ${PRIVATE_REGISTRY_SCOPE} output directory`
+    );
     if (pathsOverlap(outDirPath, registryOutDirPath)) {
       // e.g. `--out-dir @willbooster-private` or `--out-dir @willbooster-private/sub`: the
       // registry step recursively deletes registryOutDirPath, which would destroy the git
@@ -71,7 +85,10 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       console.error(chalk.red(`--out-dir must not overlap the ${PRIVATE_REGISTRY_SCOPE} registry output directory.`));
       process.exit(1);
     }
-    const stagingDirPath = canonicalizePath(path.join(rootDirPath, '.tmp', 'wb-private-registry-staging'));
+    const stagingDirPath = resolveOutputDirPath(
+      path.join('.tmp', 'wb-private-registry-staging'),
+      'The staging directory'
+    );
     if (pathsOverlap(outDirPath, canonicalizePath(path.join(rootDirPath, 'node_modules')))) {
       // The recursive delete of outDirPath would destroy the installed sources the copies read.
       console.error(chalk.red('--out-dir must not overlap node_modules.'));

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -43,7 +43,7 @@ const builder = {
 export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, InferredOptionTypes<typeof builder>> = {
   command: 'setup-private-packages',
   describe:
-    'Materialize private dependencies for Docker builds: copy git dependencies and download @willbooster-private/* registry packages (auth via .npmrc / ~/.npmrc locally, or VERDACCIO_TOKEN on CI). ' +
+    'Materialize private dependencies for Docker builds: copy git dependencies, reuse installed @willbooster-private/* registry packages from node_modules, and download only the missing ones (auth via .npmrc / ~/.npmrc locally, or VERDACCIO_TOKEN on CI; not needed when every registry package is installed). ' +
     'The Dockerfile must COPY the generated directories (e.g. `COPY @willbooster/ @willbooster/` and `COPY @willbooster-private/ @willbooster-private/`) so the in-image install resolves the rewritten file: paths.',
   builder,
   async handler(argv) {
@@ -286,6 +286,12 @@ async function copyInstalledPackage(
   privatePackage: PrivatePackage,
   destinationDirPath: string
 ): Promise<void> {
+  // A registry package's tarball may legitimately contain node_modules/ content via
+  // bundledDependencies; those files are part of the artifact and must survive the copy. Git
+  // checkouts (and non-bundled names) still exclude node_modules, which holds locally installed
+  // dependencies there.
+  const bundledDependencyNames =
+    privatePackage.kind === 'registry' ? readBundledDependencyNames(privatePackage.sourceDirPath!) : [];
   await fs.promises.cp(privatePackage.sourceDirPath!, destinationDirPath, {
     recursive: true,
     force: true,
@@ -295,10 +301,39 @@ async function copyInstalledPackage(
     dereference: true,
     filter: (src) => {
       const segments = path.relative(privatePackage.sourceDirPath!, src).split(path.sep);
-      return !segments.includes('node_modules') && !segments.includes('.git');
+      if (segments.includes('.git')) return false;
+      const nodeModulesIndex = segments.indexOf('node_modules');
+      if (nodeModulesIndex === -1) return true;
+      if (bundledDependencyNames === true) return true;
+      if (bundledDependencyNames.length === 0) return false;
+      // The node_modules (and @scope) directories themselves must copy so bundled subtrees can;
+      // only the first node_modules level filters — anything inside a bundled subtree belongs to
+      // the artifact, including its own nested node_modules.
+      const [first, second] = segments.slice(nodeModulesIndex + 1);
+      if (first === undefined) return true;
+      if (first.startsWith('@') && second === undefined) {
+        return bundledDependencyNames.some((name) => name.startsWith(`${first}/`));
+      }
+      const packageName = first.startsWith('@') ? `${first}/${second}` : first;
+      return bundledDependencyNames.includes(packageName);
     },
   });
   console.info(`Copied ${privatePackage.name} to ${path.relative(rootDirPath, privatePackage.targetDirPath)}`);
+}
+
+/** Declared bundled dependency names of the installed package; `true` bundles every dependency. */
+function readBundledDependencyNames(sourceDirPath: string): string[] | true {
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(sourceDirPath, 'package.json'), 'utf8')) as {
+      bundleDependencies?: string[] | boolean;
+      bundledDependencies?: string[] | boolean;
+    };
+    const bundled = packageJson.bundleDependencies ?? packageJson.bundledDependencies;
+    if (bundled === true) return true;
+    return Array.isArray(bundled) ? bundled.filter((name) => typeof name === 'string') : [];
+  } catch {
+    return [];
+  }
 }
 
 /**

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -55,11 +55,15 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       process.exit(1);
     }
 
-    const outDirPath = path.resolve(projects.root.dirPath, argv.outDir);
-    assertSubdirectory(projects.root.dirPath, outDirPath);
+    // Every containment/overlap check below compares canonicalized paths: a symlink component
+    // (e.g. `escape -> node_modules`) would otherwise smuggle the recursive deletes past the
+    // lexical guards and destroy the symlink's target.
+    const rootDirPath = canonicalizePath(projects.root.dirPath);
+    const outDirPath = canonicalizePath(path.resolve(rootDirPath, argv.outDir));
+    assertSubdirectory(rootDirPath, outDirPath);
     // Registry packages always materialize at the repository root: `wb optimizeForDockerBuild`
     // resolves them from `<root>/@willbooster-private` regardless of `--out-dir`.
-    const registryOutDirPath = path.join(projects.root.dirPath, PRIVATE_REGISTRY_SCOPE);
+    const registryOutDirPath = canonicalizePath(path.join(rootDirPath, PRIVATE_REGISTRY_SCOPE));
     if (pathsOverlap(outDirPath, registryOutDirPath)) {
       // e.g. `--out-dir @willbooster-private` or `--out-dir @willbooster-private/sub`: the
       // registry step recursively deletes registryOutDirPath, which would destroy the git
@@ -67,8 +71,8 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       console.error(chalk.red(`--out-dir must not overlap the ${PRIVATE_REGISTRY_SCOPE} registry output directory.`));
       process.exit(1);
     }
-    const stagingDirPath = path.join(projects.root.dirPath, '.tmp', 'wb-private-registry-staging');
-    if (pathsOverlap(outDirPath, path.join(projects.root.dirPath, 'node_modules'))) {
+    const stagingDirPath = canonicalizePath(path.join(rootDirPath, '.tmp', 'wb-private-registry-staging'));
+    if (pathsOverlap(outDirPath, canonicalizePath(path.join(rootDirPath, 'node_modules')))) {
       // The recursive delete of outDirPath would destroy the installed sources the copies read.
       console.error(chalk.red('--out-dir must not overlap node_modules.'));
       process.exit(1);
@@ -79,7 +83,7 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       console.error(chalk.red(`--out-dir must not overlap the staging directory (${stagingDirPath}).`));
       process.exit(1);
     }
-    if (path.relative(projects.root.dirPath, outDirPath) !== '@willbooster') {
+    if (path.relative(rootDirPath, outDirPath) !== '@willbooster') {
       // Pre-existing limitation of the option: the Docker manifest rewrite has no access to it.
       console.warn(
         chalk.yellow(
@@ -88,7 +92,7 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       );
     }
     const privatePackages = await collectPrivatePackages(
-      projects.root.dirPath,
+      rootDirPath,
       projects.root.packageJson,
       outDirPath,
       registryOutDirPath
@@ -107,7 +111,7 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     const downloadedPackages = registryPackages.filter((p) => !p.sourceDirPath);
     // Resolve required configuration BEFORE deleting the existing materializations, so a missing
     // registry configuration cannot destroy a previously usable output tree.
-    const auth = downloadedPackages.length > 0 ? resolvePrivateRegistryAuth(projects.root.dirPath) : undefined;
+    const auth = downloadedPackages.length > 0 ? resolvePrivateRegistryAuth(rootDirPath) : undefined;
     if (downloadedPackages.length > 0 && !auth) {
       console.error(
         chalk.red(
@@ -124,7 +128,7 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     // and a missing source path fails the build.
     await fs.promises.mkdir(outDirPath, { recursive: true });
     for (const privatePackage of copiedPackages) {
-      await copyInstalledPackage(projects.root.dirPath, privatePackage, privatePackage.targetDirPath);
+      await copyInstalledPackage(rootDirPath, privatePackage, privatePackage.targetDirPath);
     }
 
     if (registryPackages.length > 0) {
@@ -137,11 +141,7 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       try {
         for (const privatePackage of registryPackages) {
           if (privatePackage.sourceDirPath) {
-            await copyInstalledPackage(
-              projects.root.dirPath,
-              privatePackage,
-              toStagedPath(privatePackage.targetDirPath)
-            );
+            await copyInstalledPackage(rootDirPath, privatePackage, toStagedPath(privatePackage.targetDirPath));
           } else {
             await downloadAndExtractRegistryPackage(
               // downloadedPackages is non-empty on this path, so the auth check above passed.
@@ -155,7 +155,7 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
               privatePackage.name
             );
             console.info(
-              `Downloaded ${privatePackage.name} to ${path.relative(projects.root.dirPath, privatePackage.targetDirPath)}`
+              `Downloaded ${privatePackage.name} to ${path.relative(rootDirPath, privatePackage.targetDirPath)}`
             );
           }
           // A downloaded package may itself depend on private packages that were not visible
@@ -163,7 +163,7 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
           // by collectPrivatePackages.
           if (!privatePackage.sourceDirPath) {
             await collectNestedPrivatePackages(
-              projects.root.dirPath,
+              rootDirPath,
               auth!,
               privatePackage,
               privatePackages,
@@ -184,9 +184,9 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       await fs.promises.mkdir(registryOutDirPath, { recursive: true });
     }
 
-    await replacePrivateDependencies(projects.root.dirPath, privatePackages);
+    await replacePrivateDependencies(rootDirPath, privatePackages);
     console.info(
-      `Ensure the Dockerfile COPYs ${path.relative(projects.root.dirPath, outDirPath)}/ and ${PRIVATE_REGISTRY_SCOPE}/ into the image before installing dependencies.`
+      `Ensure the Dockerfile COPYs ${path.relative(rootDirPath, outDirPath)}/ and ${PRIVATE_REGISTRY_SCOPE}/ into the image before installing dependencies.`
     );
   },
 };
@@ -415,6 +415,26 @@ function assertNoVersionConflict(existing: PrivatePackage, requested: PrivatePac
       `${existing.versionSpecifier ?? existing.kind} is already selected, but ${dependentName} requires ` +
       `${requested.versionSpecifier ?? requested.kind}. Only a single version per private package is supported.`
   );
+}
+
+/**
+ * Resolves symlinks in the deepest EXISTING ancestor of the path and reattaches the not-yet
+ * existing remainder, so lexical containment/overlap checks operate on physical locations.
+ */
+function canonicalizePath(targetPath: string): string {
+  let existingPath = path.resolve(targetPath);
+  const remainderSegments: string[] = [];
+  while (!fs.existsSync(existingPath)) {
+    const parentPath = path.dirname(existingPath);
+    if (parentPath === existingPath) break;
+    remainderSegments.unshift(path.basename(existingPath));
+    existingPath = parentPath;
+  }
+  try {
+    return path.join(fs.realpathSync(existingPath), ...remainderSegments);
+  } catch {
+    return path.resolve(targetPath);
+  }
 }
 
 /** Whether the two paths are equal or one contains the other. */

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -10,6 +10,7 @@ import type { PrivateRegistryAuth } from '../utils/privateRegistry.js';
 import {
   PRIVATE_REGISTRY_SCOPE,
   downloadAndExtractRegistryPackage,
+  installedVersionSatisfies,
   isPrivateGitDependency,
   isPrivateRegistryDependency,
   resolvePrivateRegistryAuth,
@@ -19,7 +20,11 @@ import {
 interface PrivatePackage {
   name: string;
   kind: 'git' | 'registry';
-  /** Undefined for registry packages, which are downloaded instead of copied. */
+  /**
+   * Undefined for registry packages that must be downloaded; set for git packages and for
+   * registry packages whose installed copy in node_modules already satisfies the specifier
+   * (so CI steps without registry credentials can still materialize them).
+   */
   sourceDirPath: string | undefined;
   targetDirPath: string;
   versionSpecifier: string | undefined;
@@ -82,13 +87,18 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
 
     const copiedPackages = [...privatePackages.values()].filter((p) => p.kind === 'git');
     const registryPackages = [...privatePackages.values()].filter((p) => p.kind === 'registry');
+    // Registry packages whose installed copy satisfies the specifier are copied from
+    // node_modules; only the rest are downloaded, so registry credentials are needed only when a
+    // download actually happens (CI test steps deliberately receive no Verdaccio token).
+    const downloadedPackages = registryPackages.filter((p) => !p.sourceDirPath);
     // Resolve required configuration BEFORE deleting the existing materializations, so a missing
     // registry configuration cannot destroy a previously usable output tree.
-    const auth = registryPackages.length > 0 ? resolvePrivateRegistryAuth(projects.root.dirPath) : undefined;
-    if (registryPackages.length > 0 && !auth) {
+    const auth = downloadedPackages.length > 0 ? resolvePrivateRegistryAuth(projects.root.dirPath) : undefined;
+    if (downloadedPackages.length > 0 && !auth) {
       console.error(
         chalk.red(
-          `No registry configured for the ${PRIVATE_REGISTRY_SCOPE} scope; add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc.`
+          `Cannot download ${downloadedPackages.map((p) => p.name).join(', ')}: no registry configured for the ${PRIVATE_REGISTRY_SCOPE} scope; ` +
+            `add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc (or run \`bun install\` first so the installed copies can be reused).`
         )
       );
       process.exit(1);
@@ -99,10 +109,10 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     // and a missing source path fails the build.
     await fs.promises.mkdir(outDirPath, { recursive: true });
     for (const privatePackage of copiedPackages) {
-      await copyGitPackage(projects.root.dirPath, privatePackage);
+      await copyInstalledPackage(projects.root.dirPath, privatePackage, privatePackage.targetDirPath);
     }
 
-    if (auth) {
+    if (registryPackages.length > 0) {
       // Download into a staging directory and swap it in only after every download succeeded, so
       // a failing registry/token/extraction cannot destroy the last usable materialization.
       const stagingDirPath = path.join(projects.root.dirPath, '.tmp', 'wb-private-registry-staging');
@@ -112,26 +122,38 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       await fs.promises.mkdir(stagingDirPath, { recursive: true });
       try {
         for (const privatePackage of registryPackages) {
-          await downloadAndExtractRegistryPackage(
-            auth,
-            privatePackage.name,
-            privatePackage.versionSpecifier ?? 'latest',
-            toStagedPath(privatePackage.targetDirPath)
-          );
-          console.info(
-            `Downloaded ${privatePackage.name} to ${path.relative(projects.root.dirPath, privatePackage.targetDirPath)}`
-          );
+          if (privatePackage.sourceDirPath) {
+            await copyInstalledPackage(
+              projects.root.dirPath,
+              privatePackage,
+              toStagedPath(privatePackage.targetDirPath)
+            );
+          } else {
+            await downloadAndExtractRegistryPackage(
+              // downloadedPackages is non-empty on this path, so the auth check above passed.
+              auth!,
+              privatePackage.name,
+              privatePackage.versionSpecifier ?? 'latest',
+              toStagedPath(privatePackage.targetDirPath)
+            );
+            console.info(
+              `Downloaded ${privatePackage.name} to ${path.relative(projects.root.dirPath, privatePackage.targetDirPath)}`
+            );
+          }
           // A downloaded package may itself depend on private packages that were not visible
-          // before extraction; materialize them too.
-          await collectNestedPrivatePackages(
-            projects.root.dirPath,
-            auth,
-            privatePackage,
-            privatePackages,
-            outDirPath,
-            registryOutDirPath,
-            toStagedPath
-          );
+          // before extraction; materialize them too. Installed copies were already deep-scanned
+          // by collectPrivatePackages.
+          if (!privatePackage.sourceDirPath) {
+            await collectNestedPrivatePackages(
+              projects.root.dirPath,
+              auth!,
+              privatePackage,
+              privatePackages,
+              outDirPath,
+              registryOutDirPath,
+              toStagedPath
+            );
+          }
         }
         await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
         await fs.promises.rename(stagingDirPath, registryOutDirPath);
@@ -167,10 +189,14 @@ async function collectPrivatePackages(
     if (!privatePackage) continue;
     if (privatePackages.has(privatePackage.name)) continue;
 
-    if (privatePackage.kind === 'git') {
-      privatePackage.sourceDirPath = findInstalledPackageDir(rootDirPath, privatePackage.name);
-      // Nested private dependencies of an installed git package are discoverable right away;
-      // registry packages are inspected after download instead (collectNestedPrivatePackages).
+    privatePackage.sourceDirPath =
+      privatePackage.kind === 'git'
+        ? findInstalledPackageDir(rootDirPath, privatePackage.name)
+        : findInstalledRegistryPackageDir(rootDirPath, privatePackage);
+    // Nested private dependencies of an installed package are discoverable right away; registry
+    // packages without a usable installed copy are inspected after download instead
+    // (collectNestedPrivatePackages).
+    if (privatePackage.sourceDirPath) {
       for (const packageJsonPath of await findPackageJsonPaths(privatePackage.sourceDirPath)) {
         const packageJson = await readPackageJson(packageJsonPath);
         for (const nested of findPrivateDependencies(packageJson, outDirPath, registryOutDirPath)) {
@@ -225,15 +251,20 @@ async function collectNestedPrivatePackages(
 
       if (nested.kind === 'git') {
         nested.sourceDirPath = findInstalledPackageDir(rootDirPath, nested.name);
-        await copyGitPackage(rootDirPath, nested);
+        await copyInstalledPackage(rootDirPath, nested, nested.targetDirPath);
       } else {
-        await downloadAndExtractRegistryPackage(
-          auth,
-          nested.name,
-          nested.versionSpecifier ?? 'latest',
-          toStagedPath(nested.targetDirPath)
-        );
-        console.info(`Downloaded ${nested.name} (nested dependency) to ${nested.targetDirPath}`);
+        nested.sourceDirPath = findInstalledRegistryPackageDir(rootDirPath, nested);
+        if (nested.sourceDirPath) {
+          await copyInstalledPackage(rootDirPath, nested, toStagedPath(nested.targetDirPath));
+        } else {
+          await downloadAndExtractRegistryPackage(
+            auth,
+            nested.name,
+            nested.versionSpecifier ?? 'latest',
+            toStagedPath(nested.targetDirPath)
+          );
+          console.info(`Downloaded ${nested.name} (nested dependency) to ${nested.targetDirPath}`);
+        }
       }
       privatePackages.set(nested.name, nested);
       await collectNestedPrivatePackages(
@@ -249,8 +280,13 @@ async function collectNestedPrivatePackages(
   }
 }
 
-async function copyGitPackage(rootDirPath: string, privatePackage: PrivatePackage): Promise<void> {
-  await fs.promises.cp(privatePackage.sourceDirPath!, privatePackage.targetDirPath, {
+/** `destinationDirPath` may differ from `targetDirPath` while registry packages stage. */
+async function copyInstalledPackage(
+  rootDirPath: string,
+  privatePackage: PrivatePackage,
+  destinationDirPath: string
+): Promise<void> {
+  await fs.promises.cp(privatePackage.sourceDirPath!, destinationDirPath, {
     recursive: true,
     force: true,
     // Bun's isolated linker exposes installed packages through symlinks; the materialized tree
@@ -335,6 +371,51 @@ function findInstalledPackageDir(rootDirPath: string, packageName: string): stri
     );
   }
   throw new Error(`Private package is not installed: ${packageName} (${directDirPath})`);
+}
+
+/**
+ * The installed materialization of a registry package, when its version is statically known to
+ * satisfy the specifier — steps without registry credentials (e.g. CI test steps, which
+ * deliberately receive no Verdaccio token) reuse it instead of downloading. Returns undefined
+ * (falling back to a download) when no unambiguously correct installed copy exists.
+ */
+function findInstalledRegistryPackageDir(rootDirPath: string, privatePackage: PrivatePackage): string | undefined {
+  const specifier = privatePackage.versionSpecifier ?? 'latest';
+  const relativeDirPath = path.join('node_modules', ...privatePackage.name.split('/'));
+  const addCandidate = (candidateDirPaths: Set<string>, dirPath: string): void => {
+    const version = readInstalledVersion(dirPath, privatePackage.name);
+    if (version && installedVersionSatisfies(specifier, version)) candidateDirPaths.add(fs.realpathSync(dirPath));
+  };
+  // A root-level installation is THE lockfile resolution for the root dependency; the .bun store
+  // is consulted only for transitive-only packages, where multiple satisfying resolutions may
+  // coexist and picking one arbitrarily could materialize the wrong content.
+  const directCandidateDirPaths = new Set<string>();
+  addCandidate(directCandidateDirPaths, path.join(rootDirPath, relativeDirPath));
+  if (directCandidateDirPaths.size === 1) return [...directCandidateDirPaths][0];
+
+  const storeCandidateDirPaths = new Set<string>();
+  try {
+    for (const dirent of fs.readdirSync(path.join(rootDirPath, 'node_modules', '.bun'), { withFileTypes: true })) {
+      addCandidate(
+        storeCandidateDirPaths,
+        path.join(rootDirPath, 'node_modules', '.bun', dirent.name, relativeDirPath)
+      );
+    }
+  } catch {
+    // No .bun store (hoisted install); fall back to downloading.
+  }
+  return storeCandidateDirPaths.size === 1 ? [...storeCandidateDirPaths][0] : undefined;
+}
+
+function readInstalledVersion(dirPath: string, packageName: string): string | undefined {
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(dirPath, 'package.json'), 'utf8')) as PackageJson;
+    return packageJson.name === packageName && typeof packageJson.version === 'string'
+      ? packageJson.version
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function findPrivateDependencies(
@@ -462,9 +543,11 @@ function printDryRunResult(outDirPath: string, privatePackages: Map<string, Priv
   console.info(`[dry-run] Would recreate ${outDirPath}`);
   for (const privatePackage of privatePackages.values()) {
     console.info(
-      privatePackage.kind === 'git'
-        ? `[dry-run] Would copy ${privatePackage.name}: ${privatePackage.sourceDirPath ?? '(installed under node_modules)'}`
-        : `[dry-run] Would download ${privatePackage.name}@${privatePackage.versionSpecifier} to ${privatePackage.targetDirPath}`
+      privatePackage.sourceDirPath
+        ? `[dry-run] Would copy ${privatePackage.name}: ${privatePackage.sourceDirPath}`
+        : privatePackage.kind === 'git'
+          ? `[dry-run] Would copy ${privatePackage.name}: (installed under node_modules)`
+          : `[dry-run] Would download ${privatePackage.name}@${privatePackage.versionSpecifier} to ${privatePackage.targetDirPath}`
     );
   }
   console.info(`[dry-run] Would rewrite copied private dependencies to file:../<name>`);

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -45,7 +45,7 @@ const builder = {
 export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, InferredOptionTypes<typeof builder>> = {
   command: 'setup-private-packages',
   describe:
-    'Materialize private dependencies for Docker builds: copy git dependencies, reuse installed @willbooster-private/* registry packages from node_modules, and download only the missing ones (auth via .npmrc / ~/.npmrc locally, or VERDACCIO_TOKEN on CI; not needed when every registry package is installed). ' +
+    'Materialize private dependencies for Docker builds: copy git dependencies, reuse installed @willbooster-private/* registry packages whose exact-version or semver-range specifier the installed copy satisfies, and download the rest (auth via .npmrc / ~/.npmrc locally, or VERDACCIO_TOKEN on CI; dist-tag specifiers such as `latest` always download). ' +
     'The Dockerfile must COPY the generated directories (e.g. `COPY @willbooster/ @willbooster/` and `COPY @willbooster-private/ @willbooster-private/`) so the in-image install resolves the rewritten file: paths.',
   builder,
   async handler(argv) {
@@ -112,7 +112,8 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
       console.error(
         chalk.red(
           `Cannot download ${downloadedPackages.map((p) => p.name).join(', ')}: no registry configured for the ${PRIVATE_REGISTRY_SCOPE} scope; ` +
-            `add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc (or run \`bun install\` first so the installed copies can be reused).`
+            `add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc. Only installed copies satisfying an exact version or ` +
+            'semver range are reused without registry access; dist-tag specifiers (e.g. `latest`) always require it.'
         )
       );
       process.exit(1);
@@ -275,9 +276,21 @@ async function collectNestedPrivatePackages(
     )) {
       const existing = privatePackages.get(nested.name);
       if (existing) {
-        // Collapsing different requested versions into one materialization would silently violate
-        // the dependent's requirement, so conflicts must fail loudly.
-        assertNoVersionConflict(existing, nested, extractedPackage.name);
+        if (existing.kind === 'registry' && !existing.sourceDirPath && existing.resolvedVersion === undefined) {
+          // Still awaiting its download (no installed copy selected, nothing extracted yet): keep
+          // the NARROWER compatible requirement, exactly as collectPrivatePackages does for
+          // queued packages, so late-discovered nested constraints cannot fabricate conflicts.
+          const narrower = narrowerCompatibleRequirement(existing, nested);
+          if (narrower === undefined) {
+            assertNoVersionConflict(existing, nested, extractedPackage.name);
+          } else {
+            existing.versionSpecifier = narrower.versionSpecifier;
+          }
+        } else {
+          // Collapsing different requested versions into one materialization would silently
+          // violate the dependent's requirement, so conflicts must fail loudly.
+          assertNoVersionConflict(existing, nested, extractedPackage.name);
+        }
         continue;
       }
 

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -242,6 +242,9 @@ export function isExactVersion(specifier: string | undefined): boolean {
  */
 export function specifierSubset(specifier: string | undefined, requirement: string | undefined): boolean {
   if (specifier === undefined || requirement === undefined) return false;
+  // `*` resolves through the `latest` dist-tag (selectVersionFromPackument), not as a range, so
+  // it is not statically comparable in either position.
+  if (specifier === '*' || requirement === '*') return false;
   // Build metadata distinguishes registry artifacts (resolveVersion fetches an exact specifier
   // verbatim) but semver comparisons ignore it, so two exact versions must match as strings.
   if (isExactVersion(specifier) && isExactVersion(requirement)) return specifier === requirement;
@@ -268,6 +271,9 @@ export function materializedVersionSatisfies(specifier: string, version: string)
  * a registry download, so uncertainty must fall back to downloading.
  */
 export function installedVersionSatisfies(specifier: string, version: string): boolean {
+  // `*` resolves through the `latest` dist-tag (selectVersionFromPackument), so like any other
+  // dist-tag it is not statically checkable against an installed version.
+  if (specifier === '*') return false;
   // resolveVersion fetches an exact specifier verbatim (build metadata included), so an installed
   // copy may replace the download only when the version strings match exactly.
   if (isExactVersion(specifier)) return specifier === version;

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -242,6 +242,9 @@ export function isExactVersion(specifier: string | undefined): boolean {
  */
 export function specifierSubset(specifier: string | undefined, requirement: string | undefined): boolean {
   if (specifier === undefined || requirement === undefined) return false;
+  // Build metadata distinguishes registry artifacts (resolveVersion fetches an exact specifier
+  // verbatim) but semver comparisons ignore it, so two exact versions must match as strings.
+  if (isExactVersion(specifier) && isExactVersion(requirement)) return specifier === requirement;
   if (!semver.validRange(specifier) || !semver.validRange(requirement)) return false;
   return semver.subset(specifier, requirement);
 }
@@ -251,6 +254,9 @@ export function specifierSubset(specifier: string | undefined, requirement: stri
  * Dist-tags (invalid ranges) are not statically checkable and pass.
  */
 export function materializedVersionSatisfies(specifier: string, version: string): boolean {
+  // Build metadata distinguishes registry artifacts, so an exact specifier admits only the
+  // identical version string.
+  if (isExactVersion(specifier)) return specifier === version;
   if (!semver.validRange(specifier)) return true;
   return semver.satisfies(version, specifier);
 }
@@ -262,5 +268,8 @@ export function materializedVersionSatisfies(specifier: string, version: string)
  * a registry download, so uncertainty must fall back to downloading.
  */
 export function installedVersionSatisfies(specifier: string, version: string): boolean {
+  // resolveVersion fetches an exact specifier verbatim (build metadata included), so an installed
+  // copy may replace the download only when the version strings match exactly.
+  if (isExactVersion(specifier)) return specifier === version;
   return !!semver.validRange(specifier) && semver.satisfies(version, specifier);
 }

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -254,3 +254,13 @@ export function materializedVersionSatisfies(specifier: string, version: string)
   if (!semver.validRange(specifier)) return true;
   return semver.satisfies(version, specifier);
 }
+
+/**
+ * Whether the installed `version` is statically KNOWN to satisfy the registry `specifier`.
+ * Dist-tags (invalid ranges) are not statically checkable and return false — unlike
+ * materializedVersionSatisfies, callers use this to decide whether an installed copy can replace
+ * a registry download, so uncertainty must fall back to downloading.
+ */
+export function installedVersionSatisfies(specifier: string, version: string): boolean {
+  return !!semver.validRange(specifier) && semver.satisfies(version, specifier);
+}

--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -17,6 +17,8 @@ import { fsUtil } from '../utils/fsUtil.js';
 // ~/.config/fnox/ci-age.txt and the FNOX_AGE_KEY repository secrets.
 export const FNOX_AGE_RECIPIENTS = [
   { name: 'exkazuu', publicKey: 'age1j2354xhvm3fv9y77t5g6y3q8mexgk2mf00tgrkzgp73tynrvz55s8auayw' },
+  { name: 'ponharu1', publicKey: 'age18rugldf9htc6um5eplpx27k53ep4zn0lhzwffgnxzhrq0c7zgvyq3zccdy' },
+  { name: 'ponharu2', publicKey: 'age1nz2n99crjr7np9xjglwfffc3dud45dhewqzqfzpztkdwu4hj74gq6el533' },
   { name: 'ci', publicKey: 'age1a2c6ef6ahl6mmkhgqtxg0mgtd7ysspntq7rxusv26efxhnuhlcdsr9dpak' },
 ];
 

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -847,10 +847,16 @@ function forEachCommandPositionToken(
   let functionNameFollows = false;
   // Between `case <subject> in` (or after `;;`) and the pattern's closing `)`, words are patterns
   // and a leading `(` is a delimiter, not a subshell.
-  let caseContext: 'none' | 'awaitingIn' | 'pattern' | 'body' = 'none';
+  type CaseContext = 'none' | 'awaitingIn' | 'pattern' | 'body';
+  let caseContext: CaseContext = 'none';
   // `$(...)` (and a subshell) opens a nested command context; on `)` the OUTER state must be
   // restored, or `echo $(date) yarn build` would treat the outer argument `yarn` as a command.
-  const outerStates: { atCommandPosition: boolean; inDataParens: boolean; functionCandidate: boolean }[] = [];
+  const outerStates: {
+    atCommandPosition: boolean;
+    inDataParens: boolean;
+    functionCandidate: boolean;
+    caseContext: CaseContext;
+  }[] = [];
   for (const [index, token] of tokens.entries()) {
     if (isShellSeparator(token.text)) {
       if (caseContext === 'body' && token.text.startsWith(';;')) {
@@ -862,7 +868,14 @@ function forEachCommandPositionToken(
       // Separator tokens are ASCII, so index-based iteration is safe.
       for (let charIndex = 0; charIndex < token.text.length; charIndex++) {
         const char = token.text[charIndex] ?? '';
-        if (caseContext === 'awaitingIn' || caseContext === 'pattern') {
+        // An ADJACENT `$(` opens a command substitution, whose content EXECUTES even where the
+        // surrounding context is data (a case subject/pattern, an array literal).
+        const opensSubstitution =
+          char === '(' &&
+          lastWordToken !== undefined &&
+          lastWordToken.text.endsWith('$') &&
+          lastWordToken.end === token.start + charIndex;
+        if ((caseContext === 'awaitingIn' || caseContext === 'pattern') && !opensSubstitution) {
           // Inside a pattern, `(` and `|` delimit alternatives and `)` starts the branch body.
           if (caseContext === 'pattern' && char === ')') {
             caseContext = 'body';
@@ -877,6 +890,7 @@ function forEachCommandPositionToken(
             inDataParens,
             // A word ending in `$` opens a substitution, never a function definition.
             functionCandidate: lastWordToken !== undefined && !lastWordToken.text.endsWith('$'),
+            caseContext,
           });
           // Only an ADJACENT `((` (one token, since separator tokens are same-char runs) is
           // arithmetic, and an ADJACENT `name=(` opens an array literal; a spaced `( (` is a
@@ -885,15 +899,19 @@ function forEachCommandPositionToken(
             charIndex > 0 ||
             (lastWordToken !== undefined &&
               lastWordToken.text.endsWith('=') &&
-              lastWordToken.end === token.start &&
+              lastWordToken.end === token.start + charIndex &&
               /^[A-Za-z_][+\w]*=$/u.test(lastWordToken.text))
           ) {
             inDataParens = true;
+          } else if (opensSubstitution) {
+            inDataParens = false;
           }
+          caseContext = 'none';
           atCommandPosition = true;
         } else if (char === ')') {
           const outerState = outerStates.pop();
           inDataParens = outerState?.inDataParens ?? false;
+          caseContext = outerState?.caseContext ?? 'none';
           // An empty `()` pair after a plain word is a function definition: its body follows in
           // command position, and its yarn invocations really run when the function is called.
           atCommandPosition =
@@ -986,7 +1004,9 @@ function tokenizeShellCommand(script: string): ShellToken[] {
       index++;
       continue;
     }
-    if (isShellSeparator(char)) {
+    // `&<` / `&>` starts a compound redirection, so the redirect branch below must win over the
+    // separator branch: isShellSeparator('&') is true.
+    if (isShellSeparator(char) && !(char === '&' && /^[<>]$/u.test(script[index + 1] ?? ''))) {
       let end = index + 1;
       while (end < script.length && script[end] === char) end++;
       tokens.push({ text: script.slice(index, end), start: index, end });

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1004,9 +1004,10 @@ function tokenizeShellCommand(script: string): ShellToken[] {
       index++;
       continue;
     }
-    // `&<` / `&>` starts a compound redirection, so the redirect branch below must win over the
-    // separator branch: isShellSeparator('&') is true.
-    if (isShellSeparator(char) && !(char === '&' && /^[<>]$/u.test(script[index + 1] ?? ''))) {
+    // `&>` starts a compound redirection (`&<` does not exist: shells parse it as `&` then `<`),
+    // so the redirect branch below must win over the separator branch: isShellSeparator('&') is
+    // true.
+    if (isShellSeparator(char) && !(char === '&' && script[index + 1] === '>')) {
       let end = index + 1;
       while (end < script.length && script[end] === char) end++;
       tokens.push({ text: script.slice(index, end), start: index, end });
@@ -1026,7 +1027,7 @@ function tokenizeShellCommand(script: string): ShellToken[] {
     // token streams are rejected by every caller before interpretation. Compound forms — the
     // `&>file` both-streams shorthand, the `>|` clobber operator, and `>&`/`>&1`-style
     // duplications — belong to the operator token, or their `&`/`|` would read as a separator.
-    if (char === '<' || char === '>' || (char === '&' && /^[<>]$/u.test(script[index + 1] ?? ''))) {
+    if (char === '<' || char === '>' || (char === '&' && script[index + 1] === '>')) {
       let end = char === '&' ? index + 1 : index;
       while (end < script.length && (script[end] === '<' || script[end] === '>')) end++;
       if (script[end] === '&') {

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -862,7 +862,14 @@ function forEachCommandPositionToken(
   }[] = [];
   for (const [index, token] of tokens.entries()) {
     if (isShellSeparator(token.text)) {
-      if (caseContext === 'body' && token.text.startsWith(';;')) {
+      // All three case-clause terminators return to pattern context: `;;`, `;;&` (whose `&`
+      // arrives as a separate token startsWith(';;') already covers), and `;&`, which tokenizes
+      // as `;` plus an ADJACENT `&` (same-char runs are one token each).
+      if (
+        caseContext === 'body' &&
+        (token.text.startsWith(';;') ||
+          (token.text === ';' && tokens[index + 1]?.text === '&' && tokens[index + 1]?.start === token.end))
+      ) {
         caseContext = 'pattern';
         redirectionOperandFollows = false;
         previousSeparatorChar = undefined;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -849,6 +849,9 @@ function forEachCommandPositionToken(
   // and a leading `(` is a delimiter, not a subshell.
   type CaseContext = 'none' | 'awaitingIn' | 'pattern' | 'body';
   let caseContext: CaseContext = 'none';
+  // `case` statements nest (a branch body may contain another `case`); each `esac` must restore
+  // the ENCLOSING statement's context, or a later outer pattern would be scanned as executable.
+  const enclosingCaseContexts: CaseContext[] = [];
   // `$(...)` (and a subshell) opens a nested command context; on `)` the OUTER state must be
   // restored, or `echo $(date) yarn build` would treat the outer argument `yarn` as a command.
   const outerStates: {
@@ -868,13 +871,15 @@ function forEachCommandPositionToken(
       // Separator tokens are ASCII, so index-based iteration is safe.
       for (let charIndex = 0; charIndex < token.text.length; charIndex++) {
         const char = token.text[charIndex] ?? '';
-        // An ADJACENT `$(` opens a command substitution, whose content EXECUTES even where the
-        // surrounding context is data (a case subject/pattern, an array literal).
+        // An ADJACENT `$(` opens a command substitution and an ADJACENT `<(`/`>(` opens a process
+        // substitution; both EXECUTE their content even where the surrounding context is data (a
+        // case subject/pattern, an array literal). Redirect operators become lastWordToken too,
+        // so `<`/`>` adjacency is checked the same way.
         const opensSubstitution =
           char === '(' &&
           lastWordToken !== undefined &&
-          lastWordToken.text.endsWith('$') &&
-          lastWordToken.end === token.start + charIndex;
+          lastWordToken.end === token.start + charIndex &&
+          (lastWordToken.text.endsWith('$') || lastWordToken.text === '<' || lastWordToken.text === '>');
         if ((caseContext === 'awaitingIn' || caseContext === 'pattern') && !opensSubstitution) {
           // Inside a pattern, `(` and `|` delimit alternatives and `)` starts the branch body.
           if (caseContext === 'pattern' && char === ')') {
@@ -888,8 +893,8 @@ function forEachCommandPositionToken(
           outerStates.push({
             atCommandPosition,
             inDataParens,
-            // A word ending in `$` opens a substitution, never a function definition.
-            functionCandidate: lastWordToken !== undefined && !lastWordToken.text.endsWith('$'),
+            // A word opening a command or process substitution never declares a function.
+            functionCandidate: lastWordToken !== undefined && !opensSubstitution,
             caseContext,
           });
           // Only an ADJACENT `((` (one token, since separator tokens are same-char runs) is
@@ -936,7 +941,7 @@ function forEachCommandPositionToken(
     }
     if (caseContext === 'pattern') {
       // A branch-less `esac` (e.g. right after `;;`) ends the case statement.
-      if (token.text === 'esac') caseContext = 'none';
+      if (token.text === 'esac') caseContext = enclosingCaseContexts.pop() ?? 'none';
       continue;
     }
     if (inDataParens) continue;
@@ -955,11 +960,12 @@ function forEachCommandPositionToken(
       continue;
     }
     if (token.text === 'case') {
+      enclosingCaseContexts.push(caseContext);
       caseContext = 'awaitingIn';
       continue;
     }
     if (caseContext === 'body' && token.text === 'esac') {
-      caseContext = 'none';
+      caseContext = enclosingCaseContexts.pop() ?? 'none';
       atCommandPosition = false;
       continue;
     }

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1509,6 +1509,9 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       'array-subst': 'args=($(yarn list-args))',
       'case-pat': 'case "$r" in (yarn) yarn compile;; esac',
       'case-subst': 'case $(yarn kind) in x) echo matched;; esac',
+      'nested-case': 'case x in x) case y in y) yarn inner;; esac;; yarn) yarn compile;; esac',
+      'proc-subst-array': 'args=(<(yarn list-args)); echo done',
+      'proc-subst-case': 'case <(yarn kind) in x) echo matched;; esac',
       clobber: 'echo hi >| yarn && yarn compile',
       commented: 'echo ready # note; yarn compile',
       'env-opt': 'env -i yarn compile && 2>&1 yarn compile',
@@ -1587,9 +1590,14 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     'in-subst': 'echo $(bun run compile)',
     // `case` patterns (parenthesized or not) are data, while the branch bodies convert.
     'case-pat': 'case "$r" in (yarn) bun run compile;; esac',
-    // A `$(...)` substitution EXECUTES even inside data contexts (case subjects, array literals).
+    // A `$(...)` substitution EXECUTES even inside data contexts (case subjects, array literals),
+    // and so do `<(...)`/`>(...)` process substitutions.
     'array-subst': 'args=($(bun run list-args))',
     'case-subst': 'case $(bun run kind) in x) echo matched;; esac',
+    'proc-subst-array': 'args=(<(bun run list-args)); echo done',
+    'proc-subst-case': 'case <(bun run kind) in x) echo matched;; esac',
+    // An inner `esac` restores the ENCLOSING case context: the outer `yarn)` is still a pattern.
+    'nested-case': 'case x in x) case y in y) bun run inner;; esac;; yarn) bun run compile;; esac',
     // `<<` inside an arithmetic expansion is a left shift, not a heredoc.
     shift: 'echo $((1 << 2)) && bun run compile',
     // Only a real unquoted heredoc operator suppresses conversion, not quoted `<<` data.

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1502,6 +1502,7 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       'deps-up': 'yarn up -R typescript',
       dollar: "yarn 'build:$target'",
       dynamic: 'yarn build:$target && yarn run "build:$target"',
+      'amp-input': 'true &</dev/null yarn compile',
       'amp-redirect': 'node report.js &>logs/yarn.log yarn compile',
       arith: 'echo $((yarn && 1))',
       'array-lit': 'args=(yarn compile); echo done',
@@ -1596,6 +1597,8 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     redirect: 'bun run build>out.log',
     // A redirection before the command leaves it in command position.
     'redirect-first': '>build.log bun run compile',
+    // `&<` is not a compound redirection: it parses as `&` (background) followed by `<`.
+    'amp-input': 'true &</dev/null bun run compile',
     // The legacy `yarn install && ` prefix is removed before conversion, quoted or not.
     'quoted-install': 'bun run compile',
     'setup-all': 'bun run compile',

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1502,9 +1502,12 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       'deps-up': 'yarn up -R typescript',
       dollar: "yarn 'build:$target'",
       dynamic: 'yarn build:$target && yarn run "build:$target"',
+      'amp-redirect': 'node report.js &>logs/yarn.log yarn compile',
       arith: 'echo $((yarn && 1))',
       'array-lit': 'args=(yarn compile); echo done',
+      'array-subst': 'args=($(yarn list-args))',
       'case-pat': 'case "$r" in (yarn) yarn compile;; esac',
+      'case-subst': 'case $(yarn kind) in x) echo matched;; esac',
       clobber: 'echo hi >| yarn && yarn compile',
       commented: 'echo ready # note; yarn compile',
       'env-opt': 'env -i yarn compile && 2>&1 yarn compile',
@@ -1546,6 +1549,7 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     // `yarn` inside a quoted token, in argument position, after a value-taking wrapper option,
     // after a command substitution, inside an arithmetic expansion, as a redirection operand, as
     // a quoted command word's argument, or inside a comment is data, not a command.
+    'amp-redirect': 'node report.js &>logs/yarn.log yarn compile',
     arith: 'echo $((yarn && 1))',
     'array-lit': 'args=(yarn compile); echo done',
     commented: 'echo ready # note; yarn compile',
@@ -1582,6 +1586,9 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     'in-subst': 'echo $(bun run compile)',
     // `case` patterns (parenthesized or not) are data, while the branch bodies convert.
     'case-pat': 'case "$r" in (yarn) bun run compile;; esac',
+    // A `$(...)` substitution EXECUTES even inside data contexts (case subjects, array literals).
+    'array-subst': 'args=($(bun run list-args))',
+    'case-subst': 'case $(bun run kind) in x) echo matched;; esac',
     // `<<` inside an arithmetic expansion is a left shift, not a heredoc.
     shift: 'echo $((1 << 2)) && bun run compile',
     // Only a real unquoted heredoc operator suppresses conversion, not quoted `<<` data.

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -1509,6 +1509,8 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
       'array-subst': 'args=($(yarn list-args))',
       'case-pat': 'case "$r" in (yarn) yarn compile;; esac',
       'case-subst': 'case $(yarn kind) in x) echo matched;; esac',
+      'case-fallthrough': 'case x in x) yarn one ;& yarn|npm) yarn compile;; esac',
+      'case-testnext': 'case x in x) yarn one ;;& yarn) yarn two;; esac',
       'nested-case': 'case x in x) case y in y) yarn inner;; esac;; yarn) yarn compile;; esac',
       'proc-subst-array': 'args=(<(yarn list-args)); echo done',
       'proc-subst-case': 'case <(yarn kind) in x) echo matched;; esac',
@@ -1598,6 +1600,9 @@ test('converts yarn script invocations to bun while leaving Yarn built-ins untou
     'proc-subst-case': 'case <(bun run kind) in x) echo matched;; esac',
     // An inner `esac` restores the ENCLOSING case context: the outer `yarn)` is still a pattern.
     'nested-case': 'case x in x) case y in y) bun run inner;; esac;; yarn) bun run compile;; esac',
+    // `;&` and `;;&` also terminate a case clause: what follows is a pattern, not a command.
+    'case-fallthrough': 'case x in x) bun run one ;& yarn|npm) bun run compile;; esac',
+    'case-testnext': 'case x in x) bun run one ;;& yarn) bun run two;; esac',
     // `<<` inside an arithmetic expansion is a left shift, not a heredoc.
     shift: 'echo $((1 << 2)) && bun run compile',
     // Only a real unquoted heredoc operator suppresses conversion, not quoted `<<` data.


### PR DESCRIPTION
## Customer Summary

- `wb setup-private-packages` now works in environments without private-registry credentials (e.g. CI test steps) as long as the private packages are already installed, so repositories like ai-ocr can drop their custom workaround scripts.
- Repositories managed by wbfy now encrypt fnox secrets for ponharu's two machines in addition to existing recipients.
- The yarn→bun script conversion handles more shell edge cases correctly, and unsafe `--out-dir` values can no longer delete unrelated directories.

## Technical Summary

- `wb setup-private-packages`: registry packages whose installed copy in `node_modules` (root or `.bun` store) satisfies an exact-version or semver-range specifier are copied (dereferencing isolated-linker symlinks, preserving `bundledDependencies` subtrees) instead of downloaded; registry auth is resolved and required only when a download remains (dist-tag specifiers, including `*`, always download). Nested private dependencies of installed copies are deep-scanned eagerly; compatible version requirements merge order-independently (narrower requirement wins while queued, and requirements satisfied by the selected materialization's actual version are accepted); packages are marked selected before their manifests are deep-scanned so self-references validate against the selection.
- Safety: `--out-dir` must not overlap `@willbooster-private`, `node_modules`, or the staging directory, and every recursively deleted output path is rejected if it contains a symlink component (canonical/lexical mismatch).
- Version comparisons: exact versions compare as strings (build metadata distinguishes registry artifacts) in `installedVersionSatisfies`, `specifierSubset`, and `materializedVersionSatisfies`.
- `wbfy` fnox recipients: added ponharu's two age public keys; the next wbfy run on each repository re-encrypts committed secrets for the new recipient set.
- Yarn conversion scan: nested `case` statements restore the enclosing context at `esac`; `;&` and `;;&` clause terminators return to pattern context; `<(`/`>(` process substitutions and `$(...)` command substitutions execute even in data contexts; `&<` tokenizes as `&` + `<` (only `&>`/`&>>` are compound redirects).
- Docs: CLI help and README describe the credential-free reuse and its dist-tag limitation.

## Why

- ai-ocr could not use `bun wb setup-private-packages` on CI because its test step deliberately receives no Verdaccio token; the packages are already installed there, so downloading was an unnecessary hard requirement (workaround: a hand-written copy script in the repo).
- ponharu's machines must be able to decrypt fnox-managed secrets across WillBooster repositories.
- The yarn-scan fixes complete and harden the quote-aware conversion work from #1017 (#1019/#1021), covering findings from an 8-round multi-agent review.

## Testing

- `bun verify` (type check + lint) passes; `bun run test` in `packages/wb` (171 tests) and `packages/wbfy` (210 tests) passes.
- Manually verified against ai-ocr: `bun wb setup-private-packages` with no `VERDACCIO_TOKEN` copies `@willbooster-private/llm-proxy@5.38.1` from the isolated-install store without contacting the registry.
- CLI fixtures verified: bundled-dependency preservation, order-independent compatible constraints (including late-discovered nested ones via a local HTTP registry), genuine conflicts still failing, `*`/dist-tag specifiers requiring registry access, self-referencing manifests validating against the selection, and symlinked/overlapping output paths being rejected while defaults succeed.
- Multi-agent review (`skills review`, run 20260719-182356-7csa1d) converged to "No concern." after 8 rounds; CI on this PR is green.
