### PR TITLE
fix(wbfy): order README badges as workflows, semantic-release, then wbfy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # shared
 
-[![wbfy](https://img.shields.io/badge/wbfy-5266453e--local-1e90ff.svg)](https://github.com/WillBooster/shared/tree/main/packages/wbfy)
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Test](https://github.com/WillBooster/shared/actions/workflows/test.yml/badge.svg)](https://github.com/WillBooster/shared/actions/workflows/test.yml)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![wbfy](https://img.shields.io/badge/wbfy-827422f4--local-1e90ff.svg)](https://github.com/WillBooster/shared/tree/main/packages/wbfy)
 
 :recycle: An npm package designed for reusing general code across multiple projects at WillBooster Inc.

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -46,9 +46,11 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
       (await fsUtil.readFileIfExists(filePath)) ??
       `# ${config.packageJson?.name ?? path.basename(path.resolve(config.dirPath))}\n`;
 
-    const badges = [buildWbfyBadge(getWbfyVersionLabel() ?? 'applied')];
+    // Ordered by what a reader cares about most: the workflow badges report whether the code is
+    // currently healthy, then how it is released, and last the wbfy build that configured it.
+    const badges = await buildWorkflowBadges(config);
     if (fs.existsSync(path.resolve(config.dirPath, '.releaserc.json'))) badges.push(semanticReleaseBadge);
-    badges.push(...(await buildWorkflowBadges(config)));
+    badges.push(buildWbfyBadge(getWbfyVersionLabel() ?? 'applied'));
 
     // The block is written in one pass from the badges wbfy manages right now. A badge that is no
     // longer wanted — a superseded version, or one whose workflow is gone — simply is not in the

--- a/packages/wbfy/test/readme.test.ts
+++ b/packages/wbfy/test/readme.test.ts
@@ -57,15 +57,19 @@ test('stamps the released version and stays idempotent', async () => {
   });
 });
 
-test('stays idempotent with a second badge in the block', async () => {
+test('orders the block as workflows, semantic-release, then wbfy', async () => {
   await withTempDir(async (dirPath) => {
-    // The wbfy badge is inserted first, so any other badge pushes it against the body — the case
-    // where an emptied badge line used to leave a blank line behind and grow the file on every run.
+    const workflowsPath = path.resolve(dirPath, '.github', 'workflows');
+    fs.mkdirSync(workflowsPath, { recursive: true });
+    fs.writeFileSync(path.resolve(workflowsPath, 'test.yml'), 'name: test\n');
     fs.writeFileSync(path.resolve(dirPath, '.releaserc.json'), '{}\n');
     fs.writeFileSync(path.resolve(dirPath, 'README.md'), '# Project\n\nBody text.\n');
 
     const firstContent = await runGenerateReadme(dirPath, '1.2.3');
-    expect(firstContent).toContain('semantic-release');
+    expect(firstContent).toBe(
+      `# Project\n\n[![Test](https://github.com/WillBooster/example/actions/workflows/test.yml/badge.svg)](https://github.com/WillBooster/example/actions/workflows/test.yml)\n[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)\n${badgeOf('1.2.3')}\n\nBody text.\n`
+    );
+    // Rewriting the whole block means the order is re-established on every run, not just the first.
     expect(await runGenerateReadme(dirPath, '1.2.3')).toBe(firstContent);
     expect(await runGenerateReadme(dirPath, '1.2.3')).toBe(firstContent);
   });


### PR DESCRIPTION
## Customer Summary

- README のバッジの並び順を `Test` → `semantic-release` → `wbfy` に変更しました。左から順に「今このコードが健全か」「どうリリースされるか」「どの wbfy が設定したか」という関心の強い順になります。
- #1025 でバッジブロックを 1 パスで書く方式にした際、wbfy 自身の生成順がそのまま並び順になり、`wbfy` が先頭に来ていました。これを本来の順序に戻します。

## Technical Summary

- `packages/wbfy/src/generators/readme.ts`: `generateReadme` がバッジ配列を組み立てる順序を、ワークフロー → semantic-release → wbfy に変更。
- `packages/wbfy/test/readme.test.ts`: 並び順を検証するテストを追加。ブロック全体を完全一致で検証し、かつ **2 回目・3 回目の実行でも同じ順序が再現される**ことを確認します（毎回ブロックを書き直す方式なので、初回だけでなく常に順序が確定します）。
- `README.md`: 本リポジトリに `wbfy` を適用し、新しい順序を反映。

## Why

- #1025 の実装変更に伴う副作用としての並べ替えであり、意図した仕様ではありませんでした。

## Testing

- `bunx vitest run`（`packages/wbfy`）— 22 ファイル 256 テスト通過。
- `bun verify`（型チェック・lint）— 通過。
- コード変更をコミットして作業ツリーを clean にしてから `bun start <repo root>` を実行。バッジラベルが `827422f4-local`（`-dirty-local` ではない）になり、並び順が `Test` → `semantic-release` → `wbfy` になることを確認しました。

## Notes

- 破壊的変更はありません。README 本文は変更されていません。
