### PR TITLE
chore: apply wbfy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Test](https://github.com/WillBooster/shared/actions/workflows/test.yml/badge.svg)](https://github.com/WillBooster/shared/actions/workflows/test.yml)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-[![wbfy](https://img.shields.io/badge/wbfy-827422f4--local-1e90ff.svg)](https://github.com/WillBooster/shared/tree/main/packages/wbfy)
+[![wbfy](https://img.shields.io/badge/wbfy-6c3be35b--local-1e90ff.svg)](https://github.com/WillBooster/shared/tree/main/packages/wbfy)
 
 :recycle: An npm package designed for reusing general code across multiple projects at WillBooster Inc.


### PR DESCRIPTION
## Customer Summary

- 本リポジトリに `wbfy` を適用し、README の wbfy バッジのラベルを現在の `main` のコミット（`6c3be35b`）に更新しました。
- #1030 で決めたバッジの並び順（`Test` → `semantic-release` → `wbfy`）はそのままです。

## Technical Summary

- `README.md`: wbfy バッジのラベルを `827422f4-local` → `6c3be35b-local` に更新。差分はこの 1 行のみです。

## Why

- #1030 で並び順を変更した際、その適用時点（`827422f4`）のラベルが README に残っていました。`main` にマージされた現在のコミットを指すよう更新します。

## Testing

- clean な `main` から `bun start <repo root>` を実行し、**バッジのラベル 1 行のみ**が変わり、並び順・README 本文・その他のファイルは一切変わらないことを確認しました。
- 続けてもう一度 `bun start` を実行し、README がバイト単位で不変であることを確認（冪等性）。
- この 2 回目の実行時、作業ツリーは 1 回目の README 変更により dirty でしたが、ラベルは `6c3be35b-local` のままで `-dirty-local` にはなりませんでした。dirty 判定を `packages/*/src` と `packages/*/bin` に限定した設計が意図どおり機能しています。
- `bun verify`（型チェック・lint）— 通過。

## Notes

- 破壊的変更はありません。
