### PR TITLE
feat(wbfy): add remin age public key to fnox recipients

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,8 +13,8 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           check-latest: true
           node-version: lts/*

--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -20,6 +20,7 @@ export const FNOX_AGE_RECIPIENTS = [
   { name: 'ponharu1', publicKey: 'age18rugldf9htc6um5eplpx27k53ep4zn0lhzwffgnxzhrq0c7zgvyq3zccdy' },
   { name: 'ponharu2', publicKey: 'age1nz2n99crjr7np9xjglwfffc3dud45dhewqzqfzpztkdwu4hj74gq6el533' },
   { name: 'ci', publicKey: 'age1a2c6ef6ahl6mmkhgqtxg0mgtd7ysspntq7rxusv26efxhnuhlcdsr9dpak' },
+  { name: 'remin', publicKey: 'age1mw4pz9dujy9dmhk0palqawjkj7m4k7zx78yr9fjt63sa5l3e43uq6nw004' },
 ];
 
 interface FnoxToml {


### PR DESCRIPTION
## Summary

- Add `remin`'s age public key (`age1mw4pz9dujy9dmhk0palqawjkj7m4k7zx78yr9fjt63sa5l3e43uq6nw004`) to `FNOX_AGE_RECIPIENTS` in `packages/wbfy/src/generators/fnoxToml.ts`, so the next `wbfy` run on each fnox-managed repository grants `remin` decryption access.
- Apply `wbfy` to this repository to verify the change runs cleanly (only an `autofix.yml` GitHub Actions version bump resulted).

## Test plan

- `bun verify` passes (type check + lint).
- `wbfy` ran against this repo without errors.
