### PR TITLE
fix(wbfy): prepare fnox-aware public autofix jobs

### DIFF
--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -61,6 +61,7 @@ interface Types {
 
 interface Job {
   'runs-on'?: string;
+  env?: Record<string, string>;
   permissions?: Record<string, string>;
   steps?: Step[];
   uses?: string;
@@ -1125,14 +1126,12 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
 }
 
 function generateAutofixWorkflow(config: PackageConfig): Workflow {
-  // No fnox setup or FNOX_AGE_KEY here on purpose: autofix only runs cleanup/build (never app
-  // code needing secrets), it has never received DOT_ENV either, and public-repo autofix runs on
-  // fork PRs where exposing a decryption secret would be unsafe. wb degrades gracefully (warns
-  // and proceeds without fnox variables) when fnox is unavailable.
+  // No FNOX_AGE_KEY here on purpose: public-repo autofix runs on fork PRs where exposing a
+  // decryption secret would be unsafe. mise still installs fnox so plaintext defaults load, and
+  // WB_ENV satisfies wb's CI environment guard while encrypted values remain unavailable.
   const steps: Step[] = [
     { uses: 'actions/checkout@v7' },
-    { uses: 'actions/setup-node@v7', with: { 'check-latest': true, 'node-version': 'lts/*' } },
-    { uses: 'oven-sh/setup-bun@v2', with: { 'bun-version': 'latest' } },
+    { uses: 'jdx/mise-action@v4.2.0', with: { cache: true } },
     { run: 'bun install' },
     { run: 'bun run cleanup' },
   ];
@@ -1143,7 +1142,7 @@ function generateAutofixWorkflow(config: PackageConfig): Workflow {
 
   const autofixWorkflow = structuredClone(publicRepoAutofixWorkflow);
   const autofixJob = autofixWorkflow.jobs.autofix ?? { 'runs-on': 'ubuntu-latest' };
-  autofixWorkflow.jobs.autofix = { ...autofixJob, steps };
+  autofixWorkflow.jobs.autofix = { ...autofixJob, env: { WB_ENV: 'development' }, steps };
   return autofixWorkflow;
 }
 

--- a/packages/wbfy/test/autofixWorkflow.test.ts
+++ b/packages/wbfy/test/autofixWorkflow.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { load as loadYaml } from 'js-yaml';
+import { expect, test } from 'vitest';
+
+import { generateWorkflows } from '../src/generators/workflow.js';
+import { promisePool } from '../src/utils/promisePool.js';
+import { createConfig } from './testConfig.js';
+
+test('generates a public autofix workflow that can run wb with fnox on CI', async () => {
+  const tempRootPath = path.join(process.cwd(), '.tmp');
+  await fs.promises.mkdir(tempRootPath, { recursive: true });
+  const dirPath = await fs.promises.mkdtemp(path.join(tempRootPath, 'wbfy-autofix-'));
+  try {
+    await fs.promises.mkdir(path.join(dirPath, '.github', 'workflows'), { recursive: true });
+    const config = createConfig({
+      dirPath,
+      isRoot: true,
+      packageJson: { scripts: { build: 'wb build' } },
+    });
+    await generateWorkflows(config);
+    await promisePool.promiseAll();
+
+    const content = await fs.promises.readFile(path.join(dirPath, '.github', 'workflows', 'autofix.yml'), 'utf8');
+    const workflow = loadYaml(content) as { jobs: { autofix: { env?: Record<string, string>; steps?: unknown[] } } };
+    expect(workflow.jobs.autofix.env).toEqual({ WB_ENV: 'development' });
+    expect(workflow.jobs.autofix.steps).toContainEqual({ uses: 'jdx/mise-action@v4.2.0', with: { cache: true } });
+  } finally {
+    await fs.promises.rm(dirPath, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Customer Summary

- Prevents wbfy-generated public autofix workflows from failing after a repository migrates to fnox and wb 15.
- Keeps fork pull requests safe by continuing not to expose the fnox age decryption key.

## Technical Summary

- Replaces separate Node/Bun setup in public autofix workflows with `jdx/mise-action`, which installs the repository-pinned Node, Bun, and fnox tools.
- Exports `WB_ENV=development` at the autofix job level to satisfy wb 15's CI environment guard.
- Adds an integration test that generates and parses the actual autofix YAML.

## Why

- build-ts PR #676 reproduced the generated workflow failure: fnox was unavailable and wb 15 rejected the missing CI `WB_ENV` during `bun run build`.
- A target-repository hand edit would be overwritten because wbfy owns `autofix.yml` wholesale.

## Testing

- `bun --cwd packages/wbfy vitest run test/autofixWorkflow.test.ts --watch=false`
- `bun --cwd packages/wbfy verify-full`
- Applied the generated workflow to build-ts PR #676 and confirmed all GitHub Actions workflows passed.
