### PR TITLE
fix(wbfy): point Renovate preset to renamed renovate.jsonc (#1034)

### DIFF
--- a/packages/wbfy/src/generators/renovateJsonc.ts
+++ b/packages/wbfy/src/generators/renovateJsonc.ts
@@ -13,8 +13,12 @@ import { promisePool } from '../utils/promisePool.js';
 
 const jsonObj = {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['github>WillBooster/willbooster-configs:renovate.json5'],
+  extends: ['github>WillBooster/willbooster-configs:renovate.jsonc'],
 };
+
+// The preset used to live in renovate.json5; it was renamed to renovate.jsonc, so the old reference
+// now fails to resolve ("Cannot find preset's package"). Drop it while migrating, like @willbooster.
+const legacyPresets = new Set(['@willbooster', 'github>WillBooster/willbooster-configs:renovate.json5']);
 
 // $schema is optional: an existing config need not declare it.
 type Settings = Partial<typeof jsonObj> & {
@@ -247,7 +251,7 @@ function mergeRenovateExtends(generatedExtends: string[], existingExtends: strin
   // which config wins (and, being a reorder rather than an addition, also costs the array's
   // comments, which can only be preserved by insertion).
   const missingExtends = generatedExtends.filter((preset) => !existingExtends.includes(preset));
-  return [...missingExtends, ...existingExtends].filter((item) => item !== '@willbooster');
+  return [...missingExtends, ...existingExtends].filter((item) => !legacyPresets.has(item));
 }
 
 function normalize(content: string): string {

--- a/packages/wbfy/test/renovateJsonc.test.ts
+++ b/packages/wbfy/test/renovateJsonc.test.ts
@@ -28,7 +28,8 @@ async function withRepo(files: Record<string, string>, run: (dirPath: string) =>
   }
 }
 
-const preset = 'github>WillBooster/willbooster-configs:renovate.json5';
+const preset = 'github>WillBooster/willbooster-configs:renovate.jsonc';
+const legacyPreset = 'github>WillBooster/willbooster-configs:renovate.json5';
 
 test('generates renovate.jsonc in a repository without any Renovate config', async () => {
   await withRepo({}, async (dirPath) => {
@@ -133,6 +134,13 @@ test('deletes an empty superseded config, which would otherwise keep outranking 
   await withRepo({ 'renovate.json': '' }, async (dirPath) => {
     expect(fs.existsSync(path.join(dirPath, 'renovate.json'))).toBe(false);
     expect(fs.existsSync(path.join(dirPath, 'renovate.jsonc'))).toBe(true);
+  });
+});
+
+test('replaces the renamed legacy preset so Renovate can resolve it again', async () => {
+  await withRepo({ 'renovate.jsonc': JSON.stringify({ extends: [legacyPreset] }) }, async (dirPath) => {
+    const settings = parseSettings(fs.readFileSync(path.join(dirPath, 'renovate.jsonc'), 'utf8'));
+    expect(settings.extends).toEqual([preset]);
   });
 });
 

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>WillBooster/willbooster-configs:renovate.json5"],
+  "extends": ["github>WillBooster/willbooster-configs:renovate.jsonc"],
 }


### PR DESCRIPTION
## Why

The shared Renovate preset in `WillBooster/willbooster-configs` was renamed from `renovate.json5` to `renovate.jsonc`. Every repo that extends `github>WillBooster/willbooster-configs:renovate.json5` now fails with:

> Cannot find preset's package (github>WillBooster/willbooster-configs:renovate.json5)

Renovate then stops opening PRs until the config is fixed (#1034).

## What

- Update the `renovateJsonc` generator (and this repo's own `renovate.jsonc`) to reference `...:renovate.jsonc`. Renovate resolves an explicit `.jsonc` extension.
- Strip the stale `...:renovate.json5` reference during migration, the same way the legacy `@willbooster` preset is dropped, so re-running `wbfy` cleans up existing repos instead of leaving both references.
- Add a test covering the legacy-preset replacement.

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)
