### PR TITLE
fix(wbfy): keep prettier when a package imports it as a library

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -864,7 +864,10 @@ async function applyPackageJsonConventions(
   if (hasJava) {
     devDependencies.push('prettier');
   } else {
-    removePrettierArtifacts(jsonObj);
+    // Drop prettier-the-formatter (oxfmt replaces it), but keep `prettier` itself when the package
+    // imports it as a library — otherwise isolated installs turn the removed dependency into a
+    // phantom import (WillBoosterLab/judge #2042).
+    removePrettierArtifacts(jsonObj, config.depending.prettierRuntime);
   }
 
   delete jsonObj.devDependencies['lint-staged'];
@@ -2167,7 +2170,7 @@ function escapeRegExp(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
-function removePrettierArtifacts(jsonObj: WritablePackageJson): void {
+function removePrettierArtifacts(jsonObj: WritablePackageJson, keepPrettierDependency = false): void {
   delete jsonObj.prettier;
   const dependencySections: Array<Partial<Record<string, string>> | undefined> = [
     jsonObj.dependencies,
@@ -2176,7 +2179,7 @@ function removePrettierArtifacts(jsonObj: WritablePackageJson): void {
   ];
   for (const section of dependencySections) {
     if (!section) continue;
-    delete section.prettier;
+    if (!keepPrettierDependency) delete section.prettier;
     delete section['prettier-plugin-java'];
     delete section['prettier-plugin-prisma'];
     delete section['@willbooster/prettier-config'];

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -73,6 +73,7 @@ export interface PackageConfig {
     next: boolean;
     playwrightTest: boolean;
     playwrightRuntime: boolean;
+    prettierRuntime: boolean;
     prisma: boolean;
     pyright: boolean;
     react: boolean;
@@ -343,6 +344,7 @@ export async function getPackageConfig(
         playwrightTest:
           !!dependencies['@playwright/test'] || !!devDependencies['@playwright/test'] || !!devDependencies.playwright,
         playwrightRuntime: doesImportPlaywrightAtRuntime(dirPath),
+        prettierRuntime: doesImportPrettierAtRuntime(dirPath),
         prisma: !!dependencies['@prisma/client'] || !!devDependencies.prisma,
         pyright: !!devDependencies.pyright,
         reactNative: !!dependencies['react-native'],
@@ -806,17 +808,31 @@ function findCargoTomlDirPaths(dirPath: string): string[] {
 }
 
 function doesImportPlaywrightAtRuntime(dirPath: string): boolean {
+  return doesImportPackageAtRuntime(dirPath, 'playwright');
+}
+
+// `prettier` is normally stripped in favor of oxfmt, but a package that imports it as a library
+// (e.g. formatting HTML at runtime) must keep it declared, or isolated installs turn it into a
+// phantom dependency. Subpath specifiers like `prettier/standalone` count too.
+function doesImportPrettierAtRuntime(dirPath: string): boolean {
+  return doesImportPackageAtRuntime(dirPath, 'prettier');
+}
+
+function doesImportPackageAtRuntime(dirPath: string, packageName: string): boolean {
   const files = fg.globSync('{app,src}/**/*.{cjs,cts,js,jsx,mjs,mts,ts,tsx}', {
     dot: true,
     cwd: dirPath,
     ignore: [...globIgnore, '**/__tests__/**', '**/*.spec.*', '**/*.test.*', '**/playwright.config.*'],
   });
-  return files.some((file) => {
-    const content = fs.readFileSync(path.resolve(dirPath, file), 'utf8');
-    return /\bfrom\s+['"]playwright['"]|\bimport\s*\(\s*['"]playwright['"]\s*\)|\brequire\s*\(\s*['"]playwright['"]\s*\)/u.test(
-      content
-    );
-  });
+  const escapedName = packageName.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+  // Match the bare specifier or any subpath of it (`pkg` / `pkg/sub`), but never a different package
+  // that merely shares the prefix (`pkg-other`), since the char after the name must be `/` or a quote.
+  const specifier = String.raw`['"]${escapedName}(?:/[^'"]*)?['"]`;
+  const importRegExp = new RegExp(
+    String.raw`\bfrom\s+${specifier}|\bimport\s*\(\s*${specifier}\s*\)|\brequire\s*\(\s*${specifier}\s*\)`,
+    'u'
+  );
+  return files.some((file) => importRegExp.test(fs.readFileSync(path.resolve(dirPath, file), 'utf8')));
 }
 
 async function fetchRepoInfo(dirPath: string, packageJson: PackageJson): Promise<Record<string, unknown> | undefined> {

--- a/packages/wbfy/test/packageConfig.test.ts
+++ b/packages/wbfy/test/packageConfig.test.ts
@@ -50,6 +50,35 @@ test('detects a nested Tauri application from a parent package', async () => {
   }
 });
 
+test('detects prettier imported as a runtime library, ignoring prefix-sharing packages', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-package-config-'));
+  try {
+    // The packages/root layout keeps getPackageConfig from looking up a GitHub repository.
+    const packageDirPath = path.join(tempDirPath, 'packages', 'root');
+    const srcDirPath = path.join(packageDirPath, 'src');
+    fs.mkdirSync(srcDirPath, { recursive: true });
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), '{}');
+    fs.writeFileSync(path.join(packageDirPath, 'package.json'), '{}');
+    const sourcePath = path.join(srcDirPath, 'format.ts');
+
+    // A package that only shares the `prettier` prefix must not count as importing prettier.
+    fs.writeFileSync(sourcePath, "import organizeAttributes from 'prettier-plugin-organize-attributes';\n");
+    const prefixOnlyConfig = await getPackageConfig(packageDirPath);
+    expect(prefixOnlyConfig?.depending.prettierRuntime).toBe(false);
+
+    fs.writeFileSync(sourcePath, "import { format } from 'prettier';\n");
+    const bareImportConfig = await getPackageConfig(packageDirPath);
+    expect(bareImportConfig?.depending.prettierRuntime).toBe(true);
+
+    // Subpath specifiers (e.g. the browser build) count too.
+    fs.writeFileSync(sourcePath, "import { format } from 'prettier/standalone';\n");
+    const subpathImportConfig = await getPackageConfig(packageDirPath);
+    expect(subpathImportConfig?.depending.prettierRuntime).toBe(true);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('detects @semantic-release/npm in both string and tuple plugin forms', async () => {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-package-config-'));
   try {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -217,6 +217,17 @@ test('uses stable age-gated versions for generated dependencies when skipping in
   expect(packageJson.devDependencies?.prettier).toMatch(/^\d+\.\d+\.\d+$/u);
 });
 
+test('keeps prettier for packages that import it as a runtime library but drops it otherwise', async () => {
+  const importing = await generatePackageJsonFrom(
+    { dependencies: { prettier: '3.9.5' } },
+    { depending: { ...createConfig().depending, prettierRuntime: true } }
+  );
+  expect(importing.dependencies?.prettier).toBe('3.9.5');
+
+  const notImporting = await generatePackageJsonFrom({ dependencies: { prettier: '3.9.5' } });
+  expect(notImporting.dependencies?.prettier).toBeUndefined();
+});
+
 test('appends wrangler types to gen-code and postinstall for Cloudflare projects', async () => {
   const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(

--- a/packages/wbfy/test/testConfig.ts
+++ b/packages/wbfy/test/testConfig.ts
@@ -48,6 +48,7 @@ export function createConfig(overrides: Partial<PackageConfig> = {}): PackageCon
       next: false,
       playwrightRuntime: false,
       playwrightTest: false,
+      prettierRuntime: false,
       prisma: false,
       pyright: false,
       react: false,


### PR DESCRIPTION
## Problem

wbfy strips `prettier` from `package.json` (oxfmt replaces the formatter). But when a package **imports prettier as a runtime library** — e.g. `@judge/server` does `import { format } from 'prettier'` to format HTML — the removal turns it into a **phantom dependency**. Under isolated installs the package can no longer resolve prettier, so the build fails (`TS2307: Cannot find module 'prettier'`). This surfaced in the build-ts 19 / wbfy sweep on WillBoosterLab/judge (PR #2042), whose Docker build broke until `prettier` was re-declared by hand.

## Fix

- Detect runtime prettier imports per package via a new `depending.prettierRuntime` flag (mirrors the existing `playwrightRuntime`).
- When a package imports prettier, keep `prettier` in its dependencies while still dropping the formatter-only artifacts (`prettier` config key, `prettier-plugin-*`, `@willbooster/prettier-config`, `@types/prettier`).
- Generalized the source scan into `doesImportPackageAtRuntime`, which matches bare and subpath specifiers (`prettier`, `prettier/standalone`) but not prefix-sharing packages (`prettier-plugin-organize-attributes`).

## Tests

- `packageConfig.test.ts`: `doesImportPrettierAtRuntime` detection (bare import → true, subpath → true, prefix-sharing package → false).
- `packageJson.test.ts`: generator keeps `prettier` when `prettierRuntime` is true, drops it otherwise.

`bun run typecheck`, `bun wb lint`, and the touched test files all pass locally.

Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>
