### PR TITLE
fix(wb): default `wb dotenv` to the development fnox profile when WB_ENV is unset

### DIFF
--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -327,8 +327,8 @@ function runFnoxExport(
   if (options.ignoreProfileEnvVar) {
     // Without `--profile`, fnox falls back to FNOX_PROFILE; the base-adjudication export must
     // read the BASE secrets, so the inherited profile selection is cleared for it — and only for
-    // it: a profile-less PRIMARY export (e.g. `wb dotenv` without WB_ENV) keeps honoring
-    // FNOX_PROFILE.
+    // it. A PRIMARY export still honors FNOX_PROFILE: it either stays profile-less (fnox reads the
+    // variable) or folds it into the `--profile` it passes (see wb dotenv's cascade).
     delete env.FNOX_PROFILE;
   }
   const result = childProcess.spawnSync('fnox', args, {

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -83,17 +83,24 @@ function validateStandardWbEnv(value, fixTarget) {
 
 // Mirrors src/commands/dotenv.ts (readAndApplyEnvironmentVariables) for this startup fast path.
 function readAndApplyEnvironmentVariables(cwd) {
+  // The mode is FORCED only when WB_ENV is explicitly exported; it drives the forced-mode override
+  // below and the validation at the end.
   const mode = process.env.WB_ENV;
-  // Mode-specific sources drive the forced-mode override below.
+  // The cascade selects WHICH `.env.<cascade>` files and fnox profile to READ. Like wb's main loader
+  // (`WB_ENV || NODE_ENV || 'development'`) it defaults to development, so a repo that keeps dev-only
+  // secrets in `[profiles.development.secrets]` still loads them when WB_ENV is unset — reading only
+  // the base `[secrets]` table would silently drop them.
+  const cascade = mode || process.env.NODE_ENV || 'development';
+  // Mode-specific sources drive the forced-mode override below (only meaningful when the mode is forced).
   const modeVars = mode
     ? { ...readEnvFile(path.join(cwd, `.env.${mode}`)), ...readEnvFile(path.join(cwd, `.env.${mode}.local`)) }
     : {};
-  // Mirror the shared cascade's precedence: .env.<mode>.local > .env.local > .env.<mode> > .env.
+  // Mirror the shared cascade's precedence: .env.<cascade>.local > .env.local > .env.<cascade> > .env.
   const dotenvVars = {
     ...readEnvFile(path.join(cwd, '.env')),
-    ...(mode ? readEnvFile(path.join(cwd, `.env.${mode}`)) : {}),
+    ...readEnvFile(path.join(cwd, `.env.${cascade}`)),
     ...readEnvFile(path.join(cwd, '.env.local')),
-    ...(mode ? readEnvFile(path.join(cwd, `.env.${mode}.local`)) : {}),
+    ...readEnvFile(path.join(cwd, `.env.${cascade}.local`)),
   };
   // WB_ENV in process.env means the mode is explicitly forced, so values from the mode's own
   // sources (.env.<mode>[.local] and the fnox profile) win over variables inherited from the
@@ -101,7 +108,7 @@ function readAndApplyEnvironmentVariables(cwd) {
   // (see https://github.com/WillBooster/shared/issues/930).
   const modeFileOverridesProcessEnv = !!mode && !isCI(process.env.CI);
   // fnox.toml is the committed, encrypted equivalent of .env files; local .env files still win over it.
-  const fnoxVars = readFnoxEnvironmentVariables(cwd, mode, dotenvVars, modeFileOverridesProcessEnv);
+  const fnoxVars = readFnoxEnvironmentVariables(cwd, cascade, dotenvVars, modeFileOverridesProcessEnv);
   const parsed = { ...fnoxVars, ...dotenvVars };
   // Expand ${...} references against exported variables whose FILE value loses to the shell
   // (mirroring readEnvironmentVariables' effective-value semantics): a reference must resolve to

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -89,8 +89,9 @@ function readAndApplyEnvironmentVariables(cwd) {
   // The cascade selects WHICH `.env.<cascade>` files and fnox profile to READ. Like wb's main loader
   // (`WB_ENV || NODE_ENV || 'development'`) it defaults to development, so a repo that keeps dev-only
   // secrets in `[profiles.development.secrets]` still loads them when WB_ENV is unset — reading only
-  // the base `[secrets]` table would silently drop them.
-  const cascade = mode || process.env.NODE_ENV || 'development';
+  // the base `[secrets]` table would silently drop them. An explicit FNOX_PROFILE still wins over
+  // that default, because fnox honors it and `wb dotenv` without WB_ENV is documented to as well.
+  const cascade = mode || process.env.FNOX_PROFILE || process.env.NODE_ENV || 'development';
   // Mode-specific sources drive the forced-mode override below (only meaningful when the mode is forced).
   const modeVars = mode
     ? { ...readEnvFile(path.join(cwd, `.env.${mode}`)), ...readEnvFile(path.join(cwd, `.env.${mode}.local`)) }
@@ -146,18 +147,20 @@ function readAndApplyEnvironmentVariables(cwd) {
   // child will see.
   validateStandardWbEnv(mode, 'the exported variable');
   validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
-  // The exported mode selected the cascade, so a mode file silently replacing it with a DIFFERENT
-  // valid mode (e.g. `.env.production` containing `WB_ENV=development`) must be rejected as well.
+  // The cascade selected the profile/.env sources, so an env source silently resolving WB_ENV to a
+  // DIFFERENT value must be rejected: the child would run labeled one environment while carrying
+  // another's secrets. This covers both a forced `.env.production` containing `WB_ENV=development` and
+  // the default-development path (`.env.development`, read even when WB_ENV is unset, containing
+  // `WB_ENV=production`), so it compares against `cascade`, not just the forced `mode`.
   if (
-    mode &&
     process.env.WB_ENV &&
-    process.env.WB_ENV !== mode &&
+    process.env.WB_ENV !== cascade &&
     process.env.WB_SKIP_ENV_CHECK !== '1' &&
     process.env.WB_SKIP_ENV_CHECK !== 'true'
   ) {
     console.error(
-      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${mode}" environment was selected. ` +
-        `Fix the WB_ENV defined in the mode's env sources, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
+      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${cascade}" environment was selected. ` +
+        `Fix the WB_ENV defined in the env sources, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
     );
     process.exit(1);
   }
@@ -204,8 +207,8 @@ function runFnoxExport(cwd, cascade, options) {
   if (options.ignoreProfileEnvVar) {
     // Without `--profile`, fnox falls back to FNOX_PROFILE; the base-adjudication export must
     // read the BASE secrets, so the inherited profile selection is cleared for it — and only for
-    // it: a profile-less PRIMARY export (e.g. `wb dotenv` without WB_ENV) keeps honoring
-    // FNOX_PROFILE.
+    // it. A PRIMARY export still honors FNOX_PROFILE: it either stays profile-less (fnox reads the
+    // variable) or folds it into the `--profile` it passes (see wb dotenv's cascade).
     delete env.FNOX_PROFILE;
   }
   const result = childProcess.spawnSync('fnox', args, {

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -151,9 +151,13 @@ function readAndApplyEnvironmentVariables(cwd) {
   // DIFFERENT value must be rejected: the child would run labeled one environment while carrying
   // another's secrets. This covers both a forced `.env.production` containing `WB_ENV=development` and
   // the default-development path (`.env.development`, read even when WB_ENV is unset, containing
-  // `WB_ENV=production`), so it compares against `cascade`, not just the forced `mode`.
+  // `WB_ENV=production`), so it compares against `cascade`, not just the forced `mode`. Only a
+  // STANDARD cascade is enforced (mirroring Project.completeAndValidateWbEnv): a custom suffix such as
+  // `NODE_ENV=qa` legitimately selects `.env.qa` while WB_ENV stays a standard mode, so erroring on it
+  // would reject a supported cascade.
   if (
     process.env.WB_ENV &&
+    ['development', 'test', 'staging', 'production'].includes(cascade) &&
     process.env.WB_ENV !== cascade &&
     process.env.WB_SKIP_ENV_CHECK !== '1' &&
     process.env.WB_SKIP_ENV_CHECK !== 'true'

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -86,22 +86,27 @@ function readAndApplyEnvironmentVariables(cwd) {
   // The mode is FORCED only when WB_ENV is explicitly exported; it drives the forced-mode override
   // below and the validation at the end.
   const mode = process.env.WB_ENV;
-  // The cascade selects WHICH `.env.<cascade>` files and fnox profile to READ. Like wb's main loader
-  // (`WB_ENV || NODE_ENV || 'development'`) it defaults to development, so a repo that keeps dev-only
-  // secrets in `[profiles.development.secrets]` still loads them when WB_ENV is unset — reading only
-  // the base `[secrets]` table would silently drop them. An explicit FNOX_PROFILE still wins over
-  // that default, because fnox honors it and `wb dotenv` without WB_ENV is documented to as well.
-  const cascade = mode || process.env.FNOX_PROFILE || process.env.NODE_ENV || 'development';
+  // Two selectors, both defaulting to development like wb's main loader (`WB_ENV || NODE_ENV ||
+  // 'development'`) so a repo keeping dev-only secrets in `[profiles.development.secrets]` loads them
+  // when WB_ENV is unset instead of only the base table:
+  //   - envCascade picks the `.env.<envCascade>` files. It must NOT consult FNOX_PROFILE — that is a
+  //     fnox-only selector, and letting it redirect a legacy `.env`-only project's cascade would load
+  //     the wrong files.
+  //   - fnoxCascade picks the fnox `--profile` and gates the WB_ENV check below. It additionally honors
+  //     an explicit FNOX_PROFILE, because fnox honors it and `wb dotenv` without WB_ENV is documented
+  //     to as well.
+  const envCascade = mode || process.env.NODE_ENV || 'development';
+  const fnoxCascade = mode || process.env.FNOX_PROFILE || process.env.NODE_ENV || 'development';
   // Mode-specific sources drive the forced-mode override below (only meaningful when the mode is forced).
   const modeVars = mode
     ? { ...readEnvFile(path.join(cwd, `.env.${mode}`)), ...readEnvFile(path.join(cwd, `.env.${mode}.local`)) }
     : {};
-  // Mirror the shared cascade's precedence: .env.<cascade>.local > .env.local > .env.<cascade> > .env.
+  // Mirror the shared cascade's precedence: .env.<c>.local > .env.local > .env.<c> > .env (c = envCascade).
   const dotenvVars = {
     ...readEnvFile(path.join(cwd, '.env')),
-    ...readEnvFile(path.join(cwd, `.env.${cascade}`)),
+    ...readEnvFile(path.join(cwd, `.env.${envCascade}`)),
     ...readEnvFile(path.join(cwd, '.env.local')),
-    ...readEnvFile(path.join(cwd, `.env.${cascade}.local`)),
+    ...readEnvFile(path.join(cwd, `.env.${envCascade}.local`)),
   };
   // WB_ENV in process.env means the mode is explicitly forced, so values from the mode's own
   // sources (.env.<mode>[.local] and the fnox profile) win over variables inherited from the
@@ -109,7 +114,7 @@ function readAndApplyEnvironmentVariables(cwd) {
   // (see https://github.com/WillBooster/shared/issues/930).
   const modeFileOverridesProcessEnv = !!mode && !isCI(process.env.CI);
   // fnox.toml is the committed, encrypted equivalent of .env files; local .env files still win over it.
-  const fnoxVars = readFnoxEnvironmentVariables(cwd, cascade, dotenvVars, modeFileOverridesProcessEnv);
+  const fnoxVars = readFnoxEnvironmentVariables(cwd, fnoxCascade, dotenvVars, modeFileOverridesProcessEnv);
   const parsed = { ...fnoxVars, ...dotenvVars };
   // Expand ${...} references against exported variables whose FILE value loses to the shell
   // (mirroring readEnvironmentVariables' effective-value semantics): a reference must resolve to
@@ -147,23 +152,24 @@ function readAndApplyEnvironmentVariables(cwd) {
   // child will see.
   validateStandardWbEnv(mode, 'the exported variable');
   validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
-  // The cascade selected the profile/.env sources, so an env source silently resolving WB_ENV to a
-  // DIFFERENT value must be rejected: the child would run labeled one environment while carrying
-  // another's secrets. This covers both a forced `.env.production` containing `WB_ENV=development` and
-  // the default-development path (`.env.development`, read even when WB_ENV is unset, containing
-  // `WB_ENV=production`), so it compares against `cascade`, not just the forced `mode`. Only a
-  // STANDARD cascade is enforced (mirroring Project.completeAndValidateWbEnv): a custom suffix such as
-  // `NODE_ENV=qa` legitimately selects `.env.qa` while WB_ENV stays a standard mode, so erroring on it
-  // would reject a supported cascade.
+  // The fnoxCascade selected the environment (its profile provides WB_ENV in a compliant repo), so an
+  // env source silently resolving WB_ENV to a DIFFERENT value must be rejected: the child would run
+  // labeled one environment while carrying another's secrets. This covers both a forced
+  // `.env.production` containing `WB_ENV=development` and the default-development path
+  // (`.env.development`, read even when WB_ENV is unset, containing `WB_ENV=production`), so it
+  // compares against `fnoxCascade`, not just the forced `mode`. Only a STANDARD cascade is enforced
+  // (mirroring Project.completeAndValidateWbEnv): a custom suffix such as `NODE_ENV=qa` legitimately
+  // selects `.env.qa` while WB_ENV stays a standard mode, so erroring on it would reject a supported
+  // cascade.
   if (
     process.env.WB_ENV &&
-    ['development', 'test', 'staging', 'production'].includes(cascade) &&
-    process.env.WB_ENV !== cascade &&
+    ['development', 'test', 'staging', 'production'].includes(fnoxCascade) &&
+    process.env.WB_ENV !== fnoxCascade &&
     process.env.WB_SKIP_ENV_CHECK !== '1' &&
     process.env.WB_SKIP_ENV_CHECK !== 'true'
   ) {
     console.error(
-      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${cascade}" environment was selected. ` +
+      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${fnoxCascade}" environment was selected. ` +
         `Fix the WB_ENV defined in the env sources, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
     );
     process.exit(1);

--- a/packages/wb/bin/dotenv.js
+++ b/packages/wb/bin/dotenv.js
@@ -152,24 +152,25 @@ function readAndApplyEnvironmentVariables(cwd) {
   // child will see.
   validateStandardWbEnv(mode, 'the exported variable');
   validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
-  // The fnoxCascade selected the environment (its profile provides WB_ENV in a compliant repo), so an
-  // env source silently resolving WB_ENV to a DIFFERENT value must be rejected: the child would run
-  // labeled one environment while carrying another's secrets. This covers both a forced
-  // `.env.production` containing `WB_ENV=development` and the default-development path
-  // (`.env.development`, read even when WB_ENV is unset, containing `WB_ENV=production`), so it
-  // compares against `fnoxCascade`, not just the forced `mode`. Only a STANDARD cascade is enforced
-  // (mirroring Project.completeAndValidateWbEnv): a custom suffix such as `NODE_ENV=qa` legitimately
-  // selects `.env.qa` while WB_ENV stays a standard mode, so erroring on it would reject a supported
-  // cascade.
+  // The selected environment is what an env source silently resolving WB_ENV to a DIFFERENT value must
+  // agree with, else the child runs labeled one environment while carrying another's secrets. The
+  // expectation is `fnoxCascade` only when a fnox config participates (its profile provides WB_ENV in a
+  // compliant repo); in a legacy `.env`-only project FNOX_PROFILE is irrelevant, so the expectation is
+  // `envCascade`. This covers both a forced `.env.production` containing `WB_ENV=development` and the
+  // default-development path (`.env.development`, read even when WB_ENV is unset, containing
+  // `WB_ENV=production`), comparing against the selected cascade rather than just the forced `mode`.
+  // Only a STANDARD cascade is enforced (mirroring Project.completeAndValidateWbEnv): a custom suffix
+  // such as `NODE_ENV=qa` legitimately selects `.env.qa` while WB_ENV stays a standard mode.
+  const expectedCascade = hasProjectFnoxConfig(cwd) ? fnoxCascade : envCascade;
   if (
     process.env.WB_ENV &&
-    ['development', 'test', 'staging', 'production'].includes(fnoxCascade) &&
-    process.env.WB_ENV !== fnoxCascade &&
+    ['development', 'test', 'staging', 'production'].includes(expectedCascade) &&
+    process.env.WB_ENV !== expectedCascade &&
     process.env.WB_SKIP_ENV_CHECK !== '1' &&
     process.env.WB_SKIP_ENV_CHECK !== 'true'
   ) {
     console.error(
-      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${fnoxCascade}" environment was selected. ` +
+      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${expectedCascade}" environment was selected. ` +
         `Fix the WB_ENV defined in the env sources, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
     );
     process.exit(1);

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -121,26 +121,30 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
   // The mode is FORCED only when WB_ENV is explicitly exported; it drives the forced-mode override
   // below and the validation at the end.
   const mode = process.env.WB_ENV;
-  // The cascade selects WHICH `.env.<cascade>` files and fnox profile to READ. Like wb's main loader
-  // (`WB_ENV || NODE_ENV || 'development'`, see readEnvironmentVariables) it defaults to development,
-  // so a repo that keeps dev-only secrets in `[profiles.development.secrets]` still loads them when
-  // WB_ENV is unset — reading only the base `[secrets]` table would silently drop them. An explicit
-  // FNOX_PROFILE still wins over that default, because fnox honors it and `wb dotenv` without WB_ENV
-  // is documented to as well (see runFnoxExport's ignoreProfileEnvVar note). NODE_ENV is read through
-  // an alias, never as the `process.env.NODE_ENV` member expression that the bundler inlines to
-  // 'production' (which would wrongly select the production profile).
+  // Two selectors, both defaulting to development like wb's main loader (`WB_ENV || NODE_ENV ||
+  // 'development'`, see readEnvironmentVariables) so a repo keeping dev-only secrets in
+  // `[profiles.development.secrets]` loads them when WB_ENV is unset instead of only the base table:
+  //   - envCascade picks the `.env.<envCascade>` files. It must NOT consult FNOX_PROFILE — that is a
+  //     fnox-only selector, and letting it redirect a legacy `.env`-only project's cascade would load
+  //     the wrong files.
+  //   - fnoxCascade picks the fnox `--profile` and gates the WB_ENV check below. It additionally honors
+  //     an explicit FNOX_PROFILE, because fnox honors it and `wb dotenv` without WB_ENV is documented
+  //     to as well (see runFnoxExport's ignoreProfileEnvVar note).
+  // NODE_ENV is read through the `runtimeEnv` alias, never as the `process.env.NODE_ENV` member
+  // expression that the bundler inlines to 'production' (which would wrongly select production).
   const runtimeEnv = process.env;
-  const cascade = mode || runtimeEnv.FNOX_PROFILE || runtimeEnv.NODE_ENV || 'development';
+  const envCascade = mode || runtimeEnv.NODE_ENV || 'development';
+  const fnoxCascade = mode || runtimeEnv.FNOX_PROFILE || runtimeEnv.NODE_ENV || 'development';
   const readEnvFile = (fileName: string): Record<string, string> =>
     config({ path: path.join(cwd, fileName), processEnv: {}, quiet: true }).parsed ?? {};
   // Mode-specific sources drive the forced-mode override below (only meaningful when the mode is forced).
   const modeVars = mode ? { ...readEnvFile(`.env.${mode}`), ...readEnvFile(`.env.${mode}.local`) } : {};
-  // Mirror the shared cascade's precedence: .env.<cascade>.local > .env.local > .env.<cascade> > .env.
+  // Mirror the shared cascade's precedence: .env.<c>.local > .env.local > .env.<c> > .env (c = envCascade).
   const dotenvVars = {
     ...readEnvFile('.env'),
-    ...readEnvFile(`.env.${cascade}`),
+    ...readEnvFile(`.env.${envCascade}`),
     ...readEnvFile('.env.local'),
-    ...readEnvFile(`.env.${cascade}.local`),
+    ...readEnvFile(`.env.${envCascade}.local`),
   };
   // WB_ENV in process.env means the mode is explicitly forced, so values from the mode's own
   // sources (.env.<mode>[.local] and the fnox profile) win over variables inherited from the
@@ -148,7 +152,7 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
   // (see https://github.com/WillBooster/shared/issues/930).
   const modeFileOverridesProcessEnv = !!mode && !isCI(process.env.CI);
   // fnox.toml is the committed, encrypted equivalent of .env files; local .env files still win over it.
-  const [fnoxVars] = readFnoxEnvironmentVariables(cwd, cascade, dotenvVars, { modeFileOverridesProcessEnv });
+  const [fnoxVars] = readFnoxEnvironmentVariables(cwd, fnoxCascade, dotenvVars, { modeFileOverridesProcessEnv });
   const parsed = { ...fnoxVars, ...dotenvVars };
   // Expand ${...} references against exported variables whose FILE value loses to the shell
   // (mirroring readEnvironmentVariables' effective-value semantics): a reference must resolve to
@@ -188,23 +192,24 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
   // `WB_ENV=prodcution`), and a forced mode's files may even override a VALID exported value.
   validateStandardWbEnv(mode, 'the exported variable');
   validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
-  // The cascade selected the profile/.env sources, so an env source silently resolving WB_ENV to a
-  // DIFFERENT value must be rejected: the child would run labeled one environment while carrying
-  // another's secrets. This covers both a forced `.env.production` containing `WB_ENV=development` and
-  // the default-development path (`.env.development`, read even when WB_ENV is unset, containing
-  // `WB_ENV=production`), so it compares against `cascade`, not just the forced `mode`. Only a
-  // STANDARD cascade is enforced (mirroring Project.completeAndValidateWbEnv): a custom suffix such as
-  // `NODE_ENV=qa` legitimately selects `.env.qa` while WB_ENV stays a standard mode, so erroring on it
-  // would reject a supported cascade.
+  // The fnoxCascade selected the environment (its profile provides WB_ENV in a compliant repo), so an
+  // env source silently resolving WB_ENV to a DIFFERENT value must be rejected: the child would run
+  // labeled one environment while carrying another's secrets. This covers both a forced
+  // `.env.production` containing `WB_ENV=development` and the default-development path
+  // (`.env.development`, read even when WB_ENV is unset, containing `WB_ENV=production`), so it
+  // compares against `fnoxCascade`, not just the forced `mode`. Only a STANDARD cascade is enforced
+  // (mirroring Project.completeAndValidateWbEnv): a custom suffix such as `NODE_ENV=qa` legitimately
+  // selects `.env.qa` while WB_ENV stays a standard mode, so erroring on it would reject a supported
+  // cascade.
   if (
     process.env.WB_ENV &&
-    ['development', 'test', 'staging', 'production'].includes(cascade) &&
-    process.env.WB_ENV !== cascade &&
+    ['development', 'test', 'staging', 'production'].includes(fnoxCascade) &&
+    process.env.WB_ENV !== fnoxCascade &&
     process.env.WB_SKIP_ENV_CHECK !== '1' &&
     process.env.WB_SKIP_ENV_CHECK !== 'true'
   ) {
     console.error(
-      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${cascade}" environment was selected. ` +
+      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${fnoxCascade}" environment was selected. ` +
         `Fix the WB_ENV defined in the env sources, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
     );
     process.exit(1);

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -124,11 +124,13 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
   // The cascade selects WHICH `.env.<cascade>` files and fnox profile to READ. Like wb's main loader
   // (`WB_ENV || NODE_ENV || 'development'`, see readEnvironmentVariables) it defaults to development,
   // so a repo that keeps dev-only secrets in `[profiles.development.secrets]` still loads them when
-  // WB_ENV is unset — reading only the base `[secrets]` table would silently drop them. NODE_ENV is
-  // read through an alias, never as the `process.env.NODE_ENV` member expression that the bundler
-  // inlines to 'production' (which would wrongly select the production profile).
+  // WB_ENV is unset — reading only the base `[secrets]` table would silently drop them. An explicit
+  // FNOX_PROFILE still wins over that default, because fnox honors it and `wb dotenv` without WB_ENV
+  // is documented to as well (see runFnoxExport's ignoreProfileEnvVar note). NODE_ENV is read through
+  // an alias, never as the `process.env.NODE_ENV` member expression that the bundler inlines to
+  // 'production' (which would wrongly select the production profile).
   const runtimeEnv = process.env;
-  const cascade = mode || runtimeEnv.NODE_ENV || 'development';
+  const cascade = mode || runtimeEnv.FNOX_PROFILE || runtimeEnv.NODE_ENV || 'development';
   const readEnvFile = (fileName: string): Record<string, string> =>
     config({ path: path.join(cwd, fileName), processEnv: {}, quiet: true }).parsed ?? {};
   // Mode-specific sources drive the forced-mode override below (only meaningful when the mode is forced).
@@ -186,18 +188,20 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
   // `WB_ENV=prodcution`), and a forced mode's files may even override a VALID exported value.
   validateStandardWbEnv(mode, 'the exported variable');
   validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
-  // The exported mode selected the cascade, so a mode file silently replacing it with a DIFFERENT
-  // valid mode (e.g. `.env.production` containing `WB_ENV=development`) must be rejected as well.
+  // The cascade selected the profile/.env sources, so an env source silently resolving WB_ENV to a
+  // DIFFERENT value must be rejected: the child would run labeled one environment while carrying
+  // another's secrets. This covers both a forced `.env.production` containing `WB_ENV=development` and
+  // the default-development path (`.env.development`, read even when WB_ENV is unset, containing
+  // `WB_ENV=production`), so it compares against `cascade`, not just the forced `mode`.
   if (
-    mode &&
     process.env.WB_ENV &&
-    process.env.WB_ENV !== mode &&
+    process.env.WB_ENV !== cascade &&
     process.env.WB_SKIP_ENV_CHECK !== '1' &&
     process.env.WB_SKIP_ENV_CHECK !== 'true'
   ) {
     console.error(
-      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${mode}" environment was selected. ` +
-        `Fix the WB_ENV defined in the mode's env sources, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
+      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${cascade}" environment was selected. ` +
+        `Fix the WB_ENV defined in the env sources, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
     );
     process.exit(1);
   }

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -118,17 +118,27 @@ function validateStandardWbEnv(value: string | undefined, fixTarget: string): vo
 // adopted the org env standard. A NON-EMPTY WB_ENV is still validated against the standard modes,
 // though — a typo like `prodcution` would otherwise silently select the base (development) values.
 function readAndApplyEnvironmentVariables(cwd: string): void {
+  // The mode is FORCED only when WB_ENV is explicitly exported; it drives the forced-mode override
+  // below and the validation at the end.
   const mode = process.env.WB_ENV;
+  // The cascade selects WHICH `.env.<cascade>` files and fnox profile to READ. Like wb's main loader
+  // (`WB_ENV || NODE_ENV || 'development'`, see readEnvironmentVariables) it defaults to development,
+  // so a repo that keeps dev-only secrets in `[profiles.development.secrets]` still loads them when
+  // WB_ENV is unset — reading only the base `[secrets]` table would silently drop them. NODE_ENV is
+  // read through an alias, never as the `process.env.NODE_ENV` member expression that the bundler
+  // inlines to 'production' (which would wrongly select the production profile).
+  const runtimeEnv = process.env;
+  const cascade = mode || runtimeEnv.NODE_ENV || 'development';
   const readEnvFile = (fileName: string): Record<string, string> =>
     config({ path: path.join(cwd, fileName), processEnv: {}, quiet: true }).parsed ?? {};
-  // Mode-specific sources drive the forced-mode override below.
+  // Mode-specific sources drive the forced-mode override below (only meaningful when the mode is forced).
   const modeVars = mode ? { ...readEnvFile(`.env.${mode}`), ...readEnvFile(`.env.${mode}.local`) } : {};
-  // Mirror the shared cascade's precedence: .env.<mode>.local > .env.local > .env.<mode> > .env.
+  // Mirror the shared cascade's precedence: .env.<cascade>.local > .env.local > .env.<cascade> > .env.
   const dotenvVars = {
     ...readEnvFile('.env'),
-    ...(mode ? readEnvFile(`.env.${mode}`) : {}),
+    ...readEnvFile(`.env.${cascade}`),
     ...readEnvFile('.env.local'),
-    ...(mode ? readEnvFile(`.env.${mode}.local`) : {}),
+    ...readEnvFile(`.env.${cascade}.local`),
   };
   // WB_ENV in process.env means the mode is explicitly forced, so values from the mode's own
   // sources (.env.<mode>[.local] and the fnox profile) win over variables inherited from the
@@ -136,7 +146,7 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
   // (see https://github.com/WillBooster/shared/issues/930).
   const modeFileOverridesProcessEnv = !!mode && !isCI(process.env.CI);
   // fnox.toml is the committed, encrypted equivalent of .env files; local .env files still win over it.
-  const [fnoxVars] = readFnoxEnvironmentVariables(cwd, mode, dotenvVars, { modeFileOverridesProcessEnv });
+  const [fnoxVars] = readFnoxEnvironmentVariables(cwd, cascade, dotenvVars, { modeFileOverridesProcessEnv });
   const parsed = { ...fnoxVars, ...dotenvVars };
   // Expand ${...} references against exported variables whose FILE value loses to the shell
   // (mirroring readEnvironmentVariables' effective-value semantics): a reference must resolve to

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -192,9 +192,13 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
   // DIFFERENT value must be rejected: the child would run labeled one environment while carrying
   // another's secrets. This covers both a forced `.env.production` containing `WB_ENV=development` and
   // the default-development path (`.env.development`, read even when WB_ENV is unset, containing
-  // `WB_ENV=production`), so it compares against `cascade`, not just the forced `mode`.
+  // `WB_ENV=production`), so it compares against `cascade`, not just the forced `mode`. Only a
+  // STANDARD cascade is enforced (mirroring Project.completeAndValidateWbEnv): a custom suffix such as
+  // `NODE_ENV=qa` legitimately selects `.env.qa` while WB_ENV stays a standard mode, so erroring on it
+  // would reject a supported cascade.
   if (
     process.env.WB_ENV &&
+    ['development', 'test', 'staging', 'production'].includes(cascade) &&
     process.env.WB_ENV !== cascade &&
     process.env.WB_SKIP_ENV_CHECK !== '1' &&
     process.env.WB_SKIP_ENV_CHECK !== 'true'

--- a/packages/wb/src/commands/dotenv.ts
+++ b/packages/wb/src/commands/dotenv.ts
@@ -1,7 +1,11 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 
-import { readFnoxEnvironmentVariables, removeNpmAndYarnEnvironmentVariables } from '@willbooster/shared-lib-node/src';
+import {
+  hasProjectFnoxConfig,
+  readFnoxEnvironmentVariables,
+  removeNpmAndYarnEnvironmentVariables,
+} from '@willbooster/shared-lib-node/src';
 import { config } from 'dotenv';
 import { expand } from 'dotenv-expand';
 import type { ArgumentsCamelCase, Argv, CommandModule } from 'yargs';
@@ -192,24 +196,25 @@ function readAndApplyEnvironmentVariables(cwd: string): void {
   // `WB_ENV=prodcution`), and a forced mode's files may even override a VALID exported value.
   validateStandardWbEnv(mode, 'the exported variable');
   validateStandardWbEnv(process.env.WB_ENV, 'the env source or the exported variable');
-  // The fnoxCascade selected the environment (its profile provides WB_ENV in a compliant repo), so an
-  // env source silently resolving WB_ENV to a DIFFERENT value must be rejected: the child would run
-  // labeled one environment while carrying another's secrets. This covers both a forced
-  // `.env.production` containing `WB_ENV=development` and the default-development path
-  // (`.env.development`, read even when WB_ENV is unset, containing `WB_ENV=production`), so it
-  // compares against `fnoxCascade`, not just the forced `mode`. Only a STANDARD cascade is enforced
-  // (mirroring Project.completeAndValidateWbEnv): a custom suffix such as `NODE_ENV=qa` legitimately
-  // selects `.env.qa` while WB_ENV stays a standard mode, so erroring on it would reject a supported
-  // cascade.
+  // The selected environment is what an env source silently resolving WB_ENV to a DIFFERENT value must
+  // agree with, else the child runs labeled one environment while carrying another's secrets. The
+  // expectation is `fnoxCascade` only when a fnox config participates (its profile provides WB_ENV in a
+  // compliant repo); in a legacy `.env`-only project FNOX_PROFILE is irrelevant, so the expectation is
+  // `envCascade`. This covers both a forced `.env.production` containing `WB_ENV=development` and the
+  // default-development path (`.env.development`, read even when WB_ENV is unset, containing
+  // `WB_ENV=production`), comparing against the selected cascade rather than just the forced `mode`.
+  // Only a STANDARD cascade is enforced (mirroring Project.completeAndValidateWbEnv): a custom suffix
+  // such as `NODE_ENV=qa` legitimately selects `.env.qa` while WB_ENV stays a standard mode.
+  const expectedCascade = hasProjectFnoxConfig(cwd) ? fnoxCascade : envCascade;
   if (
     process.env.WB_ENV &&
-    ['development', 'test', 'staging', 'production'].includes(fnoxCascade) &&
-    process.env.WB_ENV !== fnoxCascade &&
+    ['development', 'test', 'staging', 'production'].includes(expectedCascade) &&
+    process.env.WB_ENV !== expectedCascade &&
     process.env.WB_SKIP_ENV_CHECK !== '1' &&
     process.env.WB_SKIP_ENV_CHECK !== 'true'
   ) {
     console.error(
-      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${fnoxCascade}" environment was selected. ` +
+      `WB_ENV resolves to "${process.env.WB_ENV}" although the "${expectedCascade}" environment was selected. ` +
         `Fix the WB_ENV defined in the env sources, or set WB_SKIP_ENV_CHECK=1 to skip this check.`
     );
     process.exit(1);

--- a/packages/wb/test/binDotenv.test.ts
+++ b/packages/wb/test/binDotenv.test.ts
@@ -138,6 +138,26 @@ describe('bin/index.js dotenv fast path', () => {
     expect(result.status).toBe(1);
   });
 
+  it('allows a non-standard cascade suffix (NODE_ENV=qa) to carry a standard WB_ENV', async () => {
+    // `NODE_ENV=qa` selects `.env.qa` while WB_ENV stays a standard mode — a supported cascade the
+    // mismatch guard must not reject (it enforces only standard cascades, like the main loader).
+    await fs.mkdir(path.join(projectDirPath, '.git'), { recursive: true });
+    await fs.writeFile(path.join(projectDirPath, '.env.qa'), 'WB_ENV=development\nSELECTED=qa-file\n');
+
+    const result = childProcess.spawnSync(
+      process.execPath,
+      [binIndexPath, 'dotenv', '--', 'sh', '-c', 'echo "$WB_ENV" "$SELECTED"'],
+      {
+        cwd: projectDirPath,
+        encoding: 'utf8',
+        env: { PATH: process.env.PATH, NODE_ENV: 'qa' },
+      }
+    );
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('development qa-file\n');
+    expect(result.status).toBe(0);
+  });
+
   it("restores yarn's temporary bin folder for Plug'n'Play projects without node_modules", async () => {
     // PnP installs create no node_modules/.bin, so the (otherwise stripped) BERRY_BIN_FOLDER
     // is the only source of dependency executables and must be restored.

--- a/packages/wb/test/binDotenv.test.ts
+++ b/packages/wb/test/binDotenv.test.ts
@@ -69,6 +69,31 @@ describe('bin/index.js dotenv fast path', () => {
     expect(result.status).toBe(0);
   });
 
+  it.runIf(isFnoxAvailable())('loads development-profile fnox secrets when WB_ENV is unset', async () => {
+    // An unset WB_ENV must select the development profile (like wb's main loader), not the base
+    // `[secrets]` table alone: a repo keeping dev-only secrets in `[profiles.development.secrets]`
+    // would otherwise silently miss them (https://github.com/WillBooster/shared/issues covered here).
+    await fs.mkdir(path.join(projectDirPath, '.git'), { recursive: true });
+    await fs.writeFile(
+      path.join(projectDirPath, 'fnox.toml'),
+      '[secrets]\nBASE_ONLY = { default = "base-value" }\n\n[profiles.development.secrets]\nDEV_ONLY = { default = "dev-value" }\n'
+    );
+
+    const result = childProcess.spawnSync(
+      process.execPath,
+      [binIndexPath, 'dotenv', '--', 'sh', '-c', 'echo "$BASE_ONLY" "$DEV_ONLY"'],
+      {
+        cwd: projectDirPath,
+        encoding: 'utf8',
+        // A clean env (only PATH) leaves WB_ENV and NODE_ENV unset, so the cascade defaults to development.
+        env: { PATH: process.env.PATH },
+      }
+    );
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('base-value dev-value\n');
+    expect(result.status).toBe(0);
+  });
+
   it("restores yarn's temporary bin folder for Plug'n'Play projects without node_modules", async () => {
     // PnP installs create no node_modules/.bin, so the (otherwise stripped) BERRY_BIN_FOLDER
     // is the only source of dependency executables and must be restored.

--- a/packages/wb/test/binDotenv.test.ts
+++ b/packages/wb/test/binDotenv.test.ts
@@ -158,16 +158,18 @@ describe('bin/index.js dotenv fast path', () => {
     expect(result.status).toBe(0);
   });
 
-  it('does not let FNOX_PROFILE redirect the .env cascade in a repo without fnox.toml', async () => {
+  it('does not let FNOX_PROFILE redirect the .env cascade or the WB_ENV check without fnox.toml', async () => {
     // FNOX_PROFILE is a fnox-only selector; in a legacy `.env`-only project it must NOT choose which
-    // `.env.<x>` files load — that stays `WB_ENV || NODE_ENV || development`.
+    // `.env.<x>` files load (that stays `WB_ENV || NODE_ENV || development`) NOR the environment the
+    // WB_ENV mismatch guard expects — here `.env.test` correctly resolves WB_ENV=test even though
+    // FNOX_PROFILE names production.
     await fs.mkdir(path.join(projectDirPath, '.git'), { recursive: true });
-    await fs.writeFile(path.join(projectDirPath, '.env.test'), 'SELECTED=test\n');
-    await fs.writeFile(path.join(projectDirPath, '.env.production'), 'SELECTED=production\n');
+    await fs.writeFile(path.join(projectDirPath, '.env.test'), 'WB_ENV=test\nSELECTED=test\n');
+    await fs.writeFile(path.join(projectDirPath, '.env.production'), 'WB_ENV=production\nSELECTED=production\n');
 
     const result = childProcess.spawnSync(
       process.execPath,
-      [binIndexPath, 'dotenv', '--', 'sh', '-c', 'echo "$SELECTED"'],
+      [binIndexPath, 'dotenv', '--', 'sh', '-c', 'echo "$WB_ENV" "$SELECTED"'],
       {
         cwd: projectDirPath,
         encoding: 'utf8',
@@ -175,7 +177,7 @@ describe('bin/index.js dotenv fast path', () => {
       }
     );
     expect(result.stderr).toBe('');
-    expect(result.stdout).toBe('test\n');
+    expect(result.stdout).toBe('test test\n');
     expect(result.status).toBe(0);
   });
 

--- a/packages/wb/test/binDotenv.test.ts
+++ b/packages/wb/test/binDotenv.test.ts
@@ -158,6 +158,27 @@ describe('bin/index.js dotenv fast path', () => {
     expect(result.status).toBe(0);
   });
 
+  it('does not let FNOX_PROFILE redirect the .env cascade in a repo without fnox.toml', async () => {
+    // FNOX_PROFILE is a fnox-only selector; in a legacy `.env`-only project it must NOT choose which
+    // `.env.<x>` files load — that stays `WB_ENV || NODE_ENV || development`.
+    await fs.mkdir(path.join(projectDirPath, '.git'), { recursive: true });
+    await fs.writeFile(path.join(projectDirPath, '.env.test'), 'SELECTED=test\n');
+    await fs.writeFile(path.join(projectDirPath, '.env.production'), 'SELECTED=production\n');
+
+    const result = childProcess.spawnSync(
+      process.execPath,
+      [binIndexPath, 'dotenv', '--', 'sh', '-c', 'echo "$SELECTED"'],
+      {
+        cwd: projectDirPath,
+        encoding: 'utf8',
+        env: { PATH: process.env.PATH, NODE_ENV: 'test', FNOX_PROFILE: 'production' },
+      }
+    );
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('test\n');
+    expect(result.status).toBe(0);
+  });
+
   it("restores yarn's temporary bin folder for Plug'n'Play projects without node_modules", async () => {
     // PnP installs create no node_modules/.bin, so the (otherwise stripped) BERRY_BIN_FOLDER
     // is the only source of dependency executables and must be restored.

--- a/packages/wb/test/binDotenv.test.ts
+++ b/packages/wb/test/binDotenv.test.ts
@@ -72,7 +72,7 @@ describe('bin/index.js dotenv fast path', () => {
   it.runIf(isFnoxAvailable())('loads development-profile fnox secrets when WB_ENV is unset', async () => {
     // An unset WB_ENV must select the development profile (like wb's main loader), not the base
     // `[secrets]` table alone: a repo keeping dev-only secrets in `[profiles.development.secrets]`
-    // would otherwise silently miss them (https://github.com/WillBooster/shared/issues covered here).
+    // would otherwise silently miss them.
     await fs.mkdir(path.join(projectDirPath, '.git'), { recursive: true });
     await fs.writeFile(
       path.join(projectDirPath, 'fnox.toml'),
@@ -92,6 +92,50 @@ describe('bin/index.js dotenv fast path', () => {
     expect(result.stderr).toBe('');
     expect(result.stdout).toBe('base-value dev-value\n');
     expect(result.status).toBe(0);
+  });
+
+  it.runIf(isFnoxAvailable())('honors an explicit FNOX_PROFILE when WB_ENV is unset', async () => {
+    // Defaulting to development must not override an explicitly selected FNOX_PROFILE: fnox honors it,
+    // so `wb dotenv` without WB_ENV must too (the profile still folds into the `--profile` it passes).
+    await fs.mkdir(path.join(projectDirPath, '.git'), { recursive: true });
+    await fs.writeFile(
+      path.join(projectDirPath, 'fnox.toml'),
+      '[secrets]\nSELECTED = { default = "base" }\n\n[profiles.development.secrets]\nSELECTED = { default = "development" }\n\n[profiles.test.secrets]\nSELECTED = { default = "test" }\n'
+    );
+
+    const result = childProcess.spawnSync(
+      process.execPath,
+      [binIndexPath, 'dotenv', '--', 'sh', '-c', 'echo "$SELECTED"'],
+      {
+        cwd: projectDirPath,
+        encoding: 'utf8',
+        env: { PATH: process.env.PATH, FNOX_PROFILE: 'test' },
+      }
+    );
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('test\n');
+    expect(result.status).toBe(0);
+  });
+
+  it('rejects an env source whose WB_ENV disagrees with the default development cascade', async () => {
+    // `.env.development` is read even when WB_ENV is unset (cascade defaults to development); a WB_ENV
+    // it defines that disagrees with that cascade would run the child labeled one environment while
+    // carrying another's secrets, so it must fail fast (matching the forced-mode mismatch guard).
+    await fs.mkdir(path.join(projectDirPath, '.git'), { recursive: true });
+    await fs.writeFile(path.join(projectDirPath, '.env.development'), 'WB_ENV=production\n');
+
+    const result = childProcess.spawnSync(
+      process.execPath,
+      [binIndexPath, 'dotenv', '--', 'sh', '-c', 'echo should-not-run'],
+      {
+        cwd: projectDirPath,
+        encoding: 'utf8',
+        env: { PATH: process.env.PATH },
+      }
+    );
+    expect(result.stdout).not.toContain('should-not-run');
+    expect(result.stderr).toContain('WB_ENV resolves to "production"');
+    expect(result.status).toBe(1);
   });
 
   it("restores yarn's temporary bin folder for Plug'n'Play projects without node_modules", async () => {

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -50,7 +50,7 @@ function generateAgentInstruction(
   const packageManager = 'bun';
   const description = rootConfig.packageJson?.description;
   const fnoxInstruction = fs.existsSync(path.resolve(rootConfig.dirPath, 'fnox.toml'))
-    ? `\n- Environment variables and secrets are managed in \`fnox.toml\` via mise + fnox; run commands through \`${packageManager} wb ...\` or \`fnox run -P <profile> -- <command>\` instead of expecting \`.env\` files. Profile secrets load only when a profile is selected: mode-aware wb commands (e.g. \`wb start\`, \`wb test\`) and \`wb dotenv\` select it themselves (\`wb dotenv\` uses \`WB_ENV\`, else \`FNOX_PROFILE\`, else \`NODE_ENV\`, else the development profile; set \`WB_ENV=<profile>\` to force another), while bare \`fnox run\` needs an explicit \`-P <profile>\`.`
+    ? `\n- Environment variables and secrets are managed in \`fnox.toml\` via mise + fnox; run commands through \`${packageManager} wb ...\` or \`fnox run -P <profile> -- <command>\` instead of expecting \`.env\` files. Profile secrets load only when a profile is selected: mode-aware wb commands (e.g. \`wb start\`, \`wb test\`) and \`wb dotenv\` select it themselves (\`wb dotenv\` uses \`WB_ENV\`, else \`FNOX_PROFILE\`, else \`NODE_ENV\`, else the development profile; \`WB_ENV\` accepts only \`development\`/\`test\`/\`staging\`/\`production\`, so use \`FNOX_PROFILE\` for any other profile), while bare \`fnox run\` needs an explicit \`-P <profile>\`.`
     : '';
   // Every clause states only a verified fact, reusing the workflow generator's own detectors: the
   // wrangler-config clause needs an actual config file (isCloudflare also matches a mere wrangler

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -50,7 +50,7 @@ function generateAgentInstruction(
   const packageManager = 'bun';
   const description = rootConfig.packageJson?.description;
   const fnoxInstruction = fs.existsSync(path.resolve(rootConfig.dirPath, 'fnox.toml'))
-    ? `\n- Environment variables and secrets are managed in \`fnox.toml\` via mise + fnox; run commands through \`${packageManager} wb ...\` or \`fnox run -P <profile> -- <command>\` instead of expecting \`.env\` files. Profile secrets load only when a profile is selected: mode-aware wb commands (e.g. \`wb start\`, \`wb test\`) select it themselves, while \`wb dotenv\` and bare \`fnox run\` need an explicit \`WB_ENV=<profile>\` / \`-P <profile>\`.`
+    ? `\n- Environment variables and secrets are managed in \`fnox.toml\` via mise + fnox; run commands through \`${packageManager} wb ...\` or \`fnox run -P <profile> -- <command>\` instead of expecting \`.env\` files. Profile secrets load only when a profile is selected: mode-aware wb commands (e.g. \`wb start\`, \`wb test\`) and \`wb dotenv\` select it themselves (\`wb dotenv\` defaults to the development profile when \`WB_ENV\` is unset; set \`WB_ENV=<profile>\` for another), while bare \`fnox run\` needs an explicit \`-P <profile>\`.`
     : '';
   // Every clause states only a verified fact, reusing the workflow generator's own detectors: the
   // wrangler-config clause needs an actual config file (isCloudflare also matches a mere wrangler

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -50,7 +50,7 @@ function generateAgentInstruction(
   const packageManager = 'bun';
   const description = rootConfig.packageJson?.description;
   const fnoxInstruction = fs.existsSync(path.resolve(rootConfig.dirPath, 'fnox.toml'))
-    ? `\n- Environment variables and secrets are managed in \`fnox.toml\` via mise + fnox; run commands through \`${packageManager} wb ...\` or \`fnox run -P <profile> -- <command>\` instead of expecting \`.env\` files. Profile secrets load only when a profile is selected: mode-aware wb commands (e.g. \`wb start\`, \`wb test\`) and \`wb dotenv\` select it themselves (\`wb dotenv\` defaults to the development profile when \`WB_ENV\` is unset; set \`WB_ENV=<profile>\` for another), while bare \`fnox run\` needs an explicit \`-P <profile>\`.`
+    ? `\n- Environment variables and secrets are managed in \`fnox.toml\` via mise + fnox; run commands through \`${packageManager} wb ...\` or \`fnox run -P <profile> -- <command>\` instead of expecting \`.env\` files. Profile secrets load only when a profile is selected: mode-aware wb commands (e.g. \`wb start\`, \`wb test\`) and \`wb dotenv\` select it themselves (\`wb dotenv\` uses \`WB_ENV\`, else \`FNOX_PROFILE\`, else \`NODE_ENV\`, else the development profile; set \`WB_ENV=<profile>\` to force another), while bare \`fnox run\` needs an explicit \`-P <profile>\`.`
     : '';
   // Every clause states only a verified fact, reusing the workflow generator's own detectors: the
   // wrangler-config clause needs an actual config file (isCloudflare also matches a mere wrangler


### PR DESCRIPTION
## Root cause

`wb dotenv` (both the compiled command and the `bin/dotenv.js` startup fast path) passed `process.env.WB_ENV` straight through as the fnox profile / `.env` cascade selector, so with `WB_ENV` unset it read only the base `[secrets]` table. wb's main loader (`readEnvironmentVariables`) instead derives the cascade as `WB_ENV || NODE_ENV || 'development'`, so a repo that keeps dev-only secrets in `[profiles.development.secrets]` loaded them through every wb command **except** `wb dotenv`.

Concretely this broke `bun wb dotenv -- build-ts run <script>`: build-ts's required-keys check failed with `Missing environment variables: [AUTH_SECRET, LLM_PROXY_API_KEY]` because those development-profile secrets were never loaded. (Surfaced while investigating a prompt-study deploy.)

## Fix

`wb dotenv` now derives the profile like the main loader, with two intentionally separate selectors:

- **`envCascade` = `WB_ENV || NODE_ENV || 'development'`** — selects the `.env.<cascade>` files. Deliberately excludes `FNOX_PROFILE`: it is a fnox-only selector and must not redirect a legacy `.env`-only project's cascade.
- **`fnoxCascade` = `WB_ENV || FNOX_PROFILE || NODE_ENV || 'development'`** — selects the fnox `--profile`, honoring an explicit `FNOX_PROFILE` (documented contract).

The forced-mode semantics (mode-file override, warnings) still key on an explicitly exported `WB_ENV` only. `NODE_ENV` is read through an alias so the bundler cannot inline it to `'production'`.

A **WB_ENV/selected-cascade mismatch guard** now fails fast when an env source resolves `WB_ENV` to a different environment than the one selected (e.g. `.env.development`, read by default, setting `WB_ENV=production`) — the child would otherwise run mislabeled while carrying another environment's secrets. It fires only when the expected cascade is a standard mode (`development`/`test`/`staging`/`production`, so custom suffixes like `NODE_ENV=qa` are allowed), and expects `fnoxCascade` only when a fnox config participates (`hasProjectFnoxConfig`), else `envCascade`.

Also updated: the wbfy-generated fnox instruction (`wb dotenv` now defaults to development; `WB_ENV` accepts only the four standard modes, use `FNOX_PROFILE` for others) and the now-inaccurate "profile-less PRIMARY export" comment in `runFnoxExport`.

Applied identically to `src/commands/dotenv.ts` and the hand-mirrored `bin/dotenv.js`.

## Verification

Regression tests in `binDotenv.test.ts` (routed through the released `bin/index.js` fast path):
- development-profile fnox secrets load when `WB_ENV` is unset;
- an explicit `FNOX_PROFILE` is honored;
- a `WB_ENV` mismatch in a default-read env source fails fast;
- a non-standard cascade suffix (`NODE_ENV=qa`) with a standard `WB_ENV` runs;
- `FNOX_PROFILE` does not redirect the `.env` cascade or the WB_ENV check without `fnox.toml`.

`bun wb typecheck` / `bun wb lint` pass; wb env/deploy + wbfy agents suites pass. Compiled `dist` verified to keep `i=n||r.FNOX_PROFILE||r.NODE_ENV||'development'` (NODE_ENV not inlined).
