### PR TITLE
fix(wb): exclude mise-provided host/tool vars from railway-env sync

### DIFF
--- a/packages/wb/src/commands/railwayEnv.ts
+++ b/packages/wb/src/commands/railwayEnv.ts
@@ -19,6 +19,15 @@ function isNonRailwayKey(key: string): boolean {
 }
 
 /**
+ * The keys actually declared in the project's fnox/.env sources. `mise env` is reported as a
+ * pseudo-source that mixes in host/tool variables (PATH, CARGO_HOME, RUSTUP_*, ...); those must
+ * never be pushed to Railway, so they are excluded here (mirrors wb deploy).
+ */
+export function selectDotenvSourcedKeys(envSources: ReadonlyArray<readonly [string, readonly string[]]>): Set<string> {
+  return new Set(envSources.filter(([source]) => !source.startsWith('mise env')).flatMap(([, keys]) => keys));
+}
+
+/**
  * Pick the variables to push to Railway from a resolved environment: drop empty/undefined values
  * (so a `KEY=` placeholder never blanks a real Railway variable) and Railway-managed keys, sorted
  * for a stable command and log line.
@@ -56,19 +65,26 @@ export const railwayEnvCommand: CommandModule<unknown, RailwayEnvCommandOptions>
       process.exit(1);
     }
 
-    // Restrict to variables declared in .env / .env.example (wb's environment contract); ignore
-    // process.env so Railway's own injected variables never leak in. The effective values come
-    // from project.env (fnox-resolved for WB_ENV). Mirrors wb gen-dev-vars.
-    const [envVars] = readEnvironmentVariables(argv, project.dirPath, { ignoreProcessEnv: true });
+    // Restrict to variables declared in the project's fnox/.env sources; ignore process.env so
+    // Railway's own injected variables never leak in. The effective values come from project.env
+    // (fnox-resolved for WB_ENV). Mirrors wb deploy.
+    const [envVars, envSources] = readEnvironmentVariables(argv, project.dirPath, { ignoreProcessEnv: true });
+    // `mise env` is reported as a pseudo-source that mixes in host/tool variables such as PATH and
+    // CARGO_HOME; those must never be pushed to Railway, so keep only fnox/.env-declared keys.
+    const dotenvKeys = selectDotenvSourcedKeys(envSources);
     for (const key of Object.keys(envVars)) {
-      const effectiveValue = project.env[key];
-      if (effectiveValue !== undefined) envVars[key] = effectiveValue;
+      if (!dotenvKeys.has(key)) delete envVars[key];
     }
     // fnox repos keep values out of committed files, so the declared key list lives in
     // .env.example; CI also supplies these as workflow env. project.env carries the resolved value.
     for (const key of [...readEnvExampleKeys(project), 'WB_ENV', 'NEXT_PUBLIC_WB_ENV']) {
       const effectiveValue = project.env[key];
       if (envVars[key] === undefined && effectiveValue !== undefined) envVars[key] = effectiveValue;
+    }
+    // Exported environment variables win over file values (matches wb deploy / gen-dev-vars).
+    for (const key of Object.keys(envVars)) {
+      const effectiveValue = project.env[key];
+      if (effectiveValue !== undefined) envVars[key] = effectiveValue;
     }
 
     const entries = selectRailwayVariables(envVars);

--- a/packages/wb/test/railwayEnv.test.ts
+++ b/packages/wb/test/railwayEnv.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { selectRailwayVariables } from '../src/commands/railwayEnv.js';
+import { selectDotenvSourcedKeys, selectRailwayVariables } from '../src/commands/railwayEnv.js';
+
+describe('selectDotenvSourcedKeys', () => {
+  it('keeps fnox/.env-declared keys and drops mise-provided host/tool variables', () => {
+    const keys = selectDotenvSourcedKeys([
+      ['fnox export --profile production', ['DATABASE_URL', 'DISCORD_BOT_TOKEN', 'PORT']],
+      ['mise env --env production', ['PATH', 'CARGO_HOME', 'RUSTUP_HOME', 'RUSTUP_TOOLCHAIN']],
+    ]);
+    expect([...keys].toSorted()).toEqual(['DATABASE_URL', 'DISCORD_BOT_TOKEN', 'PORT']);
+  });
+});
 
 describe('selectRailwayVariables', () => {
   it('keeps declared app variables (incl. DATABASE_URL/PORT), drops empty and Railway-managed keys, and sorts', () => {


### PR DESCRIPTION
Follow-up to #1041. `wb railway-env` pushed `mise env`-provided host/tool variables (`PATH`, `CARGO_HOME`, `RUSTUP_*`) to Railway because `readEnvironmentVariables` reports mise as a pseudo-source. Restrict the sync to fnox/.env-declared keys via the same `envSources` filter `wb deploy` uses for Worker secrets.

Caught by a dry-run against discord-bot before wiring it into any deploy: the sync now lists exactly the 9 `.env.example` app keys, no tool vars. Added a `selectDotenvSourcedKeys` unit test. No repo uses `railway-env` in its deploy yet, so this is not a live regression.

Co-authored-by: WillBooster (Claude Code) <agent@willbooster.com>
