### PR TITLE
feat(wb): auto-materialize private packages in optimizeForDockerBuild and scan workspaces

### DIFF
--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -72,12 +72,27 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
 
     // Materialize private dependencies on the host first so the per-project rewrite below resolves
     // them to file: paths and the Docker build needs no registry credentials. Only in --outside
-    // mode (the host preparation phase): the in-image second pass has no node_modules/registry to
-    // materialize from. `warn` on missing auth preserves the pre-existing behavior of continuing
-    // (and warning) when a package can be neither reused nor downloaded, so this stays a pure
-    // convenience that lets repositories drop the explicit `wb setup-private-packages` step.
-    if (argv.outside && !argv.dryRun) {
-      await materializePrivatePackages(projects.root.dirPath, collectManifests(projects), { onMissingAuth: 'warn' });
+    // mode (the in-image second pass has no node_modules/registry to materialize from) and only
+    // when a private dependency is actually declared, so repos without one are untouched — no empty
+    // output directories, no spurious "COPY" hint. Failures are non-fatal and non-destructive:
+    // materialize throws before deleting any existing output (and cleans up its staging on a failed
+    // download), so a repo lacking registry credentials keeps building exactly as before, with the
+    // per-project rewrite below emitting the existing "run wb setup-private-packages" hint. This
+    // keeps the step a pure convenience that lets repositories drop the explicit command.
+    if (argv.outside) {
+      const manifests = collectManifests(projects);
+      if (manifests.some(declaresPrivateDependency)) {
+        try {
+          await materializePrivatePackages(projects.root.dirPath, manifests, { dryRun: Boolean(argv.dryRun) });
+        } catch (error) {
+          console.warn(
+            chalk.yellow(
+              `Could not auto-materialize private packages (${error instanceof Error ? error.message : String(error)}); ` +
+                'run `wb setup-private-packages` if the Docker build needs them. Continuing.'
+            )
+          );
+        }
+      }
     }
 
     const optimizedProjects: Project[] = [];
@@ -111,6 +126,19 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
     }
   },
 };
+
+/** Whether any dependency section declares a private git or `@willbooster-private/*` registry dependency. */
+function declaresPrivateDependency(packageJson: PackageJson): boolean {
+  return dependencySectionKeys.some((key) => {
+    const deps = packageJson[key];
+    return (
+      deps !== undefined &&
+      Object.entries(deps).some(
+        ([name, value]) => isPrivateGitDependency(value) || isPrivateRegistryDependency(name, value)
+      )
+    );
+  });
+}
 
 function rewritePrivateGitHubDependencies(project: Project, packageJson: PackageJson): string[] {
   return rewritePrivateGitHubDependenciesForDir(project.rootDirPath, project.dirPath, packageJson);

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -23,6 +23,7 @@ import {
 } from '../utils/privateRegistry.js';
 
 import { prepareForRunningCommand } from './commandUtils.js';
+import { collectManifests, materializePrivatePackages } from './setupPrivatePackages.js';
 
 const dependencySectionKeys = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const;
 const sqliteFilePattern = /\.(?:sqlite3?|db)(?:[-.](?:journal|shm|wal))?$/i;
@@ -67,6 +68,16 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
     if (!projects) {
       console.error(chalk.red('No project found.'));
       process.exit(1);
+    }
+
+    // Materialize private dependencies on the host first so the per-project rewrite below resolves
+    // them to file: paths and the Docker build needs no registry credentials. Only in --outside
+    // mode (the host preparation phase): the in-image second pass has no node_modules/registry to
+    // materialize from. `warn` on missing auth preserves the pre-existing behavior of continuing
+    // (and warning) when a package can be neither reused nor downloaded, so this stays a pure
+    // convenience that lets repositories drop the explicit `wb setup-private-packages` step.
+    if (argv.outside && !argv.dryRun) {
+      await materializePrivatePackages(projects.root.dirPath, collectManifests(projects), { onMissingAuth: 'warn' });
     }
 
     const optimizedProjects: Project[] = [];

--- a/packages/wb/src/commands/optimizeForDockerBuild.ts
+++ b/packages/wb/src/commands/optimizeForDockerBuild.ts
@@ -80,7 +80,10 @@ export const optimizeForDockerBuildCommand: CommandModule<unknown, InferredOptio
     // per-project rewrite below emitting the existing "run wb setup-private-packages" hint. This
     // keeps the step a pure convenience that lets repositories drop the explicit command.
     if (argv.outside) {
-      const manifests = collectManifests(projects);
+      // Resolve the full workspace set from the repository root so a private dependency declared in
+      // any sibling workspace is materialized even when optimize runs from a subpackage directory.
+      const rootProjects = await findDescendantProjects(argv, false, projects.root.dirPath);
+      const manifests = collectManifests(rootProjects ?? projects);
       if (manifests.some(declaresPrivateDependency)) {
         try {
           await materializePrivatePackages(projects.root.dirPath, manifests, { dryRun: Boolean(argv.dryRun) });

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -104,14 +104,15 @@ export async function materializePrivatePackages(
   // symlink component: a symlink (e.g. `escape -> node_modules`, or `@willbooster-private`
   // itself linking elsewhere) would either smuggle the delete past the lexical overlap guards
   // or destroy the symlink's target. Rejecting canonical/lexical mismatches keeps every
-  // destructive operation on the intended lexical location.
+  // destructive operation on the intended lexical location. These guards THROW (not process.exit)
+  // so the automatic `wb optimizeForDockerBuild --outside` caller can catch them and continue
+  // non-fatally; the explicit command's handler catches and exits.
   const rootDirPath = canonicalizePath(rootProjectDirPath);
   const resolveOutputDirPath = (relativeOrAbsolutePath: string, label: string): string => {
     const lexicalPath = path.resolve(rootDirPath, relativeOrAbsolutePath);
     const canonicalPath = canonicalizePath(lexicalPath);
     if (canonicalPath !== lexicalPath) {
-      console.error(chalk.red(`${label} must not contain symlinks (${lexicalPath} resolves to ${canonicalPath}).`));
-      process.exit(1);
+      throw new Error(`${label} must not contain symlinks (${lexicalPath} resolves to ${canonicalPath}).`);
     }
     return lexicalPath;
   };
@@ -127,23 +128,29 @@ export async function materializePrivatePackages(
     // e.g. `--out-dir @willbooster-private` or `--out-dir @willbooster-private/sub`: the
     // registry step recursively deletes registryOutDirPath, which would destroy the git
     // packages copied into an equal or NESTED directory moments earlier.
-    console.error(chalk.red(`--out-dir must not overlap the ${PRIVATE_REGISTRY_SCOPE} registry output directory.`));
-    process.exit(1);
+    throw new Error(`--out-dir must not overlap the ${PRIVATE_REGISTRY_SCOPE} registry output directory.`);
   }
   const stagingDirPath = resolveOutputDirPath(
     path.join('.tmp', 'wb-private-registry-staging'),
-    'The staging directory'
+    'The registry staging directory'
+  );
+  const gitStagingDirPath = resolveOutputDirPath(
+    path.join('.tmp', 'wb-private-git-staging'),
+    'The git staging directory'
   );
   if (pathsOverlap(outDirPath, canonicalizePath(path.join(rootDirPath, 'node_modules')))) {
     // The recursive delete of outDirPath would destroy the installed sources the copies read.
-    console.error(chalk.red('--out-dir must not overlap node_modules.'));
-    process.exit(1);
+    throw new Error('--out-dir must not overlap node_modules.');
   }
-  if (pathsOverlap(outDirPath, stagingDirPath)) {
-    // The registry step recreates the staging directory, silently discarding anything copied
-    // into an equal or nested --out-dir moments earlier.
-    console.error(chalk.red(`--out-dir must not overlap the staging directory (${stagingDirPath}).`));
-    process.exit(1);
+  for (const [stagingLabel, stagingPath] of [
+    ['registry', stagingDirPath],
+    ['git', gitStagingDirPath],
+  ] as const) {
+    if (pathsOverlap(outDirPath, stagingPath)) {
+      // Each staging step recreates its directory, silently discarding anything copied into an
+      // equal or nested --out-dir moments earlier.
+      throw new Error(`--out-dir must not overlap the ${stagingLabel} staging directory (${stagingPath}).`);
+    }
   }
   if (path.relative(rootDirPath, outDirPath) !== '@willbooster') {
     // Pre-existing limitation of the option: the Docker manifest rewrite has no access to it.
@@ -186,12 +193,27 @@ export async function materializePrivatePackages(
   const copiedPackages = [...privatePackages.values()].filter((p) => p.kind === 'git');
   const registryPackages = [...privatePackages.values()].filter((p) => p.kind === 'registry');
 
-  await fs.promises.rm(outDirPath, { recursive: true, force: true });
-  // Both output directories always exist afterwards: Dockerfiles COPY them unconditionally,
-  // and a missing source path fails the build.
-  await fs.promises.mkdir(outDirPath, { recursive: true });
-  for (const privatePackage of copiedPackages) {
-    await copyInstalledPackage(rootDirPath, privatePackage, privatePackage.targetDirPath);
+  // Copy git packages into a staging directory and swap it in only after every copy succeeded,
+  // mirroring the registry staging below: a copy that fails partway (e.g. a dangling symlink in
+  // the installed source) must not leave a half-populated @willbooster tree that the automatic
+  // optimizeForDockerBuild caller — which catches the failure and continues — would then rewrite
+  // dependencies against. Both output directories always exist afterwards: Dockerfiles COPY them
+  // unconditionally, and a missing source path fails the build.
+  await fs.promises.rm(gitStagingDirPath, { recursive: true, force: true });
+  await fs.promises.mkdir(gitStagingDirPath, { recursive: true });
+  try {
+    for (const privatePackage of copiedPackages) {
+      await copyInstalledPackage(
+        rootDirPath,
+        privatePackage,
+        path.join(gitStagingDirPath, path.relative(outDirPath, privatePackage.targetDirPath))
+      );
+    }
+    await fs.promises.rm(outDirPath, { recursive: true, force: true });
+    await fs.promises.rename(gitStagingDirPath, outDirPath);
+  } catch (error) {
+    await fs.promises.rm(gitStagingDirPath, { recursive: true, force: true });
+    throw error;
   }
 
   if (registryPackages.length > 0) {
@@ -531,8 +553,7 @@ function assertSubdirectory(rootDirPath: string, outDirPath: string): void {
   const relativePath = path.relative(rootDirPath, outDirPath);
   if (relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)) return;
 
-  console.error(chalk.red(`Output directory must be a subdirectory of the project root: ${outDirPath}`));
-  process.exit(1);
+  throw new Error(`Output directory must be a subdirectory of the project root: ${outDirPath}`);
 }
 
 function findInstalledPackageDir(rootDirPath: string, packageName: string): string {

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import type { PackageJson } from 'type-fest';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
-import { findRootAndSelfProjects } from '../project.js';
+import { findDescendantProjects, type FoundProjects } from '../project.js';
 import type { PrivateRegistryAuth } from '../utils/privateRegistry.js';
 import {
   PRIVATE_REGISTRY_SCOPE,
@@ -49,175 +49,238 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     'The Dockerfile must COPY the generated directories (e.g. `COPY @willbooster/ @willbooster/` and `COPY @willbooster-private/ @willbooster-private/`) so the in-image install resolves the rewritten file: paths.',
   builder,
   async handler(argv) {
-    const projects = findRootAndSelfProjects(argv, false);
+    const projects = await findDescendantProjects(argv, false);
     if (!projects) {
       console.error(chalk.red('No project found.'));
       process.exit(1);
     }
 
-    // Output paths are recursively DELETED before being recreated, so none of them may contain a
-    // symlink component: a symlink (e.g. `escape -> node_modules`, or `@willbooster-private`
-    // itself linking elsewhere) would either smuggle the delete past the lexical overlap guards
-    // or destroy the symlink's target. Rejecting canonical/lexical mismatches keeps every
-    // destructive operation on the intended lexical location.
-    const rootDirPath = canonicalizePath(projects.root.dirPath);
-    const resolveOutputDirPath = (relativeOrAbsolutePath: string, label: string): string => {
-      const lexicalPath = path.resolve(rootDirPath, relativeOrAbsolutePath);
-      const canonicalPath = canonicalizePath(lexicalPath);
-      if (canonicalPath !== lexicalPath) {
-        console.error(chalk.red(`${label} must not contain symlinks (${lexicalPath} resolves to ${canonicalPath}).`));
-        process.exit(1);
-      }
-      return lexicalPath;
-    };
-    const outDirPath = resolveOutputDirPath(argv.outDir, '--out-dir');
-    assertSubdirectory(rootDirPath, outDirPath);
-    // Registry packages always materialize at the repository root: `wb optimizeForDockerBuild`
-    // resolves them from `<root>/@willbooster-private` regardless of `--out-dir`.
-    const registryOutDirPath = resolveOutputDirPath(
-      PRIVATE_REGISTRY_SCOPE,
-      `The ${PRIVATE_REGISTRY_SCOPE} output directory`
-    );
-    if (pathsOverlap(outDirPath, registryOutDirPath)) {
-      // e.g. `--out-dir @willbooster-private` or `--out-dir @willbooster-private/sub`: the
-      // registry step recursively deletes registryOutDirPath, which would destroy the git
-      // packages copied into an equal or NESTED directory moments earlier.
-      console.error(chalk.red(`--out-dir must not overlap the ${PRIVATE_REGISTRY_SCOPE} registry output directory.`));
-      process.exit(1);
-    }
-    const stagingDirPath = resolveOutputDirPath(
-      path.join('.tmp', 'wb-private-registry-staging'),
-      'The staging directory'
-    );
-    if (pathsOverlap(outDirPath, canonicalizePath(path.join(rootDirPath, 'node_modules')))) {
-      // The recursive delete of outDirPath would destroy the installed sources the copies read.
-      console.error(chalk.red('--out-dir must not overlap node_modules.'));
-      process.exit(1);
-    }
-    if (pathsOverlap(outDirPath, stagingDirPath)) {
-      // The registry step recreates the staging directory, silently discarding anything copied
-      // into an equal or nested --out-dir moments earlier.
-      console.error(chalk.red(`--out-dir must not overlap the staging directory (${stagingDirPath}).`));
-      process.exit(1);
-    }
-    if (path.relative(rootDirPath, outDirPath) !== '@willbooster') {
-      // Pre-existing limitation of the option: the Docker manifest rewrite has no access to it.
-      console.warn(
-        chalk.yellow(
-          'Note: wb optimizeForDockerBuild rewrites git dependencies to <root>/@willbooster; a custom --out-dir requires a matching Dockerfile layout.'
-        )
-      );
-    }
-    const privatePackages = await collectPrivatePackages(
-      rootDirPath,
-      projects.root.packageJson,
-      outDirPath,
-      registryOutDirPath
-    );
-
-    if (argv.dryRun) {
-      printDryRunResult(outDirPath, privatePackages);
-      return;
-    }
-
-    const copiedPackages = [...privatePackages.values()].filter((p) => p.kind === 'git');
-    const registryPackages = [...privatePackages.values()].filter((p) => p.kind === 'registry');
-    // Registry packages whose installed copy satisfies the specifier are copied from
-    // node_modules; only the rest are downloaded, so registry credentials are needed only when a
-    // download actually happens (CI test steps deliberately receive no Verdaccio token).
-    const downloadedPackages = registryPackages.filter((p) => !p.sourceDirPath);
-    // Resolve required configuration BEFORE deleting the existing materializations, so a missing
-    // registry configuration cannot destroy a previously usable output tree.
-    const auth = downloadedPackages.length > 0 ? resolvePrivateRegistryAuth(rootDirPath) : undefined;
-    if (downloadedPackages.length > 0 && !auth) {
-      console.error(
-        chalk.red(
-          `Cannot download ${downloadedPackages.map((p) => p.name).join(', ')}: no registry configured for the ${PRIVATE_REGISTRY_SCOPE} scope; ` +
-            `add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc. Only installed copies satisfying an exact version or ` +
-            'semver range are reused without registry access; dist-tag specifiers (e.g. `latest`) always require it.'
-        )
-      );
-      process.exit(1);
-    }
-
-    await fs.promises.rm(outDirPath, { recursive: true, force: true });
-    // Both output directories always exist afterwards: Dockerfiles COPY them unconditionally,
-    // and a missing source path fails the build.
-    await fs.promises.mkdir(outDirPath, { recursive: true });
-    for (const privatePackage of copiedPackages) {
-      await copyInstalledPackage(rootDirPath, privatePackage, privatePackage.targetDirPath);
-    }
-
-    if (registryPackages.length > 0) {
-      // Download into a staging directory and swap it in only after every download succeeded, so
-      // a failing registry/token/extraction cannot destroy the last usable materialization.
-      const toStagedPath = (targetDirPath: string): string =>
-        path.join(stagingDirPath, path.relative(registryOutDirPath, targetDirPath));
-      await fs.promises.rm(stagingDirPath, { recursive: true, force: true });
-      await fs.promises.mkdir(stagingDirPath, { recursive: true });
-      try {
-        for (const privatePackage of registryPackages) {
-          if (privatePackage.sourceDirPath) {
-            await copyInstalledPackage(rootDirPath, privatePackage, toStagedPath(privatePackage.targetDirPath));
-          } else {
-            await downloadAndExtractRegistryPackage(
-              // downloadedPackages is non-empty on this path, so the auth check above passed.
-              auth!,
-              privatePackage.name,
-              privatePackage.versionSpecifier ?? 'latest',
-              toStagedPath(privatePackage.targetDirPath)
-            );
-            privatePackage.resolvedVersion = readInstalledVersion(
-              toStagedPath(privatePackage.targetDirPath),
-              privatePackage.name
-            );
-            console.info(
-              `Downloaded ${privatePackage.name} to ${path.relative(rootDirPath, privatePackage.targetDirPath)}`
-            );
-          }
-          // A downloaded package may itself depend on private packages that were not visible
-          // before extraction; materialize them too. Installed copies were already deep-scanned
-          // by collectPrivatePackages.
-          if (!privatePackage.sourceDirPath) {
-            await collectNestedPrivatePackages(
-              rootDirPath,
-              auth!,
-              privatePackage,
-              privatePackages,
-              outDirPath,
-              registryOutDirPath,
-              toStagedPath
-            );
-          }
-        }
-        await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
-        await fs.promises.rename(stagingDirPath, registryOutDirPath);
-      } catch (error) {
-        await fs.promises.rm(stagingDirPath, { recursive: true, force: true });
-        throw error;
-      }
-    } else {
-      await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
-      await fs.promises.mkdir(registryOutDirPath, { recursive: true });
-    }
-
-    await replacePrivateDependencies(rootDirPath, privatePackages);
-    console.info(
-      `Ensure the Dockerfile COPYs ${path.relative(rootDirPath, outDirPath)}/ and ${PRIVATE_REGISTRY_SCOPE}/ into the image before installing dependencies.`
-    );
+    // Scan the root manifest and every workspace manifest: a private dependency may be declared in
+    // a sub-package (e.g. packages/server) rather than the root, yet it still materializes at the
+    // repository root so `wb optimizeForDockerBuild` resolves it uniformly.
+    await materializePrivatePackages(projects.root.dirPath, collectManifests(projects), {
+      outDir: argv.outDir,
+      dryRun: Boolean(argv.dryRun),
+    });
   },
 };
 
+export interface MaterializePrivatePackagesOptions {
+  /** Directory (relative to the repository root) that git dependencies are copied into. */
+  outDir?: string;
+  dryRun?: boolean;
+  /**
+   * How to handle a registry package that must be downloaded when no registry auth is configured.
+   * `error` (the default, used by the explicit `wb setup-private-packages` command) fails; `warn`
+   * (used by the automatic `wb optimizeForDockerBuild --outside` step) leaves those packages
+   * un-materialized so the pre-existing "run wb setup-private-packages" warning path stays
+   * backward compatible.
+   */
+  onMissingAuth?: 'error' | 'warn';
+}
+
+/** The root manifest followed by each distinct workspace manifest. */
+export function collectManifests(projects: FoundProjects): PackageJson[] {
+  const manifestsByDirPath = new Map<string, PackageJson>();
+  for (const project of [projects.root, ...projects.descendants]) {
+    if (!manifestsByDirPath.has(project.dirPath)) manifestsByDirPath.set(project.dirPath, project.packageJson);
+  }
+  return [...manifestsByDirPath.values()];
+}
+
+export async function materializePrivatePackages(
+  rootProjectDirPath: string,
+  manifestPackageJsons: PackageJson[],
+  options: MaterializePrivatePackagesOptions = {}
+): Promise<void> {
+  const { outDir = '@willbooster', dryRun = false, onMissingAuth = 'error' } = options;
+
+  // Output paths are recursively DELETED before being recreated, so none of them may contain a
+  // symlink component: a symlink (e.g. `escape -> node_modules`, or `@willbooster-private`
+  // itself linking elsewhere) would either smuggle the delete past the lexical overlap guards
+  // or destroy the symlink's target. Rejecting canonical/lexical mismatches keeps every
+  // destructive operation on the intended lexical location.
+  const rootDirPath = canonicalizePath(rootProjectDirPath);
+  const resolveOutputDirPath = (relativeOrAbsolutePath: string, label: string): string => {
+    const lexicalPath = path.resolve(rootDirPath, relativeOrAbsolutePath);
+    const canonicalPath = canonicalizePath(lexicalPath);
+    if (canonicalPath !== lexicalPath) {
+      console.error(chalk.red(`${label} must not contain symlinks (${lexicalPath} resolves to ${canonicalPath}).`));
+      process.exit(1);
+    }
+    return lexicalPath;
+  };
+  const outDirPath = resolveOutputDirPath(outDir, '--out-dir');
+  assertSubdirectory(rootDirPath, outDirPath);
+  // Registry packages always materialize at the repository root: `wb optimizeForDockerBuild`
+  // resolves them from `<root>/@willbooster-private` regardless of `--out-dir`.
+  const registryOutDirPath = resolveOutputDirPath(
+    PRIVATE_REGISTRY_SCOPE,
+    `The ${PRIVATE_REGISTRY_SCOPE} output directory`
+  );
+  if (pathsOverlap(outDirPath, registryOutDirPath)) {
+    // e.g. `--out-dir @willbooster-private` or `--out-dir @willbooster-private/sub`: the
+    // registry step recursively deletes registryOutDirPath, which would destroy the git
+    // packages copied into an equal or NESTED directory moments earlier.
+    console.error(chalk.red(`--out-dir must not overlap the ${PRIVATE_REGISTRY_SCOPE} registry output directory.`));
+    process.exit(1);
+  }
+  const stagingDirPath = resolveOutputDirPath(
+    path.join('.tmp', 'wb-private-registry-staging'),
+    'The staging directory'
+  );
+  if (pathsOverlap(outDirPath, canonicalizePath(path.join(rootDirPath, 'node_modules')))) {
+    // The recursive delete of outDirPath would destroy the installed sources the copies read.
+    console.error(chalk.red('--out-dir must not overlap node_modules.'));
+    process.exit(1);
+  }
+  if (pathsOverlap(outDirPath, stagingDirPath)) {
+    // The registry step recreates the staging directory, silently discarding anything copied
+    // into an equal or nested --out-dir moments earlier.
+    console.error(chalk.red(`--out-dir must not overlap the staging directory (${stagingDirPath}).`));
+    process.exit(1);
+  }
+  if (path.relative(rootDirPath, outDirPath) !== '@willbooster') {
+    // Pre-existing limitation of the option: the Docker manifest rewrite has no access to it.
+    console.warn(
+      chalk.yellow(
+        'Note: wb optimizeForDockerBuild rewrites git dependencies to <root>/@willbooster; a custom --out-dir requires a matching Dockerfile layout.'
+      )
+    );
+  }
+  const privatePackages = await collectPrivatePackages(
+    rootDirPath,
+    manifestPackageJsons,
+    outDirPath,
+    registryOutDirPath
+  );
+
+  if (dryRun) {
+    printDryRunResult(outDirPath, privatePackages);
+    return;
+  }
+
+  // Registry packages whose installed copy satisfies the specifier are copied from
+  // node_modules; only the rest are downloaded, so registry credentials are needed only when a
+  // download actually happens (CI test steps deliberately receive no Verdaccio token).
+  const downloadedPackages = [...privatePackages.values()].filter((p) => p.kind === 'registry' && !p.sourceDirPath);
+  // Resolve required configuration BEFORE deleting the existing materializations, so a missing
+  // registry configuration cannot destroy a previously usable output tree.
+  const auth = downloadedPackages.length > 0 ? resolvePrivateRegistryAuth(rootDirPath) : undefined;
+  if (downloadedPackages.length > 0 && !auth) {
+    const detail =
+      `Cannot download ${downloadedPackages.map((p) => p.name).join(', ')}: no registry configured for the ${PRIVATE_REGISTRY_SCOPE} scope; ` +
+      `add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc. Only installed copies satisfying an exact version or ` +
+      'semver range are reused without registry access; dist-tag specifiers (e.g. `latest`) always require it.';
+    if (onMissingAuth === 'error') {
+      console.error(chalk.red(detail));
+      process.exit(1);
+    }
+    // Automatic path (wb optimizeForDockerBuild --outside): leave these un-materialized instead of
+    // failing, mirroring the pre-existing behavior; the caller's per-project rewrite then warns
+    // and keeps the registry specifier so an in-image install with credentials can still resolve it.
+    console.warn(chalk.yellow(`${detail} Skipping; the Docker build will need registry credentials for them.`));
+    for (const skipped of downloadedPackages) privatePackages.delete(skipped.name);
+  }
+
+  const copiedPackages = [...privatePackages.values()].filter((p) => p.kind === 'git');
+  const registryPackages = [...privatePackages.values()].filter((p) => p.kind === 'registry');
+
+  await fs.promises.rm(outDirPath, { recursive: true, force: true });
+  // Both output directories always exist afterwards: Dockerfiles COPY them unconditionally,
+  // and a missing source path fails the build.
+  await fs.promises.mkdir(outDirPath, { recursive: true });
+  for (const privatePackage of copiedPackages) {
+    await copyInstalledPackage(rootDirPath, privatePackage, privatePackage.targetDirPath);
+  }
+
+  if (registryPackages.length > 0) {
+    // Download into a staging directory and swap it in only after every download succeeded, so
+    // a failing registry/token/extraction cannot destroy the last usable materialization.
+    const toStagedPath = (targetDirPath: string): string =>
+      path.join(stagingDirPath, path.relative(registryOutDirPath, targetDirPath));
+    await fs.promises.rm(stagingDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(stagingDirPath, { recursive: true });
+    try {
+      for (const privatePackage of registryPackages) {
+        if (privatePackage.sourceDirPath) {
+          await copyInstalledPackage(rootDirPath, privatePackage, toStagedPath(privatePackage.targetDirPath));
+        } else {
+          await downloadAndExtractRegistryPackage(
+            // downloadedPackages is non-empty on this path, so the auth check above passed.
+            auth!,
+            privatePackage.name,
+            privatePackage.versionSpecifier ?? 'latest',
+            toStagedPath(privatePackage.targetDirPath)
+          );
+          privatePackage.resolvedVersion = readInstalledVersion(
+            toStagedPath(privatePackage.targetDirPath),
+            privatePackage.name
+          );
+          console.info(
+            `Downloaded ${privatePackage.name} to ${path.relative(rootDirPath, privatePackage.targetDirPath)}`
+          );
+        }
+        // A downloaded package may itself depend on private packages that were not visible
+        // before extraction; materialize them too. Installed copies were already deep-scanned
+        // by collectPrivatePackages.
+        if (!privatePackage.sourceDirPath) {
+          await collectNestedPrivatePackages(
+            rootDirPath,
+            auth!,
+            privatePackage,
+            privatePackages,
+            outDirPath,
+            registryOutDirPath,
+            toStagedPath
+          );
+        }
+      }
+      await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
+      await fs.promises.rename(stagingDirPath, registryOutDirPath);
+    } catch (error) {
+      await fs.promises.rm(stagingDirPath, { recursive: true, force: true });
+      throw error;
+    }
+  } else {
+    await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
+    await fs.promises.mkdir(registryOutDirPath, { recursive: true });
+  }
+
+  await replacePrivateDependencies(rootDirPath, privatePackages);
+  console.info(
+    `Ensure the Dockerfile COPYs ${path.relative(rootDirPath, outDirPath)}/ and ${PRIVATE_REGISTRY_SCOPE}/ into the image before installing dependencies.`
+  );
+}
+
 async function collectPrivatePackages(
   rootDirPath: string,
-  rootPackageJson: PackageJson,
+  manifestPackageJsons: PackageJson[],
   outDirPath: string,
   registryOutDirPath: string
 ): Promise<Map<string, PrivatePackage>> {
   const privatePackages = new Map<string, PrivatePackage>();
-  // Start from the root package.json by design; workspace package dependencies are outside this command's target.
-  const packagesToProcess = findPrivateDependencies(rootPackageJson, outDirPath, registryOutDirPath);
-  const queuedPackages = new Map(packagesToProcess.map((p) => [p.name, p]));
+  // Seed from every manifest (root + workspaces); one private package may be requested by several
+  // manifests, so merge duplicates the same way nested discovery does — keep the narrower
+  // compatible requirement and fail loudly on a genuine conflict.
+  const packagesToProcess: PrivatePackage[] = [];
+  const queuedPackages = new Map<string, PrivatePackage>();
+  for (const packageJson of manifestPackageJsons) {
+    for (const requested of findPrivateDependencies(packageJson, outDirPath, registryOutDirPath)) {
+      const queued = queuedPackages.get(requested.name);
+      if (!queued) {
+        queuedPackages.set(requested.name, requested);
+        packagesToProcess.push(requested);
+        continue;
+      }
+      const narrower = narrowerCompatibleRequirement(queued, requested);
+      if (narrower === undefined) {
+        assertNoVersionConflict(queued, requested, 'a workspace manifest');
+      } else {
+        queued.versionSpecifier = narrower.versionSpecifier;
+      }
+    }
+  }
 
   for (let index = 0; index < packagesToProcess.length; index++) {
     const privatePackage = packagesToProcess[index];

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import type { PackageJson } from 'type-fest';
 import type { CommandModule, InferredOptionTypes } from 'yargs';
 
-import { findDescendantProjects, type FoundProjects } from '../project.js';
+import { findDescendantProjects, findRootAndSelfProjects, type FoundProjects } from '../project.js';
 import type { PrivateRegistryAuth } from '../utils/privateRegistry.js';
 import {
   PRIVATE_REGISTRY_SCOPE,
@@ -49,7 +49,15 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     'The Dockerfile must COPY the generated directories (e.g. `COPY @willbooster/ @willbooster/` and `COPY @willbooster-private/ @willbooster-private/`) so the in-image install resolves the rewritten file: paths.',
   builder,
   async handler(argv) {
-    const projects = await findDescendantProjects(argv, false);
+    const rootAndSelf = findRootAndSelfProjects(argv, false);
+    if (!rootAndSelf) {
+      console.error(chalk.red('No project found.'));
+      process.exit(1);
+    }
+    // Resolve the descendant set from the repository ROOT (not the current directory) so the
+    // command scans the root manifest and every workspace manifest regardless of where it runs:
+    // findDescendantProjects returns only the current project when invoked from a workspace.
+    const projects = await findDescendantProjects(argv, false, rootAndSelf.root.dirPath);
     if (!projects) {
       console.error(chalk.red('No project found.'));
       process.exit(1);
@@ -58,10 +66,15 @@ export const setupPrivatePackagesCommand: CommandModule<{ dryRun?: boolean }, In
     // Scan the root manifest and every workspace manifest: a private dependency may be declared in
     // a sub-package (e.g. packages/server) rather than the root, yet it still materializes at the
     // repository root so `wb optimizeForDockerBuild` resolves it uniformly.
-    await materializePrivatePackages(projects.root.dirPath, collectManifests(projects), {
-      outDir: argv.outDir,
-      dryRun: Boolean(argv.dryRun),
-    });
+    try {
+      await materializePrivatePackages(projects.root.dirPath, collectManifests(projects), {
+        outDir: argv.outDir,
+        dryRun: Boolean(argv.dryRun),
+      });
+    } catch (error) {
+      console.error(chalk.red(error instanceof Error ? error.message : String(error)));
+      process.exit(1);
+    }
   },
 };
 
@@ -69,14 +82,6 @@ export interface MaterializePrivatePackagesOptions {
   /** Directory (relative to the repository root) that git dependencies are copied into. */
   outDir?: string;
   dryRun?: boolean;
-  /**
-   * How to handle a registry package that must be downloaded when no registry auth is configured.
-   * `error` (the default, used by the explicit `wb setup-private-packages` command) fails; `warn`
-   * (used by the automatic `wb optimizeForDockerBuild --outside` step) leaves those packages
-   * un-materialized so the pre-existing "run wb setup-private-packages" warning path stays
-   * backward compatible.
-   */
-  onMissingAuth?: 'error' | 'warn';
 }
 
 /** The root manifest followed by each distinct workspace manifest. */
@@ -93,7 +98,7 @@ export async function materializePrivatePackages(
   manifestPackageJsons: PackageJson[],
   options: MaterializePrivatePackagesOptions = {}
 ): Promise<void> {
-  const { outDir = '@willbooster', dryRun = false, onMissingAuth = 'error' } = options;
+  const { outDir = '@willbooster', dryRun = false } = options;
 
   // Output paths are recursively DELETED before being recreated, so none of them may contain a
   // symlink component: a symlink (e.g. `escape -> node_modules`, or `@willbooster-private`
@@ -165,22 +170,17 @@ export async function materializePrivatePackages(
   // download actually happens (CI test steps deliberately receive no Verdaccio token).
   const downloadedPackages = [...privatePackages.values()].filter((p) => p.kind === 'registry' && !p.sourceDirPath);
   // Resolve required configuration BEFORE deleting the existing materializations, so a missing
-  // registry configuration cannot destroy a previously usable output tree.
+  // registry configuration cannot destroy a previously usable output tree. Throw (rather than
+  // exit) so callers can decide: `wb setup-private-packages` reports it and exits, while the
+  // automatic `wb optimizeForDockerBuild --outside` step catches it and continues, leaving the
+  // existing output untouched (nothing has been deleted yet at this point).
   const auth = downloadedPackages.length > 0 ? resolvePrivateRegistryAuth(rootDirPath) : undefined;
   if (downloadedPackages.length > 0 && !auth) {
-    const detail =
+    throw new Error(
       `Cannot download ${downloadedPackages.map((p) => p.name).join(', ')}: no registry configured for the ${PRIVATE_REGISTRY_SCOPE} scope; ` +
-      `add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc. Only installed copies satisfying an exact version or ` +
-      'semver range are reused without registry access; dist-tag specifiers (e.g. `latest`) always require it.';
-    if (onMissingAuth === 'error') {
-      console.error(chalk.red(detail));
-      process.exit(1);
-    }
-    // Automatic path (wb optimizeForDockerBuild --outside): leave these un-materialized instead of
-    // failing, mirroring the pre-existing behavior; the caller's per-project rewrite then warns
-    // and keeps the registry specifier so an in-image install with credentials can still resolve it.
-    console.warn(chalk.yellow(`${detail} Skipping; the Docker build will need registry credentials for them.`));
-    for (const skipped of downloadedPackages) privatePackages.delete(skipped.name);
+        `add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc. Only installed copies satisfying an exact version or ` +
+        'semver range are reused without registry access; dist-tag specifiers (e.g. `latest`) always require it.'
+    );
   }
 
   const copiedPackages = [...privatePackages.values()].filter((p) => p.kind === 'git');
@@ -275,7 +275,7 @@ async function collectPrivatePackages(
       }
       const narrower = narrowerCompatibleRequirement(queued, requested);
       if (narrower === undefined) {
-        assertNoVersionConflict(queued, requested, 'a workspace manifest');
+        assertNoVersionConflict(queued, requested, packageJson.name ?? 'a workspace manifest');
       } else {
         queued.versionSpecifier = narrower.versionSpecifier;
       }

--- a/packages/wb/test/setupPrivatePackages.test.ts
+++ b/packages/wb/test/setupPrivatePackages.test.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { collectManifests, materializePrivatePackages } from '../src/commands/setupPrivatePackages.js';
+import { findDescendantProjects } from '../src/project.js';
+
+describe('materializePrivatePackages', () => {
+  // A private dependency may be declared in a workspace package (e.g. packages/server) rather than
+  // the repository root; both must be materialized at the root so `wb optimizeForDockerBuild`
+  // resolves them uniformly. Uses git-URL dependencies so materialization copies from an installed
+  // node_modules copy and never touches the registry.
+  it('materializes private dependencies declared in the root and in workspace packages', async () => {
+    const rootDirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-setup-private-'));
+    try {
+      await writeJson(path.join(rootDirPath, 'package.json'), {
+        name: '@test/root',
+        workspaces: ['packages/*'],
+        dependencies: { '@willbooster/root-dep': 'git@github.com:WillBooster/root-dep.git#main' },
+      });
+      await writeJson(path.join(rootDirPath, 'packages', 'server', 'package.json'), {
+        name: '@test/server',
+        dependencies: { '@willbooster/server-dep': 'git@github.com:WillBooster/server-dep.git#main' },
+      });
+      await writeJson(path.join(rootDirPath, 'node_modules', '@willbooster', 'root-dep', 'package.json'), {
+        name: '@willbooster/root-dep',
+        version: '1.0.0',
+      });
+      await writeJson(path.join(rootDirPath, 'node_modules', '@willbooster', 'server-dep', 'package.json'), {
+        name: '@willbooster/server-dep',
+        version: '1.0.0',
+      });
+
+      const projects = await findDescendantProjects({}, false, rootDirPath);
+      expect(projects).toBeDefined();
+      await materializePrivatePackages(projects!.root.dirPath, collectManifests(projects!));
+
+      expect(await readName(path.join(rootDirPath, '@willbooster', 'root-dep'))).toBe('@willbooster/root-dep');
+      expect(await readName(path.join(rootDirPath, '@willbooster', 'server-dep'))).toBe('@willbooster/server-dep');
+    } finally {
+      await fs.rm(rootDirPath, { force: true, recursive: true });
+    }
+  });
+});
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(value));
+}
+
+async function readName(packageDirPath: string): Promise<string | undefined> {
+  const content = await fs.readFile(path.join(packageDirPath, 'package.json'), 'utf8');
+  return (JSON.parse(content) as { name?: string }).name;
+}

--- a/packages/wb/test/setupPrivatePackages.test.ts
+++ b/packages/wb/test/setupPrivatePackages.test.ts
@@ -43,6 +43,37 @@ describe('materializePrivatePackages', () => {
       await fs.rm(rootDirPath, { force: true, recursive: true });
     }
   });
+
+  // A failed git-package copy (e.g. a dangling symlink in the installed source) must not leave a
+  // half-populated @willbooster tree: git packages stage and swap in only after every copy
+  // succeeds, so a previously materialized copy survives the failure.
+  it('throws without destroying an existing materialization when a git-package copy fails', async () => {
+    const rootDirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-setup-private-'));
+    try {
+      await writeJson(path.join(rootDirPath, 'package.json'), {
+        name: '@test/root',
+        dependencies: { '@willbooster/broken': 'git@github.com:WillBooster/broken.git#main' },
+      });
+      // The installed source contains a dangling symlink, so copying it (with dereference) fails.
+      const installedDirPath = path.join(rootDirPath, 'node_modules', '@willbooster', 'broken');
+      await writeJson(path.join(installedDirPath, 'package.json'), { name: '@willbooster/broken', version: '1.0.0' });
+      await fs.symlink(path.join(installedDirPath, 'missing-target'), path.join(installedDirPath, 'dangling'));
+      // A previously materialized copy that must survive the failed refresh.
+      const materializedDirPath = path.join(rootDirPath, '@willbooster', 'broken');
+      await writeJson(path.join(materializedDirPath, 'package.json'), {
+        name: '@willbooster/broken',
+        version: '0.9.0',
+      });
+
+      const projects = await findDescendantProjects({}, false, rootDirPath);
+      await expect(materializePrivatePackages(projects!.root.dirPath, collectManifests(projects!))).rejects.toThrow();
+
+      // The pre-existing materialization is untouched (staging never swapped in).
+      expect(await readName(materializedDirPath)).toBe('@willbooster/broken');
+    } finally {
+      await fs.rm(rootDirPath, { force: true, recursive: true });
+    }
+  });
 });
 
 async function writeJson(filePath: string, value: unknown): Promise<void> {


### PR DESCRIPTION
## Motivation

Repositories currently have to call `wb setup-private-packages` (or a hand-rolled equivalent) in every Docker-build / test script before `wb optimizeForDockerBuild --outside`. Missing it produces a confusing in-image failure — e.g. WillBoosterLab/judge's CI failed at `COPY @willbooster-private/ ./@willbooster-private/: "/@willbooster-private": not found` because the docker-test script never materialized the private package.

This makes the shared tooling do it automatically so per-repo `package.json` scripts can drop the explicit step.

## Changes

**A. `wb optimizeForDockerBuild --outside` auto-materializes private packages.**
Before rewriting dependencies, the command now materializes private packages itself. Every wb-orchestrated Docker build (`wb test --e2e docker`, `wb start-docker`, deploy) and any repo that calls `wb optimizeForDockerBuild --outside` directly therefore resolves private deps to `file:` paths with no separate step.
- Gated on `--outside` (the in-image second pass has no `node_modules`/registry to materialize from) **and** on a private dependency actually being declared, so repos without one are untouched — no empty output directories, no spurious "COPY" hint.
- The call is wrapped in a non-fatal `try/catch`: any failure (missing auth, 401, download error, a symlinked output dir) is caught, warned, and the build continues with the pre-existing "run `wb setup-private-packages`" hint — it never turns a previously-succeeding build into a failure.
- Materialization is **non-destructive on failure**: `materializePrivatePackages` throws before deleting any existing output, its path-safety guards throw (rather than `process.exit`) so the caller can catch them, and both the git and registry trees are copied into staging directories and swapped in only after their copies succeed.

**B. `wb setup-private-packages` scans workspace manifests, not just the root.**
A private dependency declared in a sub-package (e.g. `packages/server/package.json`) is now discovered and materialized at the repository root. The descendant set is resolved from the repository root, so the command scans every workspace manifest even when invoked from a sub-package. Duplicate requests across manifests are merged with the same narrower-compatible-requirement / conflict rules already used for nested discovery (and conflict errors name the declaring manifest).

The handler is refactored into a reusable `materializePrivatePackages` function shared by both commands (plus an exported `collectManifests` helper).

## Backward compatibility

- Repos that still call `wb setup-private-packages` explicitly keep working (materialization is idempotent; it just runs again inside optimize).
- No new hard-failure path: the automatic step catches every failure and continues, preserving the pre-existing warning behavior.
- Root-only private deps behave identically. Repos without private deps are entirely unaffected.

## Verification

- `bun run typecheck`, lint, and the full `wb` test suite (**180 passed, 1 skipped**) pass.
- New `test/setupPrivatePackages.test.ts` exercises the real path (`findDescendantProjects` → `collectManifests` → `materializePrivatePackages`): it asserts a root- and a workspace-declared private dependency are both materialized, and that a failed git-package copy throws without destroying an existing materialization (offline git-URL fixtures, no registry).
- End-to-end against WillBoosterLab/judge (private dep in `packages/server`): `wb setup-private-packages --dry-run` now detects `@willbooster-private/llm-proxy` (previously nothing), and `wb optimizeForDockerBuild --outside` prints `Copied @willbooster-private/llm-proxy` then rewrites it with no "not materialized" warning. Also verified: a no-private-dep repo creates no output dirs, and a symlinked `@willbooster` warns and continues (exit 0) instead of hard-exiting.

## Known limitation / follow-up

- The git (`@willbooster`) and registry (`@willbooster-private`) trees are not yet committed as a single atomic transaction, so a registry failure after the git swap can leave a registry package's nested `file:` git reference dangling in the (caught-and-continued) auto path. Narrow trigger; tracked in #1046.
- A separate PR will migrate WillBoosterLab/judge to this generic mechanism (drop its hand-rolled `setup-private-packages` script, the Dockerfile `RUN node -e` rewrite, and the explicit call sites) after this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
