### PR TITLE
fix(wbfy): preserve custom gen-code steps and generate worker types before gen-code

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1376,8 +1376,10 @@ async function normalizePackageMetadata(
   } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
     // Preserve project-specific steps a repo appended to the managed `bun wb gen-code` (e.g. building extra
     // deploy assets) instead of discarding them: only the managed gen-code and the wrangler-types invocation
-    // are wbfy's to regenerate. Their relative order is kept, and the wrangler-types command is re-appended
-    // through the shared helper so it matches postinstall.
+    // are wbfy's to regenerate. The wrangler-types command stays directly after `bun wb gen-code`, with the
+    // custom segments after it, so a re-run re-parses to the same string — a custom segment BETWEEN gen-code
+    // and the generator would otherwise read as a non-transplantable prerequisite, drop the generator, and
+    // make wbfy oscillate across runs.
     const customSegments = genCodeScript
       ? splitCommandSegments(genCodeScript).filter(
           (segment) =>
@@ -1386,9 +1388,8 @@ async function normalizePackageMetadata(
             !reachesWranglerTypes(segment, jsonObj.scripts, () => true)
         )
       : [];
-    jsonObj.scripts['gen-code'] = appendWranglerTypes(
-      ['bun wb gen-code', ...customSegments].join(' && '),
-      wranglerTypes
+    jsonObj.scripts['gen-code'] = [appendWranglerTypes('bun wb gen-code', wranglerTypes), ...customSegments].join(
+      ' && '
     );
   } else if (
     genCodeScript &&

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -285,7 +285,32 @@ function updatePostinstallScript(
     const preservedSegments = involvesWranglerTypes
       ? postinstallSegments.filter((segment) => segment !== '' && !isManagedGenCodeSegment(segment, scripts))
       : [];
-    scripts.postinstall = ['wb gen-code', ...preservedSegments].join(' && ');
+    // worker-configuration.d.ts must be generated BEFORE `wb gen-code`: a types-consuming generator (e.g.
+    // chakra typegen against the Cloudflare `Env`) fails on a fresh checkout without it, and because install
+    // lifecycle failures are tolerated it then silently leaves the file ungenerated for the later type check.
+    // Insert `wb gen-code` right after the last segment that (re)generates the MANAGED worker types, keeping
+    // the project's own pipeline — prerequisites and their relative order — intact. Any invocation writing the
+    // default `worker-configuration.d.ts` counts (a bare generator, or one that only changes inputs like
+    // `--env-file`/`--config`); a `harmless` one does not (`--check`/`--help` generate nothing, and a custom
+    // output path writes a file `wb gen-code` does not consume), so it stays after gen-code as before. When
+    // none is present (e.g. an unmodeled or directory-changing pipeline) gen-code leads as it used to.
+    let lastTypesGeneratorIndex = -1;
+    for (const [index, segment] of preservedSegments.entries()) {
+      // A directory change runs the remaining segments elsewhere, so a generator past it writes another
+      // package's file — stop looking; `wb gen-code` then leads those trailing segments as before.
+      if (scriptChangesWorkingDirectory(segment)) break;
+      const generatesManagedTypes = reachesWranglerTypes(
+        segment,
+        scripts,
+        (invocationArgs) => classifyWranglerTypesInvocation(invocationArgs) !== 'harmless'
+      );
+      if (generatesManagedTypes) lastTypesGeneratorIndex = index;
+    }
+    scripts.postinstall = [
+      ...preservedSegments.slice(0, lastTypesGeneratorIndex + 1),
+      'wb gen-code',
+      ...preservedSegments.slice(lastTypesGeneratorIndex + 1),
+    ].join(' && ');
   } else if (scripts.postinstall?.includes('gen-i18n-ts')) {
     delete scripts.postinstall;
   }
@@ -1349,7 +1374,22 @@ async function normalizePackageMetadata(
   if (genCodeScript?.includes('No code generation needed')) {
     delete jsonObj.scripts['gen-code'];
   } else if (shouldGenerateWbGenCodeScript(config, genCodeScript)) {
-    jsonObj.scripts['gen-code'] = appendWranglerTypes('bun wb gen-code', wranglerTypes);
+    // Preserve project-specific steps a repo appended to the managed `bun wb gen-code` (e.g. building extra
+    // deploy assets) instead of discarding them: only the managed gen-code and the wrangler-types invocation
+    // are wbfy's to regenerate. Their relative order is kept, and the wrangler-types command is re-appended
+    // through the shared helper so it matches postinstall.
+    const customSegments = genCodeScript
+      ? splitCommandSegments(genCodeScript).filter(
+          (segment) =>
+            segment !== '' &&
+            !isManagedGenCodeSegment(segment, jsonObj.scripts) &&
+            !reachesWranglerTypes(segment, jsonObj.scripts, () => true)
+        )
+      : [];
+    jsonObj.scripts['gen-code'] = appendWranglerTypes(
+      ['bun wb gen-code', ...customSegments].join(' && '),
+      wranglerTypes
+    );
   } else if (
     genCodeScript &&
     wranglerTypes &&

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -251,12 +251,48 @@ test('appends wrangler types to gen-code and postinstall for Cloudflare projects
 // flags would silently change the generated declarations. Both managed scripts must run the very same command, or the
 // file would depend on whether install or `run gen-code` happened to run last.
 test.each([
-  ['postinstall', { postinstall: 'wb gen-code && wrangler types --strict-vars=false' }],
-  ['a script of its own', { 'gen-types': 'wrangler types --strict-vars=false' }],
-])('preserves a project-specific wrangler types invocation kept in %s', async (_description, scripts) => {
+  // The generator already runs in postinstall, so it is reordered ahead of `wb gen-code` (which consumes the
+  // generated worker types).
+  [
+    'postinstall',
+    { postinstall: 'wb gen-code && wrangler types --strict-vars=false' },
+    'wrangler types --strict-vars=false && wb gen-code',
+  ],
+  // The generator lives in a script of its own, so wbfy appends the resolved command to postinstall.
+  [
+    'a script of its own',
+    { 'gen-types': 'wrangler types --strict-vars=false' },
+    'wb gen-code && wrangler types --strict-vars=false',
+  ],
+])(
+  'preserves a project-specific wrangler types invocation kept in %s',
+  async (_description, scripts, expectedPostinstall) => {
+    const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
+    const packageJson = await generatePackageJsonFrom(
+      { scripts, ...wranglerPackageJson },
+      {
+        depending: genI18nTsDepending,
+        isCloudflare: true,
+        doesContainWranglerConfig: true,
+        packageJson: wranglerPackageJson,
+      },
+      { createI18nDir: true }
+    );
+
+    expect(packageJson.scripts).toMatchObject({
+      'gen-code': 'bun wb gen-code && wrangler types --strict-vars=false',
+      postinstall: expectedPostinstall,
+    });
+  }
+);
+
+// A project may append its own step to the managed `bun wb gen-code` (e.g. building extra deploy assets).
+// Regenerating gen-code must keep that step instead of discarding it: only the managed gen-code and the
+// wrangler-types invocation are wbfy's to rewrite.
+test('preserves project-specific steps appended to the managed gen-code script', async () => {
   const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
   const packageJson = await generatePackageJsonFrom(
-    { scripts, ...wranglerPackageJson },
+    { scripts: { 'gen-code': 'bun wb gen-code && bun run build-assets' }, ...wranglerPackageJson },
     {
       depending: genI18nTsDepending,
       isCloudflare: true,
@@ -266,10 +302,7 @@ test.each([
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts).toMatchObject({
-    'gen-code': 'bun wb gen-code && wrangler types --strict-vars=false',
-    postinstall: 'wb gen-code && wrangler types --strict-vars=false',
-  });
+  expect(packageJson.scripts?.['gen-code']).toBe('bun wb gen-code && bun run build-assets && bunx wrangler types');
 });
 
 // A build script composing gen-code with a build step reaches the generator only through the managed gen-code
@@ -298,7 +331,7 @@ test('keeps management for a script composing gen-code with a build step', async
   expect(packageJson.scripts).toMatchObject({
     'build/core': 'bun run gen-code && vite build',
     'gen-code': 'bun wb gen-code && wrangler types --strict-vars=false',
-    postinstall: 'wb gen-code && wrangler types --strict-vars=false',
+    postinstall: 'wrangler types --strict-vars=false && wb gen-code',
   });
 });
 
@@ -390,7 +423,7 @@ test('preserves a wrangler types invocation with a custom config path when overw
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --config config/worker.jsonc');
+  expect(packageJson.scripts?.postinstall).toBe('wrangler types --config config/worker.jsonc && wb gen-code');
 });
 
 // The generated file is a pure function of committed inputs only when the `Env` inference source (.dev.vars,
@@ -734,7 +767,7 @@ test('prefers the generator postinstall already runs over other scripts', async 
 
   expect(packageJson.scripts).toMatchObject({
     'gen-code': 'bun wb gen-code && wrangler types --env-interface AppEnv',
-    postinstall: 'wb gen-code && wrangler types --env-interface AppEnv',
+    postinstall: 'wrangler types --env-interface AppEnv && wb gen-code',
   });
 });
 
@@ -859,7 +892,7 @@ test('keeps generation prerequisites when rewriting postinstall', async () => {
   );
 
   expect(packageJson.scripts?.postinstall).toBe(
-    'wb gen-code && node scripts/prepareTypes.js && wrangler types --strict-vars=false'
+    'node scripts/prepareTypes.js && wrangler types --strict-vars=false && wb gen-code'
   );
 });
 
@@ -915,7 +948,7 @@ test('skips worker-types management for a piped custom-config invocation', async
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe(`wb gen-code && ${postinstall}`);
+  expect(packageJson.scripts?.postinstall).toBe(`${postinstall} && wb gen-code`);
 });
 
 // `yarn --cwd . gen-types` runs this package's script; the option value must not be mistaken for the script name.
@@ -938,7 +971,7 @@ test('preserves a wrapper invoked through a runner option with a value', async (
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && yarn --cwd . gen-types');
+  expect(packageJson.scripts?.postinstall).toBe('yarn --cwd . gen-types && wb gen-code');
 });
 
 // A gen-code wrapper is interchangeable with `wb gen-code` only when the gen-code script is the managed
@@ -958,7 +991,7 @@ test('preserves a gen-code wrapper whose script is a custom pipeline', async () 
 
   expect(packageJson.scripts).toMatchObject({
     'gen-code': 'node scripts/prepareTypes.js && wrangler types --strict-vars=false',
-    postinstall: 'wb gen-code && bun run gen-code',
+    postinstall: 'bun run gen-code && wb gen-code',
   });
 });
 
@@ -997,7 +1030,7 @@ test('preserves a gen-code wrapper whose script includes a custom-config invocat
 
   expect(packageJson.scripts).toMatchObject({
     'gen-code': 'wb gen-code && wrangler types --config config/worker.jsonc',
-    postinstall: 'wb gen-code && bun run gen-code',
+    postinstall: 'bun run gen-code && wb gen-code',
   });
 });
 
@@ -1058,7 +1091,7 @@ test('recognizes an exec-form wb gen-code segment when rewriting postinstall', a
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && wrangler types --strict-vars=false');
+  expect(packageJson.scripts?.postinstall).toBe('wrangler types --strict-vars=false && wb gen-code');
 });
 
 // Forwarded wrapper arguments (`npm run gen-types -- --check`) change the effective invocation, so the wrapper
@@ -1436,7 +1469,7 @@ test('preserves a wrapper script invoking wrangler types with a custom config wh
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.postinstall).toBe('wb gen-code && bun run gen-types');
+  expect(packageJson.scripts?.postinstall).toBe('bun run gen-types && wb gen-code');
 });
 
 test('keeps custom database scripts for drizzle projects', async () => {

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -291,18 +291,28 @@ test.each([
 // wrangler-types invocation are wbfy's to rewrite.
 test('preserves project-specific steps appended to the managed gen-code script', async () => {
   const wranglerPackageJson = { devDependencies: { wrangler: '4.69.0' } };
-  const packageJson = await generatePackageJsonFrom(
+  const config = {
+    depending: genI18nTsDepending,
+    isCloudflare: true,
+    doesContainWranglerConfig: true,
+    packageJson: wranglerPackageJson,
+  };
+  const first = await generatePackageJsonFrom(
     { scripts: { 'gen-code': 'bun wb gen-code && bun run build-assets' }, ...wranglerPackageJson },
-    {
-      depending: genI18nTsDepending,
-      isCloudflare: true,
-      doesContainWranglerConfig: true,
-      packageJson: wranglerPackageJson,
-    },
+    config,
     { createI18nDir: true }
   );
 
-  expect(packageJson.scripts?.['gen-code']).toBe('bun wb gen-code && bun run build-assets && bunx wrangler types');
+  // The wrangler-types command stays directly after `bun wb gen-code`, with the custom step after it.
+  const expected = 'bun wb gen-code && bunx wrangler types && bun run build-assets';
+  expect(first.scripts?.['gen-code']).toBe(expected);
+
+  // wbfy consumes its own output, so a second run must be a no-op: the custom step must not read as a
+  // generator prerequisite and drop the wrangler-types command (which would make gen-code oscillate).
+  const second = await generatePackageJsonFrom({ scripts: { ...first.scripts }, ...wranglerPackageJson }, config, {
+    createI18nDir: true,
+  });
+  expect(second.scripts?.['gen-code']).toBe(expected);
 });
 
 // A build script composing gen-code with a build step reaches the generator only through the managed gen-code


### PR DESCRIPTION
## Background

Surfaced applying wbfy to prompt-study (Cloudflare + chakra), whose `gen-code` also builds lesson images (`bun wb gen-code && bun wb dotenv -- build-ts run scripts/buildLessonImages.ts`). wbfy clobbered two migration-authored scripts, breaking CI and (silently) deploys.

## Bugs fixed

### 1. gen-code overwrite discarded custom steps
`shouldGenerateWbGenCodeScript` returns true for chakra/prisma/blitz/gen-i18n repos, after which wbfy replaced the **entire** `gen-code` with `bun wb gen-code`, dropping any project-specific step appended to it. Now only the managed `wb gen-code` and the wrangler-types invocation are regenerated; other segments (e.g. `buildLessonImages`) are preserved.

### 2. worker types generated after `wb gen-code`
When postinstall already ran a worker-types generator, wbfy forced `['wb gen-code', ...preserved]`, so `wrangler types` ran **after** `wb gen-code`. A types-consuming generator — chakra typegen type-checks against the Cloudflare `Env` — then fails on a fresh checkout; and since install lifecycle failures are tolerated, it silently leaves `worker-configuration.d.ts` ungenerated, failing the later cleanup lint (`Cannot find module 'cloudflare:workers'`).

Now `wb gen-code` is inserted **after the last segment that (re)generates the managed default-output file**:
- The predicate is `classifyWranglerTypesInvocation(args) !== 'harmless'`, so `--env-file`/`--config` (default output, changed inputs) count, while `--check` and custom output paths do not.
- Prerequisite pipelines stay intact (`node scripts/prepareTypes.js && wrangler types … && wb gen-code`).
- A directory change stops the search, so post-`cd` generators (writing another package's file) keep `wb gen-code` leading them.

The postinstall **append** branch (generator resolved from a separate script, none in postinstall) is intentionally left as-is here to keep the blast radius small; a follow-up can make it types-first too.

## Validation

- `packages/wbfy/test/packageJson.test.ts`: added a test for preserving custom gen-code steps; updated the reorder-affected cases to the corrected types-first order (custom-config/`cd`/non-generating cases stay gen-code-first).
- Re-ran the fixed wbfy against prompt-study: **zero diff** on `gen-code`/`postinstall` (they now match the migration's intent), so the manual restore is no longer needed.
- `bun wb typecheck` / `bun wb lint` pass; wbfy suites (113 tests) pass.
