### PR TITLE
fix(wbfy): apply minimum-release-age gate to vinext framework packages

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -135,7 +135,4 @@ minimumReleaseAgeExcludes = [
   "react",
   "react-dom",
   "react-is",
-  "@vinext/cloudflare",
-  "@vinext/types",
-  "vinext",
 ]

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -157,13 +157,6 @@ export const bunMinimumReleaseAgeExcludes = [
   // Repos pin react-is via resolutions in lockstep with react, so a fresh react release must
   // resolve immediately like react/react-dom above.
   'react-is',
-  // vinext is still pre-1.0 and its scoped packages release in lockstep, so the whole
-  // set must be listed: excluding only `vinext` still fails because Bun gates the
-  // transitive `@vinext/types`. Bun matches these names literally, so `@vinext/*`
-  // would not work here even though wbfy's own pattern matcher accepts globs.
-  '@vinext/cloudflare',
-  '@vinext/types',
-  'vinext',
 ];
 
 export type BunLinker = 'isolated' | 'hoisted';


### PR DESCRIPTION
## Why

`bunMinimumReleaseAgeExcludes` relaxed the vinext framework (`vinext`, `@vinext/cloudflare`, `@vinext/types`) from the org-wide 5-day minimum-release-age gate, letting wbfy pin and Bun install brand-new releases immediately. Since vinext is still pre-1.0 and unstable, it should clear the age window like any other third-party dependency.

## What

- Removed `vinext`, `@vinext/cloudflare`, and `@vinext/types` from `bunMinimumReleaseAgeExcludes` in `packages/wbfy/src/generators/bunfig.ts`. This affects both the generated `bunfig.toml` `minimumReleaseAgeExcludes` and wbfy's own version-pinning (`shouldApplyPackageAgeGate`).
- `vinext-progress` (a first-party WillBooster package) stays exempt under the "our packages are safe" block.
- Regenerated this repo's own `bunfig.toml` to drop the same three entries.

## Verification

- `bun verify` (type check + lint): passed
- `bun test test/bunfig.test.ts`: 4 pass
