### PR TITLE
fix(wbfy): import config packages via local path in willbooster-configs

### DIFF
--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -5,7 +5,6 @@ import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
-
 import { resolveWillboosterConfigModule } from '../utils/willboosterConfigsUtil.js';
 
 import { normalizeConfigContent } from './configContent.js';

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -17,13 +17,13 @@ const managedConfigBlocks = new ManagedConfigBlocks({
   toolName: 'oxfmt',
 });
 
-export async function generateOxfmtConfig(config: PackageConfig, rootConfig: PackageConfig): Promise<void> {
+export async function generateOxfmtConfig(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxfmtConfig', async () => {
     const legacyJsonConfigPath = path.resolve(config.dirPath, '.oxfmtrc.json');
     const filePath = path.resolve(config.dirPath, 'oxfmt.config.ts');
     const existingContent = await fsUtil.readFileIfExists(filePath);
     const desiredContent = managedConfigBlocks.getConfigContent({
-      desiredContent: getConfigContent(config, rootConfig),
+      desiredContent: getConfigContent(config),
       existingContent,
       filePath,
     });
@@ -39,8 +39,8 @@ export async function generateOxfmtConfig(config: PackageConfig, rootConfig: Pac
   });
 }
 
-function getConfigContent(config: PackageConfig, rootConfig: PackageConfig): string {
-  const oxfmtBaseConfigModule = resolveWillboosterConfigModule(config, rootConfig, '@willbooster/oxfmt-config');
+function getConfigContent(config: PackageConfig): string {
+  const oxfmtBaseConfigModule = resolveWillboosterConfigModule(config, '@willbooster/oxfmt-config');
 
   // CommonJS packages need require/module.exports here: oxfmt config files are
   // only auto-discovered as .ts, and the shared config package is ESM-only.

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -6,6 +6,8 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
+import { resolveWillboosterConfigModule } from '../utils/willboosterConfigsUtil.js';
+
 import { normalizeConfigContent } from './configContent.js';
 import { ManagedConfigBlocks } from './managedConfigBlock.js';
 
@@ -15,13 +17,13 @@ const managedConfigBlocks = new ManagedConfigBlocks({
   toolName: 'oxfmt',
 });
 
-export async function generateOxfmtConfig(config: PackageConfig): Promise<void> {
+export async function generateOxfmtConfig(config: PackageConfig, rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxfmtConfig', async () => {
     const legacyJsonConfigPath = path.resolve(config.dirPath, '.oxfmtrc.json');
     const filePath = path.resolve(config.dirPath, 'oxfmt.config.ts');
     const existingContent = await fsUtil.readFileIfExists(filePath);
     const desiredContent = managedConfigBlocks.getConfigContent({
-      desiredContent: getConfigContent(config),
+      desiredContent: getConfigContent(config, rootConfig),
       existingContent,
       filePath,
     });
@@ -37,7 +39,9 @@ export async function generateOxfmtConfig(config: PackageConfig): Promise<void> 
   });
 }
 
-function getConfigContent(config: PackageConfig): string {
+function getConfigContent(config: PackageConfig, rootConfig: PackageConfig): string {
+  const oxfmtBaseConfigModule = resolveWillboosterConfigModule(config, rootConfig, '@willbooster/oxfmt-config');
+
   // CommonJS packages need require/module.exports here: oxfmt config files are
   // only auto-discovered as .ts, and the shared config package is ESM-only.
   if (!config.isEsmPackage) {
@@ -47,7 +51,7 @@ function getConfigContent(config: PackageConfig): string {
 import type { OxfmtConfig } from 'oxfmt';
 
 // oxlint-disable unicorn/prefer-module -- Oxfmt config files are only auto-discovered as .ts, and CommonJS avoids ESM package loading issues.
-const oxfmtConfig = require('@willbooster/oxfmt-config');
+const oxfmtConfig = require('${oxfmtBaseConfigModule}');
 
 const oxfmtResolvedConfig: OxfmtConfig = oxfmtConfig.default ?? oxfmtConfig;`
     )}
@@ -60,7 +64,7 @@ ${managedConfigBlocks.getBlock('export', 'module.exports = oxfmtResolvedConfig;'
     'base',
     `import type { OxfmtConfig } from 'oxfmt';
 
-import config from '@willbooster/oxfmt-config';
+import config from '${oxfmtBaseConfigModule}';
 
 const oxfmtResolvedConfig: OxfmtConfig = config;`
   )}

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -19,7 +19,7 @@ const managedConfigBlocks = new ManagedConfigBlocks({
   toolName: 'oxlint',
 });
 
-export async function generateOxlintConfig(config: PackageConfig, rootConfig: PackageConfig): Promise<void> {
+export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
     // willbooster-configs publishes config files as product code, so migration
     // must not remove package-provided linter settings. Generated files with
@@ -33,7 +33,7 @@ export async function generateOxlintConfig(config: PackageConfig, rootConfig: Pa
       ? existingContent
       : replaceLegacyConfigReferences(
           managedConfigBlocks.getConfigContent({
-            desiredContent: getConfigContent(config, rootConfig),
+            desiredContent: getConfigContent(config),
             existingContent,
             filePath,
           })
@@ -73,9 +73,9 @@ function replaceLegacyConfigReferences(content: string): string {
   return content.replaceAll(/(?<![./])\bconfig\./gu, 'oxlintResolvedConfig.');
 }
 
-function getConfigContent(config: PackageConfig, rootConfig: PackageConfig): string {
+function getConfigContent(config: PackageConfig): string {
   const isRootConfig = config.isRoot;
-  const oxlintBaseConfigModule = resolveWillboosterConfigModule(config, rootConfig, '@willbooster/oxlint-config');
+  const oxlintBaseConfigModule = resolveWillboosterConfigModule(config, '@willbooster/oxlint-config');
 
   // Do not collapse this to a static import for every package. CommonJS packages
   // type-check auto-discovered oxlint.config.ts as CommonJS, so importing the ESM

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -5,7 +5,10 @@ import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
-import { isPublishedWillboosterConfigsPackage } from '../utils/willboosterConfigsUtil.js';
+import {
+  isPublishedWillboosterConfigsPackage,
+  resolveWillboosterConfigModule,
+} from '../utils/willboosterConfigsUtil.js';
 
 import { normalizeConfigContent } from './configContent.js';
 import { ManagedConfigBlocks } from './managedConfigBlock.js';
@@ -16,7 +19,7 @@ const managedConfigBlocks = new ManagedConfigBlocks({
   toolName: 'oxlint',
 });
 
-export async function generateOxlintConfig(config: PackageConfig, _rootConfig: PackageConfig): Promise<void> {
+export async function generateOxlintConfig(config: PackageConfig, rootConfig: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateOxlintConfig', async () => {
     // willbooster-configs publishes config files as product code, so migration
     // must not remove package-provided linter settings. Generated files with
@@ -30,7 +33,7 @@ export async function generateOxlintConfig(config: PackageConfig, _rootConfig: P
       ? existingContent
       : replaceLegacyConfigReferences(
           managedConfigBlocks.getConfigContent({
-            desiredContent: getConfigContent(config),
+            desiredContent: getConfigContent(config, rootConfig),
             existingContent,
             filePath,
           })
@@ -70,9 +73,9 @@ function replaceLegacyConfigReferences(content: string): string {
   return content.replaceAll(/(?<![./])\bconfig\./gu, 'oxlintResolvedConfig.');
 }
 
-function getConfigContent(config: PackageConfig): string {
+function getConfigContent(config: PackageConfig, rootConfig: PackageConfig): string {
   const isRootConfig = config.isRoot;
-  const oxlintBaseConfigModule = getOxlintBaseConfigModule(config);
+  const oxlintBaseConfigModule = resolveWillboosterConfigModule(config, rootConfig, '@willbooster/oxlint-config');
 
   // Do not collapse this to a static import for every package. CommonJS packages
   // type-check auto-discovered oxlint.config.ts as CommonJS, so importing the ESM
@@ -85,7 +88,7 @@ function getConfigContent(config: PackageConfig): string {
 import type { OxlintConfig } from 'oxlint';
 
 // oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids ESM package loading issues.
-const oxlintBaseConfig = require('@willbooster/oxlint-config');
+const oxlintBaseConfig = require('${oxlintBaseConfigModule}');
 
 ${getResolvedConfigContent('oxlintBaseConfig.default ?? oxlintBaseConfig', isRootConfig)}`
     )}
@@ -105,10 +108,6 @@ ${getResolvedConfigContent('oxlintBaseConfig', isRootConfig)}`
 
 ${managedConfigBlocks.getBlock('export', 'export default oxlintResolvedConfig;')}
 `;
-}
-
-function getOxlintBaseConfigModule(config: PackageConfig): string {
-  return config.packageJson?.name === '@willbooster/oxlint-config' ? './config.mjs' : '@willbooster/oxlint-config';
 }
 
 function getResolvedConfigContent(baseConfigName: string, isRootConfig: boolean): string {

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -343,7 +343,7 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
         promises.push(generateTsconfig(config));
       }
       if (doesContainJsOrTs(config)) {
-        promises.push(generateOxfmtConfig(config));
+        promises.push(generateOxfmtConfig(config, rootConfig));
         promises.push(generateOxlintConfig(config, rootConfig));
       } else if (!config.isRoot && config.doesContainPackageJson && doesContainJsOrTs(rootConfig)) {
         // Monorepo verification can invoke oxlint from every workspace. Give

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -343,7 +343,7 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
         promises.push(generateTsconfig(config));
       }
       if (doesContainJsOrTs(config)) {
-        promises.push(generateOxfmtConfig(config, rootConfig));
+        promises.push(generateOxfmtConfig(config));
         promises.push(generateOxlintConfig(config, rootConfig));
       } else if (!config.isRoot && config.doesContainPackageJson && doesContainJsOrTs(rootConfig)) {
         // Monorepo verification can invoke oxlint from every workspace. Give

--- a/packages/wbfy/src/utils/willboosterConfigsUtil.ts
+++ b/packages/wbfy/src/utils/willboosterConfigsUtil.ts
@@ -14,16 +14,18 @@ import type { PackageConfig } from '../packageConfig.js';
  * the edge is absent, isolated installs cannot resolve the bare package name, so
  * import the committed `config.mjs` build output through a relative path instead.
  */
-export function resolveWillboosterConfigModule(
-  config: PackageConfig,
-  rootConfig: PackageConfig,
-  configPackageName: string
-): string {
+export function resolveWillboosterConfigModule(config: PackageConfig, configPackageName: string): string {
   if (!config.isWillBoosterConfigs) return configPackageName;
 
   // e.g. '@willbooster/oxlint-config' -> 'oxlint-config', which is its directory under `packages/`.
   const configPackageDir = configPackageName.slice(configPackageName.indexOf('/') + 1);
-  const localEntry = path.resolve(rootConfig.dirPath, 'packages', configPackageDir, 'config.mjs');
+  // Derive the willbooster-configs root from the package being generated, not from the CLI entry
+  // path: `wbfy <repo>/packages/<pkg>` is a supported invocation whose entry config is the child
+  // package rather than the repo root, so relying on the entry would emit a nested, unresolvable
+  // path for a directly targeted config package. Every willbooster-configs package is either the
+  // root or a direct child under `packages/`, so the root is the package dir itself or its grandparent.
+  const repoRootDirPath = config.isRoot ? config.dirPath : path.resolve(config.dirPath, '..', '..');
+  const localEntry = path.resolve(repoRootDirPath, 'packages', configPackageDir, 'config.mjs');
   const relativePath = path.relative(config.dirPath, localEntry);
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
 }

--- a/packages/wbfy/src/utils/willboosterConfigsUtil.ts
+++ b/packages/wbfy/src/utils/willboosterConfigsUtil.ts
@@ -1,4 +1,32 @@
+import path from 'node:path';
+
 import type { PackageConfig } from '../packageConfig.js';
+
+/**
+ * Returns the module specifier a generated config file should use to load a
+ * willbooster-configs config package such as `@willbooster/oxlint-config`.
+ *
+ * Outside willbooster-configs this is simply the published package name. Inside
+ * willbooster-configs the package must not be declared as a dependency: the
+ * config packages import one another (e.g. oxfmt-config's oxlint.config.ts
+ * imports oxlint-config and vice versa), so a declared edge would form a
+ * dependency cycle that multi-semantic-release cannot topologically sort. Since
+ * the edge is absent, isolated installs cannot resolve the bare package name, so
+ * import the committed `config.mjs` build output through a relative path instead.
+ */
+export function resolveWillboosterConfigModule(
+  config: PackageConfig,
+  rootConfig: PackageConfig,
+  configPackageName: string
+): string {
+  if (!config.isWillBoosterConfigs) return configPackageName;
+
+  // e.g. '@willbooster/oxlint-config' -> 'oxlint-config', which is its directory under `packages/`.
+  const configPackageDir = configPackageName.slice(configPackageName.indexOf('/') + 1);
+  const localEntry = path.resolve(rootConfig.dirPath, 'packages', configPackageDir, 'config.mjs');
+  const relativePath = path.relative(config.dirPath, localEntry);
+  return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
+}
 
 export function isPublishedWillboosterConfigsPackage(config: PackageConfig): boolean {
   return (

--- a/packages/wbfy/src/utils/willboosterConfigsUtil.ts
+++ b/packages/wbfy/src/utils/willboosterConfigsUtil.ts
@@ -18,7 +18,7 @@ export function resolveWillboosterConfigModule(config: PackageConfig, configPack
   if (!config.isWillBoosterConfigs) return configPackageName;
 
   // e.g. '@willbooster/oxlint-config' -> 'oxlint-config', which is its directory under `packages/`.
-  const configPackageDir = configPackageName.slice(configPackageName.indexOf('/') + 1);
+  const configPackageDir = configPackageName.split('/').pop() ?? '';
   // Derive the willbooster-configs root from the package being generated, not from the CLI entry
   // path: `wbfy <repo>/packages/<pkg>` is a supported invocation whose entry config is the child
   // package rather than the repo root, so relying on the entry would emit a nested, unresolvable

--- a/packages/wbfy/test/willboosterConfigsUtil.test.ts
+++ b/packages/wbfy/test/willboosterConfigsUtil.test.ts
@@ -5,29 +5,24 @@ import { resolveWillboosterConfigModule } from '../src/utils/willboosterConfigsU
 import { createConfig } from './testConfig.js';
 
 describe('resolveWillboosterConfigModule', () => {
-  const rootConfig = createConfig({ dirPath: '/repo/willbooster-configs', isRoot: true, isWillBoosterConfigs: true });
-
   it('returns the published package name outside willbooster-configs', () => {
     const config = createConfig({ dirPath: '/repo/other', isWillBoosterConfigs: false });
-    expect(resolveWillboosterConfigModule(config, rootConfig, '@willbooster/oxlint-config')).toBe(
-      '@willbooster/oxlint-config'
-    );
+    expect(resolveWillboosterConfigModule(config, '@willbooster/oxlint-config')).toBe('@willbooster/oxlint-config');
   });
 
   // Inside willbooster-configs the config packages import one another, so a declared dependency edge
   // would form a cycle that multi-semantic-release cannot sort. The generated config must therefore
   // load the committed local build output via a relative path instead of the unresolvable bare name.
   it('resolves a relative path to the local config.mjs from the repository root', () => {
-    expect(resolveWillboosterConfigModule(rootConfig, rootConfig, '@willbooster/oxfmt-config')).toBe(
+    const config = createConfig({ dirPath: '/repo/willbooster-configs', isRoot: true, isWillBoosterConfigs: true });
+    expect(resolveWillboosterConfigModule(config, '@willbooster/oxfmt-config')).toBe(
       './packages/oxfmt-config/config.mjs'
     );
   });
 
   it('resolves a relative path from a sibling package under packages/', () => {
     const config = createConfig({ dirPath: '/repo/willbooster-configs/packages/shared', isWillBoosterConfigs: true });
-    expect(resolveWillboosterConfigModule(config, rootConfig, '@willbooster/oxlint-config')).toBe(
-      '../oxlint-config/config.mjs'
-    );
+    expect(resolveWillboosterConfigModule(config, '@willbooster/oxlint-config')).toBe('../oxlint-config/config.mjs');
   });
 
   it('resolves to ./config.mjs when a config package consumes itself', () => {
@@ -35,6 +30,17 @@ describe('resolveWillboosterConfigModule', () => {
       dirPath: '/repo/willbooster-configs/packages/oxlint-config',
       isWillBoosterConfigs: true,
     });
-    expect(resolveWillboosterConfigModule(config, rootConfig, '@willbooster/oxlint-config')).toBe('./config.mjs');
+    expect(resolveWillboosterConfigModule(config, '@willbooster/oxlint-config')).toBe('./config.mjs');
+  });
+
+  // `wbfy <repo>/packages/oxlint-config` targets the child directly, so the module path must be
+  // derived from the generated package's own location, not the CLI entry, to avoid a nested path.
+  it('resolves to ./config.mjs when wbfy is invoked directly on the self-consuming package', () => {
+    const config = createConfig({
+      dirPath: '/repo/willbooster-configs/packages/oxlint-config',
+      isRoot: false,
+      isWillBoosterConfigs: true,
+    });
+    expect(resolveWillboosterConfigModule(config, '@willbooster/oxlint-config')).toBe('./config.mjs');
   });
 });

--- a/packages/wbfy/test/willboosterConfigsUtil.test.ts
+++ b/packages/wbfy/test/willboosterConfigsUtil.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test';
+
+import { resolveWillboosterConfigModule } from '../src/utils/willboosterConfigsUtil.js';
+
+import { createConfig } from './testConfig.js';
+
+describe('resolveWillboosterConfigModule', () => {
+  const rootConfig = createConfig({ dirPath: '/repo/willbooster-configs', isRoot: true, isWillBoosterConfigs: true });
+
+  it('returns the published package name outside willbooster-configs', () => {
+    const config = createConfig({ dirPath: '/repo/other', isWillBoosterConfigs: false });
+    expect(resolveWillboosterConfigModule(config, rootConfig, '@willbooster/oxlint-config')).toBe(
+      '@willbooster/oxlint-config'
+    );
+  });
+
+  // Inside willbooster-configs the config packages import one another, so a declared dependency edge
+  // would form a cycle that multi-semantic-release cannot sort. The generated config must therefore
+  // load the committed local build output via a relative path instead of the unresolvable bare name.
+  it('resolves a relative path to the local config.mjs from the repository root', () => {
+    expect(resolveWillboosterConfigModule(rootConfig, rootConfig, '@willbooster/oxfmt-config')).toBe(
+      './packages/oxfmt-config/config.mjs'
+    );
+  });
+
+  it('resolves a relative path from a sibling package under packages/', () => {
+    const config = createConfig({ dirPath: '/repo/willbooster-configs/packages/shared', isWillBoosterConfigs: true });
+    expect(resolveWillboosterConfigModule(config, rootConfig, '@willbooster/oxlint-config')).toBe(
+      '../oxlint-config/config.mjs'
+    );
+  });
+
+  it('resolves to ./config.mjs when a config package consumes itself', () => {
+    const config = createConfig({
+      dirPath: '/repo/willbooster-configs/packages/oxlint-config',
+      isWillBoosterConfigs: true,
+    });
+    expect(resolveWillboosterConfigModule(config, rootConfig, '@willbooster/oxlint-config')).toBe('./config.mjs');
+  });
+});

--- a/packages/wbfy/test/willboosterConfigsUtil.test.ts
+++ b/packages/wbfy/test/willboosterConfigsUtil.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'vitest';
 
 import { resolveWillboosterConfigModule } from '../src/utils/willboosterConfigsUtil.js';
 


### PR DESCRIPTION
## Customer Summary

- Fixes a CI failure in `willbooster-configs`: after wbfy stops declaring the config packages (`@willbooster/oxfmt-config`, `@willbooster/oxlint-config`) as dependencies, a fresh install under Bun's isolated linker could not resolve them, so `bun run cleanup` failed with `ERR_MODULE_NOT_FOUND` in every generated oxfmt/oxlint config.
- No effect on any other repository — their generated configs still import the published package name unchanged.

## Technical Summary

- Added `resolveWillboosterConfigModule(config, packageName)` in `willboosterConfigsUtil.ts`. Outside willbooster-configs it returns the published package name; inside, it returns a relative path to the committed local `config.mjs` build output.
- The repo root is derived from the package being generated (root → itself, child → its grandparent under `packages/`), not from the CLI entry path, so the supported `wbfy <repo>/packages/<pkg>` direct child invocation also produces a resolvable path.
- `oxfmtConfig.ts` and `oxlintConfig.ts` use the helper for both the ESM `import` and the CommonJS `require`, covering the root config, sibling packages under `packages/`, and the self-consuming config package.
- Added `willboosterConfigsUtil.test.ts` (vitest) covering the outside/root/sibling/self and direct-child-invocation cases.

## Why

- willbooster-configs must not declare its config packages as dependencies: the config packages import one another (e.g. oxfmt-config's `oxlint.config.ts` imports oxlint-config and vice versa), so a declared edge forms a dependency cycle that multi-semantic-release cannot topologically sort. Since the edge is absent, isolated installs cannot resolve the bare name, so the config must load the committed local `config.mjs` via a relative path instead.

## Testing

- `bun run tsc --noEmit` — passed.
- `bun run vitest run test/willboosterConfigsUtil.test.ts` and `test/bunfig.test.ts` — passed.
- Ran the updated wbfy against willbooster-configs (whole-repo and directly on `packages/oxlint-config`), then reproduced CI with a fresh isolated `bun install` + `bun run cleanup` — passed (previously `ERR_MODULE_NOT_FOUND`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
