### PR TITLE
fix(wbfy): don't self-reference the shared Renovate preset in willbooster-configs

### DIFF
--- a/packages/wbfy/src/generators/renovateJsonc.ts
+++ b/packages/wbfy/src/generators/renovateJsonc.ts
@@ -257,7 +257,7 @@ function mergeRenovateExtends(
   // willbooster-configs is the shared preset itself: never inject the self-reference, and strip it
   // if a previous run (or a hand edit) left it in place.
   const presetsToAdd = config.isWillBoosterConfigs ? [] : generatedExtends;
-  const presetsToDrop = config.isWillBoosterConfigs ? new Set([...legacyPresets, sharedPreset]) : legacyPresets;
+  const presetsToDrop = config.isWillBoosterConfigs ? new Set(legacyPresets).add(sharedPreset) : legacyPresets;
 
   // Only prepend the presets that are missing. Moving one that is already listed would reorder the
   // array, and a later preset overrides an earlier one in Renovate — so re-sorting silently flips

--- a/packages/wbfy/src/generators/renovateJsonc.ts
+++ b/packages/wbfy/src/generators/renovateJsonc.ts
@@ -11,9 +11,13 @@ import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { overwriteMerge } from '../utils/mergeUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 
+// The shared preset every WillBooster / WillBoosterLab repository extends. willbooster-configs IS
+// this preset, so injecting it there would make the preset extend itself.
+const sharedPreset = 'github>WillBooster/willbooster-configs:renovate.jsonc';
+
 const jsonObj = {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['github>WillBooster/willbooster-configs:renovate.jsonc'],
+  extends: [sharedPreset],
 };
 
 // The preset used to live in renovate.json5; it was renamed to renovate.jsonc, so the old reference
@@ -165,7 +169,7 @@ function buildSettings(config: PackageConfig, liveSettings: Settings | undefined
         arrayMerge: overwriteMerge,
       }) as Settings)
     : generatedSettings;
-  newSettings.extends = mergeRenovateExtends(jsonObj.extends, liveSettings?.extends);
+  newSettings.extends = mergeRenovateExtends(config, jsonObj.extends, liveSettings?.extends);
 
   // Don't upgrade Next.js automatically
   if (config.depending.blitz) {
@@ -245,13 +249,22 @@ function parseRenovateConfig(isEditableSyntax: boolean, content: string): Settin
   }
 }
 
-function mergeRenovateExtends(generatedExtends: string[], existingExtends: string[] = []): string[] {
+function mergeRenovateExtends(
+  config: PackageConfig,
+  generatedExtends: string[],
+  existingExtends: string[] = []
+): string[] {
+  // willbooster-configs is the shared preset itself: never inject the self-reference, and strip it
+  // if a previous run (or a hand edit) left it in place.
+  const presetsToAdd = config.isWillBoosterConfigs ? [] : generatedExtends;
+  const presetsToDrop = config.isWillBoosterConfigs ? new Set([...legacyPresets, sharedPreset]) : legacyPresets;
+
   // Only prepend the presets that are missing. Moving one that is already listed would reorder the
   // array, and a later preset overrides an earlier one in Renovate — so re-sorting silently flips
   // which config wins (and, being a reorder rather than an addition, also costs the array's
   // comments, which can only be preserved by insertion).
-  const missingExtends = generatedExtends.filter((preset) => !existingExtends.includes(preset));
-  return [...missingExtends, ...existingExtends].filter((item) => !legacyPresets.has(item));
+  const missingExtends = presetsToAdd.filter((preset) => !existingExtends.includes(preset));
+  return [...missingExtends, ...existingExtends].filter((item) => !presetsToDrop.has(item));
 }
 
 function normalize(content: string): string {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -300,14 +300,7 @@ export async function getPackageConfig(
       doesContainWranglerConfig: detectWranglerConfig(dirPath),
       isRailway: detectRailway(dirPath, packageJson),
       isEsmPackage: esmPackage,
-      // Identify willbooster-configs by its authoritative GitHub repo name when known, so neither a
-      // sibling repo whose name merely starts with it (willbooster-configs-fork) nor one cloned
-      // under a parent directory named willbooster-configs is misclassified. Fall back to the exact
-      // path segment only offline (no remote/repository metadata), where both the root and its
-      // sub-package paths still contain `/willbooster-configs/`.
-      isWillBoosterConfigs: repoName
-        ? repoName.toLowerCase() === 'willbooster-configs'
-        : packageJsonPath.includes('/willbooster-configs/'),
+      isWillBoosterConfigs: detectIsWillBoosterConfigs(dirPath, packageJsonPath, repoName),
       cargoTomlDirPaths: findCargoTomlDirPaths(dirPath),
       // Also honor declared workspace patterns beyond packages/* (e.g. apps/*): treating an
       // apps/*-only monorepo as a plain package would delete its `workspaces` declaration in
@@ -689,6 +682,25 @@ export function detectWranglerConfig(dirPath: string): boolean {
   return ['wrangler.jsonc', 'wrangler.json', 'wrangler.toml'].some((fileName) =>
     fs.existsSync(path.resolve(dirPath, fileName))
   );
+}
+
+/**
+ * Detects whether dirPath belongs to the willbooster-configs repository. Prefers the authoritative
+ * GitHub repo name, which is immune to the local directory layout. That name is fetched only for the
+ * root, so sub-packages (and offline roots) walk up to the nearest git root and match its directory
+ * name: a sibling repo cloned under a parent directory named willbooster-configs stops at its own
+ * `.git`, so it is not misclassified. The path segment remains a last resort when no git root exists.
+ */
+function detectIsWillBoosterConfigs(dirPath: string, packageJsonPath: string, repoName: string | undefined): boolean {
+  if (repoName) return repoName.toLowerCase() === 'willbooster-configs';
+  let current = path.resolve(dirPath);
+  while (current !== path.dirname(current)) {
+    if (fs.existsSync(path.join(current, '.git'))) {
+      return path.basename(current).toLowerCase() === 'willbooster-configs';
+    }
+    current = path.dirname(current);
+  }
+  return packageJsonPath.includes('/willbooster-configs/');
 }
 
 function detectCloudflare(dirPath: string, packageJson: PackageJson): boolean {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -306,7 +306,7 @@ export async function getPackageConfig(
       // path segment only offline (no remote/repository metadata), where both the root and its
       // sub-package paths still contain `/willbooster-configs/`.
       isWillBoosterConfigs: repoName
-        ? repoName === 'willbooster-configs'
+        ? repoName.toLowerCase() === 'willbooster-configs'
         : packageJsonPath.includes('/willbooster-configs/'),
       cargoTomlDirPaths: findCargoTomlDirPaths(dirPath),
       // Also honor declared workspace patterns beyond packages/* (e.g. apps/*): treating an

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -300,10 +300,14 @@ export async function getPackageConfig(
       doesContainWranglerConfig: detectWranglerConfig(dirPath),
       isRailway: detectRailway(dirPath, packageJson),
       isEsmPackage: esmPackage,
-      // Match the directory segment exactly (trailing slash) so a sibling repository whose name
-      // merely starts with willbooster-configs (e.g. willbooster-configs-fork) is not misclassified;
-      // both the root and its sub-package paths still contain `/willbooster-configs/`.
-      isWillBoosterConfigs: packageJsonPath.includes('/willbooster-configs/'),
+      // Identify willbooster-configs by its authoritative GitHub repo name when known, so neither a
+      // sibling repo whose name merely starts with it (willbooster-configs-fork) nor one cloned
+      // under a parent directory named willbooster-configs is misclassified. Fall back to the exact
+      // path segment only offline (no remote/repository metadata), where both the root and its
+      // sub-package paths still contain `/willbooster-configs/`.
+      isWillBoosterConfigs: repoName
+        ? repoName === 'willbooster-configs'
+        : packageJsonPath.includes('/willbooster-configs/'),
       cargoTomlDirPaths: findCargoTomlDirPaths(dirPath),
       // Also honor declared workspace patterns beyond packages/* (e.g. apps/*): treating an
       // apps/*-only monorepo as a plain package would delete its `workspaces` declaration in

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -700,7 +700,7 @@ function detectIsWillBoosterConfigs(dirPath: string, packageJsonPath: string, re
     }
     current = path.dirname(current);
   }
-  return packageJsonPath.includes('/willbooster-configs/');
+  return packageJsonPath.toLowerCase().includes('/willbooster-configs/');
 }
 
 function detectCloudflare(dirPath: string, packageJson: PackageJson): boolean {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -300,7 +300,10 @@ export async function getPackageConfig(
       doesContainWranglerConfig: detectWranglerConfig(dirPath),
       isRailway: detectRailway(dirPath, packageJson),
       isEsmPackage: esmPackage,
-      isWillBoosterConfigs: packageJsonPath.includes('/willbooster-configs'),
+      // Match the directory segment exactly (trailing slash) so a sibling repository whose name
+      // merely starts with willbooster-configs (e.g. willbooster-configs-fork) is not misclassified;
+      // both the root and its sub-package paths still contain `/willbooster-configs/`.
+      isWillBoosterConfigs: packageJsonPath.includes('/willbooster-configs/'),
       cargoTomlDirPaths: findCargoTomlDirPaths(dirPath),
       // Also honor declared workspace patterns beyond packages/* (e.g. apps/*): treating an
       // apps/*-only monorepo as a plain package would delete its `workspaces` declaration in

--- a/packages/wbfy/test/renovateJsonc.test.ts
+++ b/packages/wbfy/test/renovateJsonc.test.ts
@@ -371,28 +371,19 @@ test('leaves an unparsable renovate.jsonc untouched', async () => {
   });
 });
 
-test('strips the self-referencing preset when regenerating willbooster-configs itself', async () => {
+test.each([
+  {
+    name: 'strips the self-referencing preset when regenerating willbooster-configs itself',
+    extends: [preset, 'config:recommended'],
+  },
+  {
+    name: 'does not inject the shared preset when generating renovate.jsonc for willbooster-configs',
+    extends: ['config:recommended'],
+  },
+])('$name', async ({ extends: initialExtends }) => {
   const tempDirPath = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-renovate-')));
   try {
-    fs.writeFileSync(
-      path.join(tempDirPath, 'renovate.jsonc'),
-      JSON.stringify({ extends: [preset, 'config:recommended'] })
-    );
-    fsUtil.setRootDirPath(tempDirPath);
-    await generateRenovateJsonc(createConfig({ dirPath: tempDirPath, isRoot: true, isWillBoosterConfigs: true }));
-    await promisePool.promiseAll();
-    const settings = parseSettings(fs.readFileSync(path.join(tempDirPath, 'renovate.jsonc'), 'utf8'));
-    expect(settings.extends).toEqual(['config:recommended']);
-  } finally {
-    fsUtil.setRootDirPath(undefined);
-    fs.rmSync(tempDirPath, { force: true, recursive: true });
-  }
-});
-
-test('does not inject the shared preset when generating renovate.jsonc for willbooster-configs', async () => {
-  const tempDirPath = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-renovate-')));
-  try {
-    fs.writeFileSync(path.join(tempDirPath, 'renovate.jsonc'), JSON.stringify({ extends: ['config:recommended'] }));
+    fs.writeFileSync(path.join(tempDirPath, 'renovate.jsonc'), JSON.stringify({ extends: initialExtends }));
     fsUtil.setRootDirPath(tempDirPath);
     await generateRenovateJsonc(createConfig({ dirPath: tempDirPath, isRoot: true, isWillBoosterConfigs: true }));
     await promisePool.promiseAll();

--- a/packages/wbfy/test/renovateJsonc.test.ts
+++ b/packages/wbfy/test/renovateJsonc.test.ts
@@ -371,6 +371,39 @@ test('leaves an unparsable renovate.jsonc untouched', async () => {
   });
 });
 
+test('strips the self-referencing preset when regenerating willbooster-configs itself', async () => {
+  const tempDirPath = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-renovate-')));
+  try {
+    fs.writeFileSync(
+      path.join(tempDirPath, 'renovate.jsonc'),
+      JSON.stringify({ extends: [preset, 'config:recommended'] })
+    );
+    fsUtil.setRootDirPath(tempDirPath);
+    await generateRenovateJsonc(createConfig({ dirPath: tempDirPath, isRoot: true, isWillBoosterConfigs: true }));
+    await promisePool.promiseAll();
+    const settings = parseSettings(fs.readFileSync(path.join(tempDirPath, 'renovate.jsonc'), 'utf8'));
+    expect(settings.extends).toEqual(['config:recommended']);
+  } finally {
+    fsUtil.setRootDirPath(undefined);
+    fs.rmSync(tempDirPath, { force: true, recursive: true });
+  }
+});
+
+test('does not inject the shared preset when generating renovate.jsonc for willbooster-configs', async () => {
+  const tempDirPath = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-renovate-')));
+  try {
+    fs.writeFileSync(path.join(tempDirPath, 'renovate.jsonc'), JSON.stringify({ extends: ['config:recommended'] }));
+    fsUtil.setRootDirPath(tempDirPath);
+    await generateRenovateJsonc(createConfig({ dirPath: tempDirPath, isRoot: true, isWillBoosterConfigs: true }));
+    await promisePool.promiseAll();
+    const settings = parseSettings(fs.readFileSync(path.join(tempDirPath, 'renovate.jsonc'), 'utf8'));
+    expect(settings.extends).toEqual(['config:recommended']);
+  } finally {
+    fsUtil.setRootDirPath(undefined);
+    fs.rmSync(tempDirPath, { force: true, recursive: true });
+  }
+});
+
 function parseSettings(content: string): Record<string, unknown> {
   // jsonc-parser recovers from syntax errors and returns whatever it could read, so a generated
   // file that is subtly malformed would still satisfy assertions about individual properties.


### PR DESCRIPTION
## Problem

`renovate.jsonc` in `WillBooster/willbooster-configs` **is** the shared preset that every WillBooster / WillBoosterLab repository extends as `github>WillBooster/willbooster-configs:renovate.jsonc`. `wbfy` was injecting that preset into every repository it manages — including willbooster-configs itself, which made the preset extend itself.

This is the root cause behind WillBooster/willbooster-configs#1055 (which removes the self-reference by hand). Without a fix here, the next `wbfy` run in willbooster-configs would re-add it.

## Fix

- `renovateJsonc.ts`: when the target is willbooster-configs, do not inject the shared preset into `extends`, and strip an existing self-reference if a previous run (or hand edit) left one in place.
- `packageConfig.ts`: harden the `isWillBoosterConfigs` classification so the fix targets only the real repository. It now prefers the authoritative GitHub repo name (immune to local directory layout); for sub-packages and offline roots — where the repo name is not fetched — it walks up to the nearest git root and matches its directory name, so a sibling repo cloned under a parent directory named `willbooster-configs` (which stops at its own `.git`) is not misclassified. Comparisons are case-insensitive throughout.

## Tests

Added a parameterized `test.each` covering both willbooster-configs cases: stripping an existing self-reference and never injecting the shared preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
