### PR TITLE
feat(wb): run library e2e tests via a Playwright-managed webServer

### DIFF
--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -368,15 +368,27 @@ export class Project {
     }
   }
 
+  /**
+   * Whether the Playwright config declares a `webServer` block, i.e. Playwright itself builds and
+   * starts the app under test. Unlike {@link skipLaunchingServerForPlaywright} this ignores CI, so
+   * it also holds for library fixtures whose only server is the one Playwright manages.
+   */
   @memoizeOne
-  get skipLaunchingServerForPlaywright(): boolean {
-    if (isCI(this.env.CI)) return false;
+  get hasPlaywrightWebServerConfig(): boolean {
     try {
       const configPath = this.findFile('playwright.config.ts');
       return /\bwebServer\b/.test(fs.readFileSync(configPath, 'utf8'));
     } catch {
       return false;
     }
+  }
+
+  @memoizeOne
+  get skipLaunchingServerForPlaywright(): boolean {
+    // On CI wb launches the app itself so the run does not depend on Playwright's `reuseExistingServer`
+    // (which is disabled on CI); locally, a `webServer` block means Playwright already owns the server.
+    if (isCI(this.env.CI)) return false;
+    return this.hasPlaywrightWebServerConfig;
   }
 
   @memoizeOne

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -178,19 +178,6 @@ export abstract class BaseScripts {
     ])}`;
   }
 
-  /**
-   * Just runs Playwright (plus the optional `test/e2e-additional` script), without launching the app.
-   * Use when Playwright's own `webServer` config builds and starts the app under test.
-   */
-  protected buildPlaywrightOnlyCommand(
-    project: Project,
-    argv: TestArgv,
-    { forwardedPlaywrightArgs = [], playwrightArgs = ['test', 'test/e2e/'] }: TestE2EOptions
-  ): string {
-    const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
-    return `${buildPlaywrightCommand(playwrightArgs, argv.targets, argv.bail, forwardedPlaywrightArgs)}${suffix}`;
-  }
-
   async testE2EProtected(
     project: Project,
     argv: TestArgv,
@@ -199,12 +186,10 @@ export abstract class BaseScripts {
   ): Promise<string> {
     project.env.PORT ||= '3000';
     const port = await checkAndKillPortProcess(project.env.PORT, project);
+    const playwrightCommand = this.buildPlaywrightOnlyCommand(project, argv, options);
     if (project.skipLaunchingServerForPlaywright) {
-      return this.buildPlaywrightOnlyCommand(project, argv, options);
+      return playwrightCommand;
     }
-    const { forwardedPlaywrightArgs = [], playwrightArgs = ['test', 'test/e2e/'] } = options;
-    const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
-    const playwrightCommand = buildPlaywrightCommand(playwrightArgs, argv.targets, argv.bail, forwardedPlaywrightArgs);
 
     return buildShellCommand([
       'YARN',
@@ -216,8 +201,21 @@ export abstract class BaseScripts {
       'first',
       `${startCommand} && exit 1`,
       `${buildWaitOnLoopbackCommand(port, '-t 600000 -i 2000')}
-        && ${playwrightCommand}${suffix}`,
+        && ${playwrightCommand}`,
     ]);
+  }
+
+  /**
+   * Just runs Playwright (plus the optional `test/e2e-additional` script), without launching the app.
+   * Use when Playwright's own `webServer` config builds and starts the app under test.
+   */
+  protected buildPlaywrightOnlyCommand(
+    project: Project,
+    argv: TestArgv,
+    { forwardedPlaywrightArgs = [], playwrightArgs = ['test', 'test/e2e/'] }: TestE2EOptions
+  ): string {
+    const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
+    return `${buildPlaywrightCommand(playwrightArgs, argv.targets, argv.bail, forwardedPlaywrightArgs)}${suffix}`;
   }
   // ------------ END: test (e2e) commands ------------
 

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -178,19 +178,33 @@ export abstract class BaseScripts {
     ])}`;
   }
 
+  /**
+   * Just runs Playwright (plus the optional `test/e2e-additional` script), without launching the app.
+   * Use when Playwright's own `webServer` config builds and starts the app under test.
+   */
+  protected buildPlaywrightOnlyCommand(
+    project: Project,
+    argv: TestArgv,
+    { forwardedPlaywrightArgs = [], playwrightArgs = ['test', 'test/e2e/'] }: TestE2EOptions
+  ): string {
+    const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
+    return `${buildPlaywrightCommand(playwrightArgs, argv.targets, argv.bail, forwardedPlaywrightArgs)}${suffix}`;
+  }
+
   async testE2EProtected(
     project: Project,
     argv: TestArgv,
     startCommand: string,
-    { forwardedPlaywrightArgs = [], playwrightArgs = ['test', 'test/e2e/'] }: TestE2EOptions
+    options: TestE2EOptions
   ): Promise<string> {
     project.env.PORT ||= '3000';
     const port = await checkAndKillPortProcess(project.env.PORT, project);
+    if (project.skipLaunchingServerForPlaywright) {
+      return this.buildPlaywrightOnlyCommand(project, argv, options);
+    }
+    const { forwardedPlaywrightArgs = [], playwrightArgs = ['test', 'test/e2e/'] } = options;
     const suffix = project.packageJson.scripts?.['test/e2e-additional'] ? ' && YARN test/e2e-additional' : '';
     const playwrightCommand = buildPlaywrightCommand(playwrightArgs, argv.targets, argv.bail, forwardedPlaywrightArgs);
-    if (project.skipLaunchingServerForPlaywright) {
-      return `${playwrightCommand}${suffix}`;
-    }
 
     return buildShellCommand([
       'YARN',

--- a/packages/wb/src/scripts/execution/plainAppScripts.ts
+++ b/packages/wb/src/scripts/execution/plainAppScripts.ts
@@ -1,8 +1,10 @@
+import type { TestArgv } from '../../commands/test.js';
 import type { Project } from '../../project.js';
 import { SERVER_LOG_FILE } from '../../utils/log.js';
 import type { ScriptArgv } from '../builder.js';
 import { dockerScripts } from '../dockerScripts.js';
 
+import type { TestE2EOptions } from './baseScripts.js';
 import { BaseScripts } from './baseScripts.js';
 
 /**
@@ -41,14 +43,32 @@ class PlainAppScripts extends BaseScripts {
     );
   }
 
-  override testE2EDev(): Promise<string> {
-    return Promise.resolve(`echo 'do nothing.'`);
+  override testE2EDev(project: Project, argv: TestArgv, options: TestE2EOptions): Promise<string> {
+    return this.testE2EWithPlaywrightManagedServer(project, argv, options);
   }
-  override testE2EProduction(): Promise<string> {
-    return Promise.resolve(`echo 'do nothing.'`);
+  override testE2EProduction(project: Project, argv: TestArgv, options: TestE2EOptions): Promise<string> {
+    return this.testE2EWithPlaywrightManagedServer(project, argv, options);
   }
   override testE2EDocker(): Promise<string> {
     return Promise.resolve(`echo 'do nothing.'`);
+  }
+
+  /**
+   * A library has no server of its own, but it may ship a self-contained Playwright fixture whose
+   * config builds and starts the app under test via a `webServer` block (e.g. a Next.js fixture that
+   * verifies the published package imports cleanly). Run Playwright directly in that case — including
+   * on CI, where Playwright's own `webServer` starts the fixture — otherwise there is nothing to run.
+   */
+  private testE2EWithPlaywrightManagedServer(
+    project: Project,
+    argv: TestArgv,
+    options: TestE2EOptions
+  ): Promise<string> {
+    return Promise.resolve(
+      project.hasPlaywrightWebServerConfig
+        ? this.buildPlaywrightOnlyCommand(project, argv, options)
+        : `echo 'do nothing.'`
+    );
   }
   override testStart(): Promise<string> {
     return Promise.resolve(`echo 'do nothing.'`);

--- a/packages/wb/test/scripts/execution/plainAppScripts.test.ts
+++ b/packages/wb/test/scripts/execution/plainAppScripts.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TestArgv } from '../../../src/commands/test.js';
+import type { Project } from '../../../src/project.js';
+import { plainAppScripts } from '../../../src/scripts/execution/plainAppScripts.js';
+
+describe('PlainAppScripts.testE2EProduction', () => {
+  it('runs Playwright directly when the library ships a self-managed webServer fixture', async () => {
+    const project = {
+      env: { WB_ENV: 'test', PORT: '3000' },
+      packageJson: { scripts: {} },
+      hasPlaywrightWebServerConfig: true,
+    } as unknown as Project;
+
+    const command = await plainAppScripts.testE2EProduction(project, {} as TestArgv, {});
+
+    expect(command).toBe('BUN playwright test test/e2e/');
+  });
+
+  it('does nothing when the library has no Playwright fixture', async () => {
+    const project = {
+      env: { WB_ENV: 'test', PORT: '3000' },
+      packageJson: { scripts: {} },
+      hasPlaywrightWebServerConfig: false,
+    } as unknown as Project;
+
+    const command = await plainAppScripts.testE2EProduction(project, {} as TestArgv, {});
+
+    expect(command).toBe(`echo 'do nothing.'`);
+  });
+});


### PR DESCRIPTION
## Problem

`wb test` silently skipped e2e tests for **libraries**. `PlainAppScripts` (used when a project is a library, i.e. `next`/`vite` are only devDependencies) overrides `testE2EProduction`/`testE2EDev` to a no-op (`echo 'do nothing.'`), on the assumption that a library has no app server to launch.

But a library legitimately ships a **self-contained Playwright fixture** — e.g. a Next.js app that verifies the published package imports cleanly without bundler config — whose `playwright.config.ts` builds and starts the app itself via a `webServer` block. For such repos, `wb test` reported success while running zero e2e tests.

This blocked migrating `@willbooster/monaco-react` (and siblings) to the wb-standard `test/unit` + `test/e2e` layout: moving its bespoke `e2e/next-app` fixture under `test/e2e/` made `wb test` skip it entirely.

## Change

- Add `Project.hasPlaywrightWebServerConfig` — whether the Playwright config declares a `webServer` block, **independent of CI** (unlike `skipLaunchingServerForPlaywright`, which is forced off on CI). `skipLaunchingServerForPlaywright` now reuses it.
- Extract `BaseScripts.buildPlaywrightOnlyCommand` (run Playwright, plus the optional `test/e2e-additional` script, without launching an app) from the existing skip branch of `testE2EProtected`.
- `PlainAppScripts.testE2E{Production,Dev}` now run Playwright directly when the library has such a fixture — **including on CI**, where Playwright's own `webServer` (with `reuseExistingServer: !CI`) builds and starts the fixture. Without a `webServer` fixture, they remain no-ops.

## Verification

- `packages/wb`: `tsc` clean, full vitest suite passes (182 passed, 1 skipped), including new `plainAppScripts.test.ts` covering both the fixture and no-fixture cases.
- Validated end-to-end against a restructured `@willbooster/monaco-react`: `wb test` now runs `vitest run test/unit/` (6 passed) followed by `playwright test test/e2e/` (5 passed), the latter building and starting the Next.js fixture via its `webServer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
