### PR TITLE
fix(wbfy): strip subsumed segments from a hand-written gen-code script

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -264,6 +264,35 @@ function rebuildPostinstallSegments(segments: string[], scripts: PackageJson.Scr
   return result;
 }
 
+/**
+ * Removes the segments `wb gen-code` performs itself (its own spellings, `wrangler types`, argument-free
+ * `gen-i18n-ts`) from a script wbfy did not generate, keeping the first managed segment's POSITION so a custom
+ * step that consumes generated output still runs after it. Returns undefined when nothing should change or the
+ * script cannot be parsed.
+ */
+function stripSubsumedGenCodeSegments(
+  script: string,
+  scripts: PackageJson.Scripts,
+  dirPath: string
+): string | undefined {
+  const segments = splitScriptSegments(script);
+  if (!segments) return undefined;
+  const rebuilt: string[] = [];
+  let generationPlaced = false;
+  for (const segment of segments) {
+    const kind = classifyScriptSegment(segment, scripts, true, dirPath);
+    if (kind === 'custom' || kind === 'genCodeWrapper') {
+      rebuilt.push(segment);
+    } else if (!generationPlaced) {
+      rebuilt.push('bun wb gen-code');
+      generationPlaced = true;
+    }
+  }
+  if (!generationPlaced) return undefined;
+  const rebuiltScript = rebuilt.join(' && ');
+  return rebuiltScript === script ? undefined : rebuiltScript;
+}
+
 function updatePostinstallScript(
   scripts: PackageJson.Scripts,
   managesWorkerTypes: boolean,
@@ -1345,6 +1374,13 @@ async function normalizePackageMetadata(
     if (customSegments) {
       jsonObj.scripts['gen-code'] = ['bun wb gen-code', ...customSegments].join(' && ');
     }
+  } else if (genCodeScript) {
+    // A hand-written gen-code script wbfy would not generate itself still has to lose the invocations `wb gen-code`
+    // now subsumes; without this the redundant `wrangler types` survives every future run, which is the drift this
+    // consolidation exists to remove. Only wbfy's own segments go — custom steps keep their position, and an
+    // unparseable script is left alone.
+    const stripped = stripSubsumedGenCodeSegments(genCodeScript, jsonObj.scripts, config.dirPath);
+    if (stripped !== undefined) jsonObj.scripts['gen-code'] = stripped;
   }
   normalizeGenI18nTsScript(config, jsonObj);
   updatePostinstallScript(

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -413,6 +413,35 @@ test('keeps a wb gen-code postinstall for an unmanaged worker package', async ()
   expect(packageJson.scripts?.postinstall).toBe('wb gen-code');
 });
 
+// A hand-written gen-code script wbfy would not generate itself still has to lose what `wb gen-code` subsumes,
+// or the redundant invocation survives every future run.
+test('strips a subsumed wrangler types from a gen-code script wbfy does not generate', async () => {
+  const wranglerPackageJson = {
+    devDependencies: { wrangler: '4.69.0' },
+    scripts: { 'gen-code': 'wb gen-code && bunx wrangler types' },
+  };
+  const packageJson = await generatePackageJsonFrom(
+    { ...wranglerPackageJson },
+    { isCloudflare: true, doesContainWranglerConfig: true, packageJson: wranglerPackageJson }
+  );
+
+  expect(packageJson.scripts?.['gen-code']).toBe('bun wb gen-code');
+});
+
+// Its custom steps must keep running, and keep their position relative to the generation.
+test('keeps custom steps when stripping an unmanaged gen-code script', async () => {
+  const wranglerPackageJson = {
+    devDependencies: { wrangler: '4.69.0' },
+    scripts: { 'gen-code': 'wb gen-code && bunx wrangler types && bun run build-assets' },
+  };
+  const packageJson = await generatePackageJsonFrom(
+    { ...wranglerPackageJson },
+    { isCloudflare: true, doesContainWranglerConfig: true, packageJson: wranglerPackageJson }
+  );
+
+  expect(packageJson.scripts?.['gen-code']).toBe('bun wb gen-code && bun run build-assets');
+});
+
 // Silently dropping a project's own install step (e.g. applying patches) would break its install.
 test('preserves custom postinstall segments', async () => {
   const packageJson = await generatePackageJsonFrom(


### PR DESCRIPTION
## Problem

`wb gen-code` generates `worker-configuration.d.ts` as of wb 16 (#1052), so a repository's own `wrangler types` inside `gen-code` is redundant. wbfy normalizes `postinstall` and deletes a redundant `gen-types`, but only rewrites **`gen-code`** when `shouldGenerateWbGenCodeScript` is true — i.e. when wbfy would generate that script itself.

A repository with a hand-written `gen-code` therefore kept the redundant segment, and no future wbfy run would remove it. Observed on `moti-ai` after applying wbfy 5.0.0:

```json
{ "gen-code": "wb gen-code && bunx wrangler types", "postinstall": "wb gen-code" }
```

That package IS managed (it carries the `/worker-configuration.d.ts` gitignore rule), so `wb gen-code` already generated the file and the trailing invocation regenerated the same ~500KB output again on every install.

Not a correctness failure — the output is identical — but it defeats what the consolidation was for: the per-repository `wrangler types` spellings survive in exactly the repositories that hand-wrote a `gen-code` script, and hand-fixing them (as moti-ai needed) does not stop the drift returning.

## Fix

When a `gen-code` script exists that wbfy would not generate, run the same segment classification used for `postinstall` over it: drop what `wb gen-code` subsumes (its own spellings, `wrangler types`, argument-free `gen-i18n-ts`), keep custom steps **in position** — one may consume the generated output — and leave an unparseable script alone.

## Verification

- `packages/wbfy` 238 tests, `packages/wb` 191 tests, typecheck and `bun wb lint` clean.
- Two regression cases added: the bare `wb gen-code && bunx wrangler types` shape from moti-ai, and one where a custom `bun run build-assets` must survive and stay after the generation.

Closes #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
