### PR TITLE
fix(wb): commit the git and registry materializations atomically

### DIFF
--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -734,7 +734,10 @@ export async function swapMaterializedTrees(
   toStagedPath: (targetDirPath: string) => string,
   backupRootDirPath: string
 ): Promise<void> {
-  await fs.promises.rm(backupRootDirPath, { recursive: true, force: true });
+  // A UNIQUE directory per invocation: when a rollback fails its backup is retained for manual
+  // recovery, and a fixed path would let the next run delete the only remaining copy.
+  await fs.promises.mkdir(path.dirname(backupRootDirPath), { recursive: true });
+  const backupDirRoot = await fs.promises.mkdtemp(`${backupRootDirPath}-`);
   // Recorded BEFORE the staged tree is renamed in: between setting the live tree aside and
   // installing its replacement the previous materialization exists only in the backup, and a record
   // added after the rename would leave that window unrecoverable.
@@ -744,8 +747,7 @@ export async function swapMaterializedTrees(
     for (const [index, outDirPath] of outDirPaths.entries()) {
       // Indexed (not named after the directory) so two output trees sharing a basename cannot
       // overwrite each other's backup.
-      const backupDirPath = path.join(backupRootDirPath, String(index));
-      await fs.promises.mkdir(backupRootDirPath, { recursive: true });
+      const backupDirPath = path.join(backupDirRoot, String(index));
       const hadPreviousTree = fs.existsSync(outDirPath);
       if (hadPreviousTree) await fs.promises.rename(outDirPath, backupDirPath);
       swappedDirs.push({ outDirPath, backupDirPath, hadPreviousTree });
@@ -773,8 +775,16 @@ export async function swapMaterializedTrees(
     throw error;
   } finally {
     // Only when nothing is left to recover: deleting the backups after a failed restore would
-    // destroy the last copy of the previous materialization.
-    if (!restoreFailed) await fs.promises.rm(backupRootDirPath, { recursive: true, force: true });
+    // destroy the last copy of the previous materialization. And by this point both trees are
+    // already committed, so a cleanup failure (e.g. a read-only directory `fs.cp` preserved) must
+    // not turn a successful materialization into a reported failure.
+    if (!restoreFailed) {
+      try {
+        await fs.promises.rm(backupDirRoot, { recursive: true, force: true });
+      } catch (cleanupError) {
+        console.warn(chalk.yellow(`Failed to remove ${backupDirRoot}: ${String(cleanupError)}`));
+      }
+    }
   }
 }
 

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -729,13 +729,17 @@ function replacePackageJsonDependencies(
  * first so a failing rename can restore the previous state instead of leaving one tree replaced
  * and the other stale.
  */
-async function swapMaterializedTrees(
+export async function swapMaterializedTrees(
   outDirPaths: string[],
   toStagedPath: (targetDirPath: string) => string,
   backupRootDirPath: string
 ): Promise<void> {
   await fs.promises.rm(backupRootDirPath, { recursive: true, force: true });
+  // Recorded BEFORE the staged tree is renamed in: between setting the live tree aside and
+  // installing its replacement the previous materialization exists only in the backup, and a record
+  // added after the rename would leave that window unrecoverable.
   const swappedDirs: { outDirPath: string; backupDirPath: string; hadPreviousTree: boolean }[] = [];
+  let restoreFailed = false;
   try {
     for (const [index, outDirPath] of outDirPaths.entries()) {
       // Indexed (not named after the directory) so two output trees sharing a basename cannot
@@ -744,9 +748,9 @@ async function swapMaterializedTrees(
       await fs.promises.mkdir(backupRootDirPath, { recursive: true });
       const hadPreviousTree = fs.existsSync(outDirPath);
       if (hadPreviousTree) await fs.promises.rename(outDirPath, backupDirPath);
+      swappedDirs.push({ outDirPath, backupDirPath, hadPreviousTree });
       await fs.promises.mkdir(path.dirname(outDirPath), { recursive: true });
       await fs.promises.rename(toStagedPath(outDirPath), outDirPath);
-      swappedDirs.push({ outDirPath, backupDirPath, hadPreviousTree });
     }
   } catch (error) {
     // Reverse order: undo the most recent swap first.
@@ -756,13 +760,21 @@ async function swapMaterializedTrees(
         if (swapped.hadPreviousTree) await fs.promises.rename(swapped.backupDirPath, swapped.outDirPath);
       } catch (rollbackError) {
         // Reporting the original failure matters more, but a failed rollback leaves the tree
-        // missing, so it must not pass silently.
-        console.error(chalk.red(`Failed to restore ${swapped.outDirPath}: ${String(rollbackError)}`));
+        // missing, so it must not pass silently — and its backup is then the ONLY remaining copy.
+        restoreFailed = true;
+        console.error(
+          chalk.red(
+            `Failed to restore ${swapped.outDirPath}: ${String(rollbackError)}\n` +
+              `The previous materialization is kept at ${swapped.backupDirPath}; move it back by hand.`
+          )
+        );
       }
     }
     throw error;
   } finally {
-    await fs.promises.rm(backupRootDirPath, { recursive: true, force: true });
+    // Only when nothing is left to recover: deleting the backups after a failed restore would
+    // destroy the last copy of the previous materialization.
+    if (!restoreFailed) await fs.promises.rm(backupRootDirPath, { recursive: true, force: true });
   }
 }
 

--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -130,28 +130,30 @@ export async function materializePrivatePackages(
     // packages copied into an equal or NESTED directory moments earlier.
     throw new Error(`--out-dir must not overlap the ${PRIVATE_REGISTRY_SCOPE} registry output directory.`);
   }
-  const stagingDirPath = resolveOutputDirPath(
-    path.join('.tmp', 'wb-private-registry-staging'),
-    'The registry staging directory'
-  );
-  const gitStagingDirPath = resolveOutputDirPath(
-    path.join('.tmp', 'wb-private-git-staging'),
-    'The git staging directory'
-  );
+  const stagingRootDirPath = resolveOutputDirPath(path.join('.tmp', 'wb-private-staging'), 'The staging directory');
+  const backupRootDirPath = resolveOutputDirPath(path.join('.tmp', 'wb-private-backup'), 'The backup directory');
   if (pathsOverlap(outDirPath, canonicalizePath(path.join(rootDirPath, 'node_modules')))) {
     // The recursive delete of outDirPath would destroy the installed sources the copies read.
     throw new Error('--out-dir must not overlap node_modules.');
   }
-  for (const [stagingLabel, stagingPath] of [
-    ['registry', stagingDirPath],
-    ['git', gitStagingDirPath],
+  for (const [label, temporaryDirPath] of [
+    ['staging', stagingRootDirPath],
+    ['backup', backupRootDirPath],
   ] as const) {
-    if (pathsOverlap(outDirPath, stagingPath)) {
-      // Each staging step recreates its directory, silently discarding anything copied into an
-      // equal or nested --out-dir moments earlier.
-      throw new Error(`--out-dir must not overlap the ${stagingLabel} staging directory (${stagingPath}).`);
+    if (pathsOverlap(outDirPath, temporaryDirPath) || pathsOverlap(registryOutDirPath, temporaryDirPath)) {
+      // Both directories are recursively recreated, silently discarding anything materialized into
+      // an equal or nested output directory moments earlier.
+      throw new Error(`Output directories must not overlap the ${label} directory (${temporaryDirPath}).`);
     }
   }
+  // Staging MIRRORS each output tree's repository-root-relative location (e.g.
+  // `<root>/@willbooster-private/a` stages at `<staging>/@willbooster-private/a`), so the relative
+  // distance between any two staged trees equals the distance between their final locations. That
+  // makes cross-tree `file:` rewrites (e.g. `../../@willbooster/<name>`) computed against staging
+  // correct after the swap, which lets every failure-prone step — download, extraction, nested
+  // discovery, rewriting — finish before either live tree is touched.
+  const toStagedPath = (finalPath: string): string =>
+    path.join(stagingRootDirPath, path.relative(rootDirPath, finalPath));
   if (path.relative(rootDirPath, outDirPath) !== '@willbooster') {
     // Pre-existing limitation of the option: the Docker manifest rewrite has no access to it.
     console.warn(
@@ -193,83 +195,56 @@ export async function materializePrivatePackages(
   const copiedPackages = [...privatePackages.values()].filter((p) => p.kind === 'git');
   const registryPackages = [...privatePackages.values()].filter((p) => p.kind === 'registry');
 
-  // Copy git packages into a staging directory and swap it in only after every copy succeeded,
-  // mirroring the registry staging below: a copy that fails partway (e.g. a dangling symlink in
-  // the installed source) must not leave a half-populated @willbooster tree that the automatic
-  // optimizeForDockerBuild caller — which catches the failure and continues — would then rewrite
-  // dependencies against. Both output directories always exist afterwards: Dockerfiles COPY them
-  // unconditionally, and a missing source path fails the build.
-  await fs.promises.rm(gitStagingDirPath, { recursive: true, force: true });
-  await fs.promises.mkdir(gitStagingDirPath, { recursive: true });
+  // Materialize BOTH trees into staging and swap them in only after every failure-prone step
+  // succeeded: a registry fetch/extraction/nested-discovery/rewrite failure must leave both live
+  // trees exactly as they were. Otherwise the automatic `wb optimizeForDockerBuild --outside`
+  // caller — which catches the failure and continues — would rewrite dependencies against
+  // inconsistent trees (e.g. a registry manifest pointing at a deleted `@willbooster/<name>`).
+  await fs.promises.rm(stagingRootDirPath, { recursive: true, force: true });
   try {
+    // Both output directories always exist afterwards: Dockerfiles COPY them unconditionally, and
+    // a missing source path fails the build.
+    await fs.promises.mkdir(toStagedPath(outDirPath), { recursive: true });
+    await fs.promises.mkdir(toStagedPath(registryOutDirPath), { recursive: true });
     for (const privatePackage of copiedPackages) {
-      await copyInstalledPackage(
+      await copyInstalledPackage(rootDirPath, privatePackage, toStagedPath(privatePackage.targetDirPath));
+    }
+    for (const privatePackage of registryPackages) {
+      if (privatePackage.sourceDirPath) {
+        await copyInstalledPackage(rootDirPath, privatePackage, toStagedPath(privatePackage.targetDirPath));
+        continue;
+      }
+      await downloadAndExtractRegistryPackage(
+        // downloadedPackages is non-empty on this path, so the auth check above passed.
+        auth!,
+        privatePackage.name,
+        privatePackage.versionSpecifier ?? 'latest',
+        toStagedPath(privatePackage.targetDirPath)
+      );
+      privatePackage.resolvedVersion = readInstalledVersion(
+        toStagedPath(privatePackage.targetDirPath),
+        privatePackage.name
+      );
+      console.info(`Downloaded ${privatePackage.name} to ${path.relative(rootDirPath, privatePackage.targetDirPath)}`);
+      // A downloaded package may itself depend on private packages that were not visible before
+      // extraction; materialize them too. Installed copies were already deep-scanned by
+      // collectPrivatePackages.
+      await collectNestedPrivatePackages(
         rootDirPath,
+        auth!,
         privatePackage,
-        path.join(gitStagingDirPath, path.relative(outDirPath, privatePackage.targetDirPath))
+        privatePackages,
+        outDirPath,
+        registryOutDirPath,
+        toStagedPath
       );
     }
-    await fs.promises.rm(outDirPath, { recursive: true, force: true });
-    await fs.promises.rename(gitStagingDirPath, outDirPath);
-  } catch (error) {
-    await fs.promises.rm(gitStagingDirPath, { recursive: true, force: true });
-    throw error;
-  }
 
-  if (registryPackages.length > 0) {
-    // Download into a staging directory and swap it in only after every download succeeded, so
-    // a failing registry/token/extraction cannot destroy the last usable materialization.
-    const toStagedPath = (targetDirPath: string): string =>
-      path.join(stagingDirPath, path.relative(registryOutDirPath, targetDirPath));
-    await fs.promises.rm(stagingDirPath, { recursive: true, force: true });
-    await fs.promises.mkdir(stagingDirPath, { recursive: true });
-    try {
-      for (const privatePackage of registryPackages) {
-        if (privatePackage.sourceDirPath) {
-          await copyInstalledPackage(rootDirPath, privatePackage, toStagedPath(privatePackage.targetDirPath));
-        } else {
-          await downloadAndExtractRegistryPackage(
-            // downloadedPackages is non-empty on this path, so the auth check above passed.
-            auth!,
-            privatePackage.name,
-            privatePackage.versionSpecifier ?? 'latest',
-            toStagedPath(privatePackage.targetDirPath)
-          );
-          privatePackage.resolvedVersion = readInstalledVersion(
-            toStagedPath(privatePackage.targetDirPath),
-            privatePackage.name
-          );
-          console.info(
-            `Downloaded ${privatePackage.name} to ${path.relative(rootDirPath, privatePackage.targetDirPath)}`
-          );
-        }
-        // A downloaded package may itself depend on private packages that were not visible
-        // before extraction; materialize them too. Installed copies were already deep-scanned
-        // by collectPrivatePackages.
-        if (!privatePackage.sourceDirPath) {
-          await collectNestedPrivatePackages(
-            rootDirPath,
-            auth!,
-            privatePackage,
-            privatePackages,
-            outDirPath,
-            registryOutDirPath,
-            toStagedPath
-          );
-        }
-      }
-      await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
-      await fs.promises.rename(stagingDirPath, registryOutDirPath);
-    } catch (error) {
-      await fs.promises.rm(stagingDirPath, { recursive: true, force: true });
-      throw error;
-    }
-  } else {
-    await fs.promises.rm(registryOutDirPath, { recursive: true, force: true });
-    await fs.promises.mkdir(registryOutDirPath, { recursive: true });
+    await replacePrivateDependencies(stagingRootDirPath, privatePackages, toStagedPath);
+    await swapMaterializedTrees([outDirPath, registryOutDirPath], toStagedPath, backupRootDirPath);
+  } finally {
+    await fs.promises.rm(stagingRootDirPath, { recursive: true, force: true });
   }
-
-  await replacePrivateDependencies(rootDirPath, privatePackages);
   console.info(
     `Ensure the Dockerfile COPYs ${path.relative(rootDirPath, outDirPath)}/ and ${PRIVATE_REGISTRY_SCOPE}/ into the image before installing dependencies.`
   );
@@ -363,13 +338,9 @@ async function collectNestedPrivatePackages(
   registryOutDirPath: string,
   toStagedPath: (targetDirPath: string) => string
 ): Promise<void> {
-  // Registry packages still live in the staging directory at this point (they are swapped into
-  // place only after every download succeeded); git packages are copied straight to their final
-  // location, so their manifest must be read there.
-  const extractedDirPath =
-    extractedPackage.kind === 'registry'
-      ? toStagedPath(extractedPackage.targetDirPath)
-      : extractedPackage.targetDirPath;
+  // Every materialized package — including a late-discovered nested git dependency — lives in
+  // staging until the atomic swap, so its manifests must be read there.
+  const extractedDirPath = toStagedPath(extractedPackage.targetDirPath);
   // Scan EVERY manifest of the materialized package (org git dependencies are whole monorepo
   // checkouts with packages/*/package.json), mirroring collectPrivatePackages' deep scan — the
   // dependency-rewrite step walks the same set, so anything declared there must be materialized.
@@ -401,7 +372,7 @@ async function collectNestedPrivatePackages(
 
       if (nested.kind === 'git') {
         nested.sourceDirPath = findInstalledPackageDir(rootDirPath, nested.name);
-        await copyInstalledPackage(rootDirPath, nested, nested.targetDirPath);
+        await copyInstalledPackage(rootDirPath, nested, toStagedPath(nested.targetDirPath));
       } else {
         const installed = findInstalledRegistryPackage(rootDirPath, nested);
         nested.sourceDirPath = installed?.dirPath;
@@ -711,16 +682,18 @@ function narrowerCompatibleRequirement(
 }
 
 async function replacePrivateDependencies(
-  rootDirPath: string,
-  privatePackages: Map<string, PrivatePackage>
+  stagingRootDirPath: string,
+  privatePackages: Map<string, PrivatePackage>,
+  toStagedPath: (targetDirPath: string) => string
 ): Promise<void> {
   for (const privatePackage of privatePackages.values()) {
-    for (const packageJsonPath of await findPackageJsonPaths(privatePackage.targetDirPath)) {
+    for (const packageJsonPath of await findPackageJsonPaths(toStagedPath(privatePackage.targetDirPath))) {
       const packageJson = await readPackageJson(packageJsonPath);
-      if (!replacePackageJsonDependencies(packageJsonPath, packageJson, privatePackages)) continue;
+      if (!replacePackageJsonDependencies(packageJsonPath, packageJson, privatePackages, toStagedPath)) continue;
 
       await fs.promises.writeFile(packageJsonPath, `${JSON.stringify(packageJson, undefined, 2)}\n`, 'utf8');
-      console.info(`Rewrote private dependencies in ${path.relative(rootDirPath, packageJsonPath)}`);
+      // Staging mirrors the root-relative layout, so this is the manifest's post-swap location.
+      console.info(`Rewrote private dependencies in ${path.relative(stagingRootDirPath, packageJsonPath)}`);
     }
   }
 }
@@ -728,7 +701,8 @@ async function replacePrivateDependencies(
 function replacePackageJsonDependencies(
   packageJsonPath: string,
   packageJson: PackageJson,
-  privatePackages: Map<string, PrivatePackage>
+  privatePackages: Map<string, PrivatePackage>,
+  toStagedPath: (targetDirPath: string) => string
 ): boolean {
   let changed = false;
   for (const key of dependencyKeys) {
@@ -740,11 +714,56 @@ function replacePackageJsonDependencies(
       const targetPackage = privatePackages.get(name);
       if (!targetPackage) continue;
 
-      dependencies[name] = `file:${path.relative(path.dirname(packageJsonPath), targetPackage.targetDirPath)}`;
+      // Both sides are staged paths: staging mirrors the root-relative layout, so the relative
+      // specifier is identical to the one the final locations would produce.
+      dependencies[name] =
+        `file:${path.relative(path.dirname(packageJsonPath), toStagedPath(targetPackage.targetDirPath))}`;
       changed = true;
     }
   }
   return changed;
+}
+
+/**
+ * Move every staged tree onto its final location as one transaction: each live tree is set aside
+ * first so a failing rename can restore the previous state instead of leaving one tree replaced
+ * and the other stale.
+ */
+async function swapMaterializedTrees(
+  outDirPaths: string[],
+  toStagedPath: (targetDirPath: string) => string,
+  backupRootDirPath: string
+): Promise<void> {
+  await fs.promises.rm(backupRootDirPath, { recursive: true, force: true });
+  const swappedDirs: { outDirPath: string; backupDirPath: string; hadPreviousTree: boolean }[] = [];
+  try {
+    for (const [index, outDirPath] of outDirPaths.entries()) {
+      // Indexed (not named after the directory) so two output trees sharing a basename cannot
+      // overwrite each other's backup.
+      const backupDirPath = path.join(backupRootDirPath, String(index));
+      await fs.promises.mkdir(backupRootDirPath, { recursive: true });
+      const hadPreviousTree = fs.existsSync(outDirPath);
+      if (hadPreviousTree) await fs.promises.rename(outDirPath, backupDirPath);
+      await fs.promises.mkdir(path.dirname(outDirPath), { recursive: true });
+      await fs.promises.rename(toStagedPath(outDirPath), outDirPath);
+      swappedDirs.push({ outDirPath, backupDirPath, hadPreviousTree });
+    }
+  } catch (error) {
+    // Reverse order: undo the most recent swap first.
+    for (const swapped of swappedDirs.toReversed()) {
+      try {
+        await fs.promises.rm(swapped.outDirPath, { recursive: true, force: true });
+        if (swapped.hadPreviousTree) await fs.promises.rename(swapped.backupDirPath, swapped.outDirPath);
+      } catch (rollbackError) {
+        // Reporting the original failure matters more, but a failed rollback leaves the tree
+        // missing, so it must not pass silently.
+        console.error(chalk.red(`Failed to restore ${swapped.outDirPath}: ${String(rollbackError)}`));
+      }
+    }
+    throw error;
+  } finally {
+    await fs.promises.rm(backupRootDirPath, { recursive: true, force: true });
+  }
 }
 
 async function findPackageJsonPaths(dirPath: string): Promise<string[]> {

--- a/packages/wb/test/setupPrivatePackages.test.ts
+++ b/packages/wb/test/setupPrivatePackages.test.ts
@@ -2,9 +2,13 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 
-import { collectManifests, materializePrivatePackages } from '../src/commands/setupPrivatePackages.js';
+import {
+  collectManifests,
+  materializePrivatePackages,
+  swapMaterializedTrees,
+} from '../src/commands/setupPrivatePackages.js';
 import { findDescendantProjects } from '../src/project.js';
 
 describe('materializePrivatePackages', () => {
@@ -134,3 +138,36 @@ async function readVersion(packageDirPath: string): Promise<string | undefined> 
   const content = await fs.readFile(path.join(packageDirPath, 'package.json'), 'utf8');
   return (JSON.parse(content) as { version?: string }).version;
 }
+
+// The live tree is set aside BEFORE its replacement is renamed in, so a failure in that window
+// leaves the previous materialization only in the backup. It must still be restored.
+test('restores the tree whose staged replacement fails to move in', async () => {
+  const rootDirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-swap-'));
+  try {
+    const firstOutDirPath = path.join(rootDirPath, '@willbooster');
+    const secondOutDirPath = path.join(rootDirPath, '@willbooster-private');
+    const stagingRootDirPath = path.join(rootDirPath, '.tmp', 'staging');
+    const toStagedPath = (targetDirPath: string): string =>
+      path.join(stagingRootDirPath, path.relative(rootDirPath, targetDirPath));
+
+    // Both trees already materialized, and only the FIRST has a staged replacement — so the second
+    // rename fails after its live tree has already been moved aside.
+    for (const outDirPath of [firstOutDirPath, secondOutDirPath]) {
+      await fs.mkdir(outDirPath, { recursive: true });
+      await fs.writeFile(path.join(outDirPath, 'marker.txt'), 'previous');
+    }
+    await fs.mkdir(toStagedPath(firstOutDirPath), { recursive: true });
+    await fs.writeFile(path.join(toStagedPath(firstOutDirPath), 'marker.txt'), 'staged');
+
+    await expect(
+      swapMaterializedTrees([firstOutDirPath, secondOutDirPath], toStagedPath, path.join(rootDirPath, '.tmp', 'backup'))
+    ).rejects.toThrow();
+
+    // Neither tree may be left replaced or missing.
+    for (const outDirPath of [firstOutDirPath, secondOutDirPath]) {
+      expect(await fs.readFile(path.join(outDirPath, 'marker.txt'), 'utf8')).toBe('previous');
+    }
+  } finally {
+    await fs.rm(rootDirPath, { force: true, recursive: true });
+  }
+});

--- a/packages/wb/test/setupPrivatePackages.test.ts
+++ b/packages/wb/test/setupPrivatePackages.test.ts
@@ -74,6 +74,50 @@ describe('materializePrivatePackages', () => {
       await fs.rm(rootDirPath, { force: true, recursive: true });
     }
   });
+
+  // The git and registry trees must commit as ONE transaction: a registry fetch failure used to
+  // leave the already-swapped @willbooster tree next to a stale @willbooster-private tree, so a
+  // registry manifest referencing file:../../@willbooster/<name> could dangle. The registry is made
+  // unreachable via a reserved `.invalid` host, so the download always fails without a live server.
+  it('leaves both materialized trees untouched when a registry download fails', async () => {
+    const rootDirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-setup-private-'));
+    try {
+      await writeJson(path.join(rootDirPath, 'package.json'), {
+        name: '@test/root',
+        dependencies: {
+          '@willbooster/needed': 'git@github.com:WillBooster/needed.git#main',
+          '@willbooster-private/a': '1.0.0',
+        },
+      });
+      await fs.writeFile(
+        path.join(rootDirPath, '.npmrc'),
+        '@willbooster-private:registry=http://wb-unreachable-registry.invalid\n'
+      );
+      // Installed only for the git dependency: the registry package has no installed copy, so it
+      // must be downloaded — and that download fails.
+      await writeJson(path.join(rootDirPath, 'node_modules', '@willbooster', 'needed', 'package.json'), {
+        name: '@willbooster/needed',
+        version: '1.0.0',
+      });
+      // Pre-existing linked materializations that must both survive the failure.
+      const gitDirPath = path.join(rootDirPath, '@willbooster', 'needed');
+      await writeJson(path.join(gitDirPath, 'package.json'), { name: '@willbooster/needed', version: '0.9.0' });
+      const registryDirPath = path.join(rootDirPath, '@willbooster-private', 'a');
+      await writeJson(path.join(registryDirPath, 'package.json'), {
+        name: '@willbooster-private/a',
+        version: '0.9.0',
+        dependencies: { '@willbooster/needed': 'file:../../@willbooster/needed' },
+      });
+
+      const projects = await findDescendantProjects({}, false, rootDirPath);
+      await expect(materializePrivatePackages(projects!.root.dirPath, collectManifests(projects!))).rejects.toThrow();
+
+      expect(await readVersion(gitDirPath)).toBe('0.9.0');
+      expect(await readVersion(registryDirPath)).toBe('0.9.0');
+    } finally {
+      await fs.rm(rootDirPath, { force: true, recursive: true });
+    }
+  });
 });
 
 async function writeJson(filePath: string, value: unknown): Promise<void> {
@@ -84,4 +128,9 @@ async function writeJson(filePath: string, value: unknown): Promise<void> {
 async function readName(packageDirPath: string): Promise<string | undefined> {
   const content = await fs.readFile(path.join(packageDirPath, 'package.json'), 'utf8');
   return (JSON.parse(content) as { name?: string }).name;
+}
+
+async function readVersion(packageDirPath: string): Promise<string | undefined> {
+  const content = await fs.readFile(path.join(packageDirPath, 'package.json'), 'utf8');
+  return (JSON.parse(content) as { version?: string }).version;
 }


### PR DESCRIPTION
Closes #1046

## Problem

`materializePrivatePackages` swapped the git staging tree into `@willbooster` **before** any registry work began, and copied late-discovered nested git packages (via `collectNestedPrivatePackages`) straight into that live tree. Any registry fetch / extraction / nested-discovery / rewrite failure therefore left `@willbooster` already replaced while `@willbooster-private` was stale, so a registry manifest referencing `file:../../@willbooster/<name>` could dangle. `wb optimizeForDockerBuild --outside` makes this reachable: it catches the failure and continues rewriting dependencies against the inconsistent trees.

## Fix

- Both trees now materialize into a single staging root (`.tmp/wb-private-staging`) that **mirrors each output tree's repository-root-relative location**. Because both trees are prefix-substituted by the same staging root, the relative distance between any two staged trees equals the distance between their final locations — so cross-tree relative `file:` specifiers computed in staging (`../../@willbooster/<name>`) are correct after the swap. This is what makes it safe to rewrite dependencies before committing.
- Late-discovered nested git dependencies are copied into staging too, not into the live tree.
- Dependency rewriting happens in staging, so it is inside the failure-safe region.
- `swapMaterializedTrees` then commits both trees as one transaction: each live tree is moved aside to a backup before its staged replacement is renamed in, and a failing rename rolls the already-swapped trees back.

The success path is otherwise unchanged: both output directories still always exist afterwards, and the same packages land in the same places.

## Test

`leaves both materialized trees untouched when a registry download fails` sets up pre-existing linked git/registry materializations (the registry manifest points at `file:../../@willbooster/needed`) and forces the registry fetch to fail by configuring `@willbooster-private:registry` to a reserved `.invalid` host in the project `.npmrc` — no live registry needed, matching the existing failure-path tests' style. It asserts both trees still hold the previous (`0.9.0`) content. The test fails on `main` (the git tree is already refreshed to `1.0.0`) and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
