### PR TITLE
feat: add WB_ALLOW_MISSING_SECRETS opt-in to load only resolvable fnox secrets

### DIFF
--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -316,10 +316,26 @@ function runFnoxExport(
   cascade: string | undefined,
   options: { quiet: boolean; ignoreProfileEnvVar?: boolean }
 ): Record<string, unknown> | undefined {
-  // `--if-missing error`: fnox otherwise exits 0 and silently omits secrets it fails to resolve
-  // (e.g. a missing age key), which would be indistinguishable from undeclared secrets.
+  // `--if-missing error` (default): fnox otherwise exits 0 and silently omits secrets it fails to
+  // resolve (e.g. a missing age key), which would be indistinguishable from undeclared secrets.
+  // Opt-in escape hatch `WB_ALLOW_MISSING_SECRETS=1`: switch to `warn` so a keyless context — e.g. a
+  // Docker/Railway image build that only inlines non-secret public values (`APP_TITLE`,
+  // `NEXT_PUBLIC_*`) while the age key is deliberately absent — still loads the resolvable values
+  // (plaintext defaults plus any secret that DID decrypt) instead of failing outright. `warn`, not
+  // `ignore`, keeps fnox reporting the skipped secret names on stderr (surfaced below), so relaxing
+  // the check stays auditable rather than silently dropping declared secrets.
   // `--non-interactive`: prompts or browser auth flows would hang forever because stdin is ignored.
-  const args = ['export', '--format', 'json', '--no-color', '--if-missing', 'error', '--non-interactive'];
+  const allowMissingSecrets =
+    process.env.WB_ALLOW_MISSING_SECRETS === '1' || process.env.WB_ALLOW_MISSING_SECRETS === 'true';
+  const args = [
+    'export',
+    '--format',
+    'json',
+    '--no-color',
+    '--if-missing',
+    allowMissingSecrets ? 'warn' : 'error',
+    '--non-interactive',
+  ];
   const env = { ...process.env };
   if (cascade) {
     args.push('--profile', cascade);
@@ -346,6 +362,12 @@ function runFnoxExport(
       );
     }
     return;
+  }
+
+  if (allowMissingSecrets && !options.quiet && result.stderr?.trim()) {
+    // With `--if-missing warn`, fnox exits 0 but reports the secrets it could not resolve on stderr.
+    // Surface them so relaxing the check via WB_ALLOW_MISSING_SECRETS does not hide a real gap.
+    console.warn(`WB_ALLOW_MISSING_SECRETS: continuing without unresolved fnox secrets.\n${result.stderr.trim()}`);
   }
 
   let parsed: unknown;

--- a/packages/shared-lib-node/test/env.test.ts
+++ b/packages/shared-lib-node/test/env.test.ts
@@ -1,4 +1,7 @@
 import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -136,6 +139,30 @@ describe('readAndApplyEnvironmentVariables()', () => {
       REF: 'ref-base-fnox',
     });
   });
+
+  it.runIf(isFnoxAvailable())(
+    'should skip undecryptable fnox secrets under WB_ALLOW_MISSING_SECRETS instead of failing',
+    () => {
+      // Force a keyless fnox by pointing its config dir at an empty directory, so the fixture's
+      // age-encrypted SECRET cannot be decrypted on any developer machine or CI runner.
+      const emptyConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fnox-nokey-'));
+      process.env.FNOX_CONFIG_DIR = emptyConfigDir;
+
+      // Default (strict `--if-missing error`): the failed decryption aborts the whole export, so no
+      // fnox values load — a declared secret must not be indistinguishable from an undeclared one.
+      const strict = readAndApplyEnvironmentVariables({ autoCascadeEnv: true }, 'test/fixtures/app-fnox-undecryptable');
+      expect(strict.PUB_ONLY).toBeUndefined();
+
+      // Opt-in: load the resolvable (plaintext) values and skip only the undecryptable secret.
+      process.env.WB_ALLOW_MISSING_SECRETS = '1';
+      const lenient = readAndApplyEnvironmentVariables(
+        { autoCascadeEnv: true },
+        'test/fixtures/app-fnox-undecryptable'
+      );
+      expect(lenient.PUB_ONLY).toBe('public-value');
+      expect(lenient.SECRET).toBeUndefined();
+    }
+  );
 });
 
 describe('readEnvironmentVariables()', () => {

--- a/packages/shared-lib-node/test/fixtures/app-fnox-undecryptable/fnox.toml
+++ b/packages/shared-lib-node/test/fixtures/app-fnox-undecryptable/fnox.toml
@@ -1,0 +1,9 @@
+[providers.age]
+type = "age"
+recipients = [
+  "age1j2354xhvm3fv9y77t5g6y3q8mexgk2mf00tgrkzgp73tynrvz55s8auayw", # exkazuu
+]
+
+[secrets]
+PUB_ONLY = { default = "public-value" }
+SECRET= { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKZWM0VEUyRFJzNzR0ZkZ1cWtRZXJZc1ViS25kYnR1UjVvcEN0QTMvaTFFClJYcEt6d2V5UkpSWDNzLzdFenlsOERweVJHa3FLY2NsMG56dU0vRVJPRjAKLT4gamZ0ekVWLWdyZWFzZSAiKj0gNH1edXNAZwpDcnkxN2xLN3lnQTI5ZndYdDFvU0NpWFZueDhZQmdSQwotLS0gcGp2L3ROMklSWDdCVVY2V0JpL3Y4RHdvSUh1dXdOeThkMkF0ck1jeFlURQpHUS8rNJtE4yROdOkzGcv3jrJV3hRanmHKYQ/FS34VvU4gREufihcIOPs/3w==" }


### PR DESCRIPTION
## Customer Summary

- Adds an opt-in environment variable, `WB_ALLOW_MISSING_SECRETS=1`, that lets `wb`/shared-lib-node load a repo's **non-secret (plaintext) fnox values even when the age key is absent**, instead of failing to load anything.
- Motivating case: a Docker/Railway image build that only needs to inline public values (`APP_TITLE`, `NEXT_PUBLIC_*`) no longer needs the age private key handed to the build just to recover a few non-secret strings.

## Technical Summary

- `runFnoxExport` (packages/shared-lib-node/src/env.ts) invokes `fnox export` with `--if-missing error` by default (unchanged). When `WB_ALLOW_MISSING_SECRETS` is `1`/`true`, it uses `--if-missing warn` instead: fnox exits 0, returns the resolvable values (plaintext defaults + any secret that decrypted), and omits the undecryptable ones.
- Chose `warn` over `ignore` so fnox still reports the skipped secret names on stderr; wb surfaces them with a `WB_ALLOW_MISSING_SECRETS: continuing without unresolved fnox secrets` warning, keeping the relaxation auditable rather than silently dropping declared secrets.
- Default (strict) behavior is unchanged, so existing fail-fast on a genuinely missing/mis-keyed secret is preserved.

## Why

- Today `--if-missing error` makes wb discard the **entire** fnox source (plaintext defaults included) when any encrypted secret can't be decrypted. That forces the org-wide age key onto build environments that only consume public values — over-privileged. This opt-in solves that at the tooling level (generalizes to keyless CI install replays, prerender steps, etc.).

## Testing

- New test `should skip undecryptable fnox secrets under WB_ALLOW_MISSING_SECRETS instead of failing` (packages/shared-lib-node/test/env.test.ts) with fixture `app-fnox-undecryptable`. It forces a keyless fnox via an empty `FNOX_CONFIG_DIR` (deterministic on any machine/CI): strict mode loads nothing, opt-in loads `PUB_ONLY` and skips the encrypted `SECRET`.
- `bunx vitest run test/env.test.ts` → 20/20 pass. `@willbooster/shared-lib-node` typecheck + lint pass.
- Also verified fnox's `--if-missing warn` semantics directly (exit 0, plaintext returned, undecryptable secret omitted with a stderr warning).

## Notes

- For a **fully** keyless build that also runs the `--check-env=.env.example` required-keys check, combine with the existing `WB_SKIP_ENV_CHECK` (the `.env.example` check is orthogonal to fnox decryption). A follow-up could make `WB_ALLOW_MISSING_SECRETS` also exempt the specific keys fnox reported as undecryptable from `--check-env`.
