### PR TITLE
fix(wbfy): exclude framework workspace app dirs from the root tsconfig

### DIFF
--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -173,25 +173,34 @@ function buildRootJsonObj(config: PackageConfig): TsConfigJson {
 // and behaves the same. Their app sources therefore only type-check under their own config.
 const frameworkDependencyNames = ['blitz', 'next', 'vinext'];
 
+// A framework app lives in `app/` or, under the src-directory layout, `src/app/`. The root project
+// includes `<workspace>/src/**/*`, so `src/app` leaks in just as a repo-wide glob can pull in `app`.
+const frameworkAppDirNames = ['app', 'src/app'];
+
 /** Root `exclude` entries (posix, relative to the root) for every framework workspace's app directory. */
 function getFrameworkWorkspaceAppExcludes(config: PackageConfig): string[] {
   if (!config.doesContainSubPackageJsons) return [];
   const excludes: string[] = [];
   for (const workspaceDirPath of getWorkspaceSubDirPaths(config)) {
-    const appDirPath = path.resolve(workspaceDirPath, 'app');
-    if (!fs.existsSync(appDirPath) || !dependsOnFramework(path.resolve(workspaceDirPath, 'package.json'))) continue;
-    excludes.push(path.relative(config.dirPath, appDirPath).replaceAll('\\', '/'));
+    if (!dependsOnFramework(path.resolve(workspaceDirPath, 'package.json'))) continue;
+    for (const appDirName of frameworkAppDirNames) {
+      const appDirPath = path.resolve(workspaceDirPath, appDirName);
+      if (fs.existsSync(appDirPath)) excludes.push(path.relative(config.dirPath, appDirPath).replaceAll('\\', '/'));
+    }
   }
   return excludes;
 }
 
 function dependsOnFramework(manifestPath: string): boolean {
-  let manifest: PackageJson;
+  let manifest: PackageJson | null;
   try {
-    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as PackageJson;
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as PackageJson | null;
   } catch {
     return false;
   }
+  // A manifest that parses to a non-object (e.g. a file literally containing `null`) declares no
+  // dependencies; guard the property access, which would otherwise throw outside the try above.
+  if (!manifest || typeof manifest !== 'object') return false;
   const dependencies = { ...manifest.dependencies, ...manifest.devDependencies };
   return frameworkDependencyNames.some((dependencyName) => dependencies[dependencyName]);
 }

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -146,6 +146,13 @@ function buildRootJsonObj(config: PackageConfig): TsConfigJson {
       // whose directory is an ancestor of a workspace yields package-owned subpath entries
       // instead of the whole subtree (see getWorkspaceDirPatterns).
       ...workspacePatterns.excludes,
+      // The managed includes above deliberately omit framework `app/**` directories (see
+      // subJsonObj.include's comment), but a repo-authored broad include such as `e2e/**\/*`
+      // can still drag a framework workspace's app sources into the root project, where they
+      // fail under the root compiler options — their bare `next/*` imports resolve only through
+      // the framework workspace's own tsconfig `paths`. Exclude those app directories so the
+      // root project never type-checks them, no matter how broad the repo's include globs are.
+      ...getFrameworkWorkspaceAppExcludes(config),
       ...(settings.exclude ?? []),
     ]),
   ].toSorted();
@@ -159,6 +166,34 @@ function buildRootJsonObj(config: PackageConfig): TsConfigJson {
     ]),
   ];
   return settings;
+}
+
+// Framework packages own their tsconfig (generateTsconfig skips them) and shim bare imports such as
+// `next/navigation` through package-local `paths`; vinext is the org's Next.js-equivalent framework
+// and behaves the same. Their app sources therefore only type-check under their own config.
+const frameworkDependencyNames = ['blitz', 'next', 'vinext'];
+
+/** Root `exclude` entries (posix, relative to the root) for every framework workspace's app directory. */
+function getFrameworkWorkspaceAppExcludes(config: PackageConfig): string[] {
+  if (!config.doesContainSubPackageJsons) return [];
+  const excludes: string[] = [];
+  for (const workspaceDirPath of getWorkspaceSubDirPaths(config)) {
+    const appDirPath = path.resolve(workspaceDirPath, 'app');
+    if (!fs.existsSync(appDirPath) || !dependsOnFramework(path.resolve(workspaceDirPath, 'package.json'))) continue;
+    excludes.push(path.relative(config.dirPath, appDirPath).replaceAll('\\', '/'));
+  }
+  return excludes;
+}
+
+function dependsOnFramework(manifestPath: string): boolean {
+  let manifest: PackageJson;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as PackageJson;
+  } catch {
+    return false;
+  }
+  const dependencies = { ...manifest.dependencies, ...manifest.devDependencies };
+  return frameworkDependencyNames.some((dependencyName) => dependencies[dependencyName]);
 }
 
 const managedWorkspaceIncludeSuffixes = ['*.config.ts', 'scripts/**/*', 'src/**/*', 'test/**/*'];

--- a/packages/wbfy/src/generators/tsconfig.ts
+++ b/packages/wbfy/src/generators/tsconfig.ts
@@ -40,7 +40,9 @@ const subJsonObj = {
 
 export async function generateTsconfig(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateTsconfig', async () => {
-    if (config.depending.blitz || config.depending.next) {
+    // vinext is the org's Next.js-equivalent framework and owns its tsconfig just like Next/Blitz,
+    // so it must skip the standard generation that would overwrite the framework's own settings.
+    if (config.depending.blitz || config.depending.next || config.depending.vinext) {
       await cleanupLegacyTsconfigModuleSettings(config);
       return;
     }
@@ -252,6 +254,17 @@ function removeStaleManagedWorkspaceEntries(
     if (typeof entry !== 'string' || generatedExclude.has(entry)) return true;
     if (entry.endsWith('/test/fixtures')) {
       return !stalePrefixes.has(entry.slice(0, -'/test/fixtures'.length));
+    }
+    // A framework app exclude (`<workspace>/app`, `<workspace>/src/app`) for a still-declared
+    // workspace is pruned by coversWorkspaceDir below when no longer generated; this catches the
+    // remaining case, where the workspace itself was removed and its prefix is therefore stale.
+    // (A wrong suffix strip yields a prefix absent from stalePrefixes, so testing every name is safe.)
+    if (
+      frameworkAppDirNames.some(
+        (appDirName) => entry.endsWith(`/${appDirName}`) && stalePrefixes.has(entry.slice(0, -(appDirName.length + 1)))
+      )
+    ) {
+      return false;
     }
     return !coversWorkspaceDir(entry, workspaceDirPaths);
   });

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -181,24 +181,29 @@ test('keeps a nested workspace in the root project when its ancestor package is 
   }
 });
 
-test('excludes a framework workspace app directory from the root project but not a plain one', async () => {
+test('excludes framework workspace app and src/app directories from the root project but not a plain one', async () => {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-tsconfig-'));
   try {
     // A framework workspace (here vinext, the org's Next.js-equivalent) shims bare imports such as
     // `next/navigation` through its own tsconfig paths, so its app sources fail under the root
     // compiler options. A plain workspace's app directory carries no such requirement and must stay.
-    const workspaces = ['e2e/fixture', 'packages/plain'];
+    const workspaces = ['e2e/fixture', 'apps/src-layout', 'packages/plain', 'packages/broken'];
     fs.writeFileSync(
       path.join(tempDirPath, 'package.json'),
       JSON.stringify({ name: 'root', private: true, workspaces })
     );
-    for (const [workspaceDirName, dependencies] of [
-      ['e2e/fixture', { vinext: '1.0.0' }],
-      ['packages/plain', {}],
+    for (const [workspaceDirName, appDirName, manifest] of [
+      ['e2e/fixture', 'app', JSON.stringify({ dependencies: { vinext: '1.0.0' } })],
+      // The src-directory layout keeps the framework app under src/app, which the root project's
+      // managed `src/**/*` include would otherwise pull in.
+      ['apps/src-layout', 'src/app', JSON.stringify({ dependencies: { next: '15.0.0' } })],
+      ['packages/plain', 'app', JSON.stringify({ dependencies: {} })],
+      // A manifest that parses to a non-object must not crash framework detection.
+      ['packages/broken', 'app', 'null'],
     ] as const) {
-      const appDirPath = path.join(tempDirPath, workspaceDirName, 'app');
+      const appDirPath = path.join(tempDirPath, workspaceDirName, appDirName);
       fs.mkdirSync(appDirPath, { recursive: true });
-      fs.writeFileSync(path.join(tempDirPath, workspaceDirName, 'package.json'), JSON.stringify({ dependencies }));
+      fs.writeFileSync(path.join(tempDirPath, workspaceDirName, 'package.json'), manifest);
       fs.writeFileSync(path.join(appDirPath, 'page.tsx'), 'export default () => null;\n');
     }
     const config = createConfig({
@@ -214,7 +219,9 @@ test('excludes a framework workspace app directory from the root project but not
       exclude?: string[];
     };
     expect(tsconfig.exclude).toContain('e2e/fixture/app');
+    expect(tsconfig.exclude).toContain('apps/src-layout/src/app');
     expect(tsconfig.exclude).not.toContain('packages/plain/app');
+    expect(tsconfig.exclude).not.toContain('packages/broken/app');
   } finally {
     fs.rmSync(tempDirPath, { recursive: true, force: true });
   }

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -227,6 +227,45 @@ test('excludes framework workspace app and src/app directories from the root pro
   }
 });
 
+test('prunes a stale framework app exclude after its workspace is removed', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-tsconfig-'));
+  try {
+    const appDirPath = path.join(tempDirPath, 'apps/web/app');
+    fs.mkdirSync(appDirPath, { recursive: true });
+    fs.writeFileSync(path.join(tempDirPath, 'apps/web/package.json'), JSON.stringify({ dependencies: { next: '15' } }));
+    fs.writeFileSync(path.join(appDirPath, 'page.tsx'), 'export default () => null;\n');
+    fs.mkdirSync(path.join(tempDirPath, 'packages/plain/src'), { recursive: true });
+    fs.writeFileSync(path.join(tempDirPath, 'packages/plain/package.json'), JSON.stringify({}));
+
+    const generateWith = async (workspaces: string[]): Promise<string[]> => {
+      fs.writeFileSync(
+        path.join(tempDirPath, 'package.json'),
+        JSON.stringify({ name: 'root', private: true, workspaces })
+      );
+      const config = createConfig({
+        dirPath: tempDirPath,
+        isRoot: true,
+        doesContainSubPackageJsons: true,
+        doesContainTypeScript: true,
+        packageJson: { name: 'root', workspaces },
+      });
+      await generateTsconfig(config);
+      await promisePool.promiseAll();
+      const tsconfig = JSON.parse(fs.readFileSync(path.join(tempDirPath, 'tsconfig.json'), 'utf8')) as {
+        exclude?: string[];
+      };
+      return tsconfig.exclude ?? [];
+    };
+
+    expect(await generateWith(['apps/web', 'packages/plain'])).toContain('apps/web/app');
+    // Removing apps/web from the workspaces makes its managed includes stale, so its now-orphaned
+    // app exclude must not survive into the regenerated root tsconfig.
+    expect(await generateWith(['packages/plain'])).not.toContain('apps/web/app');
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('keeps a commented Next tsconfig byte-identical when no cleanup is needed', async () => {
   const commentedContent = `{
   "compilerOptions": {

--- a/packages/wbfy/test/tsconfig.test.ts
+++ b/packages/wbfy/test/tsconfig.test.ts
@@ -181,6 +181,45 @@ test('keeps a nested workspace in the root project when its ancestor package is 
   }
 });
 
+test('excludes a framework workspace app directory from the root project but not a plain one', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-tsconfig-'));
+  try {
+    // A framework workspace (here vinext, the org's Next.js-equivalent) shims bare imports such as
+    // `next/navigation` through its own tsconfig paths, so its app sources fail under the root
+    // compiler options. A plain workspace's app directory carries no such requirement and must stay.
+    const workspaces = ['e2e/fixture', 'packages/plain'];
+    fs.writeFileSync(
+      path.join(tempDirPath, 'package.json'),
+      JSON.stringify({ name: 'root', private: true, workspaces })
+    );
+    for (const [workspaceDirName, dependencies] of [
+      ['e2e/fixture', { vinext: '1.0.0' }],
+      ['packages/plain', {}],
+    ] as const) {
+      const appDirPath = path.join(tempDirPath, workspaceDirName, 'app');
+      fs.mkdirSync(appDirPath, { recursive: true });
+      fs.writeFileSync(path.join(tempDirPath, workspaceDirName, 'package.json'), JSON.stringify({ dependencies }));
+      fs.writeFileSync(path.join(appDirPath, 'page.tsx'), 'export default () => null;\n');
+    }
+    const config = createConfig({
+      dirPath: tempDirPath,
+      isRoot: true,
+      doesContainSubPackageJsons: true,
+      doesContainTypeScript: true,
+      packageJson: { name: 'root', workspaces },
+    });
+    await generateTsconfig(config);
+    await promisePool.promiseAll();
+    const tsconfig = JSON.parse(fs.readFileSync(path.join(tempDirPath, 'tsconfig.json'), 'utf8')) as {
+      exclude?: string[];
+    };
+    expect(tsconfig.exclude).toContain('e2e/fixture/app');
+    expect(tsconfig.exclude).not.toContain('packages/plain/app');
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('keeps a commented Next tsconfig byte-identical when no cleanup is needed', async () => {
   const commentedContent = `{
   "compilerOptions": {


### PR DESCRIPTION
## Why

wbfy's root `tsconfig.json` deliberately keeps framework `app/**` directories out of its managed `include` entries, because framework packages (Next.js/Blitz/vinext) own their tsconfig and shim bare imports such as `next/navigation` through package-local `paths`. Type-checking those app sources under the root compiler options produces false errors.

That intent was only enforced by *omitting* `app/**` from the includes. A repo-authored broad include glob (e.g. a fixture repo whose root tsconfig has `include: ["e2e/**/*"]`) still drags the framework workspace's app sources into the root project, breaking `tsc`/type-aware lint:

```
e2e/fixture/app/page.tsx: error TS2307: Cannot find module 'next/form' ...
e2e/fixture/app/PushButton.tsx: error TS2305: Module '"next/navigation"' has no exported member 'useRouter'.
```

This surfaced when applying wbfy to `vinext-progress`, whose e2e fixture is a `vinext` app workspace.

## What

- `buildRootJsonObj` now adds every framework workspace's `app` directory to the root tsconfig `exclude`, so the root project never type-checks it regardless of how broad the repo's include globs are.
- Framework detection covers `next`, `blitz`, and `vinext` (the org's Next.js-equivalent framework).
- Added a test asserting a framework workspace's `app` dir is excluded while a plain workspace's is not.

All 274 wbfy tests pass; `bun verify` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
