### PR TITLE
feat(wbfy): generate a Renovate config validation hook for willbooster-configs

### DIFF
--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -87,6 +87,9 @@ exit "$failed"
       // there would validate two lines and catch nothing. `--no-global` validates the preset as a
       // repo config instead of a self-hosted global config, and `@latest` keeps npm from silently
       // installing an ancient Renovate that cannot even parse JSONC when the local Node lags behind.
+      // Staging a deletion of renovate.jsonc leaves no file for inspection, so Lefthook skips this
+      // job instead of running the validator on a missing path — deliberately, because deleting the
+      // shared preset is not an operation this hook needs to guard.
       name: 'validate-renovate-config',
       glob: 'renovate.jsonc',
       run: 'npx --yes --package renovate@latest -- renovate-config-validator --strict --no-global {staged_files}',

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -81,6 +81,15 @@ done
 exit "$failed"
 `.trim(),
     },
+    {
+      // Only willbooster-configs gets this job: every other repository's renovate.jsonc merely
+      // extends the shared preset, and the validator does not resolve remote presets, so running it
+      // there would validate two lines and catch nothing. `--no-global` validates the preset as a
+      // repo config instead of a self-hosted global config.
+      name: 'validate-renovate-config',
+      glob: 'renovate.jsonc',
+      run: 'npx --yes --package renovate -- renovate-config-validator --strict --no-global {staged_files}',
+    },
   ],
 };
 
@@ -179,15 +188,17 @@ ${quietLintCommand}
 }
 
 function getPreCommitJobs(config: PackageConfig): LefthookJob[] {
-  return preCommitSettings.jobs.map((job) =>
-    job.name === 'cleanup'
-      ? {
-          ...job,
-          glob: getCleanupGlobs(config),
-          run: getCleanupCommand(config),
-        }
-      : job
-  );
+  return preCommitSettings.jobs
+    .filter((job) => job.name !== 'validate-renovate-config' || config.isWillBoosterConfigs)
+    .map((job) =>
+      job.name === 'cleanup'
+        ? {
+            ...job,
+            glob: getCleanupGlobs(config),
+            run: getCleanupCommand(config),
+          }
+        : job
+    );
 }
 
 function getCleanupGlobs(config: PackageConfig): string {

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -85,10 +85,11 @@ exit "$failed"
       // Only willbooster-configs gets this job: every other repository's renovate.jsonc merely
       // extends the shared preset, and the validator does not resolve remote presets, so running it
       // there would validate two lines and catch nothing. `--no-global` validates the preset as a
-      // repo config instead of a self-hosted global config.
+      // repo config instead of a self-hosted global config, and `@latest` keeps npm from silently
+      // installing an ancient Renovate that cannot even parse JSONC when the local Node lags behind.
       name: 'validate-renovate-config',
       glob: 'renovate.jsonc',
-      run: 'npx --yes --package renovate -- renovate-config-validator --strict --no-global {staged_files}',
+      run: 'npx --yes --package renovate@latest -- renovate-config-validator --strict --no-global {staged_files}',
     },
   ],
 };

--- a/packages/wbfy/test/lefthook.test.ts
+++ b/packages/wbfy/test/lefthook.test.ts
@@ -32,6 +32,23 @@ test('post-merge cache clearing covers workspace frameworks with workspace-relat
   }
 });
 
+test('the Renovate config validation job is generated only for willbooster-configs', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-lefthook-'));
+  try {
+    const otherConfig = createConfig({ dirPath: tempDirPath, isRoot: true });
+    await generateLefthookUpdatingPackageJson(otherConfig);
+    expect(fs.readFileSync(path.join(tempDirPath, 'lefthook.yml'), 'utf8')).not.toContain('renovate-config-validator');
+
+    const configsConfig = createConfig({ dirPath: tempDirPath, isRoot: true, isWillBoosterConfigs: true });
+    await generateLefthookUpdatingPackageJson(configsConfig);
+    expect(fs.readFileSync(path.join(tempDirPath, 'lefthook.yml'), 'utf8')).toContain(
+      'renovate-config-validator --strict --no-global {staged_files}'
+    );
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
 test('post-merge cache clearing stays root-relative for a root-level Next.js app without a Vite cache hook', async () => {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-lefthook-'));
   try {


### PR DESCRIPTION
## Why

Every repository's `renovate.jsonc` generated by wbfy is just an `extends` of `github>WillBooster/willbooster-configs:renovate.jsonc`, so a broken rule in that shared preset reaches all repositories as soon as it lands on `main` (see WillBooster/willbooster-configs#1058).

Validating the downstream copies would not help: `renovate-config-validator` does not resolve remote presets — a config extending a nonexistent preset validates successfully:

```jsonc
{ "extends": ["github>WillBooster/definitely-not-a-real-repo-xyz"] }  // → Config validated successfully
```

Running it everywhere would therefore validate two lines per repository, catch nothing, and cost a ~360 MB one-off download per developer.

## What

`packages/wbfy/src/generators/lefthook.ts`: add a `pre-commit` job scoped to `renovate.jsonc` that runs

```
npx --yes --package renovate@latest -- renovate-config-validator --strict --no-global {staged_files}
```

and emit it only when `config.isWillBoosterConfigs`, i.e. in the repository that actually owns the preset.

- `--no-global` validates the file as a repo config instead of the default self-hosted global config.
- `@latest` is required because npm resolves the newest *engine-compatible* Renovate: with an older Node it silently installs an ancient Renovate that cannot even parse JSONC (observed as `renovate@42.99.0` / `"Unsupported file type"` in [this CI run](https://github.com/WillBooster/willbooster-configs/actions/runs/29913572441)).

The CI counterpart lives in WillBooster/willbooster-configs#1059.

## Verification

- New test in `packages/wbfy/test/lefthook.test.ts` asserts the job is absent for a normal repository and present for willbooster-configs (the condition has no type-level or lint-level safeguard).
- Applied the generated job to willbooster-configs, reintroduced the willbooster-configs#1058 defect, and ran `lefthook run pre-commit` → the job failed with the expected `Your input contains * or **` error; the fixed file passes.
- Staging a deletion of `renovate.jsonc` makes Lefthook skip the job (`no files for inspection`) rather than run the validator on a missing path; this is deliberate and now documented in a code comment.
- `bun verify` passes.
