### PR TITLE
fix(wbfy): update CI age identity file path to age-ci-wb.txt

### DIFF
--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -14,7 +14,7 @@ import { fsUtil } from '../utils/fsUtil.js';
 // machine ran wbfy. To grant a new member or environment access, append its public key here; the
 // next wbfy run on each repository rewrites the recipients in fnox.toml and re-encrypts the
 // committed secrets. Only public keys may appear in this repository; CI's private key lives in
-// ~/.config/fnox/ci-age.txt and the FNOX_AGE_KEY repository secrets.
+// ~/.config/fnox/age-ci-wb.txt and the FNOX_AGE_KEY repository secrets.
 export const FNOX_AGE_RECIPIENTS = [
   { name: 'exkazuu', publicKey: 'age1j2354xhvm3fv9y77t5g6y3q8mexgk2mf00tgrkzgp73tynrvz55s8auayw' },
   { name: 'ponharu1', publicKey: 'age18rugldf9htc6um5eplpx27k53ep4zn0lhzwffgnxzhrq0c7zgvyq3zccdy' },

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -429,7 +429,7 @@ async function fetchDefaultBranchFnoxConfigs(
 function readCiAgeSecretKey(): string | undefined {
   // The CI-dedicated identity is separate from the personal one (~/.config/fnox/age.txt) so that
   // the personal key never leaves the local machine and the CI key can be rotated independently.
-  const identityPath = path.join(os.homedir(), '.config', 'fnox', 'ci-age.txt');
+  const identityPath = path.join(os.homedir(), '.config', 'fnox', 'age-ci-wb.txt');
   let content: string;
   try {
     content = fs.readFileSync(identityPath, 'utf8');


### PR DESCRIPTION
## Customer Summary

- No user-facing behavior change; this only updates an internal file path used by CI secret provisioning.

## Technical Summary

- `readCiAgeSecretKey()` in `packages/wbfy/src/github/secret.ts` now reads the CI age identity from `~/.config/fnox/age-ci-wb.txt` instead of `~/.config/fnox/ci-age.txt`.
- Updated the matching comment in `packages/wbfy/src/generators/fnoxToml.ts` that documents where the CI private key lives.

## Why

- The local file `ci-age.txt` was renamed to `age-ci-wb.txt`, so the code and comments referencing its path needed to match.

## Testing

- `bun verify`
