### PR TITLE
fix(wb): prevent infinite recursion when a package script invokes `wb run` with its own name

### DIFF
--- a/packages/wb/src/commands/run.ts
+++ b/packages/wb/src/commands/run.ts
@@ -62,13 +62,21 @@ function buildRunCommand(cwd: string, args: readonly string[], env: NodeJS.Proce
 }
 
 function readPackageScript(cwd: string, name: string): string | undefined {
-  try {
-    const packageJson = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8')) as {
-      scripts?: Record<string, string>;
-    };
-    return packageJson.scripts?.[name];
-  } catch {
-    return undefined;
+  // `bun run` resolves scripts from the nearest ancestor package.json, so match that scope
+  // (e.g. --working-dir may point to a manifest-less subdirectory of the recursing package).
+  for (let currentPath = path.resolve(cwd); ; currentPath = path.dirname(currentPath)) {
+    const packageJsonPath = path.join(currentPath, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      try {
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+          scripts?: Record<string, string>;
+        };
+        return packageJson.scripts?.[name];
+      } catch {
+        return undefined;
+      }
+    }
+    if (path.dirname(currentPath) === currentPath) return undefined;
   }
 }
 

--- a/packages/wb/src/commands/run.ts
+++ b/packages/wb/src/commands/run.ts
@@ -32,7 +32,7 @@ export const runCommand: CommandModule = {
     const env = fs.existsSync(path.join(cwd, 'package.json'))
       ? new Project(cwd, argv, true).env
       : readStandaloneEnvironment(argv, cwd);
-    const command = buildRunCommand(cwd, args);
+    const command = buildRunCommand(cwd, args, env);
     if (argv.dryRun) {
       console.info(`Would run: ${command.join(' ')}`);
       return;
@@ -44,14 +44,32 @@ export const runCommand: CommandModule = {
   },
 };
 
-function buildRunCommand(cwd: string, args: readonly string[]): string[] {
+function buildRunCommand(cwd: string, args: readonly string[], env: NodeJS.ProcessEnv): string[] {
   if (!usesBunRuntime(cwd)) return ['node', ...args];
   // `bun run` resolves package.json scripts before local binaries, so a script that invokes
   // `wb run <its own name>` (e.g. "vitest": "wb run vitest run") would respawn itself forever.
-  // When invoked from the same-named lifecycle script, bypass script resolution and execute the
-  // binary directly; runCommandWithEnvironment prepends node_modules/.bin to PATH.
-  if (args[0] === process.env.npm_lifecycle_event) return [...args];
+  // Bypass script resolution only for genuine self-recursion: the target names the lifecycle
+  // script that spawned this process AND the current package declares that very script text —
+  // a cross-package delegation via --working-dir reaches a different script text, so it still
+  // runs the destination's script. runCommandWithEnvironment prepends node_modules/.bin to
+  // PATH, resolving the direct execution to the local binary.
+  const target = args[0];
+  if (target && target === env.npm_lifecycle_event) {
+    const script = readPackageScript(cwd, target);
+    if (script !== undefined && script === env.npm_lifecycle_script) return [...args];
+  }
   return ['bun', 'run', ...args];
+}
+
+function readPackageScript(cwd: string, name: string): string | undefined {
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+    return packageJson.scripts?.[name];
+  } catch {
+    return undefined;
+  }
 }
 
 function readStandaloneEnvironment(argv: ArgumentsCamelCase, cwd: string): NodeJS.ProcessEnv {

--- a/packages/wb/src/commands/run.ts
+++ b/packages/wb/src/commands/run.ts
@@ -32,7 +32,7 @@ export const runCommand: CommandModule = {
     const env = fs.existsSync(path.join(cwd, 'package.json'))
       ? new Project(cwd, argv, true).env
       : readStandaloneEnvironment(argv, cwd);
-    const command = usesBunRuntime(cwd) ? ['bun', 'run', ...args] : ['node', ...args];
+    const command = buildRunCommand(cwd, args);
     if (argv.dryRun) {
       console.info(`Would run: ${command.join(' ')}`);
       return;
@@ -43,6 +43,16 @@ export const runCommand: CommandModule = {
     });
   },
 };
+
+function buildRunCommand(cwd: string, args: readonly string[]): string[] {
+  if (!usesBunRuntime(cwd)) return ['node', ...args];
+  // `bun run` resolves package.json scripts before local binaries, so a script that invokes
+  // `wb run <its own name>` (e.g. "vitest": "wb run vitest run") would respawn itself forever.
+  // When invoked from the same-named lifecycle script, bypass script resolution and execute the
+  // binary directly; runCommandWithEnvironment prepends node_modules/.bin to PATH.
+  if (args[0] === process.env.npm_lifecycle_event) return [...args];
+  return ['bun', 'run', ...args];
+}
 
 function readStandaloneEnvironment(argv: ArgumentsCamelCase, cwd: string): NodeJS.ProcessEnv {
   const [envVars, envPathAndLoadedEnvVarNamePairs] = readEnvironmentVariables(argv, cwd, {

--- a/packages/wb/test/binDotenv.test.ts
+++ b/packages/wb/test/binDotenv.test.ts
@@ -567,6 +567,34 @@ describe('bin/index.js run command', () => {
     expect(result.status).toBe(0);
   });
 
+  it('bypasses the same-named package script when run from a manifest-less subdirectory', async () => {
+    const probeScript = 'wb --working-dir subdir run probe argument';
+    await fs.writeFile(
+      path.join(projectDirPath, 'package.json'),
+      JSON.stringify({ packageManager: 'bun@1.3.14', scripts: { probe: probeScript } })
+    );
+    const subDirPath = path.join(projectDirPath, 'subdir');
+    await fs.mkdir(subDirPath, { recursive: true });
+    const binDirPath = path.join(projectDirPath, 'node_modules', '.bin');
+    await fs.mkdir(binDirPath, { recursive: true });
+    await fs.writeFile(path.join(binDirPath, 'probe'), '#!/bin/sh\necho "bin:$@"\n', { mode: 0o755 });
+
+    const result = childProcess.spawnSync(
+      process.execPath,
+      [binIndexPath, '--working-dir', subDirPath, '--quiet-env', 'run', 'probe', 'argument'],
+      {
+        cwd: projectDirPath,
+        encoding: 'utf8',
+        // `bun run probe` from the manifest-less subdirectory would still find and re-enter the
+        // ancestor package's script, so the guard must match the nearest ancestor manifest.
+        env: { PATH: process.env.PATH, npm_lifecycle_event: 'probe', npm_lifecycle_script: probeScript },
+      }
+    );
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('bin:argument\n');
+    expect(result.status).toBe(0);
+  });
+
   it('still runs the destination package script when a same-named script delegates across packages', async () => {
     const childDirPath = path.join(projectDirPath, 'cross-package');
     await fs.mkdir(childDirPath, { recursive: true });

--- a/packages/wb/test/binDotenv.test.ts
+++ b/packages/wb/test/binDotenv.test.ts
@@ -545,6 +545,27 @@ describe('bin/index.js run command', () => {
     expect(result.status).toBe(0);
   });
 
+  it('bypasses the same-named package script and runs the local binary instead', async () => {
+    await fs.writeFile(
+      path.join(projectDirPath, 'package.json'),
+      JSON.stringify({ packageManager: 'bun@1.3.14', scripts: { probe: 'wb run probe argument' } })
+    );
+    const binDirPath = path.join(projectDirPath, 'node_modules', '.bin');
+    await fs.mkdir(binDirPath, { recursive: true });
+    await fs.writeFile(path.join(binDirPath, 'probe'), '#!/bin/sh\necho "bin:$@"\n', { mode: 0o755 });
+
+    const result = childProcess.spawnSync(process.execPath, [binIndexPath, 'run', '--quiet-env', 'probe', 'argument'], {
+      cwd: projectDirPath,
+      encoding: 'utf8',
+      // Simulate being spawned from the "probe" package script, where `bun run probe` would
+      // re-enter the script itself forever.
+      env: { PATH: process.env.PATH, npm_lifecycle_event: 'probe' },
+    });
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('bin:argument\n');
+    expect(result.status).toBe(0);
+  });
+
   it('prints usage instead of starting a runtime without a script', () => {
     const result = childProcess.spawnSync(process.execPath, [binIndexPath, 'run'], {
       cwd: projectDirPath,

--- a/packages/wb/test/binDotenv.test.ts
+++ b/packages/wb/test/binDotenv.test.ts
@@ -546,9 +546,10 @@ describe('bin/index.js run command', () => {
   });
 
   it('bypasses the same-named package script and runs the local binary instead', async () => {
+    const probeScript = 'wb run probe argument';
     await fs.writeFile(
       path.join(projectDirPath, 'package.json'),
-      JSON.stringify({ packageManager: 'bun@1.3.14', scripts: { probe: 'wb run probe argument' } })
+      JSON.stringify({ packageManager: 'bun@1.3.14', scripts: { probe: probeScript } })
     );
     const binDirPath = path.join(projectDirPath, 'node_modules', '.bin');
     await fs.mkdir(binDirPath, { recursive: true });
@@ -559,10 +560,41 @@ describe('bin/index.js run command', () => {
       encoding: 'utf8',
       // Simulate being spawned from the "probe" package script, where `bun run probe` would
       // re-enter the script itself forever.
-      env: { PATH: process.env.PATH, npm_lifecycle_event: 'probe' },
+      env: { PATH: process.env.PATH, npm_lifecycle_event: 'probe', npm_lifecycle_script: probeScript },
     });
     expect(result.stderr).toBe('');
     expect(result.stdout).toBe('bin:argument\n');
+    expect(result.status).toBe(0);
+  });
+
+  it('still runs the destination package script when a same-named script delegates across packages', async () => {
+    const childDirPath = path.join(projectDirPath, 'cross-package');
+    await fs.mkdir(childDirPath, { recursive: true });
+    await fs.writeFile(
+      path.join(projectDirPath, 'package.json'),
+      JSON.stringify({ packageManager: 'bun@1.3.14', scripts: { probe: 'wb --working-dir cross-package run probe' } })
+    );
+    await fs.writeFile(
+      path.join(childDirPath, 'package.json'),
+      JSON.stringify({ packageManager: 'bun@1.3.14', scripts: { probe: 'node -e "console.log(\'child-probe-ran\')"' } })
+    );
+
+    const result = childProcess.spawnSync(
+      process.execPath,
+      [binIndexPath, '--working-dir', childDirPath, '--quiet-env', 'run', 'probe'],
+      {
+        cwd: projectDirPath,
+        encoding: 'utf8',
+        // Simulate delegation from the outer package's "probe" script: the lifecycle event
+        // matches the target, but the destination declares a different script text.
+        env: {
+          PATH: process.env.PATH,
+          npm_lifecycle_event: 'probe',
+          npm_lifecycle_script: 'wb --working-dir cross-package run probe',
+        },
+      }
+    );
+    expect(result.stdout).toContain('child-probe-ran');
     expect(result.status).toBe(0);
   });
 


### PR DESCRIPTION
## Customer Summary

- Fixes an infinite process spawn loop: a package script that invokes `wb run` with its own name (e.g. `"vitest": "wb run vitest run --dir test/unit"`) respawned itself until `spawn EAGAIN`, because `bun run` resolves package.json scripts before local binaries.
- `wb run` now detects genuine self-recursion and executes the local binary directly instead of re-entering the script, while cross-package delegations via `--working-dir` keep running the destination package's script.

## Technical Summary

- `buildRunCommand` bypasses `bun run` script resolution only when the target names the invoking lifecycle script (`env.npm_lifecycle_event`) AND the nearest ancestor package.json of the working directory declares that exact script text (`env.npm_lifecycle_script`) — mirroring bun's nearest-ancestor script resolution, so a manifest-less subdirectory of the recursing package is also covered.
- Lifecycle variables are read from the resolved project `env` (repo rule: `project.env` over `process.env`).
- The direct execution resolves via `PATH`, which `runCommandWithEnvironment` already prefixes with the ancestor `node_modules/.bin` directories, matching the former `wb dotenv -- <bin>` behavior.
- Node-runtime projects are unaffected (`node <file>` never resolves package scripts).

## Testing

- `bun run vitest run test/binDotenv.test.ts` in `packages/wb` (28 tests, including three new regression cases: self-recursion, cross-package delegation, manifest-less subdirectory)
- Real `bun run` end-to-end check of the self-recursion scenario
- `bun verify`
- Multi-agent review-fix rounds (Codex, Claude Code, Antigravity): all findings fixed, final round no concern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
