### PR TITLE
feat!: remove .env.example support

### DIFF
--- a/packages/shared-lib-node/src/env.ts
+++ b/packages/shared-lib-node/src/env.ts
@@ -31,11 +31,6 @@ export const yargsOptionsBuilderForEnv = {
     type: 'boolean',
     default: true,
   },
-  'check-env': {
-    description: 'Check whether the keys of the loaded .env files are same with the given .env file.',
-    type: 'string',
-    default: '.env.example',
-  },
   'quiet-env': {
     description: 'Suppress .env file loading information.',
     type: 'boolean',
@@ -211,13 +206,6 @@ export function readEnvironmentVariables(
     );
   }
 
-  if (argv.checkEnv) {
-    const exampleKeys = Object.keys(readEnvFile(path.join(cwd, argv.checkEnv)));
-    const missingKeys = exampleKeys.filter((key) => !(key in envVars) && !(key in process.env));
-    if (missingKeys.length > 0) {
-      throw new Error(`Missing environment variables in [${envPaths.join(', ')}]: [${missingKeys.join(', ')}]`);
-    }
-  }
   // Expand references against the live environment for keys NOT loaded from files, so that a
   // reference to an exported key (excluded from envVars by process-env precedence) resolves to
   // the effective value instead of an empty string. Loaded keys are deliberately absent from

--- a/packages/wb/README.md
+++ b/packages/wb/README.md
@@ -51,9 +51,6 @@ Options:
       --include-root-env  Include .env files in root directory if the project is
                           in a monorepo and --env option is not used.
                                                        [boolean] [default: true]
-      --check-env         Check whether the keys of the loaded .env files are
-                          same with the given .env file.
-                                              [string] [default: ".env.example"]
   -v, --verbose           Whether to show verbose information          [boolean]
   -w, --working-dir       A working directory                           [string]
   -d, --dry-run, --dry    Whether to skip actual command execution     [boolean]

--- a/packages/wb/bin/runArgs.js
+++ b/packages/wb/bin/runArgs.js
@@ -12,7 +12,7 @@ const booleanOptionNames = new Set([
   'v',
   'version',
 ]);
-const valueOptionNames = new Set(['cascade-env', 'check-env', 'env', 'working-dir', 'w']);
+const valueOptionNames = new Set(['cascade-env', 'env', 'working-dir', 'w']);
 const boundaryMarkerEnvName = 'WB_INTERNAL_RUN_BOUNDARY_MARKER';
 
 export function protectRunScriptArgs(argv) {

--- a/packages/wb/src/commands/deploy.ts
+++ b/packages/wb/src/commands/deploy.ts
@@ -19,8 +19,6 @@ import { findWranglerConfigPath } from '../utils/wrangler.js';
 import type { ResolvedWranglerConfig, WranglerD1Database } from '../utils/wranglerConfig.js';
 import { resolveWranglerConfigForEnv, usesWranglerNativeMigrations } from '../utils/wranglerConfig.js';
 
-import { readEnvExampleKeys } from './genDevVars.js';
-
 /**
  * Keys that drive the deploy itself (or are meaningful only locally) and thus must never be
  * pushed to the Worker as secrets. `WB_ENV` / `NEXT_PUBLIC_WB_ENV` belong in wrangler `vars`.
@@ -224,10 +222,6 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
     for (const key of Object.keys(envVars)) {
       if (!dotenvKeys.has(key)) delete envVars[key];
     }
-    const requiredKeys = readEnvExampleKeys(project);
-    for (const key of requiredKeys) {
-      envVars[key] ??= project.env[key] ?? '';
-    }
     // Names declared via wrangler `secrets.required` may likewise be supplied purely as
     // exported environment variables (e.g. CI workflow env) instead of dotenv values.
     for (const key of resolvedConfig.requiredSecretNames) {
@@ -240,11 +234,7 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       const effectiveValue = project.env[key];
       if (effectiveValue !== undefined) envVars[key] = effectiveValue;
     }
-    const { missingKeys, secrets } = selectWorkerSecrets(
-      envVars,
-      [...resolvedConfig.varKeys, ...resolvedConfig.bindingNames],
-      requiredKeys
-    );
+    const secrets = selectWorkerSecrets(envVars, [...resolvedConfig.varKeys, ...resolvedConfig.bindingNames]);
     // `--var WB_VERSION:...` takes precedence over configuration values on deploy, so a
     // resource binding of that name would silently become a string variable.
     if (project.env.WB_VERSION && resolvedConfig.bindingNames.includes('WB_VERSION')) {
@@ -257,14 +247,6 @@ export const deployCommand: CommandModule<unknown, DeployCommandOptions> = {
       console.warn(
         chalk.yellow(`Skipping env keys that collide with Worker binding names: ${bindingCollisions.join(', ')}`)
       );
-    }
-    if (missingKeys.length > 0) {
-      console.error(
-        chalk.red(
-          `Missing required environment variables (from .env.example or wrangler secrets.required): ${missingKeys.join(', ')}`
-        )
-      );
-      process.exit(1);
     }
     // Wrangler validates `secrets.required` only during the real upload — after migrations —
     // so wb checks upfront: each required name must be a key in the outgoing payload (presence,
@@ -573,14 +555,8 @@ export function readCloudflareEnvFiles(dirPath: string, rootDirPath: string | un
  * every explicitly set value — including empty strings, which clear stale remote secrets
  * since `wrangler deploy --secrets-file` is additive — except wrangler `vars` (a secret may
  * not share a name with a var), deploy-control keys, and local `file:` DATABASE_URLs.
- * Returns the required keys (from .env.example) that are still empty so the deploy can
- * abort before any remote mutation.
  */
-export function selectWorkerSecrets(
-  envVars: Record<string, string>,
-  configVarKeys: string[],
-  requiredKeys: string[]
-): { missingKeys: string[]; secrets: Record<string, string> } {
+export function selectWorkerSecrets(envVars: Record<string, string>, configVarKeys: string[]): Record<string, string> {
   const configKeys = new Set(configVarKeys);
   const secrets: Record<string, string> = {};
   // No runtime undefined check on `value`: envVars is built exclusively from dotenv-parsed
@@ -591,8 +567,7 @@ export function selectWorkerSecrets(
     if (key === 'DATABASE_URL' && value.startsWith('file:')) continue;
     secrets[key] = value;
   }
-  const missingKeys = requiredKeys.filter((key) => !configKeys.has(key) && !isNonSecretKey(key) && !envVars[key]);
-  return { missingKeys, secrets };
+  return secrets;
 }
 
 /**

--- a/packages/wb/src/commands/genDevVars.ts
+++ b/packages/wb/src/commands/genDevVars.ts
@@ -33,10 +33,11 @@ export const genDevVarsCommand: CommandModule<unknown, GenDevVarsCommandOptions>
       process.exit(1);
     }
 
-    // Restrict to the variables loaded from .env files (wb's environment contract) so that
+    // Restrict to variables loaded from the project's declared environment sources so that
     // unrelated process environment variables never leak into the generated file. Ignore
     // process.env because the parent wb process injects the .env values into it, which would
-    // otherwise suppress loading them here.
+    // otherwise suppress loading them here. wbfy declares the WB_ENV-family keys in fnox, so
+    // they are already included; process-only keys are intentionally outside this allowlist.
     const [envVars] = readEnvironmentVariables(argv, project.dirPath, { ignoreProcessEnv: true });
     // Explicitly exported environment variables must win over dotenv values for file-defined
     // keys (project.env applies that precedence), or `AUTH_SECRET=... wb start` would serve

--- a/packages/wb/src/commands/genDevVars.ts
+++ b/packages/wb/src/commands/genDevVars.ts
@@ -6,7 +6,6 @@ import chalk from 'chalk';
 import { parse as parseDotenv } from 'dotenv';
 import type { ArgumentsCamelCase, Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
-import type { Project } from '../project.js';
 import { findSelfProject } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
@@ -51,16 +50,6 @@ export const genDevVarsCommand: CommandModule<unknown, GenDevVarsCommandOptions>
       if (effectiveValue === '' && envVars[key] !== '') explicitlyEmptiedKeys.add(key);
       envVars[key] = effectiveValue;
     }
-    // Supplement with process environment values for the keys named in .env.example: CI often
-    // provides them as workflow env instead of .env files (still an allowlist, so unrelated
-    // process environment variables cannot leak).
-    for (const key of [...readEnvExampleKeys(project), 'WB_ENV', 'NEXT_PUBLIC_WB_ENV']) {
-      const effectiveValue = project.env[key];
-      if (envVars[key] || effectiveValue === undefined) continue;
-      if (envVars[key] === undefined && effectiveValue === '') explicitlyEmptiedKeys.add(key);
-      envVars[key] = effectiveValue;
-    }
-
     const lines = Object.entries(envVars)
       .filter(([key, value]) => value !== '' || explicitlyEmptiedKeys.has(key))
       .toSorted(([a], [b]) => a.localeCompare(b))
@@ -76,18 +65,6 @@ export const genDevVarsCommand: CommandModule<unknown, GenDevVarsCommandOptions>
     console.info(chalk.green(`Generated ${outputPath} with ${lines.length} environment variables.`));
   },
 };
-
-export function readEnvExampleKeys(project: Project): string[] {
-  let envExamplePath: string;
-  try {
-    envExamplePath = project.findFile('.env.example');
-  } catch {
-    return [];
-  }
-  // dotenv's own parser covers `export KEY=` prefixes and whitespace around `=`,
-  // which a line regex would silently miss.
-  return Object.keys(parseDotenv(fs.readFileSync(envExamplePath, 'utf8')));
-}
 
 /**
  * Quote a value for dotenv (which wrangler uses for .dev.vars). Every candidate representation

--- a/packages/wb/src/commands/railwayEnv.ts
+++ b/packages/wb/src/commands/railwayEnv.ts
@@ -5,12 +5,10 @@ import type { ArgumentsCamelCase, Argv, CommandModule, InferredOptionTypes } fro
 import { findSelfProject } from '../project.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
-import { readEnvExampleKeys } from './genDevVars.js';
-
 // Railway injects its own system variables and platform-managed values; never mirror those back,
 // and skip local-only keys. App variables (including DATABASE_URL, PORT) stay eligible because
 // fnox is the source of truth — a repo that must NOT own a value (e.g. a Railway reference
-// variable pointing at a linked database service) simply keeps it out of fnox/.env.example.
+// variable pointing at a linked database service) simply keeps it out of fnox.
 const NON_RAILWAY_KEYS = new Set(['CI']);
 const NON_RAILWAY_KEY_PREFIXES = ['RAILWAY_', 'NIXPACKS_'];
 
@@ -74,12 +72,6 @@ export const railwayEnvCommand: CommandModule<unknown, RailwayEnvCommandOptions>
     const dotenvKeys = selectDotenvSourcedKeys(envSources);
     for (const key of Object.keys(envVars)) {
       if (!dotenvKeys.has(key)) delete envVars[key];
-    }
-    // fnox repos keep values out of committed files, so the declared key list lives in
-    // .env.example; CI also supplies these as workflow env. project.env carries the resolved value.
-    for (const key of [...readEnvExampleKeys(project), 'WB_ENV', 'NEXT_PUBLIC_WB_ENV']) {
-      const effectiveValue = project.env[key];
-      if (envVars[key] === undefined && effectiveValue !== undefined) envVars[key] = effectiveValue;
     }
     // Exported environment variables win over file values (matches wb deploy / gen-dev-vars).
     for (const key of Object.keys(envVars)) {

--- a/packages/wb/test/concurrently.test.ts
+++ b/packages/wb/test/concurrently.test.ts
@@ -276,7 +276,6 @@ describe('concurrentlyCommand', () => {
         '.env.test',
         '--include-root-env=false',
         '--cascade-env=staging',
-        '--check-env=.env.required',
         'echo first',
         'echo second',
       ]);
@@ -284,7 +283,6 @@ describe('concurrentlyCommand', () => {
     expect(argv.env).toEqual(['.env.test']);
     expect(argv.includeRootEnv).toBe(false);
     expect(argv.cascadeEnv).toBe('staging');
-    expect(argv.checkEnv).toBe('.env.required');
     expect(argv.commands).toEqual(['echo first', 'echo second']);
     expect(command.handler).toHaveBeenCalledOnce();
   });

--- a/packages/wb/test/deploy.test.ts
+++ b/packages/wb/test/deploy.test.ts
@@ -246,7 +246,7 @@ describe('readCloudflareEnvFiles', () => {
 
 describe('selectWorkerSecrets', () => {
   it('excludes wrangler vars, deploy-control keys, and file: DATABASE_URL, but keeps empty values', () => {
-    const { missingKeys, secrets } = selectWorkerSecrets(
+    const secrets = selectWorkerSecrets(
       {
         AUTH_SECRET: 'auth',
         NEXT_PUBLIC_BASE_URL: 'https://example.com',
@@ -258,8 +258,7 @@ describe('selectWorkerSecrets', () => {
         OPTIONAL_FEATURE_TOKEN: '',
         PORT: '8080',
       },
-      ['NEXT_PUBLIC_BASE_URL'],
-      []
+      ['NEXT_PUBLIC_BASE_URL']
     );
     expect(secrets).toEqual({ AUTH_SECRET: 'auth', OPTIONAL_FEATURE_TOKEN: '' });
     // Wrangler system/authentication variables never become Worker secrets.
@@ -279,23 +278,16 @@ describe('selectWorkerSecrets', () => {
           WRANGLER_R2_SQL_AUTH_TOKEN: 't',
           CLOUDFLARE_R2_ACCESS_KEY_ID: 'app-key',
         },
-        [],
         []
-      ).secrets
+      )
     ).toEqual({ CLOUDFLARE_R2_ACCESS_KEY_ID: 'app-key' });
-    expect(missingKeys).toEqual([]);
   });
 
-  it('keeps a non-file DATABASE_URL and reports missing required keys', () => {
-    const { missingKeys, secrets } = selectWorkerSecrets(
-      { DATABASE_URL: 'postgres://db.example.com/app', AUTH_SECRET: '' },
-      [],
-      ['DATABASE_URL', 'AUTH_SECRET', 'PORT']
-    );
-    expect(secrets).toEqual({ DATABASE_URL: 'postgres://db.example.com/app', AUTH_SECRET: '' });
-    // PORT is a local-only key, so it is not required even when .env.example lists it;
-    // a required key that resolves to empty is reported as missing.
-    expect(missingKeys).toEqual(['AUTH_SECRET']);
+  it('keeps a non-file DATABASE_URL and explicitly empty secrets', () => {
+    expect(selectWorkerSecrets({ DATABASE_URL: 'postgres://db.example.com/app', AUTH_SECRET: '' }, [])).toEqual({
+      DATABASE_URL: 'postgres://db.example.com/app',
+      AUTH_SECRET: '',
+    });
   });
 });
 

--- a/packages/wb/test/genCode.test.ts
+++ b/packages/wb/test/genCode.test.ts
@@ -47,10 +47,10 @@ describe('getGenCodeScripts', () => {
     // The named file exists, so the project's own invocation infers Env members from it that the bare
     // invocation here would drop.
     const dirPath = await createWorkerProject(
-      { devDependencies: { wrangler: '4.70.0' }, scripts: { 'gen-types': 'wrangler types --env-file .env.example' } },
+      { devDependencies: { wrangler: '4.70.0' }, scripts: { 'gen-types': 'wrangler types --env-file custom.env' } },
       true
     );
-    await fs.writeFile(path.join(dirPath, '.env.example'), 'API_KEY=\n');
+    await fs.writeFile(path.join(dirPath, 'custom.env'), 'API_KEY=\n');
 
     try {
       expect(getGenCodeScripts(new Project(dirPath, {}, false))).not.toContain('YARN wrangler types');
@@ -75,7 +75,7 @@ describe('getGenCodeScripts', () => {
   it.each([
     ['strict vars', 'wrangler types --check --strict-vars=false'],
     ['a custom output path', 'wrangler types --check --path src/env.d.ts'],
-    ['a quoted env file', 'wrangler types --env-file ".env.example"'],
+    ['a quoted env file', 'wrangler types --env-file "custom.env"'],
     ['a directory change', 'cd sub && wrangler types'],
   ])('does not generate worker types when a script checks %s', async (_description, script) => {
     const dirPath = await createWorkerProject(

--- a/packages/wb/test/scripts/execution/baseScripts.test.ts
+++ b/packages/wb/test/scripts/execution/baseScripts.test.ts
@@ -182,8 +182,6 @@ describe('BaseScripts.testE2E', () => {
         '.env.test',
         '--include-root-env=false',
         '--cascade-env=staging',
-        '--check-env',
-        '.env.custom',
         '--verbose',
         'start',
         `semi;colon`,
@@ -241,7 +239,6 @@ describe('BaseScripts.testE2E', () => {
         '.env.local.test',
         '--include-root-env=false',
         '--auto-cascade-env=false',
-        '--check-env=.env.required',
         'start',
       ]) as unknown as ScriptArgv;
     normalizeArgs(argv);
@@ -251,7 +248,6 @@ describe('BaseScripts.testE2E', () => {
       '--env=.env.local.test',
       '--auto-cascade-env=false',
       '--include-root-env=false',
-      '--check-env=.env.required',
     ]);
 
     const command = await scriptsWithWait.startProduction(project, argv);
@@ -260,7 +256,6 @@ describe('BaseScripts.testE2E', () => {
     expect(command).toContain('--env=.env.local.test');
     expect(command).toContain('--include-root-env=false');
     expect(command).toContain('--auto-cascade-env=false');
-    expect(command).toContain('--check-env=.env.required');
   });
 
   it('resets file-based Drizzle databases before test starts', async () => {

--- a/packages/wb/test/scripts/execution/httpServerScripts.test.ts
+++ b/packages/wb/test/scripts/execution/httpServerScripts.test.ts
@@ -111,7 +111,6 @@ describe('HttpServerScripts.testE2E', () => {
         '.env.local.test',
         '--include-root-env=false',
         '--auto-cascade-env=false',
-        '--check-env=.env.required',
         'test',
       ]) as unknown as TestArgv;
     normalizeArgs(argv);
@@ -123,12 +122,10 @@ describe('HttpServerScripts.testE2E', () => {
       '--env=.env.local.test',
       '--auto-cascade-env=false',
       '--include-root-env=false',
-      '--check-env=.env.required',
     ]);
     expect(command).toContain('--env=.env.test');
     expect(command).toContain('--env=.env.local.test');
     expect(command).toContain('--include-root-env=false');
     expect(command).toContain('--auto-cascade-env=false');
-    expect(command).toContain('--check-env=.env.required');
   });
 });

--- a/packages/wbfy/src/fixers/envExample.ts
+++ b/packages/wbfy/src/fixers/envExample.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { logger } from '../logger.js';
+import type { PackageConfig } from '../packageConfig.js';
+import { fsUtil } from '../utils/fsUtil.js';
+
+export async function removeEnvExample(config: PackageConfig): Promise<void> {
+  return logger.functionIgnoringException('removeEnvExample', async () => {
+    const filePath = path.resolve(config.dirPath, '.env.example');
+    if (!(await fs.promises.lstat(filePath).catch(() => {}))) return;
+    if (await fsUtil.removeConfined(filePath)) console.log(`Removed ${filePath}`);
+  });
+}

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -187,7 +187,7 @@ async function doesDefineNextPublicBaseUrl(dirPath: string): Promise<boolean> {
 }
 
 function getEnvFilePaths(dirPath: string): string[] {
-  const envFileNames = ['.env', '.env.test', '.env.example', 'mise.toml', 'mise.test.toml'];
+  const envFileNames = ['.env', '.env.test', 'fnox.toml', 'mise.toml', 'mise.test.toml'];
   const envFilePaths: string[] = [];
 
   for (let currentDirPath = path.resolve(dirPath); ; currentDirPath = path.dirname(currentDirPath)) {

--- a/packages/wbfy/src/generators/wbEnv.ts
+++ b/packages/wbfy/src/generators/wbEnv.ts
@@ -185,8 +185,12 @@ export function insertWbEnvIntoFnoxToml(content: string, needsNextPublic: boolea
   // the corrected wording instead of keeping the stale claim forever.
   const outdatedWbEnvCommentPattern =
     /^# CI sets WB_ENV as a process env var, which wins over fnox;(?! when loaded through wb).*$/mu;
+  const obsoleteRequiredKeysCommentPattern =
+    /^# \(wb's required-keys check treats every \.env\.example key, including WB_ENV, as required\)\.\n?/mu;
   const keyNames = needsNextPublic ? ['WB_ENV', 'NEXT_PUBLIC_WB_ENV'] : ['WB_ENV'];
-  let updatedContent = content.replace(outdatedWbEnvCommentPattern, wbEnvComment);
+  let updatedContent = content
+    .replace(outdatedWbEnvCommentPattern, wbEnvComment)
+    .replace(obsoleteRequiredKeysCommentPattern, '');
   for (const mode of wbEnvModes) {
     // The staging mode is optional: complete it only when the repository already declares the profile.
     if (mode === 'staging' && !settings.profiles?.staging) continue;

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -558,7 +558,7 @@ export function generateCloudflareDeployWorkflow(rootConfig: PackageConfig): Wor
 
 // wb's global options that consume a following value token (from sharedOptionsBuilder plus
 // yargsOptionsBuilderForEnv); every other `-`-prefixed token before the subcommand is a boolean.
-const wbGlobalValueOptions = new Set(['--working-dir', '-w', '--env', '--cascade-env', '--check-env']);
+const wbGlobalValueOptions = new Set(['--working-dir', '-w', '--env', '--cascade-env']);
 
 // Subcommands that run a BINARY (so the following token can be the wb executable), per runner: bun
 // reserves only `x` (`bun dlx`/`bun exec` run a package script of that name), npm has `exec`/`x`,

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -13,6 +13,7 @@ import { fixTypeDefinitions } from './fixers/typeDefinition.js';
 import { fixTypos } from './fixers/typos.js';
 import { fixWbDbCommand } from './fixers/wbDbCommand.js';
 import { untrackCloudflareEnv } from './fixers/cloudflareEnv.js';
+import { removeEnvExample } from './fixers/envExample.js';
 import { untrackWorkerTypes } from './fixers/workerTypes.js';
 import { generateAgentInstructions } from './generators/agents.js';
 import type { BunLinker } from './generators/bunfig.js';
@@ -221,6 +222,7 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
       }
     }
     assertSafeDependencySources(allPackageConfigs);
+    for (const config of allPackageConfigs) await removeEnvExample(config);
 
     // Managed repositories use Bun with mise (and optionally fnox); Yarn artifacts are removed.
     // Deciding the linker requires running installs, so --skip-deps keeps the previous linker

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -269,7 +269,7 @@ test('normalizes managed scripts of a Cloudflare project to wb gen-code', async 
 test.each([
   ['a generator appended to gen-code', { 'gen-code': 'wb gen-code && wrangler types' }],
   ['a bare generator in postinstall', { postinstall: 'wrangler types' }],
-  ['an env-file generator', { postinstall: 'wrangler types --env-file .env.example' }],
+  ['an env-file generator', { postinstall: 'wrangler types --env-file custom.env' }],
   ['a bunx generator', { postinstall: 'wb gen-code && bunx wrangler types' }],
   ['a gen-types script', { 'gen-types': 'wrangler types' }],
   [

--- a/packages/wbfy/test/unit/envExample.test.ts
+++ b/packages/wbfy/test/unit/envExample.test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { removeEnvExample } from '../../src/fixers/envExample.js';
+import { fsUtil } from '../../src/utils/fsUtil.js';
+import { createConfig } from '../testConfig.js';
+
+test('removes .env.example from a managed package', async () => {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-env-example-'));
+  fsUtil.setRootDirPath(dirPath);
+  try {
+    const filePath = path.join(dirPath, '.env.example');
+    await fs.writeFile(filePath, 'API_KEY=\n');
+
+    await removeEnvExample(createConfig({ dirPath }));
+
+    await expect(fs.stat(filePath)).rejects.toMatchObject({ code: 'ENOENT' });
+  } finally {
+    fsUtil.setRootDirPath(undefined);
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+});

--- a/packages/wbfy/test/wbEnv.test.ts
+++ b/packages/wbfy/test/wbEnv.test.ts
@@ -113,9 +113,7 @@ test('rewrites the outdated precedence comment variant without a trailing period
   const migrated = insertWbEnvIntoFnoxToml(withOutdatedVariant, false) ?? '';
   expect(migrated).not.toContain('these defaults only fill it locally');
   expect(migrated).toContain('bare fnox run/export uses the fnox value, so pass -P <profile>');
-  expect(migrated).toContain(
-    "# (wb's required-keys check treats every .env.example key, including WB_ENV, as required)."
-  );
+  expect(migrated).not.toContain('required-keys check');
   expect(migrated.split('# CI sets WB_ENV').length - 1).toBe(1);
   expect(insertWbEnvIntoFnoxToml(migrated, false)).toBe(migrated);
 });


### PR DESCRIPTION
## Customer Summary

- Remove the obsolete `.env.example` requirement from current fnox-based repositories.
- Make `wbfy` delete existing `.env.example` files before dependency installation during reconfiguration.
- Treat `fnox.toml` and platform-native declarations such as Wrangler `secrets.required` as the sources of truth.

## Technical Summary

- Remove the `--check-env` option and required-key checking from shared-lib-node and wb.
- Stop supplementing Cloudflare, Railway, and `.dev.vars` values from `.env.example` keys.
- Read Playwright environment-key declarations from `fnox.toml` instead of `.env.example`.
- Remove obsolete `.env.example` files and generated comments through wbfy.
- Document why `gen-dev-vars` receives WB_ENV-family keys from fnox without process-only supplementation.

## Why

- Latest wb requires fnox, so maintaining a second key list in `.env.example` creates drift and blocks keyless lifecycle-script execution without providing compatibility value.

## Testing

- `bun test packages/wbfy/test/unit/envExample.test.ts packages/wbfy/test/wbEnv.test.ts packages/wbfy/test/packageJson.test.ts packages/wb/test/deploy.test.ts packages/wb/test/genCode.test.ts packages/wb/test/concurrently.test.ts packages/wb/test/scripts/execution/baseScripts.test.ts packages/wb/test/scripts/execution/httpServerScripts.test.ts`
- `bun verify-full`
- Codex, Claude, and Antigravity review-fix review: no concerns after retries.
- GitHub Actions after merging the latest `main`: all workflows passed.
