### PR TITLE
feat(wbfy): inject TAKUMI_GUARD_TOKEN and re-test wiring into workflow callers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,4 +17,5 @@ jobs:
       github_hosted_runner: true
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAKUMI_GUARD_TOKEN: ${{ secrets.TAKUMI_GUARD_TOKEN }}
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,15 @@ on:
     branches:
       - main
       - wbfy
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 permissions:
+  actions: write
   contents: write
   pull-requests: read
+  statuses: write
 jobs:
   test:
     uses: WillBooster/reusable-workflows/.github/workflows/test.yml@main
@@ -18,4 +21,5 @@ jobs:
       github_hosted_runner: true
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAKUMI_GUARD_TOKEN: ${{ secrets.TAKUMI_GUARD_TOKEN }}
       VERDACCIO_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -104,6 +104,9 @@ const workflows = {
       push: {
         branches: ['main', 'wbfy'],
       },
+      // The reusable test workflow re-runs this caller via workflow_dispatch after its autofix
+      // push-back (a GITHUB_TOKEN push triggers no workflows by itself).
+      workflow_dispatch: null,
     },
     // cf. https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
     concurrency: {
@@ -111,10 +114,14 @@ const workflows = {
       'cancel-in-progress': true,
     },
     permissions: {
+      // for dispatching this workflow again after the autofix push-back
+      actions: 'write',
       // for linter fix
       contents: 'write',
       // for pkg-preflight PR file listing
       'pull-requests': 'read',
+      // for the commit status the reusable test workflow posts on workflow_dispatch runs
+      statuses: 'write',
     },
     jobs: {
       test: {
@@ -493,8 +500,11 @@ async function writeWorkflowYaml(
     case 'test':
     case 'test-rust': {
       // Don't use `paths-ignore` for test because GitHub's Branch Protection and Rulesets require job running.
-      // The reusable test workflow no longer needs Actions write access.
-      delete newSettings.permissions?.actions;
+      // test-rust never pushes back, so it needs no Actions write access; test needs it again to
+      // dispatch itself after the autofix push-back (reusable-workflows#466).
+      if (kind === 'test-rust') {
+        delete newSettings.permissions?.actions;
+      }
       if (newSettings.on?.pull_request) {
         delete newSettings.on.pull_request['paths-ignore'];
       }
@@ -1038,6 +1048,10 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   const orgWorkflowCall = parseOrgReusableWorkflowCall(job.uses);
   const calledReusableWorkflow = orgWorkflowCall?.ref === 'main' ? orgWorkflowCall.workflowName : undefined;
   if (secrets && calledReusableWorkflow && installCapableReusableWorkflows.has(calledReusableWorkflow)) {
+    // The callee routes public (default-registry) installs through the Takumi Guard
+    // malicious-package-blocking proxy when this token resolves; an unset organization secret
+    // expands to '' and the callee treats that as "feature off", so passing it is always safe.
+    secrets.TAKUMI_GUARD_TOKEN = '${{ secrets.TAKUMI_GUARD_TOKEN }}';
     // The callee generates the workspace .npmrc for @willbooster-private/* from VERDACCIO_TOKEN
     // before installing dependencies, which every repository needs regardless of its fnox
     // migration state.

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -1163,6 +1163,12 @@ function generateAutofixWorkflow(config: PackageConfig): Workflow {
 }
 
 async function writeYaml(newSettings: Workflow, filePath: string): Promise<void> {
+  // A permissions object emptied by the per-kind deletions (e.g. an existing test-rust caller
+  // whose only entry was `actions`) must be dropped entirely: `permissions: {}` strips EVERY
+  // token permission from the workflow, unlike the absent key which keeps the defaults.
+  if (newSettings.permissions && Object.keys(newSettings.permissions).length === 0) {
+    delete newSettings.permissions;
+  }
   const yamlText = removeTrailingSpaces(
     yaml.dump(newSettings, { lineWidth: -1, noCompatMode: true, styles: { '!!null': 'empty' } })
   );


### PR DESCRIPTION
## Customer Summary

- Repositories maintained with `wbfy` automatically gain support for the Takumi Guard malicious-package-blocking registry proxy: regenerated CI workflow callers pass the new optional `TAKUMI_GUARD_TOKEN` secret, so registering that secret is all that is needed to turn the protection on (nothing changes where the secret is absent).
- Regenerated test workflows can re-test automatic lint-fix commits: they gain the trigger and permissions the reusable workflows need after the switch from SSH deploy keys to GitHub's built-in token.

## Technical Summary

- `normalizeJob` injects `TAKUMI_GUARD_TOKEN: ${{ secrets.TAKUMI_GUARD_TOKEN }}` into callers of the five install-capable `@main` reusable workflows, alongside `VERDACCIO_TOKEN` (an unset organization secret expands to `''`, which the callee treats as feature-off; the WillBoosterLab mirror was synced first — commit 04fc02a — so its callees declare the secret and Lab callers cannot startup-fail).
- The generated `test` caller template declares `workflow_dispatch:` and grants `actions: write` + `statuses: write` on top of `contents: write`; the `permissions.actions` deletion now applies to `test-rust` only (it never pushes back).
- `writeYaml` drops a permissions object emptied by the per-kind deletions before dumping — `permissions: {}` would strip every token permission, unlike the absent key which keeps the defaults.
- This repository's own `test.yml`/`release.yml` callers are updated to the new shape.

## Why

- WillBooster/reusable-workflows#466 added the optional `TAKUMI_GUARD_TOKEN` secret and replaced SSH deploy-key pushes with `GITHUB_TOKEN` pushes that re-run the caller's test workflow via `workflow_dispatch`; without caller-side wiring, Guard stays off and pushed autofix commits are never re-tested.

## Testing

- `bun run vitest run test/` in `packages/wbfy`: 271 tests pass; `bun verify` passes.
- Verified via the GitHub contents API that all five install-capable workflows declare `TAKUMI_GUARD_TOKEN` at `@main` in BOTH `WillBooster/reusable-workflows` and the `WillBoosterLab` mirror.
- Three-agent review (Codex, Claude Code, Antigravity) over two rounds converged on "no concern".

## Notes

- `wbfy --env` does not yet provision or verify `TAKUMI_GUARD_TOKEN`; for WillBooster-org repositories an admin registers it as an organization secret, and WillBoosterLab repositories need a manual repository secret (follow-up if Guard becomes mandatory).
