### PR TITLE
ci: allow dispatching the release workflow manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  # Allows re-triggering a release whose publish failed (e.g. run 30050778519).
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch:` trigger to the Release caller so a release whose publish step failed can be re-triggered without a new push to `main`. Context: run [30050778519](https://github.com/WillBooster/shared/actions/runs/30050778519) pushed the `@willbooster/wb@17.0.0` tag and then failed to publish because the generated `.npmrc` routed the publish to the Takumi Guard proxy (405) — fixed upstream in WillBooster/reusable-workflows#469; the orphan tag has been deleted so merging this PR re-releases 17.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
