### PR TITLE
fix: publish packages directly to npmjs

### DIFF
--- a/packages/shared-lib-node/package.json
+++ b/packages/shared-lib-node/package.json
@@ -65,6 +65,7 @@
     "vitest": "4.1.5"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/wb/package.json
+++ b/packages/wb/package.json
@@ -72,6 +72,7 @@
     "node": ">= 22.18.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/wbfy/package.json
+++ b/packages/wbfy/package.json
@@ -75,6 +75,7 @@
     "node": ">=24"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/test/unit/publishConfig.test.ts
+++ b/test/unit/publishConfig.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test';
+
+const releasedPackages = ['shared-lib-node', 'wb', 'wbfy'];
+
+describe('npm publishing', () => {
+  test.each(releasedPackages)('%s publishes directly to npmjs', async (packageName) => {
+    const packageJson = await Bun.file(`packages/${packageName}/package.json`).json();
+
+    expect(packageJson.publishConfig.registry).toBe('https://registry.npmjs.org/');
+  });
+});


### PR DESCRIPTION
## Customer Summary

- The interrupted `.env.example` removal release can publish `wb`, `wbfy`, and `shared-lib-node` successfully while dependency installation remains protected by Takumi Guard.
- There is no package API change beyond the already merged `.env.example` removal.

## Technical Summary

- Add `publishConfig.registry=https://registry.npmjs.org/` to the three packages changed by #1068.
- Add a regression test requiring an explicit npmjs publish destination for those release participants.
- Include the latest main change that allows manual Release dispatch.

## Why

Takumi Guard is the default install registry in CI, but it intentionally rejects publishing. semantic-release gives `publishConfig.registry` precedence over the generated `.npmrc`, which separates the publish destination from the install/prepare registry without breaking multi-package dependency preparation.

## Testing

- `bun test test/unit/publishConfig.test.ts`
- `bun verify-full`
- Pull request CI passed
