### PR TITLE
feat(wbfy): pin the publish registry of public-repo packages to npmjs

### DIFF
--- a/packages/shared-lib-blitz-next/package.json
+++ b/packages/shared-lib-blitz-next/package.json
@@ -60,6 +60,7 @@
     "vitest": "4.1.5"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/shared-lib-next/package.json
+++ b/packages/shared-lib-next/package.json
@@ -63,6 +63,7 @@
     "next": "*"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/shared-lib-react/package.json
+++ b/packages/shared-lib-react/package.json
@@ -76,6 +76,7 @@
     "react-dom": "~19.2.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/shared-lib/package.json
+++ b/packages/shared-lib/package.json
@@ -59,6 +59,7 @@
     "vitest": "4.1.5"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1290,6 +1290,10 @@ async function normalizePackageMetadata(
   if (!jsonObj.private && jsonObj.license !== 'UNLICENSED' && rootConfig.isPublicRepo) {
     jsonObj.publishConfig ??= {};
     jsonObj.publishConfig.access ??= 'public';
+    // Without an explicit registry, npm resolves the publish target from the workspace .npmrc,
+    // whose default registry on CI may be the Takumi Guard install proxy — which rejects
+    // `npm publish` with 405 (shared#1072). `??=` keeps a deliberately different registry.
+    jsonObj.publishConfig.registry ??= 'https://registry.npmjs.org/';
   }
   const [owner] = gitHubUtil.getOrgAndName(config.repository ?? '');
   if (owner === 'WillBooster' || owner === 'WillBoosterLab') {

--- a/packages/wbfy/src/packageConfig.ts
+++ b/packages/wbfy/src/packageConfig.ts
@@ -233,7 +233,12 @@ export async function getPackageConfig(
     const isRoot = options?.isRoot ?? !isWorkspaceOfEnclosingRoot(dirPath);
 
     let repoInfo: Record<string, unknown> | undefined;
-    if (isRoot) {
+    // Fetch visibility for the CLI entry even when it is a workspace child (`wbfy
+    // <repo>/packages/<app>`): generators read isPublicRepo from their rootConfig parameter,
+    // which IS the child config in that invocation, so a stub `false` there would drop the
+    // public-repo publishConfig handling. Discovered children (options.isRoot === false) still
+    // skip the fetch — they inherit the enclosing root's visibility via rootConfig instead.
+    if (options?.isRoot !== false) {
       repoInfo = await fetchRepoInfo(dirPath, packageJson);
     }
 
@@ -862,10 +867,14 @@ function doesImportPackageAtRuntime(dirPath: string, packageName: string): boole
 }
 
 async function fetchRepoInfo(dirPath: string, packageJson: PackageJson): Promise<Record<string, unknown> | undefined> {
-  const git = simpleGit(dirPath);
-  const remotes = await git.getRemotes(true);
-  const origin = remotes.find((r) => r.name === 'origin');
-  const remoteUrl = origin?.refs.fetch ?? origin?.refs.push;
+  let remoteUrl: string | undefined;
+  try {
+    const remotes = await simpleGit(dirPath).getRemotes(true);
+    const origin = remotes.find((r) => r.name === 'origin');
+    remoteUrl = origin?.refs.fetch ?? origin?.refs.push;
+  } catch {
+    // Not a git repository (e.g. a scratch directory); fall back to package.json's repository.
+  }
   if (typeof remoteUrl === 'string') {
     const json = await requestRepoInfo(remoteUrl);
     if (json) return json;

--- a/packages/wbfy/test/packageConfig.test.ts
+++ b/packages/wbfy/test/packageConfig.test.ts
@@ -6,6 +6,15 @@ import { expect, test } from 'vitest';
 
 import { getPackageConfig } from '../src/packageConfig.js';
 
+// Regression test for the direct workspace-child invocation (`wbfy <repo>/packages/<app>`):
+// the entry keeps its child classification, but repository visibility must still be fetched
+// because generators read isPublicRepo from this config as their rootConfig.
+test('fetches repository visibility when the CLI entry is a workspace child', async () => {
+  const config = await getPackageConfig(path.resolve(import.meta.dirname, '..', '..', 'shared-lib'));
+  expect(config?.isRoot).toBe(false);
+  expect(config?.isPublicRepo).toBe(true);
+});
+
 test('detects Tauri packages from every supported signal', async () => {
   expect(await detectTauri({ packageJson: { dependencies: { '@tauri-apps/api': '2.0.0' } } })).toBe(true);
   expect(await detectTauri({ packageJson: { devDependencies: { '@tauri-apps/api': '2.0.0' } } })).toBe(true);

--- a/packages/wbfy/test/packageJson.test.ts
+++ b/packages/wbfy/test/packageJson.test.ts
@@ -12,6 +12,7 @@ interface GeneratedPackageJson {
   dependencies?: Record<string, string | undefined>;
   devDependencies?: Record<string, string | undefined>;
   private?: boolean;
+  publishConfig?: { access?: string; registry?: string };
   scripts?: Record<string, string | undefined>;
   trustedDependencies?: string[];
 }
@@ -1035,6 +1036,31 @@ test('removes stale private from a monorepo root with a publishConfig', async ()
   );
 
   expect(packageJson.private).toBeUndefined();
+});
+
+test('pins the publish registry of a public-repo package to npmjs', async () => {
+  const packageJson = await generatePackageJsonFrom({ name: 'public-lib', license: 'Apache-2.0' });
+
+  expect(packageJson.publishConfig).toEqual({ access: 'public', registry: 'https://registry.npmjs.org/' });
+});
+
+test('keeps a deliberately different publish registry', async () => {
+  const packageJson = await generatePackageJsonFrom({
+    name: 'public-lib',
+    license: 'Apache-2.0',
+    publishConfig: { registry: 'https://npm.example.com/' },
+  });
+
+  expect(packageJson.publishConfig?.registry).toBe('https://npm.example.com/');
+});
+
+test('adds no publishConfig in a private repository', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    { name: 'private-repo-lib', license: 'Apache-2.0' },
+    { isPublicRepo: false }
+  );
+
+  expect(packageJson.publishConfig).toBeUndefined();
 });
 
 test('strips `bun --bun` from user-authored scripts invoking Node-based tools', async () => {

--- a/test/unit/publishConfig.test.ts
+++ b/test/unit/publishConfig.test.ts
@@ -5,7 +5,10 @@ import { describe, expect, test } from 'bun:test';
 const packageDirectories = await readdir('packages');
 const packageVisibilities = await Promise.all(
   packageDirectories.map(async (name) => {
-    const packageJson = await Bun.file(`packages/${name}/package.json`).json();
+    const packageJsonFile = Bun.file(`packages/${name}/package.json`);
+    // Tolerate stray entries in packages/ (e.g. .DS_Store or a scratch directory).
+    if (!(await packageJsonFile.exists())) return [];
+    const packageJson = await packageJsonFile.json();
     return packageJson.private ? [] : [name];
   })
 );

--- a/test/unit/publishConfig.test.ts
+++ b/test/unit/publishConfig.test.ts
@@ -1,8 +1,20 @@
+import { readdir } from 'node:fs/promises';
+
 import { describe, expect, test } from 'bun:test';
 
-const releasedPackages = ['shared-lib-node', 'wb', 'wbfy'];
+const packageDirectories = await readdir('packages');
+const packageVisibilities = await Promise.all(
+  packageDirectories.map(async (name) => {
+    const packageJson = await Bun.file(`packages/${name}/package.json`).json();
+    return packageJson.private ? [] : [name];
+  })
+);
+const releasedPackages = packageVisibilities.flat();
 
 describe('npm publishing', () => {
+  // Without an explicit registry, npm resolves the publish target from the workspace .npmrc,
+  // whose default registry on CI may be the Takumi Guard install proxy — which rejects
+  // `npm publish` with 405 (run 30050778519).
   test.each(releasedPackages)('%s publishes directly to npmjs', async (packageName) => {
     const packageJson = await Bun.file(`packages/${packageName}/package.json`).json();
 


### PR DESCRIPTION
## Customer Summary

- Public packages maintained with `wbfy` can no longer fail to publish because of the Takumi Guard malicious-package proxy: wbfy now writes the correct npm publish destination into each public package, so releases keep working when Guard is enabled.

## Technical Summary

- wbfy's package.json generator injects `"registry": "https://registry.npmjs.org/"` into the `publishConfig` it already manages for public-repo packages (`??=` keeps a deliberately different registry; private repositories are untouched — their Verdaccio publishers declare `publishConfig.registry` per org policy).
- Direct workspace-child invocations (`wbfy <repo>/packages/<app>`) now fetch repository visibility: generators read `isPublicRepo` from their rootConfig parameter, which IS the child config in that invocation, so the previous root-only fetch silently disabled all public-repo publishConfig handling there; `fetchRepoInfo` also tolerates non-git directories.
- The four remaining public packages of this repository (`shared-lib`, `shared-lib-react`, `shared-lib-next`, `shared-lib-blitz-next`) gain the explicit registry, completing #1072's three-package hotfix.
- `test/unit/publishConfig.test.ts` enumerates every non-private package dynamically (tolerating stray entries in `packages/`), and wbfy gains four generator/config tests (registry injection, explicit-registry preservation, private-repo no-op, child-entry visibility).

## Why

- Without an explicit `publishConfig.registry`, npm resolves the publish target from the workspace `.npmrc`, whose default registry on CI is the Takumi Guard install proxy when `TAKUMI_GUARD_TOKEN` is set — the proxy rejects `npm publish` with 405 (run 30050778519). The workflow-level env pin was rejected (reusable-workflows#470) because it would bypass Guard for release-step installs, so the package-level `publishConfig.registry` is the mechanism that fixes publishes without weakening install protection.

## Testing

- `packages/wbfy`: `vitest run test/packageJson.test.ts test/packageConfig.test.ts` — 78 tests pass (4 new).
- `bun test test/unit/publishConfig.test.ts` — all 7 public packages verified.
- `bun verify` passes; CI green; three-agent review over two rounds converged on "no concern".
