### PR TITLE
feat(wbfy): make workflow-file updates opt-in for the self-applying caller

### DIFF
--- a/.github/workflows/wbfy.yml
+++ b/.github/workflows/wbfy.yml
@@ -7,7 +7,8 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 permissions:
-  contents: read
+  actions: write
+  contents: write
 jobs:
   wbfy:
     uses: WillBooster/reusable-workflows/.github/workflows/wbfy.yml@main

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -229,11 +229,13 @@ const workflows = {
       'cancel-in-progress': true,
     },
     permissions: {
-      // Least privilege: the reusable workflow's wbfy job runs dependency lifecycle scripts, so
-      // its GITHUB_TOKEN must not be able to write repository contents; the push happens in a
-      // separate trusted job authenticated with the WBFY_GH_TOKEN PAT (wbfy rewrites files under
-      // .github/workflows/, which a GITHUB_TOKEN push could not touch anyway).
-      contents: 'read',
+      // The reusable workflow's push job pushes the wbfy branch with GITHUB_TOKEN (workflow-file
+      // changes are skipped — updating them is opt-in via the WBFY_GH_TOKEN secret) and then
+      // dispatches test.yml on the pushed branch, since a GITHUB_TOKEN push triggers no
+      // workflows. Its wbfy job, which runs dependency lifecycle scripts, downgrades itself to a
+      // read-only token.
+      actions: 'write',
+      contents: 'write',
     },
     jobs: {
       wbfy: {
@@ -243,9 +245,11 @@ const workflows = {
   },
 } as const;
 
-// The push PAT secret of the self-applying wbfy caller. Deliberately NOT the historical
-// GH_BOT_PAT: that name sits in secret.ts's DEPRECATED_SECRET_NAMES, so already-released wbfy
-// versions DELETE it during `wbfy --env` — reusing it would let an old wbfy wipe the new secret.
+// The OPT-IN push PAT secret of the self-applying wbfy caller: without it the reusable workflow
+// pushes with GITHUB_TOKEN and skips workflow-file changes (GitHub rejects every GITHUB_TOKEN
+// write under .github/workflows/). Deliberately NOT the historical GH_BOT_PAT: that name sits in
+// secret.ts's DEPRECATED_SECRET_NAMES, so already-released wbfy versions DELETE it during
+// `wbfy --env` — reusing it would let an old wbfy wipe the new secret.
 export const wbfyGhTokenSecretName = 'WBFY_GH_TOKEN';
 
 /**

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -155,8 +155,11 @@ async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, rep
     // while the workflow silently keeps skipping them (or a policy-violating repository-level
     // copy silently serves as the only source).
     if (assignedButUnusableNames.has('WBFY_GH_TOKEN')) {
+      // A same-named repository secret takes precedence over the organization secret, so with one
+      // present the updates still run (from the policy-violating copy the next check flags) — only
+      // without it are they silently skipped.
       console.error(
-        `The organization secret WBFY_GH_TOKEN is assigned to ${owner}/${repo} but falls beyond the 100-organization-secret limit a workflow run can use (only the alphabetically first 100 are usable), so workflow-file updates are silently skipped. Ask a WillBooster org admin to prune the assigned organization secrets.`
+        `The organization secret WBFY_GH_TOKEN is assigned to ${owner}/${repo} but falls beyond the 100-organization-secret limit a workflow run can use (only the alphabetically first 100 are usable)${repoLevelNames.has('WBFY_GH_TOKEN') ? '' : ', so workflow-file updates are silently skipped'}. Ask a WillBooster org admin to prune the assigned organization secrets.`
       );
       verified = false;
     }

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -164,8 +164,11 @@ async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, rep
       verified = false;
     }
     if (repoLevelNames.has('WBFY_GH_TOKEN') && !usableOrgNames.has('WBFY_GH_TOKEN')) {
+      // With an assigned-but-beyond-limit organization secret, "register it" would be wrong
+      // advice (it is already assigned) and deleting the fallback first would silently disable
+      // workflow-file updates — pruning must come first.
       console.error(
-        `${owner}/${repo} has a repository-level WBFY_GH_TOKEN secret without a usable organization secret, which violates the WillBooster org-secret policy. Ask a WillBooster org admin to register the organization secret (or extend its repository access), then delete the repository-level copy manually (e.g. \`gh secret delete WBFY_GH_TOKEN --repo ${owner}/${repo}\`).`
+        `${owner}/${repo} has a repository-level WBFY_GH_TOKEN secret without a usable organization secret, which violates the WillBooster org-secret policy. ${assignedButUnusableNames.has('WBFY_GH_TOKEN') ? 'Ask a WillBooster org admin to prune the assigned organization secrets FIRST (making the organization secret usable)' : 'Ask a WillBooster org admin to register the organization secret (or extend its repository access)'}, then delete the repository-level copy manually (e.g. \`gh secret delete WBFY_GH_TOKEN --repo ${owner}/${repo}\`).`
       );
       verified = false;
     }

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -79,10 +79,9 @@ export async function setupSecrets(config: PackageConfig): Promise<void> {
 async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, repo: string): Promise<void> {
   const octokit = getOctokit(owner);
   const requiredNames = ['VERDACCIO_TOKEN'];
-  // The self-applying wbfy caller pushes the `wbfy` branch with the WBFY_GH_TOKEN secret (a PAT
-  // with contents:write and workflow scope; a GITHUB_TOKEN push cannot touch workflow files, and
-  // the push is atomic, so the PAT is required in practice).
-  if (!isWbfyWorkflowDenied(config.repository)) requiredNames.push('WBFY_GH_TOKEN');
+  // WBFY_GH_TOKEN is deliberately NOT required: the self-applying wbfy caller pushes non-workflow
+  // changes with GITHUB_TOKEN, and updating workflow files is opt-in (the secret, or a local wbfy
+  // run). The deny-listed and shadowing checks below still cover the secret where it exists.
   // Both requirement checks are deliberately based on the LOCAL working tree: workflow generation
   // keys FNOX_AGE_KEY injection on the local root fnox.toml too, and a config added on a feature
   // branch will need its secret as soon as it merges — surfacing the missing org secret before
@@ -249,18 +248,18 @@ async function uploadSecrets(config: PackageConfig, owner: string, repo: string)
     process.exitCode = 1;
     return;
   }
-  // The self-applying wbfy caller pushes the `wbfy` branch with the WBFY_GH_TOKEN secret (a PAT
-  // with contents:write and workflow scope; a GITHUB_TOKEN push cannot touch workflow files, and
-  // the push is atomic, so the PAT is required in practice). GitHub Free cannot share
-  // organization secrets with private repositories, so WillBoosterLab repositories receive it as
-  // a repository secret. It is deliberately sourced from a DEDICATED environment variable, never
-  // from GH_BOT_PAT_FOR_WILLBOOSTERLAB: anyone with write access to one repository can read its
-  // Actions secrets, so the uploaded value must be a least-privilege PAT (fine-grained, Contents
-  // and Workflows write only) rather than the bot PAT that can also administer settings,
-  // rulesets, and secrets across the organization. Deny-listed repositories get no caller
-  // workflow, so they need no push token either. Known accepted risk: the SAME least-privilege
-  // PAT value reaches every allowed repository, so one compromised repository exposes push access
-  // to the others — replacing it with per-repository short-lived GitHub App tokens is tracked in
+  // OPT-IN: the self-applying wbfy caller pushes non-workflow changes with GITHUB_TOKEN; the
+  // WBFY_GH_TOKEN secret (a PAT with contents:write and workflow scope) is only needed when a
+  // repository should have its workflow files updated automatically too. When the operator sets
+  // WBFY_GH_TOKEN_FOR_WILLBOOSTERLAB, it is uploaded as a repository secret (GitHub Free cannot
+  // share organization secrets with private repositories). It is deliberately sourced from a
+  // DEDICATED environment variable, never from GH_BOT_PAT_FOR_WILLBOOSTERLAB: anyone with write
+  // access to one repository can read its Actions secrets, so the uploaded value must be a
+  // least-privilege PAT (fine-grained, Contents and Workflows write only) rather than the bot
+  // PAT that can also administer settings, rulesets, and secrets across the organization.
+  // Deny-listed repositories get no caller workflow, so they need no push token either. Known
+  // accepted risk of opting in: the SAME least-privilege PAT value reaches every opted-in
+  // repository — replacing it with per-repository short-lived GitHub App tokens is tracked in
   // https://github.com/WillBooster/shared/issues/1077.
   const wbfyGhToken = isWbfyWorkflowDenied(config.repository)
     ? undefined
@@ -268,13 +267,6 @@ async function uploadSecrets(config: PackageConfig, owner: string, repo: string)
   // Also keep WBFY_GH_TOKEN in the obsolete set on deny-listed repositories so the regular
   // cleanup pass removes any stale copy the early revocation above missed.
   const wbfyObsoleteSecretNames = isWbfyWorkflowDenied(config.repository) ? ['WBFY_GH_TOKEN'] : [];
-  if (!isWbfyWorkflowDenied(config.repository) && !wbfyGhToken) {
-    console.error(
-      'Set the WBFY_GH_TOKEN_FOR_WILLBOOSTERLAB environment variable (a least-privilege fine-grained PAT with only Contents and Workflows write on WillBoosterLab repositories — NOT the bot PAT) so wbfy --env can upload the WBFY_GH_TOKEN secret. Secrets were neither verified nor uploaded.'
-    );
-    process.exitCode = 1;
-    return;
-  }
   let secretsToUpload: Record<string, string>;
   let obsoleteSecretNames: string[];
   // Decide the fnox migration state SOLELY from the remote default branch: an unmerged local

--- a/packages/wbfy/src/github/secret.ts
+++ b/packages/wbfy/src/github/secret.ts
@@ -149,6 +149,23 @@ async function verifyOrgManagedSecrets(config: PackageConfig, owner: string, rep
       );
       verified = false;
     }
+  } else {
+    // WBFY_GH_TOKEN is opt-in (its complete absence is fine), but a CONFIGURED token must still
+    // be usable — otherwise the repository looks opted into automatic workflow-file updates
+    // while the workflow silently keeps skipping them (or a policy-violating repository-level
+    // copy silently serves as the only source).
+    if (assignedButUnusableNames.has('WBFY_GH_TOKEN')) {
+      console.error(
+        `The organization secret WBFY_GH_TOKEN is assigned to ${owner}/${repo} but falls beyond the 100-organization-secret limit a workflow run can use (only the alphabetically first 100 are usable), so workflow-file updates are silently skipped. Ask a WillBooster org admin to prune the assigned organization secrets.`
+      );
+      verified = false;
+    }
+    if (repoLevelNames.has('WBFY_GH_TOKEN') && !usableOrgNames.has('WBFY_GH_TOKEN')) {
+      console.error(
+        `${owner}/${repo} has a repository-level WBFY_GH_TOKEN secret without a usable organization secret, which violates the WillBooster org-secret policy. Ask a WillBooster org admin to register the organization secret (or extend its repository access), then delete the repository-level copy manually (e.g. \`gh secret delete WBFY_GH_TOKEN --repo ${owner}/${repo}\`).`
+      );
+      verified = false;
+    }
   }
   // A repository secret silently overrides a same-named organization secret, so a stale
   // repository-level copy would keep winning even after the admin rotates the org value. Only a

--- a/packages/wbfy/test/unit/wbfyWorkflow.test.ts
+++ b/packages/wbfy/test/unit/wbfyWorkflow.test.ts
@@ -49,7 +49,7 @@ test('generates a scheduled self-applying wbfy caller for a public repository', 
     expect(workflow.on?.schedule).toEqual([{ cron: getWbfyWorkflowCron('github:WillBooster/example') }]);
     // oxlint-disable-next-line unicorn/no-null -- GitHub Actions valueless events are YAML nulls.
     expect(workflow.on?.workflow_dispatch).toBeNull();
-    expect(workflow.permissions).toEqual({ contents: 'read' });
+    expect(workflow.permissions).toEqual({ actions: 'write', contents: 'write' });
     const job = workflow.jobs.wbfy;
     expect(job?.uses).toBe('WillBooster/reusable-workflows/.github/workflows/wbfy.yml@main');
     expect(job?.secrets).toEqual({


### PR DESCRIPTION
## Summary

Pairs with WillBooster/reusable-workflows#475 (follow-up to #1076 / reusable-workflows#472). The nightly self-applying wbfy caller no longer requires any PAT:

- Generated callers now grant `permissions: contents: write, actions: write` — the reusable workflow pushes non-workflow changes with `GITHUB_TOKEN` (its wbfy job self-downgrades to read-only) and dispatches `test.yml` on the pushed `wbfy` branch, since a `GITHUB_TOKEN` push triggers no workflows.
- Workflow-file updates are **opt-in**: they are skipped with a warning unless the repository has the `WBFY_GH_TOKEN` secret (or an operator runs wbfy locally). `GITHUB_TOKEN` cannot write `.github/workflows/` through any path (git push / contents API / GraphQL — verified empirically).
- `wbfy --env` accordingly no longer requires `WBFY_GH_TOKEN`: it is verified/uploaded only where present (WillBoosterLab upload happens only when `WBFY_GH_TOKEN_FOR_WILLBOOSTERLAB` is set). Deny-list revocation and org-secret shadowing checks are unchanged.

## Merge order

**Merge WillBooster/reusable-workflows#475 FIRST.** The generated callers grant `contents: write` / `actions: write` and rely on the callee's job-level downgrade (`jobs.wbfy.permissions: contents: read`); the wbfy.yml currently at `@main` has no job-level permissions, so merging this PR before #475 would hand a write token to dependency lifecycle scripts.

## Test plan

- `packages/wbfy`: full vitest suite passes (291 tests).
- tsc / oxlint / oxfmt clean.
- E2E without any secret on `WillBooster/minimal-promise-pool` via reusable-workflows#475's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
