### PR TITLE
feat(wbfy): unify the badge version across npx and local runs, and skip an already-applied version

### DIFF
--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import type { Paragraph, PhrasingContent, RootContent } from 'mdast';
+import type { Image, Link, Paragraph, PhrasingContent, RootContent } from 'mdast';
 import { fromMarkdown } from 'mdast-util-from-markdown';
 
 import { logger } from '../logger.js';
@@ -15,6 +15,7 @@ const semanticReleaseBadge =
   '[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)';
 
 const wbfyBadgeUrlPrefix = 'https://img.shields.io/badge/wbfy-';
+const wbfyBadgeUrlSuffix = '-1e90ff.svg';
 const wbfyBadgeLink = 'https://github.com/WillBooster/shared/tree/main/packages/wbfy';
 
 /**
@@ -33,7 +34,29 @@ const managedBadgePatterns = [
 
 function buildWbfyBadge(label: string): string {
   // Hyphens are escaped as `--` per shields.io's badge path syntax, so `v1.2.3-rc.1` stays intact.
-  return `[![wbfy](${wbfyBadgeUrlPrefix}${label.replaceAll('-', '--')}-1e90ff.svg)](${wbfyBadgeLink})`;
+  return `[![wbfy](${wbfyBadgeUrlPrefix}${label.replaceAll('-', '--')}${wbfyBadgeUrlSuffix})](${wbfyBadgeLink})`;
+}
+
+/** The version label the wbfy badge in the repository's README records, i.e. the build that wbfied it. */
+export async function readAppliedWbfyVersionLabel(dirPath: string): Promise<string | undefined> {
+  const readme = await fsUtil.readFileIfExists(path.resolve(dirPath, 'README.md'));
+  // The README is parsed rather than scanned, for the same reason writeBadgeBlock parses it: a badge
+  // quoted in a fenced example (wbfy's own documentation does exactly that) is not an applied badge.
+  return readme === undefined ? undefined : findWbfyBadgeLabel(fromMarkdown(readme).children);
+}
+
+function findWbfyBadgeLabel(nodes: RootContent[]): string | undefined {
+  for (const node of nodes) {
+    if (isBadgeNode(node)) {
+      const { url } = node.children[0];
+      if (url.startsWith(wbfyBadgeUrlPrefix) && url.endsWith(wbfyBadgeUrlSuffix)) {
+        return url.slice(wbfyBadgeUrlPrefix.length, -wbfyBadgeUrlSuffix.length).replaceAll('--', '-');
+      }
+    }
+    const label = 'children' in node ? findWbfyBadgeLabel(node.children as RootContent[]) : undefined;
+    if (label) return label;
+  }
+  return undefined;
 }
 
 export async function generateReadme(config: PackageConfig): Promise<void> {
@@ -251,7 +274,7 @@ function isBadgeBlockNode(node: RootContent): node is Paragraph {
 }
 
 /** A badge is one `[![alt](image)](link)`, the only shape wbfy ever writes. */
-function isBadgeNode(node: RootContent | PhrasingContent): boolean {
+function isBadgeNode(node: RootContent | PhrasingContent): node is Link & { children: [Image] } {
   return node.type === 'link' && node.children.length === 1 && node.children[0]?.type === 'image';
 }
 

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -40,21 +40,23 @@ function buildWbfyBadge(label: string): string {
 /** The version label the wbfy badge in the repository's README records, i.e. the build that wbfied it. */
 export async function readAppliedWbfyVersionLabel(dirPath: string): Promise<string | undefined> {
   const readme = await fsUtil.readFileIfExists(path.resolve(dirPath, 'README.md'));
-  // The README is parsed rather than scanned, for the same reason writeBadgeBlock parses it: a badge
-  // quoted in a fenced example (wbfy's own documentation does exactly that) is not an applied badge.
-  return readme === undefined ? undefined : findWbfyBadgeLabel(fromMarkdown(readme).children);
-}
+  if (readme === undefined) return undefined;
 
-function findWbfyBadgeLabel(nodes: RootContent[]): string | undefined {
-  for (const node of nodes) {
-    if (isBadgeNode(node)) {
-      const { url } = node.children[0];
+  // The README is parsed rather than scanned, for the same reason writeBadgeBlock parses it, and
+  // only the shape writeBadgeBlock itself writes counts as an applied badge: a top-level paragraph
+  // of badges. A badge anywhere else is content that merely mentions one — a fenced example (wbfy's
+  // own documentation has those), a block quote, a list item — and reading it as applied would skip
+  // every fixer for the repository. Every top-level block is examined rather than just the one after
+  // the title, because older versions stamped the block above it.
+  for (const node of fromMarkdown(readme).children) {
+    if (!isBadgeBlockNode(node)) continue;
+    for (const badge of node.children) {
+      if (!isBadgeNode(badge)) continue;
+      const { url } = badge.children[0];
       if (url.startsWith(wbfyBadgeUrlPrefix) && url.endsWith(wbfyBadgeUrlSuffix)) {
         return url.slice(wbfyBadgeUrlPrefix.length, -wbfyBadgeUrlSuffix.length).replaceAll('--', '-');
       }
     }
-    const label = 'children' in node ? findWbfyBadgeLabel(node.children as RootContent[]) : undefined;
-    if (label) return label;
   }
   return undefined;
 }

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -39,7 +39,11 @@ function buildWbfyBadge(label: string): string {
 
 /** The version label the wbfy badge in the repository's README records, i.e. the build that wbfied it. */
 export async function readAppliedWbfyVersionLabel(dirPath: string): Promise<string | undefined> {
-  const readme = await fsUtil.readFileIfExists(path.resolve(dirPath, 'README.md'));
+  // Confined, and tolerant of any read failure: a README that resolves outside the repository (a
+  // committed symlink) or cannot be read at all says nothing about which build configured THIS
+  // repository, and the answer only ever suppresses work — so anything but a readable in-repository
+  // README means "not known to be applied" and the run proceeds.
+  const readme = await fsUtil.readFileConfinedIfExists(path.resolve(dirPath, 'README.md')).catch(() => {});
   if (readme === undefined) return undefined;
 
   // The README is parsed rather than scanned, for the same reason writeBadgeBlock parses it, and

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -34,7 +34,7 @@ import { generateOxlintConfig } from './generators/oxlintConfig.js';
 import { generatePrettierignore } from './generators/prettierignore.js';
 import { generatePyrightConfigJson } from './generators/pyrightConfig.js';
 import { fixRailwayignore } from './generators/railwayignore.js';
-import { generateReadme } from './generators/readme.js';
+import { generateReadme, readAppliedWbfyVersionLabel } from './generators/readme.js';
 import { generateReleaserc } from './generators/releaserc.js';
 import { generateRenovateJsonc } from './generators/renovateJsonc.js';
 import { generateTsconfig } from './generators/tsconfig.js';
@@ -62,7 +62,7 @@ import { doesContainJsOrTs } from './utils/packageCapabilities.js';
 import { promisePool } from './utils/promisePool.js';
 import { spawnSync, spawnSyncAndReturnStatus, spawnSyncAndReturnStdout } from './utils/spawnUtil.js';
 import { disposeTypeScriptApi } from './utils/typescriptApi.js';
-import { getWbfyVersion } from './utils/version.js';
+import { getWbfyVersion, getWbfyVersionLabel } from './utils/version.js';
 import { getWorkspaceSubDirPaths } from './utils/workspaceUtil.js';
 
 async function main(): Promise<void> {
@@ -81,6 +81,12 @@ async function main(): Promise<void> {
         type: 'boolean',
         default: false,
         alias: 'e',
+      },
+      force: {
+        description: 'Apply wbfy even when the repository already records this wbfy version',
+        type: 'boolean',
+        default: false,
+        alias: 'f',
       },
       skipDeps: {
         description:
@@ -103,7 +109,7 @@ async function main(): Promise<void> {
 
   let hasInvalidPackageConfig = false;
   try {
-    hasInvalidPackageConfig = await willboosterifyPaths(argv.paths as string[], argv.skipDeps);
+    hasInvalidPackageConfig = await willboosterifyPaths(argv.paths as string[], argv.skipDeps, argv.force);
   } finally {
     // The TypeScript compiler server spawned for AST parsing keeps an open IPC
     // channel that would otherwise prevent the Node.js process from exiting.
@@ -114,7 +120,7 @@ async function main(): Promise<void> {
   }
 }
 
-async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<boolean> {
+async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: boolean): Promise<boolean> {
   // wbfy rewrites repositories to the Bun + mise toolchain and runs `bun add` / `bun install`;
   // proceeding without Bun would delete Yarn state and then fail to produce a Bun lockfile.
   // The version floor matters too: older Bun silently ignores the generated bunfig.toml options
@@ -130,11 +136,26 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean): Promise<
     return true;
   }
 
+  // A `-dirty-local` label identifies an edited checkout, whose next build produces different files
+  // under the same label, so such a run is never treated as already applied.
+  const versionLabel = getWbfyVersionLabel();
+  const skippableVersionLabel =
+    !force && versionLabel && !versionLabel.endsWith('-dirty-local') ? versionLabel : undefined;
+
   let hasInvalidPackageConfig = false;
   for (const rootDirPath of paths) {
     // Confine every generated file to this repository (see fsUtil.generateFile). Set BEFORE any
     // fixer writes, and reset on every iteration so a multi-path run never keeps the previous root.
     fsUtil.setRootDirPath(fs.existsSync(rootDirPath) ? rootDirPath : undefined);
+
+    // The badge records the build that generated the repository's configuration, so the same build
+    // would only rewrite what is already there. Skipping is a deliberate trade: the parts of a run
+    // that depend on state OUTSIDE the repository (GitHub settings, dependency updates, the fetched
+    // .gitignore) do get skipped too, which is what --force is for.
+    if (skippableVersionLabel && (await readAppliedWbfyVersionLabel(rootDirPath)) === skippableVersionLabel) {
+      console.info(`Skip ${rootDirPath}: wbfy ${skippableVersionLabel} is already applied. Pass --force to re-apply.`);
+      continue;
+    }
     // Read-only preflight before ANY fixer mutates the repository: Yarn configuration without an
     // automatic Bun translation must abort the whole migration for this path, not just the file
     // removal — otherwise wbfy would leave a half-migrated repository that neither tool can build.

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -125,7 +125,9 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
   // proceeding without Bun would delete Yarn state and then fail to produce a Bun lockfile.
   // The version floor matters too: older Bun silently ignores the generated bunfig.toml options
   // (globalStore, publicHoistPattern) and would validate a different install layout than the one
-  // repositories get once mise upgrades them.
+  // repositories get once mise upgrades them. It stays unconditional even though the already-applied
+  // check below can make a run a no-op: a missing or outdated Bun is a broken environment wbfy must
+  // report, and hiding it whenever every path happens to be skipped would surface it only later.
   const bunVersion = spawnSyncAndReturnStdout('bun', ['--version'], '.');
   if (!semver.valid(bunVersion)) {
     console.error('wbfy requires Bun. Install Bun (e.g. via mise) and re-run.');

--- a/packages/wbfy/src/utils/version.ts
+++ b/packages/wbfy/src/utils/version.ts
@@ -23,7 +23,7 @@ const wbfyDirPathInRepo = path.join('packages', 'wbfy');
  * neither is available (e.g. an unreleased build extracted from a source archive).
  */
 export function getWbfyVersionLabel(): string | undefined {
-  const { version, dirPath } = readWbfyPackageJson();
+  const { name, version, dirPath } = readWbfyPackageJson();
   if (!version.startsWith(unreleasedVersionPrefix)) return version;
 
   // git resolves the NEAREST enclosing repository, which for an unreleased build placed under a
@@ -51,7 +51,21 @@ export function getWbfyVersionLabel(): string | undefined {
   // The label is best-effort build provenance, not a reproducible-build attestation.
   const isDirty = getGitDirtyState(gitRootDirPath);
   if (isDirty === undefined) return undefined;
-  return isDirty ? `${commitHash}-dirty-local` : `${commitHash}-local`;
+  if (isDirty) return `${commitHash}-dirty-local`;
+  // An unmodified checkout sitting on a release tag runs exactly the code that was published under
+  // that version, so it is labeled with the version instead of the commit that only wbfy developers
+  // could resolve back to one.
+  return findReleasedVersionAtHead(name, dirPath) ?? `${commitHash}-local`;
+}
+
+/** `@semantic-release/npm` tags each release `<package name>@<version>`. */
+function findReleasedVersionAtHead(packageName: string, cwd: string): string | undefined {
+  const tagPrefix = `${packageName}@`;
+  // A commit carries at most one release tag per package, so the first match is the only match.
+  return runGit(['tag', '--points-at', 'HEAD'], cwd)
+    ?.split('\n')
+    .find((tag) => tag.startsWith(tagPrefix))
+    ?.slice(tagPrefix.length);
 }
 
 function isWbfyRepository(gitRootDirPath: string): boolean {
@@ -106,7 +120,7 @@ function runGit(args: string[], cwd: string): string | undefined {
   return proc.status === 0 ? proc.stdout.trim() || undefined : undefined;
 }
 
-function readWbfyPackageJson(): { version: string; dirPath: string } {
+function readWbfyPackageJson(): { name: string; version: string; dirPath: string } {
   // fileURLToPath, not URL.pathname: the latter keeps percent-encoding, so an installation path
   // containing e.g. a space would resolve to a nonexistent directory and the search would walk up
   // to an unrelated package.
@@ -117,6 +131,9 @@ function readWbfyPackageJson(): { version: string; dirPath: string } {
     if (parentDirPath === dirPath) throw new Error("wbfy's own package.json is missing.");
     dirPath = parentDirPath;
   }
-  const packageJson = JSON.parse(fs.readFileSync(path.join(dirPath, 'package.json'), 'utf8')) as { version: string };
-  return { version: packageJson.version, dirPath };
+  const packageJson = JSON.parse(fs.readFileSync(path.join(dirPath, 'package.json'), 'utf8')) as {
+    name: string;
+    version: string;
+  };
+  return { name: packageJson.name, version: packageJson.version, dirPath };
 }

--- a/packages/wbfy/test/unit/readme.test.ts
+++ b/packages/wbfy/test/unit/readme.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { afterEach, expect, test, vi } from 'vitest';
 
-import { generateReadme, writeBadgeBlock } from '../../src/generators/readme.js';
+import { generateReadme, readAppliedWbfyVersionLabel, writeBadgeBlock } from '../../src/generators/readme.js';
 import { fsUtil } from '../../src/utils/fsUtil.js';
 import { promisePool } from '../../src/utils/promisePool.js';
 import * as version from '../../src/utils/version.js';
@@ -270,6 +270,29 @@ test('marks a run from an unreleased checkout with its commit hash', async () =>
     const localContent = await runGenerateReadme(dirPath, 'abc1234-local');
     expect(localContent).toContain(badgeOf('abc1234--local'));
     expect(localContent).not.toContain('1.2.3');
+  });
+});
+
+// The already-applied check in the CLI compares this against the running build's label, so a label
+// that does not survive the badge round trip would either re-apply forever or skip a different build.
+test('reads back the version label the badge records', async () => {
+  await withTempDir(async (dirPath) => {
+    expect(await readAppliedWbfyVersionLabel(dirPath)).toBeUndefined();
+
+    await runGenerateReadme(dirPath, '1.2.3');
+    expect(await readAppliedWbfyVersionLabel(dirPath)).toBe('1.2.3');
+
+    // Hyphens are escaped as `--` in the badge URL and must be unescaped back.
+    await runGenerateReadme(dirPath, 'abc1234-local');
+    expect(await readAppliedWbfyVersionLabel(dirPath)).toBe('abc1234-local');
+  });
+});
+
+test('ignores a wbfy badge that is only quoted in the README', async () => {
+  await withTempDir(async (dirPath) => {
+    fs.writeFileSync(path.resolve(dirPath, 'README.md'), `# example\n\n\`\`\`md\n${badgeOf('1.2.3')}\n\`\`\`\n`);
+
+    expect(await readAppliedWbfyVersionLabel(dirPath)).toBeUndefined();
   });
 });
 

--- a/packages/wbfy/test/unit/readme.test.ts
+++ b/packages/wbfy/test/unit/readme.test.ts
@@ -302,6 +302,31 @@ test.each([
   });
 });
 
+// The answer only suppresses work, so anything unreadable must leave the run to proceed instead of
+// aborting the CLI — including the paths it has not processed yet.
+test('reports no applied version when the README cannot be read', async () => {
+  await withTempDir(async (dirPath) => {
+    const error: NodeJS.ErrnoException = new Error('EACCES: permission denied');
+    error.code = 'EACCES';
+    vi.spyOn(fsUtil, 'readFileConfinedIfExists').mockRejectedValue(error);
+
+    expect(await readAppliedWbfyVersionLabel(dirPath)).toBeUndefined();
+  });
+});
+
+test('ignores a README resolving outside the repository', async () => {
+  await withTempDir(async (dirPath) => {
+    await withTempDir(async (outsideDirPath) => {
+      const outsideFilePath = path.resolve(outsideDirPath, 'README.md');
+      fs.writeFileSync(outsideFilePath, `# outside\n\n${badgeOf('1.2.3')}\n`);
+      fs.symlinkSync(outsideFilePath, path.resolve(dirPath, 'README.md'));
+      fsUtil.setRootDirPath(dirPath);
+
+      expect(await readAppliedWbfyVersionLabel(dirPath)).toBeUndefined();
+    });
+  });
+});
+
 test('creates a missing README with a version-less badge', async () => {
   await withTempDir(async (dirPath) => {
     expect(await runGenerateReadme(dirPath, undefined)).toBe(`# example\n\n${badgeOf('applied')}\n`);

--- a/packages/wbfy/test/unit/readme.test.ts
+++ b/packages/wbfy/test/unit/readme.test.ts
@@ -288,9 +288,15 @@ test('reads back the version label the badge records', async () => {
   });
 });
 
-test('ignores a wbfy badge that is only quoted in the README', async () => {
+// Content that merely mentions a badge is not an applied badge, and reading it as one would skip
+// every fixer for the repository.
+test.each([
+  ['a fenced example', `\`\`\`md\n${badgeOf('1.2.3')}\n\`\`\``],
+  ['a block quote', `> ${badgeOf('1.2.3')}`],
+  ['a list item', `- ${badgeOf('1.2.3')}`],
+])('ignores a wbfy badge inside %s', async (_, body) => {
   await withTempDir(async (dirPath) => {
-    fs.writeFileSync(path.resolve(dirPath, 'README.md'), `# example\n\n\`\`\`md\n${badgeOf('1.2.3')}\n\`\`\`\n`);
+    fs.writeFileSync(path.resolve(dirPath, 'README.md'), `# example\n\n${body}\n`);
 
     expect(await readAppliedWbfyVersionLabel(dirPath)).toBeUndefined();
   });


### PR DESCRIPTION
## 目的

1. `npx` 等で起動した wbfy と、手元のチェックアウトから起動した wbfy とで、バッジに埋め込まれるバージョンを一致させる。
2. そのバージョン情報を使い、同じバージョンの wbfy を同じリポジトリへ重ねて適用することを避ける。

## 変更

### 1. リリースタグ上のチェックアウトはリリース版数を名乗る (`utils/version.ts`)

未リリースビルド（＝チェックアウト実行）でも、作業ツリーがクリーンなら `git tag --points-at HEAD` を引き、`@willbooster/wbfy@<version>` タグが HEAD にあればそのバージョンをラベルにする。これで公開版と同一コミットの手元実行は npx 実行と同じバッジになる。タグなしは従来通り `<commit hash>-local`、dirty は `<commit hash>-dirty-local`。

### 2. 適用済みバージョンならスキップ (`generators/readme.ts`, `index.ts`)

- `readAppliedWbfyVersionLabel()` を追加し、対象リポジトリの README のバッジからラベルを読み戻す（`--` のアンエスケープ込み）。README はスキャンではなく CommonMark パースするので、コードフェンス内に引用されたバッジは適用済みとみなさない。
- 実行中のラベルと一致したら、そのパスを何も変更せずスキップし `Skip <path>: wbfy <version> is already applied. Pass --force to re-apply.` を表示する。判定はどの fixer よりも前（リポジトリを一切変更する前）に行う。
- `-dirty-local` は同じラベルでも生成物が変わりうるのでスキップ対象外。
- `--force` (`-f`) で従来通り再適用できる。スキップはリポジトリ外の状態に依存する処理（GitHub 設定、依存更新、gitignore.io の取得）も飛ばすため、その際の逃げ道。

## 動作確認

- `bun verify` 通過
- `packages/wbfy/test/unit/readme.test.ts` 56 件通過（バッジのラウンドトリップと、フェンス内バッジを無視することのテストを追加）
