### PR TITLE
fix(wbfy): strip Takumi Guard proxy URLs from bun.lock on pre-commit

### DIFF
--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -99,16 +99,22 @@ exit "$failed"
       name: 'normalize-bun-lockfile',
       glob: 'bun.lock',
       run: `
+# Abort on any failure: a partially written temp file must never replace the lockfile.
+set -e
 # Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
 for file in {staged_files}; do
-  normalized="$(mktemp)"
+  # A sibling temp file seeded with \`cp -p\` keeps the lockfile's original mode (a bare \`mktemp\`
+  # hands it 0600, and git tracks only the executable bit, so that would change silently) and
+  # makes the replacement an atomic same-directory rename.
+  normalized="$file.wbfy-normalizing"
+  trap 'rm -f "$normalized"' EXIT
+  cp -p "$file" "$normalized"
   sed -E 's#"https://npm\\.flatt\\.tech/[^"]*"#""#g' "$file" > "$normalized"
-  if cmp -s "$file" "$normalized"; then
-    rm -f "$normalized"
-  else
+  if ! cmp -s "$file" "$normalized"; then
     mv "$normalized" "$file"
     echo "Removed Takumi Guard proxy URLs from $file so the lockfile stays registry-agnostic."
   fi
+  rm -f "$normalized"
 done
 `.trim(),
       stage_fixed: true,

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -93,6 +93,9 @@ exit "$failed"
       // not depend on these URLs — with an empty `resolved`, bun derives the download URL from
       // the configured registry — so strip them. Only the Guard host is stripped: a scoped
       // registry such as Verdaccio legitimately records its own URL for private packages.
+      // Staging a DELETION of bun.lock leaves no file for inspection, so Lefthook skips this job
+      // rather than passing a missing path to the loop (verified); the rewrite therefore cannot
+      // resurrect a deleted lockfile as an empty file.
       name: 'normalize-bun-lockfile',
       glob: 'bun.lock',
       run: `

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -82,6 +82,35 @@ exit "$failed"
 `.trim(),
     },
     {
+      // bun records an absolute `resolved` URL for an already-locked package whenever the
+      // configured registry does not serve the tarball host in the package metadata — which is
+      // exactly what the Takumi Guard proxy does. So an install run with Guard as the default
+      // registry (CI, or a developer who put it in ~/.npmrc) bakes npm.flatt.tech URLs into
+      // bun.lock, and committing them pins a SHARED lockfile to one environment's mirror: every
+      // later install downloads through the proxy, and a cold-cache install fails outright with
+      // 401 for anyone whose npmrc carries a registry.npmjs.org token, because bun sends the
+      // default registry's credentials to whatever host the lockfile names. Guard coverage does
+      // not depend on these URLs — with an empty `resolved`, bun derives the download URL from
+      // the configured registry — so strip them. Only the Guard host is stripped: a scoped
+      // registry such as Verdaccio legitimately records its own URL for private packages.
+      name: 'normalize-bun-lockfile',
+      glob: 'bun.lock',
+      run: `
+# Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
+for file in {staged_files}; do
+  normalized="$(mktemp)"
+  sed -E 's#"https://npm\\.flatt\\.tech/[^"]*"#""#g' "$file" > "$normalized"
+  if cmp -s "$file" "$normalized"; then
+    rm -f "$normalized"
+  else
+    mv "$normalized" "$file"
+    echo "Removed Takumi Guard proxy URLs from $file so the lockfile stays registry-agnostic."
+  fi
+done
+`.trim(),
+      stage_fixed: true,
+    },
+    {
       // Only willbooster-configs gets this job: every other repository's renovate.jsonc merely
       // extends the shared preset, and the validator does not resolve remote presets, so running it
       // there would validate two lines and catch nothing. `--no-global` validates the preset as a

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -103,10 +103,12 @@ exit "$failed"
 set -e
 # Lefthook expands {staged_files} as shell-escaped args, so paths with spaces stay intact.
 for file in {staged_files}; do
-  # A sibling temp file seeded with \`cp -p\` keeps the lockfile's original mode (a bare \`mktemp\`
-  # hands it 0600, and git tracks only the executable bit, so that would change silently) and
-  # makes the replacement an atomic same-directory rename.
-  normalized="$file.wbfy-normalizing"
+  # A sibling temp file makes the replacement an atomic same-directory rename, and \`cp -p\` gives
+  # it the lockfile's original mode (mktemp alone creates 0600, and git tracks only the executable
+  # bit, so that would change silently). The name must stay unpredictable and be created by
+  # mktemp: a repository-committed symlink at a fixed sibling path would otherwise be followed by
+  # \`cp\` and the redirection, and the \`mv\` would then turn bun.lock into that symlink.
+  normalized="$(mktemp "$file.wbfy-normalizing.XXXXXX")"
   trap 'rm -f "$normalized"' EXIT
   cp -p "$file" "$normalized"
   sed -E 's#"https://npm\\.flatt\\.tech/[^"]*"#""#g' "$file" > "$normalized"


### PR DESCRIPTION
## Problem

bun records an absolute `resolved` URL for an **already-locked** package whenever the configured registry does not serve the tarball host named in the package metadata — which is exactly what a transparent proxy like Takumi Guard does:

| registry | `dist.tarball` for `is-odd@3.0.1` | `resolved` written |
|---|---|---|
| `registry.npmjs.org` | `https://registry.npmjs.org/...` | `""` |
| `registry.npmmirror.com` | `https://registry.npmmirror.com/...` | `""` |
| `npm.flatt.tech` (Guard) | `https://registry.npmjs.org/...` | absolute URL **on the proxy host** |

So an install with Guard as the default registry bakes `npm.flatt.tech` URLs into `bun.lock`, and committing them pins a **shared** lockfile to one environment's mirror. Cold-cache `bun install` from such a lockfile:

| `~/.npmrc` | Result |
|---|---|
| empty | 1038 packages installed, all via the proxy |
| `//registry.npmjs.org/:_authToken=…` only | **519 packages fail with `401 Unauthorized`** |
| `//verdaccio…:_authToken=…` only | works |

bun attaches the **default registry's** token to a lockfile-pinned URL regardless of that URL's host, and Guard rejects any bearer that is not its own. The standard developer npmrc is therefore exactly the configuration that breaks — and only on a cold cache, so a warm machine hides it. This already reached `main` in WillBooster/daily-booster#8 (746 packages rewritten in one autofix commit) and is being reverted in WillBooster/daily-booster#10.

## Why this belongs in wbfy, not only in CI

WillBooster/reusable-workflows#479 normalizes the lockfile before the autofix commit, which covers CI. It does **not** cover a developer who puts Guard in their own `~/.npmrc` — and doing so is worth encouraging, because CI-only Guard protects the place it matters least (the hardened CI path already installs with `--ignore-scripts` and strips credentials from the lifecycle replay), while a malicious `postinstall` on a laptop reaches `~/.config/fnox/age.txt`, which decrypts every org secret.

Verified that a developer-side `registry=https://npm.flatt.tech/` does reintroduce the URLs: a baseline npmjs lockfile grew proxy URLs after a local install, and in one large repository even a fully satisfied no-op `bun install` re-added all 746. This pre-commit job is what makes rolling Guard out beyond CI safe.

## Change

A `normalize-bun-lockfile` pre-commit job, globbed to `bun.lock` with `stage_fixed: true`, rewriting `"https://npm.flatt.tech/…"` back to `""`.

Only the Guard host is stripped. A scoped registry legitimately records its own URL — `@willbooster-private/*` packages carry Verdaccio URLs in every repo today (confirmed in ai-ocr), and those must not be touched.

## Verification

- Generated output inspected; the escaped `\.` survives YAML serialization intact
- Shell logic run against daily-booster's real polluted lockfile: 746 proxy URLs → 0, and the result is byte-identical to the clean lockfile
- Idempotent: a second run reports no change
- `packages/wbfy` lefthook unit tests pass (3/3); `bun verify` passes

## Related

- WillBooster/reusable-workflows#479 — the CI-side normalization
- WillBooster/agentic-workflows#456 — corrects the guidelines, which had the lockfile/proxy relationship backwards
- oven-sh/bun#35524 — upstream report of the rewriting behaviour
