### PR TITLE
feat(wb): name the tools behind verify's cleanup and typecheck steps

### DIFF
--- a/packages/wb/src/commands/typecheck.ts
+++ b/packages/wb/src/commands/typecheck.ts
@@ -32,13 +32,7 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
 
   let removedNextDir = false as boolean;
   const promises = projects.descendants.map(async (project) => {
-    const commands: string[] = [];
-    if (!project.packageJson.workspaces || project.hasSourceCode) {
-      commands.push(...buildTypeScriptTypeCheckCommands(project));
-    }
-    if (!project.packageJson.workspaces && project.hasOwnDependency('pyright')) {
-      commands.push('YARN pyright');
-    }
+    const commands = buildTypeCheckCommands(project);
     while (commands.length > 0) {
       const exitCode = await runWithSpawnInParallel(commands.join(' && '), project, argv, {
         // Disable interactive mode
@@ -73,6 +67,22 @@ export async function typeCheck(argv: TypeCheckCommandArgv): Promise<number> {
       )
     );
   return finalExitCode;
+}
+
+/**
+ * Every type-check command this project runs, as `BUN`/`YARN`-prefixed scripts. Exported so
+ * `wb verify`'s step recap can name the same tools instead of re-deriving the conditions, which
+ * would silently go stale the next time this list changes.
+ */
+export function buildTypeCheckCommands(project: Project): string[] {
+  const commands: string[] = [];
+  if (!project.packageJson.workspaces || project.hasSourceCode) {
+    commands.push(...buildTypeScriptTypeCheckCommands(project));
+  }
+  if (!project.packageJson.workspaces && project.hasOwnDependency('pyright')) {
+    commands.push('YARN pyright');
+  }
+  return commands;
 }
 
 function buildTypeScriptTypeCheckCommands(project: Project): string[] {

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -163,6 +163,10 @@ function findTestProject(project: Project, argv: TestCommandArgv): Project {
  */
 async function buildStepDetails(argv: VerifyCodeCommandArgv): Promise<{ cleanup: string; typecheck?: string }> {
   const cleanup = 'lint --fix --format';
+  // Deliberately resolved with no explicit dirPath, exactly as `lint` (lint.ts) and `typeCheck`
+  // (typecheck.ts) resolve theirs, so the labels always describe the very project set those commands
+  // process. Threading a dirPath in — the self project's, say — would let the two diverge, which is
+  // the drift this function exists to prevent.
   const projects = await findDescendantProjects(argv, false);
   if (!projects) return { cleanup };
 

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
 import type { ArgumentsCamelCase, CommandModule, InferredOptionTypes } from 'yargs';
 
 import type { Project } from '../project.js';
-import { findRootAndSelfProjects, findSelfProject } from '../project.js';
+import { findDescendantProjects, findRootAndSelfProjects, findSelfProject } from '../project.js';
 import { configureEnv } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
@@ -82,9 +82,13 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv, steps: 
       runPackageCommand(genCodeCommand, project, argv)
     );
   }
+  // Resolved after `install`, so a dependency the install added is reflected, and reused by both
+  // step details below. `lint` and `typecheck` each resolve the same set again internally; this
+  // extra resolution only reads the already-parsed package.json files.
+  const stepDetails = await buildStepDetails(argv);
   // `lint --fix --format` prints nothing on success, so without the step summary a passing `verify`
   // looks like it never linted at all — and it silently rewrote the working tree while at it.
-  await runStep(steps, { detail: 'lint --fix --format', name: 'cleanup' }, () =>
+  await runStep(steps, { detail: stepDetails.cleanup, name: 'cleanup' }, () =>
     runInProcessCommand('cleanup', () =>
       lint({
         ...argv,
@@ -100,7 +104,7 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv, steps: 
   // `dist`). Keep the typecheck command so `verify` stays equivalent to "the repository compiles".
   // The overlap with lint is deliberate: `--type-aware` also powers type-aware lint rules, and
   // dropping only `--type-check` from lint saves ~0.1s, far less than the coverage it would cost.
-  await runStep(steps, { name: 'typecheck' }, () =>
+  await runStep(steps, { detail: stepDetails.typecheck, name: 'typecheck' }, () =>
     runInProcessCommand('typecheck', () => typeCheck({ ...argv, _: ['typecheck'] } as unknown as TypeCheckCommandArgv))
   );
 }
@@ -141,6 +145,45 @@ function findTestProject(project: Project, argv: TestCommandArgv): Project {
     throw new Error(`Project not found: ${project.dirPath}`);
   }
   return testProject;
+}
+
+/**
+ * Names the tools behind the `cleanup` and `typecheck` steps.
+ *
+ * Both steps type-check, which reads as redundant until the recap says how they differ: `cleanup`
+ * type-checks through oxlint, which sees only the files it lints (the shared config ignores
+ * `__generated__`, `@types`, `dist`, ...), while `typecheck` runs the compiler over the whole
+ * tsconfig program. Every label is derived from the resolved projects rather than hard-coded, so a
+ * repository whose `cleanup` runs flake8 or `dart analyze` is never told it ran oxlint.
+ */
+async function buildStepDetails(argv: VerifyCodeCommandArgv): Promise<{ cleanup: string; typecheck?: string }> {
+  const cleanup = 'lint --fix --format';
+  const projects = await findDescendantProjects(argv, false);
+  if (!projects) return { cleanup };
+
+  // Mirrors the guards the two commands themselves apply: `buildLintCommand` adds the type-aware
+  // flags only for oxlint projects that also ship oxlint-tsgolint, and `typeCheck` builds its
+  // commands only for projects with source code of their own.
+  const runsTypeAwareLint = projects.descendants.some(
+    (project) => hasOwnSourceCode(project) && project.preferredLinter === 'oxlint' && project.hasTypeAwareOxlint
+  );
+  const typeCheckCommands = [
+    projects.descendants.some((project) => hasOwnSourceCode(project) && project.hasOwnDependency('typescript'))
+      ? 'tsc --noEmit'
+      : undefined,
+    projects.descendants.some((project) => !project.packageJson.workspaces && project.hasOwnDependency('pyright'))
+      ? 'pyright'
+      : undefined,
+  ].filter((command) => command !== undefined);
+  return {
+    cleanup: runsTypeAwareLint ? `${cleanup} (oxlint --type-aware --type-check)` : cleanup,
+    typecheck: typeCheckCommands.length > 0 ? typeCheckCommands.join(' + ') : undefined,
+  };
+}
+
+/** A workspace root without sources of its own runs neither lint nor typecheck commands. */
+function hasOwnSourceCode(project: Project): boolean {
+  return !project.packageJson.workspaces || project.hasSourceCode;
 }
 
 /** Times a step and records it for the final summary. Steps that fail exit the process instead. */

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -10,9 +10,9 @@ import { findDescendantProjects, findRootAndSelfProjects, findSelfProject } from
 import { configureEnv } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
-import { lint, type LintCommandArgv } from './lint.js';
+import { buildLintCommand, lint, type LintCommandArgv } from './lint.js';
 import { test, type TestCommandArgv, withDefaultTestCascadeEnv } from './test.js';
-import { typeCheck, type TypeCheckCommandArgv } from './typecheck.js';
+import { buildTypeCheckCommands, typeCheck, type TypeCheckCommandArgv } from './typecheck.js';
 
 const builder = {
   full: {
@@ -28,7 +28,11 @@ type PackageCommandArgv = Pick<VerifyCodeCommandArgv, 'dryRun' | 'verbose'>;
 
 /** A completed `wb verify` step, recorded so the final summary can prove every step actually ran. */
 interface VerifyStep {
-  /** What the step ran, e.g. `lint --fix --format`. Omitted when no single command describes it. */
+  /**
+   * A short description of what the step ran, e.g. `tsc --noEmit`. Aggregated across the descendant
+   * projects, so ` + ` means each tool ran somewhere, not that one command ran them all. Omitted when
+   * nothing beyond the step name describes it.
+   */
   detail?: string;
   durationMs: number;
   name: string;
@@ -162,24 +166,26 @@ async function buildStepDetails(argv: VerifyCodeCommandArgv): Promise<{ cleanup:
   const projects = await findDescendantProjects(argv, false);
   if (!projects) return { cleanup };
 
-  // Mirrors the guards the two commands themselves apply: `buildLintCommand` adds the type-aware
-  // flags only for oxlint projects that also ship oxlint-tsgolint, and `typeCheck` builds its
-  // commands only for projects with source code of their own.
+  // Asks the real builders what they would run rather than restating their conditions, so a change
+  // to either command cannot leave these labels describing something it stopped doing. Only the
+  // project selection is restated: `lint` and `typeCheck` apply it around their builders, not
+  // inside them.
   const runsTypeAwareLint = projects.descendants.some(
-    (project) => hasOwnSourceCode(project) && project.preferredLinter === 'oxlint' && project.hasTypeAwareOxlint
+    (project) =>
+      hasOwnSourceCode(project) && buildLintCommand(project, { fix: true, format: true })?.includes('--type-aware')
   );
   const typeCheckCommands = [
-    projects.descendants.some((project) => hasOwnSourceCode(project) && project.hasOwnDependency('typescript'))
-      ? 'tsc --noEmit'
-      : undefined,
-    projects.descendants.some((project) => !project.packageJson.workspaces && project.hasOwnDependency('pyright'))
-      ? 'pyright'
-      : undefined,
-  ].filter((command) => command !== undefined);
+    ...new Set(projects.descendants.flatMap((project) => buildTypeCheckCommands(project).map(toDisplayCommand))),
+  ];
   return {
     cleanup: runsTypeAwareLint ? `${cleanup} (oxlint --type-aware --type-check)` : cleanup,
     typecheck: typeCheckCommands.length > 0 ? typeCheckCommands.join(' + ') : undefined,
   };
+}
+
+/** Drops the package-manager placeholder `runWithSpawn` expands, leaving the tool call to show. */
+function toDisplayCommand(command: string): string {
+  return command.replace(/^(?:BUN|YARN) /u, '');
 }
 
 /** A workspace root without sources of its own runs neither lint nor typecheck commands. */

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -82,9 +82,10 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv, steps: 
       runPackageCommand(genCodeCommand, project, argv)
     );
   }
-  // Resolved after `install`, so a dependency the install added is reflected, and reused by both
-  // step details below. `lint` and `typecheck` each resolve the same set again internally; this
-  // extra resolution only reads the already-parsed package.json files.
+  // Resolved after `gen-code` so a generated `src` directory is already there for `hasSourceCode`,
+  // which is an existsSync check, and reused by both step details below. `Project` memoizes per
+  // instance and `getAllDescendantProjects` builds fresh ones, so this repeats the workspace glob
+  // and manifest parse that `lint` and `typecheck` each perform anyway — cheap, but not free.
   const stepDetails = await buildStepDetails(argv);
   // `lint --fix --format` prints nothing on success, so without the step summary a passing `verify`
   // looks like it never linted at all — and it silently rewrote the working tree while at it.


### PR DESCRIPTION
## Customer Summary

- `wb verify`'s step recap now says which tool each step ran, so the two type-checking steps no longer look redundant.
- Nothing about what `verify` executes changes — this is labelling only.

```
  ✔ install    0.3s  bun install
  ✔ cleanup    1.8s  lint --fix --format (oxlint --type-aware --type-check)
  ✔ typecheck  0.5s  tsc --noEmit
```

## Technical Summary

- `buildStepDetails` labels the `cleanup` and `typecheck` steps by asking the real command builders what they would run, rather than restating their conditions:
  - `buildTypeCheckCommands` is extracted from `typeCheck` and exported, so both the command and the label come from one definition. `toDisplayCommand` strips the `BUN`/`YARN` placeholder `runWithSpawn` would expand, and a `Set` dedupes tools shared by several descendants.
  - The oxlint suffix asks `buildLintCommand` whether it emits `--type-aware` instead of re-deriving `preferredLinter === 'oxlint' && hasTypeAwareOxlint`.
- Only the project selection (`hasOwnSourceCode`) is restated, because `lint` and `typeCheck` apply it around their builders rather than inside them.
- Projects are resolved with `findDescendantProjects(argv, false)` and no explicit `dirPath` — byte-identical to `lint.ts:122` and `typecheck.ts:27` — so the labels always describe the same project set those commands process.
- The `detail` JSDoc is reworded: a detail may now be annotated, or aggregate several tools across descendants (` + ` means each tool ran somewhere, not that one command ran them all).

## Why

Follow-up to #1098. Its recap listed the two steps as:

```
  ✔ cleanup    1.9s  lint --fix --format
  ✔ typecheck  0.6s
```

which prompts the obvious question — isn't the type check part of lint? It partly is: wbfy forces `typeAware: true, typeCheck: true` in the generated `oxlint.config.ts`, so `cleanup` does type-check. But the two are not redundant, and the recap gave no way to see how they differ:

- `cleanup` type-checks through oxlint, which sees only the files it lints. `@willbooster/oxlint-config`'s `ignorePatterns` exclude `**/@types/**`, `**/__generated__/**`, `**/dist/**`, `**/bin/**`, `**/build/**`, …
- `typecheck` runs the compiler over the whole tsconfig program.

Neither is a superset of the other: a file outside the tsconfig `include` is type-checked by oxlint but not by `tsc`, and a file under `dist/` that `tsc` compiles is ignored by oxlint.

## Testing

- `bun verify` and `bun run test` (297 tests) in the branch's worktree.
- Built the CLI and ran it against four project shapes:

| Project | `cleanup` detail | `typecheck` detail |
| --- | --- | --- |
| this repo (oxlint + tsgolint + TypeScript) | `lint --fix --format (oxlint --type-aware --type-check)` | `tsc --noEmit` |
| bare project, no TypeScript, no oxlint | `lint --fix --format` | *(none)* |
| bare project, TypeScript only | `lint --fix --format` | `tsc --noEmit` |
| bare project, TypeScript + pyright | `lint --fix --format` | `tsc --noEmit + pyright` |

- Confirmed the `--dry-run` listing carries the same details, and that the recap output is unchanged for this repo after the refactor.

## Notes

- Supporting evidence for keeping both steps, measured while investigating: `--type-aware` alone still runs type-aware lint rules (`no-floating-promises` fired) but reports no TypeScript diagnostics — only `--type-check` surfaces `TS2322`. Dropping `--type-check` costs ~0.1s per package (0.60s → 0.50s, 3 runs each), so removing it would trade real coverage for almost nothing. The lefthook `pre-push` hook runs `bun wb lint --quiet` with no typecheck, which makes oxlint's `--type-check` the only type gate there.
- The extra `findDescendantProjects` call is not free: `Project` memoizes per instance and `getAllDescendantProjects` builds fresh ones, so the workspace glob and manifest parse are repeated rather than reused. The call site says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
