### PR TITLE
feat(wbfy): generate the App-based autofix apply workflow for private repositories

### DIFF
--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -688,10 +688,11 @@ async function writeWorkflowYaml(
     case 'test':
     case 'test-rust': {
       // Don't use `paths-ignore` for test because GitHub's Branch Protection and Rulesets require job running.
-      // test-rust calls no action that needs Actions write access, so the template's grant is
-      // dropped for it; test keeps it for the reason stated on the test template's permissions
-      // above (skip-duplicate-actions with cancel_others: true) — NOT for the retired push-back
-      // dispatch, which the reusable test workflow no longer performs.
+      // The test-rust template declares no permissions at all, so this delete only strips an
+      // `actions` grant merged in from an existing test-rust.yml an older wbfy generated — it is a
+      // no-op for a fresh one. test keeps its grant for the reason stated on the test template's
+      // permissions above (skip-duplicate-actions with cancel_others: true), NOT for the retired
+      // push-back dispatch, which the reusable test workflow no longer performs.
       if (kind === 'test-rust') {
         delete newSettings.permissions?.actions;
       }

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -478,9 +478,20 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
     // pushes through its own GitHub App and also covers fork pull requests. Private repositories
     // (autofix.ci does not serve them) instead let the reusable test workflow upload a patch and
     // autofix-apply.yml commit it with the WillBooster Autofixer App.
-    const obsoleteAutofixKind = rootConfig.isPublicRepo ? 'autofix-apply' : 'autofix';
-    fileNamesByKind.delete(obsoleteAutofixKind);
-    await promisePool.run(() => fsUtil.removeConfined(path.join(workflowsPath, `${obsoleteAutofixKind}.yml`)));
+    if (rootConfig.isRepoVisibilityKnown) {
+      const obsoleteAutofixKind = rootConfig.isPublicRepo ? 'autofix-apply' : 'autofix';
+      fileNamesByKind.delete(obsoleteAutofixKind);
+      await promisePool.run(() => fsUtil.removeConfined(path.join(workflowsPath, `${obsoleteAutofixKind}.yml`)));
+    } else {
+      // A failed GitHub lookup collapses isPublicRepo to false, and unlike the merge-based
+      // generators this branch both DELETES one file and CREATES the other — so guessing wrong
+      // strips a public repository's autofix.ci workflow AND gives it the private App-based one,
+      // which refuses fork pull requests. Touch neither and retry on a later successful lookup,
+      // the same choice the wbfy caller makes above.
+      console.warn('Skipped generating the autofix workflows because the repository visibility is unknown.');
+      fileNamesByKind.delete('autofix');
+      fileNamesByKind.delete('autofix-apply');
+    }
 
     for (const [kind, fileName] of fileNamesByKind) {
       // 実際はKnownKind以外の値も代入されることに注意

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -688,8 +688,10 @@ async function writeWorkflowYaml(
     case 'test':
     case 'test-rust': {
       // Don't use `paths-ignore` for test because GitHub's Branch Protection and Rulesets require job running.
-      // test-rust never pushes back, so it needs no Actions write access; test needs it again to
-      // dispatch itself after the autofix push-back (reusable-workflows#466).
+      // test-rust calls no action that needs Actions write access, so the template's grant is
+      // dropped for it; test keeps it for the reason stated on the test template's permissions
+      // above (skip-duplicate-actions with cancel_others: true) — NOT for the retired push-back
+      // dispatch, which the reusable test workflow no longer performs.
       if (kind === 'test-rust') {
         delete newSettings.permissions?.actions;
       }

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -104,8 +104,10 @@ const workflows = {
       push: {
         branches: ['main', 'wbfy'],
       },
-      // The reusable test workflow re-runs this caller via workflow_dispatch after its autofix
-      // push-back (a GITHUB_TOKEN push triggers no workflows by itself).
+      // The reusable autofix and wbfy workflows re-run this caller via workflow_dispatch after
+      // their GITHUB_TOKEN push-back (such a push triggers no workflows by itself). The reusable
+      // TEST workflow no longer pushes at all — its fixes travel through autofix-apply.yml — but
+      // the trigger stays for those two.
       workflow_dispatch: null,
     },
     // cf. https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
@@ -113,10 +115,13 @@ const workflows = {
       group: '${{ github.workflow }}-${{ github.ref }}',
       'cancel-in-progress': true,
     },
+    // None of these may be narrowed just because the reusable test workflow stopped pushing:
     permissions: {
-      // for dispatching this workflow again after the autofix push-back
+      // for the test job's skip-duplicate-actions call with cancel_others: true, and for the
+      // workflow_dispatch the autofix/wbfy workflows issue after their push-back
       actions: 'write',
-      // for linter fix
+      // for `semantic-release --dry-run`, which does a `git push --dry-run` to verify write
+      // access and aborts with EGITNOPERMISSION without it
       contents: 'write',
       // for pkg-preflight PR file listing
       'pull-requests': 'read',
@@ -126,6 +131,31 @@ const workflows = {
     jobs: {
       test: {
         uses: 'WillBooster/reusable-workflows/.github/workflows/test.yml@main',
+      },
+    },
+  },
+  // Commits the patch the test run uploaded, as a GitHub App, from the base repository's context.
+  // Private repositories only: public ones use autofix.ci (see generateAutofixWorkflow), whose own
+  // App does the same job and additionally handles fork pull requests.
+  'autofix-apply': {
+    name: 'Apply autofix',
+    on: {
+      workflow_run: {
+        // Matches the `name:` of the test caller above, not its filename.
+        workflows: ['Test'],
+        types: ['completed'],
+      },
+    },
+    // A called workflow can only REDUCE the caller's token, never elevate it, so `actions: read`
+    // has to be granted here: without it the apply job cannot list or download the artifact of
+    // the run that triggered it.
+    permissions: {
+      actions: 'read',
+      contents: 'read',
+    },
+    jobs: {
+      apply: {
+        uses: 'WillBooster/reusable-workflows/.github/workflows/autofix-apply.yml@main',
       },
     },
   },
@@ -391,7 +421,8 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
       if (!entry.isFile() || !entry.name.endsWith('.yml') || obsoleteGenPrFileNames.has(entry.name)) continue;
       fileNamesByKind.set(entry.name.slice(0, -'.yml'.length), entry.name);
     }
-    const mandatoryKinds = ['test', 'autofix', 'semantic-pr', 'close-comment'];
+    // Both autofix kinds are listed; the visibility check below drops whichever does not apply.
+    const mandatoryKinds = ['test', 'autofix', 'autofix-apply', 'semantic-pr', 'close-comment'];
     if (rootConfig.depending.semanticRelease) {
       mandatoryKinds.push('release');
     }
@@ -443,12 +474,13 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
       fileNamesByKind.delete('sync-force');
       fileNamesByKind.delete('sync-init');
     }
-    if (!rootConfig.isPublicRepo) {
-      // The reusable test workflow already fixes and pushes code on private repos,
-      // so a separate autofix workflow only duplicates the same process.
-      fileNamesByKind.delete('autofix');
-      await promisePool.run(() => fsUtil.removeConfined(path.join(workflowsPath, 'autofix.yml')));
-    }
+    // The two autofix paths are mutually exclusive. Public repositories run autofix.ci, which
+    // pushes through its own GitHub App and also covers fork pull requests. Private repositories
+    // (autofix.ci does not serve them) instead let the reusable test workflow upload a patch and
+    // autofix-apply.yml commit it with the WillBooster Autofixer App.
+    const obsoleteAutofixKind = rootConfig.isPublicRepo ? 'autofix-apply' : 'autofix';
+    fileNamesByKind.delete(obsoleteAutofixKind);
+    await promisePool.run(() => fsUtil.removeConfined(path.join(workflowsPath, `${obsoleteAutofixKind}.yml`)));
 
     for (const [kind, fileName] of fileNamesByKind) {
       // 実際はKnownKind以外の値も代入されることに注意
@@ -1208,6 +1240,13 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
     secrets.VERDACCIO_TOKEN = '${{ secrets.VERDACCIO_TOKEN }}';
     delete secrets.GH_BOT_PAT;
     delete secrets.WBFY_GH_TOKEN;
+  }
+  // The apply workflow declares exactly one secret. The App ID it pairs with is a constant in the
+  // callee, not an input: an App ID is public (an unauthenticated GET /apps/{slug} returns it) and
+  // useless without the key, and one Autofixer App serves every organization, so callers have
+  // nothing else to configure.
+  if (secrets && calledReusableWorkflow === 'autofix-apply') {
+    secrets.AUTOFIX_APP_PRIVATE_KEY = '${{ secrets.AUTOFIX_APP_PRIVATE_KEY }}';
   }
   if (secrets && calledReusableWorkflow && installCapableReusableWorkflows.has(calledReusableWorkflow)) {
     // The callee routes public (default-registry) installs through the Takumi Guard

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -104,10 +104,12 @@ const workflows = {
       push: {
         branches: ['main', 'wbfy'],
       },
-      // The reusable autofix and wbfy workflows re-run this caller via workflow_dispatch after
-      // their GITHUB_TOKEN push-back (such a push triggers no workflows by itself). The reusable
-      // TEST workflow no longer pushes at all — its fixes travel through autofix-apply.yml — but
-      // the trigger stays for those two.
+      // The reusable wbfy workflow re-runs this caller via workflow_dispatch after its
+      // GITHUB_TOKEN push-back (such a push triggers no workflows by itself), so the trigger has
+      // to stay. Being a dispatch TARGET needs only this trigger — the API call requires
+      // actions:write on the DISPATCHER's token, which wbfy.yml declares on its own push job.
+      // The reusable test workflow no longer pushes or dispatches at all; its fixes travel
+      // through autofix-apply.yml.
       workflow_dispatch: null,
     },
     // cf. https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
@@ -117,8 +119,8 @@ const workflows = {
     },
     // None of these may be narrowed just because the reusable test workflow stopped pushing:
     permissions: {
-      // for the test job's skip-duplicate-actions call with cancel_others: true, and for the
-      // workflow_dispatch the autofix/wbfy workflows issue after their push-back
+      // for the test job's skip-duplicate-actions call with cancel_others: true (the reusable
+      // test workflow declares no permissions of its own, so its jobs run on this token)
       actions: 'write',
       // for `semantic-release --dry-run`, which does a `git push --dry-run` to verify write
       // access and aborts with EGITNOPERMISSION without it

--- a/packages/wbfy/test/unit/autofixWorkflow.test.ts
+++ b/packages/wbfy/test/unit/autofixWorkflow.test.ts
@@ -37,7 +37,8 @@ test('generates a public autofix workflow that can run wb with fnox on CI', asyn
 // nothing else in the build can check: a wrong choice silently leaves a repository with no working
 // autofix (or, worse, a public repository calling the private App-based one).
 test('a private repository gets the App-based apply workflow instead of autofix.ci', async () => {
-  const dirPath = await generateInto({ isPublicRepo: false });
+  // Seeded so the assertion below proves the obsolete workflow is DELETED, not merely skipped.
+  const dirPath = await generateInto({ isPublicRepo: false }, ['autofix.yml']);
   try {
     const workflowsPath = path.join(dirPath, '.github', 'workflows');
     expect(fs.existsSync(path.join(workflowsPath, 'autofix.yml'))).toBe(false);
@@ -63,7 +64,7 @@ test('a private repository gets the App-based apply workflow instead of autofix.
 });
 
 test('a public repository keeps autofix.ci and gets no apply workflow', async () => {
-  const dirPath = await generateInto({ isPublicRepo: true });
+  const dirPath = await generateInto({ isPublicRepo: true }, ['autofix-apply.yml']);
   try {
     const workflowsPath = path.join(dirPath, '.github', 'workflows');
     expect(fs.existsSync(path.join(workflowsPath, 'autofix.yml'))).toBe(true);
@@ -108,11 +109,19 @@ test('unknown repository visibility leaves both autofix workflows untouched', as
   }
 });
 
-async function generateInto(overrides: Partial<PackageConfig>): Promise<string> {
+/**
+ * `seedFileNames` are written before generating. Without them an "is absent afterwards" assertion
+ * passes on a file that was simply never created, which would leave the removal itself untested.
+ */
+async function generateInto(overrides: Partial<PackageConfig>, seedFileNames: string[] = []): Promise<string> {
   const tempRootPath = path.join(process.cwd(), '.tmp');
   await fs.promises.mkdir(tempRootPath, { recursive: true });
   const dirPath = await fs.promises.mkdtemp(path.join(tempRootPath, 'wbfy-autofix-'));
-  await fs.promises.mkdir(path.join(dirPath, '.github', 'workflows'), { recursive: true });
+  const workflowsPath = path.join(dirPath, '.github', 'workflows');
+  await fs.promises.mkdir(workflowsPath, { recursive: true });
+  for (const fileName of seedFileNames) {
+    await fs.promises.writeFile(path.join(workflowsPath, fileName), 'name: Seeded\non: push\njobs: {}\n');
+  }
   await generateWorkflows(createConfig({ dirPath, isRoot: true, ...overrides }));
   await promisePool.promiseAll();
   return dirPath;

--- a/packages/wbfy/test/unit/autofixWorkflow.test.ts
+++ b/packages/wbfy/test/unit/autofixWorkflow.test.ts
@@ -79,9 +79,9 @@ test("the test caller keeps the permissions the reusable workflow's other steps 
   try {
     const content = await fs.promises.readFile(path.join(dirPath, '.github', 'workflows', 'test.yml'), 'utf8');
     const workflow = loadYaml(content) as { permissions: Record<string, string>; on: Record<string, unknown> };
-    // contents:write for semantic-release --dry-run's push check, actions:write for the test job's
-    // skip-duplicate-actions cancel_others and the autofix/wbfy dispatch. Dropping either because
-    // "test.yml no longer pushes" breaks callers.
+    // contents:write for semantic-release's unconditional push check, actions:write for the test
+    // job's skip-duplicate-actions cancel_others. Dropping either because "test.yml no longer
+    // pushes" breaks callers.
     expect(workflow.permissions).toMatchObject({ actions: 'write', contents: 'write', statuses: 'write' });
     expect(workflow.on).toHaveProperty('workflow_dispatch');
   } finally {
@@ -92,18 +92,36 @@ test("the test caller keeps the permissions the reusable workflow's other steps 
 // A failed GitHub lookup collapses isPublicRepo to false. Because this branch both deletes one
 // workflow and creates the other, guessing "private" would strip a public repository's autofix.ci
 // setup and hand it the App-based workflow that refuses fork pull requests.
-test('unknown repository visibility leaves both autofix workflows untouched', async () => {
+test('unknown repository visibility leaves existing autofix workflows byte-identical', async () => {
   const dirPath = await generateInto({ isPublicRepo: true });
   try {
     const workflowsPath = path.join(dirPath, '.github', 'workflows');
     const publicAutofix = await fs.promises.readFile(path.join(workflowsPath, 'autofix.yml'), 'utf8');
+    // Sentinel content rather than a generated file: only an untouched file stays unequal to what
+    // the generator would have written, which is what proves nothing deleted or rewrote it.
+    const sentinel = 'name: Sentinel\non: push\njobs: {}\n';
+    await fs.promises.writeFile(path.join(workflowsPath, 'autofix-apply.yml'), sentinel);
 
     // Exactly what getPackageConfig produces for a public repository whose lookup failed.
     await generateWorkflows(createConfig({ dirPath, isRoot: true, isPublicRepo: false, isRepoVisibilityKnown: false }));
     await promisePool.promiseAll();
 
     expect(await fs.promises.readFile(path.join(workflowsPath, 'autofix.yml'), 'utf8')).toBe(publicAutofix);
+    expect(await fs.promises.readFile(path.join(workflowsPath, 'autofix-apply.yml'), 'utf8')).toBe(sentinel);
+  } finally {
+    await fs.promises.rm(dirPath, { recursive: true, force: true });
+  }
+});
+
+test('unknown repository visibility creates neither autofix workflow from scratch', async () => {
+  const dirPath = await generateInto({ isPublicRepo: false, isRepoVisibilityKnown: false });
+  try {
+    const workflowsPath = path.join(dirPath, '.github', 'workflows');
+    // Guessing either way would commit a workflow the repository may not be allowed to have.
+    expect(fs.existsSync(path.join(workflowsPath, 'autofix.yml'))).toBe(false);
     expect(fs.existsSync(path.join(workflowsPath, 'autofix-apply.yml'))).toBe(false);
+    // The rest of the mandatory set is unaffected by the visibility guard.
+    expect(fs.existsSync(path.join(workflowsPath, 'test.yml'))).toBe(true);
   } finally {
     await fs.promises.rm(dirPath, { recursive: true, force: true });
   }

--- a/packages/wbfy/test/unit/autofixWorkflow.test.ts
+++ b/packages/wbfy/test/unit/autofixWorkflow.test.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 import { load as loadYaml } from 'js-yaml';
 import { expect, test } from 'vitest';
 
+import type { PackageConfig } from '../../src/packageConfig.js';
+
 import { generateWorkflows } from '../../src/generators/workflow.js';
 import { promisePool } from '../../src/utils/promisePool.js';
 import { createConfig } from '../helpers/testConfig.js';
@@ -26,6 +28,71 @@ test('generates a public autofix workflow that can run wb with fnox on CI', asyn
     const workflow = loadYaml(content) as { jobs: { autofix: { env?: Record<string, string>; steps?: unknown[] } } };
     expect(workflow.jobs.autofix.env).toEqual({ WB_ENV: 'development' });
     expect(workflow.jobs.autofix.steps).toContainEqual({ uses: 'jdx/mise-action@v4.2.0', with: { cache: true } });
+  } finally {
+    await fs.promises.rm(dirPath, { recursive: true, force: true });
+  }
+});
+
+// The two autofix paths are mutually exclusive and chosen purely by repository visibility, which
+// nothing else in the build can check: a wrong choice silently leaves a repository with no working
+// autofix (or, worse, a public repository calling the private App-based one).
+async function generateInto(overrides: Partial<PackageConfig>): Promise<string> {
+  const tempRootPath = path.join(process.cwd(), '.tmp');
+  await fs.promises.mkdir(tempRootPath, { recursive: true });
+  const dirPath = await fs.promises.mkdtemp(path.join(tempRootPath, 'wbfy-autofix-'));
+  await fs.promises.mkdir(path.join(dirPath, '.github', 'workflows'), { recursive: true });
+  await generateWorkflows(createConfig({ dirPath, isRoot: true, ...overrides }));
+  await promisePool.promiseAll();
+  return dirPath;
+}
+
+test('a private repository gets the App-based apply workflow instead of autofix.ci', async () => {
+  const dirPath = await generateInto({ isPublicRepo: false });
+  try {
+    const workflowsPath = path.join(dirPath, '.github', 'workflows');
+    expect(fs.existsSync(path.join(workflowsPath, 'autofix.yml'))).toBe(false);
+
+    const content = await fs.promises.readFile(path.join(workflowsPath, 'autofix-apply.yml'), 'utf8');
+    const workflow = loadYaml(content) as {
+      on: { workflow_run: { workflows: string[]; types: string[] } };
+      permissions: Record<string, string>;
+      jobs: { apply: { uses: string; secrets: Record<string, string> } };
+    };
+    expect(workflow.on.workflow_run).toEqual({ workflows: ['Test'], types: ['completed'] });
+    // A called workflow can only reduce the caller's token, so actions:read must be granted here
+    // or the apply job cannot read the triggering run's artifact.
+    expect(workflow.permissions).toEqual({ actions: 'read', contents: 'read' });
+    expect(workflow.jobs.apply.uses).toBe('WillBooster/reusable-workflows/.github/workflows/autofix-apply.yml@main');
+    // The App ID is a constant in the callee, so the key is the only thing a caller passes.
+    expect(workflow.jobs.apply.secrets).toEqual({
+      AUTOFIX_APP_PRIVATE_KEY: '${{ secrets.AUTOFIX_APP_PRIVATE_KEY }}',
+    });
+  } finally {
+    await fs.promises.rm(dirPath, { recursive: true, force: true });
+  }
+});
+
+test('a public repository keeps autofix.ci and gets no apply workflow', async () => {
+  const dirPath = await generateInto({ isPublicRepo: true });
+  try {
+    const workflowsPath = path.join(dirPath, '.github', 'workflows');
+    expect(fs.existsSync(path.join(workflowsPath, 'autofix.yml'))).toBe(true);
+    expect(fs.existsSync(path.join(workflowsPath, 'autofix-apply.yml'))).toBe(false);
+  } finally {
+    await fs.promises.rm(dirPath, { recursive: true, force: true });
+  }
+});
+
+test("the test caller keeps the permissions the reusable workflow's other steps still need", async () => {
+  const dirPath = await generateInto({ isPublicRepo: false });
+  try {
+    const content = await fs.promises.readFile(path.join(dirPath, '.github', 'workflows', 'test.yml'), 'utf8');
+    const workflow = loadYaml(content) as { permissions: Record<string, string>; on: Record<string, unknown> };
+    // contents:write for semantic-release --dry-run's push check, actions:write for the test job's
+    // skip-duplicate-actions cancel_others and the autofix/wbfy dispatch. Dropping either because
+    // "test.yml no longer pushes" breaks callers.
+    expect(workflow.permissions).toMatchObject({ actions: 'write', contents: 'write', statuses: 'write' });
+    expect(workflow.on).toHaveProperty('workflow_dispatch');
   } finally {
     await fs.promises.rm(dirPath, { recursive: true, force: true });
   }

--- a/packages/wbfy/test/unit/autofixWorkflow.test.ts
+++ b/packages/wbfy/test/unit/autofixWorkflow.test.ts
@@ -36,16 +36,6 @@ test('generates a public autofix workflow that can run wb with fnox on CI', asyn
 // The two autofix paths are mutually exclusive and chosen purely by repository visibility, which
 // nothing else in the build can check: a wrong choice silently leaves a repository with no working
 // autofix (or, worse, a public repository calling the private App-based one).
-async function generateInto(overrides: Partial<PackageConfig>): Promise<string> {
-  const tempRootPath = path.join(process.cwd(), '.tmp');
-  await fs.promises.mkdir(tempRootPath, { recursive: true });
-  const dirPath = await fs.promises.mkdtemp(path.join(tempRootPath, 'wbfy-autofix-'));
-  await fs.promises.mkdir(path.join(dirPath, '.github', 'workflows'), { recursive: true });
-  await generateWorkflows(createConfig({ dirPath, isRoot: true, ...overrides }));
-  await promisePool.promiseAll();
-  return dirPath;
-}
-
 test('a private repository gets the App-based apply workflow instead of autofix.ci', async () => {
   const dirPath = await generateInto({ isPublicRepo: false });
   try {
@@ -97,3 +87,33 @@ test("the test caller keeps the permissions the reusable workflow's other steps 
     await fs.promises.rm(dirPath, { recursive: true, force: true });
   }
 });
+
+// A failed GitHub lookup collapses isPublicRepo to false. Because this branch both deletes one
+// workflow and creates the other, guessing "private" would strip a public repository's autofix.ci
+// setup and hand it the App-based workflow that refuses fork pull requests.
+test('unknown repository visibility leaves both autofix workflows untouched', async () => {
+  const dirPath = await generateInto({ isPublicRepo: true });
+  try {
+    const workflowsPath = path.join(dirPath, '.github', 'workflows');
+    const publicAutofix = await fs.promises.readFile(path.join(workflowsPath, 'autofix.yml'), 'utf8');
+
+    // Exactly what getPackageConfig produces for a public repository whose lookup failed.
+    await generateWorkflows(createConfig({ dirPath, isRoot: true, isPublicRepo: false, isRepoVisibilityKnown: false }));
+    await promisePool.promiseAll();
+
+    expect(await fs.promises.readFile(path.join(workflowsPath, 'autofix.yml'), 'utf8')).toBe(publicAutofix);
+    expect(fs.existsSync(path.join(workflowsPath, 'autofix-apply.yml'))).toBe(false);
+  } finally {
+    await fs.promises.rm(dirPath, { recursive: true, force: true });
+  }
+});
+
+async function generateInto(overrides: Partial<PackageConfig>): Promise<string> {
+  const tempRootPath = path.join(process.cwd(), '.tmp');
+  await fs.promises.mkdir(tempRootPath, { recursive: true });
+  const dirPath = await fs.promises.mkdtemp(path.join(tempRootPath, 'wbfy-autofix-'));
+  await fs.promises.mkdir(path.join(dirPath, '.github', 'workflows'), { recursive: true });
+  await generateWorkflows(createConfig({ dirPath, isRoot: true, ...overrides }));
+  await promisePool.promiseAll();
+  return dirPath;
+}


### PR DESCRIPTION
## Customer Summary

- Private repositories get a new `.github/workflows/autofix-apply.yml`. It is what makes CI's automatic formatter/linter fixes land on a pull request again, now pushed by a GitHub App so every required check re-runs on the fixed commit.
- Public repositories are unchanged: they keep using autofix.ci, which already pushes through its own App and additionally handles fork pull requests.
- Repositories need one new organization secret, `AUTOFIX_APP_PRIVATE_KEY`. Until it is registered, CI simply fails with the diff instead of fixing it — nothing breaks.
- When wbfy cannot confirm a repository's visibility (offline, rate-limited, or a credential without access), it now leaves both autofix workflows alone rather than guessing.

## Technical Summary

Follows WillBooster/reusable-workflows#480, which split producing an autofix patch from committing it.

- Adds an `autofix-apply` workflow kind: `workflow_run` on the `Test` workflow, `permissions: {actions: read, contents: read}`, calling `WillBooster/reusable-workflows/.github/workflows/autofix-apply.yml@main`.
- Adds it to `mandatoryKinds` and generalizes the visibility branch: whichever autofix kind does not apply is deleted, so a public repository loses `autofix-apply.yml` and a private one loses `autofix.yml`.
- **Guards that branch on `isRepoVisibilityKnown`.** `isPublicRepo` is `repoInfo?.private === false`, so it collapses to `false` on a failed lookup. Unlike the merge-based generators, this branch both *deletes* one file and *creates* the other, so guessing "private" would strip a public repository's autofix.ci workflow and hand it the App-based one that refuses fork pull requests. When visibility is unknown both kinds are dropped with a warning and no removal, mirroring the existing wbfy-caller guard.
- Injects `AUTOFIX_APP_PRIVATE_KEY` for callers of `autofix-apply`, keyed on the *called* reusable workflow like the existing injections. No App ID is passed: it is a constant in the callee, public information, and useless without the key.
- Corrects the now-stale permission rationales on the generated `test` caller, in **both** places that reason about them.

## Why

`test.yml` no longer pushes autofix commits itself; it uploads a patch that a separate `workflow_run` job commits as a GitHub App. Without this generator change no private repository has that job, so autofix stops applying (fail-closed: CI shows the diff and fails, the same as GitHub-hosted runs already did).

The permission comments matter beyond documentation, and the review round found two of them wrong before this landed:

- `contents: write` **must stay**: semantic-release calls `verifyAuth()` unconditionally — not gated on `--dry-run` — which performs `git push --dry-run` and aborts with `EGITNOPERMISSION` without it. Callers such as prompt-study, build-ts and agentic-workflows reach that step.
- `actions: write` **must stay**, but only because of the test job's `fkirc/skip-duplicate-actions` call with `cancel_others: true`. The reusable `test.yml` declares no `permissions:` of its own, so its jobs run on the caller's token. Being a `workflow_dispatch` *target* needs only the trigger — the dispatch API call requires `actions: write` on the *dispatcher's* token, which `wbfy.yml` declares on its own push job.
- The `test-rust` `delete newSettings.permissions?.actions` is a migration for legacy on-disk files: that template declares no `permissions` at all, so it is a no-op for a freshly generated caller.

## Testing

- `bun verify` — passed (install, lint with `oxlint --type-aware --type-check`, `tsc --noEmit`).
- `bun wb test` in `packages/wbfy` — 29 files / 301 tests passed, including six cases in `test/unit/autofixWorkflow.test.ts`.
- **Every new guard was verified against the mutation it exists to catch**, not just asserted:
  - replacing the visibility guard with `if (true)` fails "unknown repository visibility leaves existing autofix workflows byte-identical";
  - adding a `removeConfined` inside the else branch fails the same test (it seeds *sentinel* content, so only an untouched file compares equal);
  - removing `fileNamesByKind.delete('autofix')` fails "creates neither autofix workflow from scratch";
  - deleting the `removeConfined` call for the obsolete kind fails the private and public tests — which it did **not** before the tests were changed to seed the file that must disappear (`fs.promises.rm` uses `force: true`, so removing a nonexistent path is silent).
- End-to-end against real repositories, running this local checkout on scratch clones: `WillBooster/prompt-study` (private) → `autofix-apply.yml` generated exactly as expected, `autofix.yml` absent, `test.yml` unchanged; `WillBooster/gen-i18n-ts` (public) → a seeded `autofix-apply.yml` removed, `autofix.yml` regenerated with the pinned `autofix-ci/action`.
- Empirically confirmed a freshly generated `test-rust.yml` has no `permissions` block, which is what makes the migration comment accurate.
- Reviewed across 9 rounds by Codex, Claude Code and Antigravity until all three reported no concern; 6 findings fixed.

## Notes

- **Merge prerequisite: the WillBoosterLab mirror must be synced first.** `normalizeJob` rewrites the callee to `WillBoosterLab/reusable-workflows/...` for Lab repositories, and that mirror does not yet contain `autofix-apply.yml` (`gh api repos/WillBoosterLab/reusable-workflows/contents/.github/workflows/autofix-apply.yml?ref=main` → 404; its HEAD is `sync .../3beb8ade`, older than the source's `94ecbe7`). A Lab repository wbfy-ified before the sync would get a `startup_failure` on every completed `Test` run. The repository owner is running `bun run sync` in reusable-workflows.
- `AUTOFIX_APP_PRIVATE_KEY` must be registered as an **organization** secret by an org admin per `guidelines-for-mise-fnox`; the WillBooster Autofixer App (`4388928`) is already installed organization-wide.
- The generated caller triggers on `workflow_run.workflows: ['Test']`, matching the `name:` of the wbfy-generated test caller rather than its filename. A repository that renames its test workflow silently stops triggering the apply workflow; accepted, since wbfy owns that name and hard-coding it keeps the caller free of inputs.
- Only self-hosted runs currently produce a patch (the reusable workflow declines on hosted runners, where the checkout is the pull-request merge ref), so the apply workflow is a no-op there.
- Out of scope, found during review and left alone: `writeWorkflowYaml`'s `case 'release'` still branches on `isPublicRepo` alone and deletes `permissions['id-token']`, so a public repository whose lookup fails loses `id-token: write` from its existing `release.yml` until a later successful run. Verified pre-existing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
