### PR TITLE
feat(wbfy): strip retired push-back leftovers from test callers

### DIFF
--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -82,7 +82,7 @@ const workflows = {
     on: {
       pull_request: null,
       push: {
-        branches: ['main', 'wbfy'],
+        branches: ['main'],
       },
       // Nothing dispatches this caller any more (the workflows that pushed back and re-triggered
       // it are retired); the trigger stays only so a maintainer can re-run the tests by hand.
@@ -115,7 +115,7 @@ const workflows = {
     on: {
       pull_request: null,
       push: {
-        branches: ['main', 'wbfy'],
+        branches: ['main'],
       },
     },
     concurrency: {
@@ -507,12 +507,21 @@ async function writeWorkflowYaml(
       if (kind === 'test-rust') {
         delete newSettings.permissions?.actions;
       }
+      // `statuses: write` served the aggregate commit status the reusable test workflow posted
+      // for its retired push-back dispatch runs; older wbfy-generated callers still carry it, and
+      // the array-combining merge would keep it forever without this delete.
+      delete newSettings.permissions?.statuses;
       if (newSettings.on?.pull_request) {
         delete newSettings.on.pull_request['paths-ignore'];
       }
       if (newSettings.on?.push) {
         delete newSettings.on.push['paths-ignore'];
-        newSettings.on.push.branches = newSettings.on.push.branches.filter((branch) => branch !== 'renovate/**');
+        // The `wbfy` push branch existed for the retired nightly self-applying wbfy caller, which
+        // pushed that branch directly; wbfy runs now arrive as pull requests covered by the
+        // pull_request trigger, so the branch entry merged in from older callers is stripped.
+        newSettings.on.push.branches = newSettings.on.push.branches.filter(
+          (branch) => branch !== 'renovate/**' && branch !== 'wbfy'
+        );
       }
       break;
     }

--- a/packages/wbfy/test/unit/wbfyWorkflow.test.ts
+++ b/packages/wbfy/test/unit/wbfyWorkflow.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { load } from 'js-yaml';
 import { expect, test } from 'vitest';
 
 import { generateWorkflows } from '../../src/generators/workflow.js';
@@ -60,6 +61,39 @@ jobs:
       expect(fs.existsSync(path.join(workflowsPath, 'wbfy.yml'))).toBe(false);
     });
   }
+});
+
+test('strips the retired push-back leftovers from an existing test caller', async () => {
+  await withTempRepo(async (dirPath, workflowsPath) => {
+    await fs.promises.writeFile(
+      path.join(workflowsPath, 'test.yml'),
+      `name: Test
+on:
+  pull_request:
+  push:
+    branches: [main, wbfy]
+  workflow_dispatch:
+permissions:
+  actions: write
+  contents: write
+  pull-requests: read
+  statuses: write
+jobs:
+  test:
+    uses: WillBooster/reusable-workflows/.github/workflows/test.yml@main
+`
+    );
+    const config = createConfig({ dirPath, isRoot: true });
+    await generateWorkflows(config);
+    await promisePool.promiseAll();
+
+    const generated = load(await fs.promises.readFile(path.join(workflowsPath, 'test.yml'), 'utf8')) as {
+      on: { push: { branches: string[] } };
+      permissions: Record<string, string>;
+    };
+    expect(generated.on.push.branches).toEqual(['main']);
+    expect(generated.permissions).toEqual({ actions: 'write', contents: 'write', 'pull-requests': 'read' });
+  });
 });
 
 test('keeps a custom workflow that merely shares the wbfy.yml file name', async () => {


### PR DESCRIPTION
## Customer Summary

- Repositories regenerated by wbfy no longer keep CI wiring that only served the retired automated-fix flows: the `wbfy` push-branch trigger and the `statuses: write` permission disappear from test workflow callers.
- No behavior change for day-to-day development; pull-request test runs are unaffected.

## Technical Summary

- Removed `wbfy` from the `on.push.branches` of the test / test-rust caller templates in `packages/wbfy/src/generators/workflow.ts`, and filter the merged-in `wbfy` entry out of existing callers (alongside the existing `renovate/**` filter).
- Delete a merged-in `permissions.statuses` from test / test-rust callers; the existing empty-permissions cleanup in `writeYaml` drops the object when it empties.
- Added a unit test pinning that an existing caller with `branches: [main, wbfy]` and `statuses: write` regenerates without them.

## Why

- The nightly self-applying wbfy caller pushed a branch named `wbfy` (hence the push trigger), and the reusable test workflow posted an aggregate commit status for autofix push-back dispatch runs (hence `statuses: write`). Both flows are retired (reusable-workflows#484/#485, shared#1110/#1112), but wbfy's array-combining merge preserved these leftovers from older callers forever, so the fleet-wide wbfy run would never converge callers to the post-retirement shape.

## Testing

- `bun run vitest run test/unit` in `packages/wbfy` (30 files / 307 tests passed, including the new case).
- `bun verify` at the repository root.
