### PR TITLE
feat(wb): pass the project's declared env vars into Docker containers

### DIFF
--- a/packages/wb/src/commands/railwayEnv.ts
+++ b/packages/wb/src/commands/railwayEnv.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import type { ArgumentsCamelCase, Argv, CommandModule, InferredOptionTypes } from 'yargs';
 
 import { findSelfProject } from '../project.js';
+import { selectFnoxSourcedKeys } from '../utils/envSources.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 
 // Railway injects its own system variables and platform-managed values; never mirror those back,
@@ -14,15 +15,6 @@ const NON_RAILWAY_KEY_PREFIXES = ['RAILWAY_', 'NIXPACKS_'];
 
 function isNonRailwayKey(key: string): boolean {
   return NON_RAILWAY_KEYS.has(key) || NON_RAILWAY_KEY_PREFIXES.some((prefix) => key.startsWith(prefix));
-}
-
-/**
- * The keys actually declared in the project's fnox sources. `mise env` is reported as a
- * pseudo-source that mixes in host/tool variables (PATH, CARGO_HOME, RUSTUP_*, ...); those must
- * never be pushed to Railway, so they are excluded here (mirrors wb deploy).
- */
-export function selectFnoxSourcedKeys(envSources: ReadonlyArray<readonly [string, readonly string[]]>): Set<string> {
-  return new Set(envSources.filter(([source]) => !source.startsWith('mise env')).flatMap(([, keys]) => keys));
 }
 
 /**

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -17,6 +17,7 @@ import type { PackageJson } from 'type-fest';
 
 import { prependNodeModulesBinToPath } from './utils/binPath.js';
 import { isCI } from './utils/ci.js';
+import { selectFnoxSourcedKeys } from './utils/envSources.js';
 import { findWranglerConfigPath } from './utils/wrangler.js';
 
 /** The file `wrangler types` writes by default. */
@@ -132,6 +133,25 @@ export class Project {
   get dockerImageName(): string {
     const name = this.packageJson.name || 'unknown';
     return name.replaceAll('@', '').replaceAll('/', '-');
+  }
+
+  private declaredEnvKeyCache: Set<string> | undefined;
+
+  /**
+   * The names of the environment variables the PROJECT declares (its fnox/.env sources), excluding
+   * both the ambient process environment and the `mise env` pseudo-source that reports host/tool
+   * variables such as PATH. `env` cannot answer this: it merges process.env, so a project variable
+   * is indistinguishable from an inherited one there.
+   */
+  get declaredEnvKeys(): Set<string> {
+    if (this.declaredEnvKeyCache) return this.declaredEnvKeyCache;
+    if (!this.loadEnv) {
+      this.declaredEnvKeyCache = new Set();
+      return this.declaredEnvKeyCache;
+    }
+    const [, envSources] = readEnvironmentVariables(this.argv, this.dirPath, { ignoreProcessEnv: true });
+    this.declaredEnvKeyCache = selectFnoxSourcedKeys(envSources);
+    return this.declaredEnvKeyCache;
   }
 
   // Cached in a plain field rather than with @memoizeOne: that decorator keys its cache on a hash

--- a/packages/wb/src/scripts/dockerScripts.ts
+++ b/packages/wb/src/scripts/dockerScripts.ts
@@ -32,7 +32,7 @@ class DockerScripts {
     spawnSyncOnExit(this.stop(project), project);
     const allocateTty = additionalArgs.includes('/bin/bash');
     const miseAgeKeyEnvOption = project.env.MISE_AGE_KEY ? '--env MISE_AGE_KEY ' : '';
-    return `docker run --rm ${allocateTty ? '-it ' : ''}${miseAgeKeyEnvOption}--publish ${project.env.PORT}:8080 --name ${project.dockerImageName} ${additionalOptions} ${project.dockerImageName} ${additionalArgs}`;
+    return `docker run --rm ${allocateTty ? '-it ' : ''}${miseAgeKeyEnvOption}${selectContainerEnvOptions(project)}--publish ${project.env.PORT}:8080 --name ${project.dockerImageName} ${additionalOptions} ${project.dockerImageName} ${additionalArgs}`;
   }
 
   stop(project: Project): string {
@@ -45,3 +45,30 @@ class DockerScripts {
 }
 
 export const dockerScripts = new DockerScripts();
+
+// Variables the IMAGE itself owns: a Dockerfile pins the container port (the published mapping
+// targets 8080, not the host-side PORT) and the runtime mode it was built for, and before fnox the
+// baked .env files lost to those `ENV` values too because process.env wins over env sources.
+const IMAGE_OWNED_KEYS = new Set(['NODE_ENV', 'PORT']);
+
+/**
+ * `docker run --env KEY` options for every variable the project declares, so a container gets the
+ * app's environment. Since fnox replaced the .env files that images used to bake in — the age key
+ * that decrypts them must never enter a container — a container would otherwise start with no
+ * configuration at all. Only NAMES are passed: docker then forwards each value from wb's own
+ * environment, keeping secrets out of the command line (visible in `ps` output and CI logs).
+ */
+function selectContainerEnvOptions(project: Project): string {
+  const options = selectContainerEnvKeys(project.declaredEnvKeys, project.env).map((key) => `--env ${key}`);
+  return options.length > 0 ? `${options.join(' ')} ` : '';
+}
+
+/** The declared variables to forward into a container, sorted for a stable command. */
+export function selectContainerEnvKeys(
+  declaredEnvKeys: ReadonlySet<string>,
+  env: Record<string, string | undefined>
+): string[] {
+  return [...declaredEnvKeys]
+    .filter((key) => !IMAGE_OWNED_KEYS.has(key) && env[key] !== undefined)
+    .toSorted((a, b) => a.localeCompare(b));
+}

--- a/packages/wb/src/utils/envSources.ts
+++ b/packages/wb/src/utils/envSources.ts
@@ -1,0 +1,8 @@
+/**
+ * The keys actually declared in the project's fnox sources. `mise env` is reported as a
+ * pseudo-source that mixes in host/tool variables (PATH, CARGO_HOME, RUSTUP_*, ...); those must
+ * never be treated as the project's own variables, so they are excluded here.
+ */
+export function selectFnoxSourcedKeys(envSources: ReadonlyArray<readonly [string, readonly string[]]>): Set<string> {
+  return new Set(envSources.filter(([source]) => !source.startsWith('mise env')).flatMap(([, keys]) => keys));
+}

--- a/packages/wb/test/unit/railwayEnv.test.ts
+++ b/packages/wb/test/unit/railwayEnv.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { selectFnoxSourcedKeys, selectRailwayVariables } from '../../src/commands/railwayEnv.js';
+import { selectRailwayVariables } from '../../src/commands/railwayEnv.js';
+import { selectFnoxSourcedKeys } from '../../src/utils/envSources.js';
 
 describe('selectFnoxSourcedKeys', () => {
   it('keeps fnox-declared keys and drops mise-provided host/tool variables', () => {

--- a/packages/wb/test/unit/scripts/dockerScripts.test.ts
+++ b/packages/wb/test/unit/scripts/dockerScripts.test.ts
@@ -7,7 +7,20 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { Project } from '../../../src/project.js';
-import { dockerScripts } from '../../../src/scripts/dockerScripts.js';
+import { dockerScripts, selectContainerEnvKeys } from '../../../src/scripts/dockerScripts.js';
+
+describe('selectContainerEnvKeys', () => {
+  it('forwards the declared variables but never the ones the image owns', () => {
+    const keys = selectContainerEnvKeys(new Set(['DATABASE_URL', 'NODE_ENV', 'PORT', 'APP_ORIGIN', 'UNRESOLVED']), {
+      APP_ORIGIN: 'https://example.com',
+      DATABASE_URL: 'file:./test.sqlite3',
+      NODE_ENV: 'test',
+      PATH: '/usr/bin',
+      PORT: '3000',
+    });
+    expect(keys).toEqual(['APP_ORIGIN', 'DATABASE_URL']);
+  });
+});
 
 describe.runIf(isDockerAvailable())('dockerScripts', () => {
   it('removes a non-running container before reuse', async () => {


### PR DESCRIPTION
## 背景

fnox 移行後、Docker イメージにはアプリの環境変数が焼き込まれません（fnox の秘密情報を復号する age 鍵をコンテナへ持ち込むことは禁止されているため）。その結果、`wb` が起動する `docker run`（`wb start --mode docker` など）は環境変数を一切持たないコンテナを立ち上げ、最初に必要になった値で失敗します。WillBooster/survey-system の fnox 移行（WillBooster/survey-system#538）で判明しました。

## 変更

- `docker run` に、プロジェクトが宣言している環境変数それぞれの `--env <KEY>` を渡します。**名前のみ**を渡すため、値は wb 自身の環境から docker が引き継ぎ、コマンドライン（`ps` 出力や CI ログ）には現れません。
- `NODE_ENV` と `PORT` はイメージ側が所有するため除外します（公開ポートのマッピングはイメージのポートを指しており、fnox 以前も焼き込まれた `.env` より Dockerfile の `ENV` が優先されていました）。
- `Project#declaredEnvKeys` を追加。`env` はプロセス環境をマージしてしまうため、プロジェクト自身が宣言した変数を区別できません。
- `selectFnoxSourcedKeys` を `railwayEnv.ts` から `utils/envSources.ts` へ移動（`project.ts` からコマンドモジュールを import しないため）。

`docker build` には何も渡していません: ビルド引数はイメージ履歴に残るため、秘密情報を焼き込まないためです。

## テスト

- `selectContainerEnvKeys` のユニットテストを追加。
- survey-system（fnox 移行済み、`.env` を焼き込まない Dockerfile）で、ローカルビルドした wb が生成する `docker run --env <NAME> ...` を実行し、コンテナが prisma のマイグレーション・シードを完了して HTTP 200 を返すことを確認しました。`wb start --mode docker` が生成するコマンド文字列も期待どおり（`PORT` と `NODE_ENV` は除外）です。
