### PR TITLE
feat: close both Takumi Guard gaps for self-contained repositories

### DIFF
--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -32,9 +32,12 @@ export const genCodeCommand: CommandModule = {
 
     // Before the early return below: `gen-code` is the `postinstall` script wbfy generates, making
     // this the first wb code that runs after bun may have rewritten the lockfile, and a repository
-    // with nothing to generate needs the normalization just as much.
+    // with nothing to generate needs the normalization just as much. `rootDirPath` rather than
+    // `projects.root.dirPath`: bun runs a workspace package's postinstall from that package's
+    // directory, and findRootAndSelfProjects only climbs out of `packages/*`, so a workspace such
+    // as `apps/web` would otherwise look for `apps/web/bun.lock` instead of the repository's.
     if (!argv.dryRun) {
-      normalizeBunLockfile(projects.root.dirPath);
+      normalizeBunLockfile(projects.self.rootDirPath);
     }
 
     const genCodeTargets = projects.descendants

--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -9,6 +9,7 @@ import { findDescendantProjects } from '../project.js';
 import { findDrizzleConfig, wrapWithDrizzleConfigDir } from '../scripts/drizzleScripts.js';
 import { prismaScripts } from '../scripts/prismaScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
+import { normalizeBunLockfile } from '../utils/bunLockfile.js';
 import { writeWorkerTypesEnvStub } from '../utils/workerTypesEnv.js';
 
 const builder = {} as const;
@@ -27,6 +28,13 @@ export const genCodeCommand: CommandModule = {
     if (!projects) {
       console.error(chalk.red('No project found.'));
       process.exit(1);
+    }
+
+    // Before the early return below: `gen-code` is the `postinstall` script wbfy generates, making
+    // this the first wb code that runs after bun may have rewritten the lockfile, and a repository
+    // with nothing to generate needs the normalization just as much.
+    if (!argv.dryRun) {
+      normalizeBunLockfile(projects.root.dirPath);
     }
 
     const genCodeTargets = projects.descendants

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -9,6 +9,7 @@ import type { Project } from '../project.js';
 import { findDescendantProjects, findRootAndSelfProjects, findSelfProject } from '../project.js';
 import { configureEnv } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { normalizeBunLockfile } from '../utils/bunLockfile.js';
 
 import { buildLintCommand, lint, type LintCommandArgv } from './lint.js';
 import { test, type TestCommandArgv, withDefaultTestCascadeEnv } from './test.js';
@@ -80,6 +81,11 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv, steps: 
   await runStep(steps, { detail: installCommand, name: 'install' }, () =>
     runPackageCommand(installCommand, project, argv)
   );
+  // The repository may have no `gen-code` script (where the same normalization runs at postinstall),
+  // and `verify` is the command a developer runs before committing.
+  if (!argv.dryRun) {
+    normalizeBunLockfile(project.rootDirPath);
+  }
   if (project.packageJson.scripts?.['gen-code']) {
     const genCodeCommand = `${project.packageManagerCommand} gen-code`;
     await runStep(steps, { detail: genCodeCommand, name: 'gen-code' }, () =>

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -78,13 +78,20 @@ async function verifyCodeFully(project: Project, argv: VerifyCodeCommandArgv, st
 
 async function verifyCode(project: Project, argv: VerifyCodeCommandArgv, steps: VerifyStep[]): Promise<void> {
   const installCommand = `${project.packageManagerCommand} install`;
-  await runStep(steps, { detail: installCommand, name: 'install' }, () =>
-    runPackageCommand(installCommand, project, argv)
+  // `allowFailure` so a failed install still reaches the normalization below: bun rewrites the
+  // lockfile before running lifecycle scripts, so a script failure would otherwise leave Guard
+  // URLs in the working tree. The failure is reported and exits exactly as runPackageCommand would.
+  const installExitCode = await runStep(steps, { detail: installCommand, name: 'install' }, () =>
+    runPackageCommand(installCommand, project, argv, { allowFailure: true })
   );
   // The repository may have no `gen-code` script (where the same normalization runs at postinstall),
   // and `verify` is the command a developer runs before committing.
   if (!argv.dryRun) {
     normalizeBunLockfile(project.rootDirPath);
+  }
+  if (installExitCode !== 0) {
+    console.info(chalk.red(chalk.bold(`Failed (exit code ${installExitCode}):`), installCommand));
+    process.exit(installExitCode);
   }
   if (project.packageJson.scripts?.['gen-code']) {
     const genCodeCommand = `${project.packageManagerCommand} gen-code`;

--- a/packages/wb/src/utils/bunLockfile.ts
+++ b/packages/wb/src/utils/bunLockfile.ts
@@ -1,10 +1,16 @@
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
 import chalk from 'chalk';
 
-/** A Takumi Guard URL can only appear in bun.lock as a package's `resolved` value. */
-const guardResolvedUrlPattern = /"https:\/\/npm\.flatt\.tech\/[^"]*"/g;
+/**
+ * Anchored to `", ` so it only clears a registry entry's `resolved` slot, mirroring
+ * reusable-workflows' normalization: a DIRECT tarball dependency would carry the same host in two
+ * other places that must survive — the workspace descriptor (`"pkg": "https://…"`, preceded by
+ * `": `) and its package tuple's first element (`"pkg@https://…"`).
+ */
+const guardResolvedUrlPattern = /(", )"https:\/\/npm\.flatt\.tech\/[^"]*"/g;
 
 /**
  * Strip Takumi Guard proxy URLs from the root `bun.lock`, returning whether the file changed.
@@ -35,10 +41,18 @@ export function normalizeBunLockfile(rootDirPath: string): boolean {
     return false;
   }
 
-  const normalizedContent = content.replaceAll(guardResolvedUrlPattern, '""');
+  const normalizedContent = content.replaceAll(guardResolvedUrlPattern, '$1""');
   if (normalizedContent === content) return false;
 
-  fs.writeFileSync(lockfilePath, normalizedContent);
+  // A sibling temp file makes the replacement an atomic same-directory rename, so an interrupted
+  // write cannot leave a truncated bun.lock behind (same strategy as wbfy's lefthook generator).
+  const temporaryPath = `${lockfilePath}.wb-normalizing.${process.pid}.${crypto.randomUUID()}`;
+  try {
+    fs.writeFileSync(temporaryPath, normalizedContent, { mode: fs.statSync(lockfilePath).mode });
+    fs.renameSync(temporaryPath, lockfilePath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
   console.info(chalk.green(`Removed Takumi Guard proxy URLs from ${lockfilePath} to keep it registry-agnostic.`));
   return true;
 }

--- a/packages/wb/src/utils/bunLockfile.ts
+++ b/packages/wb/src/utils/bunLockfile.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import chalk from 'chalk';
+
+/** A Takumi Guard URL can only appear in bun.lock as a package's `resolved` value. */
+const guardResolvedUrlPattern = /"https:\/\/npm\.flatt\.tech\/[^"]*"/g;
+
+/**
+ * Strip Takumi Guard proxy URLs from the root `bun.lock`, returning whether the file changed.
+ *
+ * bun records an absolute `resolved` URL for an already-locked package whenever the configured
+ * registry does not serve the tarball host named in the package metadata — which is exactly what
+ * the Takumi Guard proxy does. So any install run with Guard as the DEFAULT registry (CI, or a
+ * developer who put it in ~/.npmrc) bakes npm.flatt.tech URLs into the lockfile, and committing
+ * them pins a SHARED lockfile to one environment's mirror: every later install downloads through
+ * the proxy, and a cold-cache install fails outright with 401 for anyone whose npmrc carries a
+ * registry.npmjs.org token, because bun sends the default registry's credentials to whatever host
+ * the lockfile names. Guard coverage does not depend on these URLs — with an empty `resolved`, bun
+ * derives the download URL from the configured registry — so they are pure damage.
+ *
+ * wbfy generates a pre-commit hook that strips the same URLs, but that only fires at `git commit`.
+ * Running this right after an install closes the window in between, where the rewritten lockfile is
+ * simply the working tree's state: a bypassed hook, a commit from a tool that does not run hooks,
+ * or a diff read by a human or an agent all see it. Only the Guard host is stripped; a scoped
+ * registry such as Verdaccio legitimately records its own URL for private packages.
+ */
+export function normalizeBunLockfile(rootDirPath: string): boolean {
+  const lockfilePath = path.join(rootDirPath, 'bun.lock');
+  let content: string;
+  try {
+    content = fs.readFileSync(lockfilePath, 'utf8');
+  } catch {
+    // A yarn/npm project, or a repository whose lockfile is gitignored: nothing to normalize.
+    return false;
+  }
+
+  const normalizedContent = content.replaceAll(guardResolvedUrlPattern, '""');
+  if (normalizedContent === content) return false;
+
+  fs.writeFileSync(lockfilePath, normalizedContent);
+  console.info(chalk.green(`Removed Takumi Guard proxy URLs from ${lockfilePath} to keep it registry-agnostic.`));
+  return true;
+}

--- a/packages/wb/src/utils/bunLockfile.ts
+++ b/packages/wb/src/utils/bunLockfile.ts
@@ -48,7 +48,8 @@ export function normalizeBunLockfile(rootDirPath: string): boolean {
   // write cannot leave a truncated bun.lock behind (same strategy as wbfy's lefthook generator).
   const temporaryPath = `${lockfilePath}.wb-normalizing.${process.pid}.${crypto.randomUUID()}`;
   try {
-    const mode = fs.statSync(lockfilePath).mode;
+    // `& 0o777`: stat's mode carries the file-type bits, which chmod is not specified to accept.
+    const mode = fs.statSync(lockfilePath).mode & 0o777;
     fs.writeFileSync(temporaryPath, normalizedContent, { mode });
     // writeFileSync's `mode` is masked by the process umask; chmod applies the original bits as is.
     fs.chmodSync(temporaryPath, mode);

--- a/packages/wb/src/utils/bunLockfile.ts
+++ b/packages/wb/src/utils/bunLockfile.ts
@@ -48,7 +48,10 @@ export function normalizeBunLockfile(rootDirPath: string): boolean {
   // write cannot leave a truncated bun.lock behind (same strategy as wbfy's lefthook generator).
   const temporaryPath = `${lockfilePath}.wb-normalizing.${process.pid}.${crypto.randomUUID()}`;
   try {
-    fs.writeFileSync(temporaryPath, normalizedContent, { mode: fs.statSync(lockfilePath).mode });
+    const mode = fs.statSync(lockfilePath).mode;
+    fs.writeFileSync(temporaryPath, normalizedContent, { mode });
+    // writeFileSync's `mode` is masked by the process umask; chmod applies the original bits as is.
+    fs.chmodSync(temporaryPath, mode);
     fs.renameSync(temporaryPath, lockfilePath);
   } finally {
     fs.rmSync(temporaryPath, { force: true });

--- a/packages/wb/test/unit/bunLockfile.test.ts
+++ b/packages/wb/test/unit/bunLockfile.test.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { normalizeBunLockfile } from '../../src/utils/bunLockfile.js';
+
+describe('normalizeBunLockfile', () => {
+  it('empties every Takumi Guard resolved URL and leaves other registries alone', async () => {
+    await withTempDir(async (dirPath) => {
+      const lockfilePath = path.join(dirPath, 'bun.lock');
+      await fs.writeFile(
+        lockfilePath,
+        `{
+  "packages": {
+    "chalk": ["chalk@5.6.2", "https://npm.flatt.tech/chalk/-/chalk-5.6.2.tgz", {}, "sha512-a"],
+    "cosmiconfig": ["cosmiconfig@9.0.0", "", {}, "sha512-b"],
+    "@willbooster-private/x": ["@willbooster-private/x@1.0.0", "https://verdaccio-production-e389.up.railway.app/@willbooster-private/x/-/x-1.0.0.tgz", {}, "sha512-c"]
+  }
+}
+`
+      );
+
+      expect(normalizeBunLockfile(dirPath)).toBe(true);
+      const content = await fs.readFile(lockfilePath, 'utf8');
+      expect(content).not.toContain('npm.flatt.tech');
+      expect(content).toContain('["chalk@5.6.2", "", {}, "sha512-a"]');
+      // A scoped private registry legitimately records its own URL.
+      expect(content).toContain('https://verdaccio-production-e389.up.railway.app/');
+
+      // Idempotent: a clean lockfile is left byte-for-byte alone.
+      expect(normalizeBunLockfile(dirPath)).toBe(false);
+      expect(await fs.readFile(lockfilePath, 'utf8')).toBe(content);
+    });
+  });
+
+  it('does nothing without a bun.lock', async () => {
+    await withTempDir(async (dirPath) => {
+      expect(normalizeBunLockfile(dirPath)).toBe(false);
+    });
+  });
+});
+
+async function withTempDir(runTest: (dirPath: string) => Promise<void>): Promise<void> {
+  const dirPath = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'wb-bun-lockfile-')));
+  try {
+    await runTest(dirPath);
+  } finally {
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+}

--- a/packages/wbfy/src/generators/selfContainedWorkflow.ts
+++ b/packages/wbfy/src/generators/selfContainedWorkflow.ts
@@ -137,83 +137,6 @@ function removeTrailingSpaces(text: string): string {
   return text.replaceAll(/[ \t]+$/gm, '');
 }
 
-/**
- * The install sequence every generated workflow shares: a plain `bun install`, hardened into the
- * reusable workflows' three-step dance when the repository registers a TAKUMI_GUARD_TOKEN secret.
- *
- * Takumi Guard (https://flatt.tech/takumi/features/guard) is a registry proxy that blocks
- * known-malicious packages. Routing the DEFAULT registry through it is what protects the install,
- * and the token authenticates that proxy — so the token has to be present while dependencies are
- * resolved, which is exactly when a compromised dependency's lifecycle script would run. Hence the
- * split: resolve and download with `--ignore-scripts` and the token, then replay the skipped
- * lifecycle scripts in a second install that has no token (every package is already cached, and
- * Guard serves anonymously anyway). Only bun is generated here, and bun reads .npmrc, so no
- * package-manager branching is needed.
- */
-function buildInstallSteps(): Step[] {
-  return [
-    {
-      if: "${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}",
-      name: 'Generate .npmrc for Takumi Guard',
-      // The token is written as a literal `${TAKUMI_GUARD_TOKEN}` reference that bun expands at
-      // install time, so the secret itself never lands in a file. The managed lines are stripped
-      // from an existing .npmrc first: a repository outside the organizations may legitimately
-      // commit one (scope mappings for another registry), and dropping only these two lines keeps
-      // the rest of it in effect. Replacing the file with `mv` rather than appending in place stops
-      // a committed symlink from redirecting the write into, say, a persistent home npmrc.
-      run: `set -euo pipefail
-NPMRC="$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")"
-if [[ -e .npmrc ]]; then
-  grep -vE '^registry=|^//npm\\.flatt\\.tech/:_authToken' .npmrc > "$NPMRC" || true
-fi
-echo 'registry=https://npm.flatt.tech/' >> "$NPMRC"
-echo '//npm.flatt.tech/:_authToken=\${TAKUMI_GUARD_TOKEN}' >> "$NPMRC"
-rm -f .npmrc
-mv "$NPMRC" .npmrc`,
-    },
-    {
-      name: 'Install dependencies',
-      run: `set -euo pipefail
-if [[ "$HAS_TAKUMI_GUARD_TOKEN" == "true" ]]; then
-  bun install --ignore-scripts
-else
-  bun install
-fi`,
-      // Step-scoped: a job-level token would be readable by every dependency lifecycle script the
-      // tokenless replay below runs.
-      env: { TAKUMI_GUARD_TOKEN: '${{ secrets.TAKUMI_GUARD_TOKEN }}' },
-    },
-    {
-      if: "${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}",
-      name: 'Run dependency lifecycle scripts without registry credentials',
-      // A repeated `bun install` is a no-op that replays nothing, so node_modules has to go first.
-      // A failing repository postinstall is tolerated exactly as the reusable workflows tolerate
-      // it: the token-free environment also lacks FNOX_AGE_KEY, so a postinstall that wants
-      // decrypted secrets cannot succeed here and must not take the whole job down.
-      run: `set -euo pipefail
-rm -rf node_modules
-bun install || {
-  echo "::warning::Lifecycle scripts failed; completing the install without them"
-  rm -rf node_modules
-  bun install --ignore-scripts
-}`,
-    },
-    {
-      if: "${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}",
-      name: 'Remove the generated .npmrc',
-      // Nothing after the install needs the proxy, and leaving it in place would break the one
-      // thing Guard refuses to serve: it answers `npm publish` with 405, so a release workflow
-      // whose package lacks an explicit publishConfig.registry would fail to publish.
-      run: `set -euo pipefail
-if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
-  git checkout -- .npmrc
-else
-  rm -f .npmrc
-fi`,
-    },
-  ];
-}
-
 function buildTestWorkflow(config: PackageConfig, allPackageConfigs: PackageConfig[]): Workflow {
   const usesFnox = fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'));
   // Playwright may be declared only in workspace packages; `wb test-on-ci` runs every declaring
@@ -442,6 +365,88 @@ function buildReleaseWorkflow(config: PackageConfig, hasProductionDeployWorkflow
       },
     },
   };
+}
+
+/**
+ * The install sequence every generated workflow shares: a plain `bun install`, hardened into the
+ * reusable workflows' three-step dance when the repository registers a TAKUMI_GUARD_TOKEN secret.
+ *
+ * Takumi Guard (https://flatt.tech/takumi/features/guard) is a registry proxy that blocks
+ * known-malicious packages. Routing the DEFAULT registry through it is what protects the install,
+ * and the token authenticates that proxy — so the token has to be present while dependencies are
+ * resolved, which is exactly when a compromised dependency's lifecycle script would run. Hence the
+ * split: resolve and download with `--ignore-scripts` and the token, then replay the skipped
+ * lifecycle scripts in a second install that has no token (every package is already cached, and
+ * Guard serves anonymously anyway). Only bun is generated here, and bun reads .npmrc, so no
+ * package-manager branching is needed.
+ *
+ * The shell details deliberately mirror reusable-workflows' production-proven install steps: bare
+ * `$RUNNER_TEMP` (set by the runner application on every runner, and `set -u` fails loudly if not),
+ * `[[ -e .npmrc ]]`, and the second `rm -rf node_modules` in the fallback (an interrupted lifecycle
+ * run may leave node_modules inconsistent, so the retry starts clean rather than trusting a repair).
+ */
+function buildInstallSteps(): Step[] {
+  return [
+    {
+      if: "${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}",
+      name: 'Generate .npmrc for Takumi Guard',
+      // The token is written as a literal `${TAKUMI_GUARD_TOKEN}` reference that bun expands at
+      // install time, so the secret itself never lands in a file. The managed lines are stripped
+      // from an existing .npmrc first: a repository outside the organizations may legitimately
+      // commit one (scope mappings for another registry), and dropping only these two lines keeps
+      // the rest of it in effect. Replacing the file with `mv` rather than appending in place stops
+      // a committed symlink from redirecting the write into, say, a persistent home npmrc.
+      run: `set -euo pipefail
+NPMRC="$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")"
+if [[ -e .npmrc ]]; then
+  grep -vE '^registry=|^//npm\\.flatt\\.tech/:_authToken' .npmrc > "$NPMRC" || true
+fi
+echo 'registry=https://npm.flatt.tech/' >> "$NPMRC"
+echo '//npm.flatt.tech/:_authToken=\${TAKUMI_GUARD_TOKEN}' >> "$NPMRC"
+rm -f .npmrc
+mv "$NPMRC" .npmrc`,
+    },
+    {
+      name: 'Install dependencies',
+      run: `set -euo pipefail
+if [[ "$HAS_TAKUMI_GUARD_TOKEN" == "true" ]]; then
+  bun install --ignore-scripts
+else
+  bun install
+fi`,
+      // Step-scoped: a job-level token would be readable by every dependency lifecycle script the
+      // tokenless replay below runs.
+      env: { TAKUMI_GUARD_TOKEN: '${{ secrets.TAKUMI_GUARD_TOKEN }}' },
+    },
+    {
+      if: "${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}",
+      name: 'Run dependency lifecycle scripts without registry credentials',
+      // A repeated `bun install` is a no-op that replays nothing, so node_modules has to go first.
+      // A failing repository postinstall is tolerated exactly as the reusable workflows tolerate
+      // it: the token-free environment also lacks FNOX_AGE_KEY, so a postinstall that wants
+      // decrypted secrets cannot succeed here and must not take the whole job down.
+      run: `set -euo pipefail
+rm -rf node_modules
+bun install || {
+  echo "::warning::Lifecycle scripts failed; completing the install without them"
+  rm -rf node_modules
+  bun install --ignore-scripts
+}`,
+    },
+    {
+      if: "${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}",
+      name: 'Remove the generated .npmrc',
+      // Nothing after the install needs the proxy, and leaving it in place would break the one
+      // thing Guard refuses to serve: it answers `npm publish` with 405, so a release workflow
+      // whose package lacks an explicit publishConfig.registry would fail to publish.
+      run: `set -euo pipefail
+if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+  git checkout -- .npmrc
+else
+  rm -f .npmrc
+fi`,
+    },
+  ];
 }
 
 function buildSemanticPrWorkflow(): Workflow {

--- a/packages/wbfy/src/generators/selfContainedWorkflow.ts
+++ b/packages/wbfy/src/generators/selfContainedWorkflow.ts
@@ -35,6 +35,21 @@ const semanticPullRequestAction = 'amannn/action-semantic-pull-request@45b9ed7cf
 // v3.0.3; deploys are network-heavy and benefit from retries with a long timeout.
 const retryAction = 'nick-fields/retry@dd56f1ca8ca991e2385c18ab6dd36ea7f9fdb55f';
 
+/**
+ * Job-level env that turns the Takumi Guard install path on, mirroring the reusable workflows.
+ *
+ * `secrets` is unavailable in a step-level `if:`, so the presence of the token is exposed as a
+ * non-secret signal; an unset secret expands to `false` and leaves every Guard step skipped, which
+ * is what keeps the generated workflows runnable in a repository that never registers the secret.
+ * TAKUMI_GUARD_TOKEN itself is defined-but-EMPTY job-wide so the `${TAKUMI_GUARD_TOKEN}` reference
+ * in the generated .npmrc still expands (to '') in the steps that deliberately run without the
+ * token; a reference to an undefined variable is what breaks an install, an empty one is fine.
+ */
+const guardJobEnv: Record<string, string> = {
+  HAS_TAKUMI_GUARD_TOKEN: '${{ !!secrets.TAKUMI_GUARD_TOKEN }}',
+  TAKUMI_GUARD_TOKEN: '',
+};
+
 interface Step {
   name?: string;
   id?: string;
@@ -122,6 +137,83 @@ function removeTrailingSpaces(text: string): string {
   return text.replaceAll(/[ \t]+$/gm, '');
 }
 
+/**
+ * The install sequence every generated workflow shares: a plain `bun install`, hardened into the
+ * reusable workflows' three-step dance when the repository registers a TAKUMI_GUARD_TOKEN secret.
+ *
+ * Takumi Guard (https://flatt.tech/takumi/features/guard) is a registry proxy that blocks
+ * known-malicious packages. Routing the DEFAULT registry through it is what protects the install,
+ * and the token authenticates that proxy — so the token has to be present while dependencies are
+ * resolved, which is exactly when a compromised dependency's lifecycle script would run. Hence the
+ * split: resolve and download with `--ignore-scripts` and the token, then replay the skipped
+ * lifecycle scripts in a second install that has no token (every package is already cached, and
+ * Guard serves anonymously anyway). Only bun is generated here, and bun reads .npmrc, so no
+ * package-manager branching is needed.
+ */
+function buildInstallSteps(): Step[] {
+  return [
+    {
+      if: "${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}",
+      name: 'Generate .npmrc for Takumi Guard',
+      // The token is written as a literal `${TAKUMI_GUARD_TOKEN}` reference that bun expands at
+      // install time, so the secret itself never lands in a file. The managed lines are stripped
+      // from an existing .npmrc first: a repository outside the organizations may legitimately
+      // commit one (scope mappings for another registry), and dropping only these two lines keeps
+      // the rest of it in effect. Replacing the file with `mv` rather than appending in place stops
+      // a committed symlink from redirecting the write into, say, a persistent home npmrc.
+      run: `set -euo pipefail
+NPMRC="$(mktemp "$RUNNER_TEMP/npmrc.XXXXXX")"
+if [[ -e .npmrc ]]; then
+  grep -vE '^registry=|^//npm\\.flatt\\.tech/:_authToken' .npmrc > "$NPMRC" || true
+fi
+echo 'registry=https://npm.flatt.tech/' >> "$NPMRC"
+echo '//npm.flatt.tech/:_authToken=\${TAKUMI_GUARD_TOKEN}' >> "$NPMRC"
+rm -f .npmrc
+mv "$NPMRC" .npmrc`,
+    },
+    {
+      name: 'Install dependencies',
+      run: `set -euo pipefail
+if [[ "$HAS_TAKUMI_GUARD_TOKEN" == "true" ]]; then
+  bun install --ignore-scripts
+else
+  bun install
+fi`,
+      // Step-scoped: a job-level token would be readable by every dependency lifecycle script the
+      // tokenless replay below runs.
+      env: { TAKUMI_GUARD_TOKEN: '${{ secrets.TAKUMI_GUARD_TOKEN }}' },
+    },
+    {
+      if: "${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}",
+      name: 'Run dependency lifecycle scripts without registry credentials',
+      // A repeated `bun install` is a no-op that replays nothing, so node_modules has to go first.
+      // A failing repository postinstall is tolerated exactly as the reusable workflows tolerate
+      // it: the token-free environment also lacks FNOX_AGE_KEY, so a postinstall that wants
+      // decrypted secrets cannot succeed here and must not take the whole job down.
+      run: `set -euo pipefail
+rm -rf node_modules
+bun install || {
+  echo "::warning::Lifecycle scripts failed; completing the install without them"
+  rm -rf node_modules
+  bun install --ignore-scripts
+}`,
+    },
+    {
+      if: "${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}",
+      name: 'Remove the generated .npmrc',
+      // Nothing after the install needs the proxy, and leaving it in place would break the one
+      // thing Guard refuses to serve: it answers `npm publish` with 405, so a release workflow
+      // whose package lacks an explicit publishConfig.registry would fail to publish.
+      run: `set -euo pipefail
+if git ls-files --error-unmatch -- .npmrc > /dev/null 2>&1; then
+  git checkout -- .npmrc
+else
+  rm -f .npmrc
+fi`,
+    },
+  ];
+}
+
 function buildTestWorkflow(config: PackageConfig, allPackageConfigs: PackageConfig[]): Workflow {
   const usesFnox = fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'));
   // Playwright may be declared only in workspace packages; `wb test-on-ci` runs every declaring
@@ -142,7 +234,7 @@ function buildTestWorkflow(config: PackageConfig, allPackageConfigs: PackageConf
   const steps: Step[] = [
     { uses: checkoutAction },
     { uses: miseAction },
-    { run: 'bun install' },
+    ...buildInstallSteps(),
     ...(playwrightDirPaths.length > 0
       ? ([
           ...playwrightDirPaths.map(
@@ -223,7 +315,7 @@ function buildTestWorkflow(config: PackageConfig, allPackageConfigs: PackageConf
     jobs: {
       test: {
         'runs-on': 'ubuntu-latest',
-        env: { FORCE_COLOR: '3', WB_ENV: 'test' },
+        env: { FORCE_COLOR: '3', WB_ENV: 'test', ...guardJobEnv },
         steps,
       },
     },
@@ -254,7 +346,7 @@ function buildDeployWorkflow(
     jobs: {
       deploy: {
         'runs-on': 'ubuntu-latest',
-        env: { WB_ENV: environment },
+        env: { WB_ENV: environment, ...guardJobEnv },
         steps: [
           // fetch-depth 0 so `git describe` sees the tags WB_VERSION is derived from.
           { uses: checkoutAction, with: { 'fetch-depth': 0 } },
@@ -263,7 +355,7 @@ function buildDeployWorkflow(
             name: 'Set WB_VERSION',
             run: 'set -euo pipefail\nWB_VERSION=$(git describe --always --tags)\necho "WB_VERSION=$WB_VERSION" >> "$GITHUB_ENV"',
           },
-          { run: 'bun install' },
+          ...buildInstallSteps(),
           {
             name: 'Deploy',
             uses: retryAction,
@@ -303,11 +395,12 @@ function buildReleaseWorkflow(config: PackageConfig, hasProductionDeployWorkflow
     jobs: {
       release: {
         'runs-on': 'ubuntu-latest',
+        env: { ...guardJobEnv },
         steps: [
           // fetch-depth 0: semantic-release reads the full history to compute the next version.
           { uses: checkoutAction, with: { 'fetch-depth': 0 } },
           { uses: miseAction },
-          { run: 'bun install' },
+          ...buildInstallSteps(),
           ...(hasProductionDeployWorkflow
             ? [
                 {

--- a/packages/wbfy/test/unit/selfContainedWorkflow.test.ts
+++ b/packages/wbfy/test/unit/selfContainedWorkflow.test.ts
@@ -17,7 +17,10 @@ interface ParsedWorkflow {
   jobs: Record<
     string,
     {
+      env?: Record<string, string>;
       steps: {
+        name?: string;
+        if?: string;
         run?: string;
         uses?: string;
         env?: Record<string, string>;
@@ -44,7 +47,6 @@ test('generates self-contained test and semantic-pr workflows without reusable-w
     expect(testContent).not.toContain('reusable-workflows');
     const testWorkflow = yaml.load(testContent) as ParsedWorkflow;
     const runCommands = testWorkflow.jobs.test?.steps.map((step) => step.run).filter(Boolean);
-    expect(runCommands).toContain('bun install');
     expect(runCommands).toContain('bun run test/ci');
     // No TypeScript and no Playwright in this repository.
     expect(runCommands).not.toContain('bun run typecheck');
@@ -79,8 +81,8 @@ test('includes typecheck, Playwright caching and step-scoped FNOX_AGE_KEY when t
     expect(steps.some((step) => step.uses?.startsWith('actions/cache@'))).toBe(true);
     expect(content).toContain('playwright install --with-deps');
     // Step-scoped, not job-wide: `bun install` must not see the age identity.
-    const installStep = steps.find((step) => step.run === 'bun install');
-    expect(installStep?.env).toBeUndefined();
+    const installStep = steps.find((step) => step.name === 'Install dependencies');
+    expect(installStep?.env?.FNOX_AGE_KEY).toBeUndefined();
     const testStep = steps.find((step) => step.run === 'bun run test/ci');
     expect(testStep?.env?.FNOX_AGE_KEY).toBe('${{ secrets.FNOX_AGE_KEY }}');
   });
@@ -240,6 +242,48 @@ test('never overwrites a hand-written workflow and regenerates a marked one', as
     const regenerated = await fs.readFile(path.join(workflowsPath, 'semantic-pr.yml'), 'utf8');
     expect(regenerated).toContain('amannn/action-semantic-pull-request');
     expect(regenerated).not.toContain('Stale');
+  });
+});
+
+test('hardens every install with the Takumi Guard proxy without exposing the token to lifecycle scripts', async () => {
+  await withTempRepo(async (dirPath) => {
+    const config = createConfig({
+      dirPath,
+      isRoot: true,
+      isWillBoosterRepo: false,
+      repository: 'github:someone/example',
+      packageJson: { scripts: { deploy: 'WB_ENV=production bun wb deploy' } },
+    });
+    await generateSelfContainedWorkflows(config);
+    await promisePool.promiseAll();
+
+    const workflowsPath = path.join(dirPath, '.github', 'workflows');
+    for (const fileName of ['test.yml', 'deploy-production.yml']) {
+      const workflow = yaml.load(await fs.readFile(path.join(workflowsPath, fileName), 'utf8')) as ParsedWorkflow;
+      const job = Object.values(workflow.jobs)[0];
+      // The `if:` gates read the non-secret signal, and the empty token keeps the generated
+      // .npmrc's ${TAKUMI_GUARD_TOKEN} reference expandable in the tokenless steps.
+      expect(job?.env?.HAS_TAKUMI_GUARD_TOKEN).toBe('${{ !!secrets.TAKUMI_GUARD_TOKEN }}');
+      expect(job?.env?.TAKUMI_GUARD_TOKEN).toBe('');
+
+      const steps = job?.steps ?? [];
+      const installStep = steps.find((step) => step.name === 'Install dependencies');
+      expect(installStep?.env?.TAKUMI_GUARD_TOKEN).toBe('${{ secrets.TAKUMI_GUARD_TOKEN }}');
+      expect(installStep?.run).toContain('bun install --ignore-scripts');
+      // Without the secret the very same step still installs normally.
+      expect(installStep?.run).toContain('bun install\nfi');
+
+      // The replay runs the lifecycle scripts, so it must not carry the token.
+      const replayStep = steps.find(
+        (step) => step.name === 'Run dependency lifecycle scripts without registry credentials'
+      );
+      expect(replayStep?.env).toBeUndefined();
+      expect(replayStep?.if).toBe("${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}");
+      // Guard answers `npm publish` with 405, so the proxy must not outlive the install.
+      const cleanupStep = steps.find((step) => step.name === 'Remove the generated .npmrc');
+      expect(cleanupStep?.if).toBe("${{ env.HAS_TAKUMI_GUARD_TOKEN == 'true' }}");
+      expect(steps.indexOf(cleanupStep!)).toBeGreaterThan(steps.indexOf(replayStep!));
+    }
   });
 });
 


### PR DESCRIPTION
## Customer Summary

- Repositories outside the WillBooster / WillBoosterLab organizations (which get self-contained GitHub Actions workflows) can now route CI dependency installs through the Takumi Guard malware-blocking proxy simply by registering a `TAKUMI_GUARD_TOKEN` secret; repositories without the secret keep installing exactly as before.
- Developers and CI no longer see `bun.lock` rewritten with `npm.flatt.tech` proxy URLs after an install: `wb` strips them automatically, so diffs stay clean and a shared lockfile never gets pinned to one environment's mirror.

## Technical Summary

- `wbfy` (`selfContainedWorkflow.ts`): `buildInstallSteps()` generates the reusable workflows' hardened install sequence in `test.yml`, both deploy workflows, and `release.yml` — generate a `.npmrc` pointing the default registry at Guard (token as a literal `${TAKUMI_GUARD_TOKEN}` reference, `mv`-replaced against committed symlinks), `bun install --ignore-scripts` with a step-scoped token, a tokenless lifecycle replay (`rm -rf node_modules && bun install`, failures tolerated with `::warning::`), then remove the generated `.npmrc` (Guard answers `npm publish` with 405). Guard steps are gated on a job-level `HAS_TAKUMI_GUARD_TOKEN` signal since `secrets` is unavailable in step-level `if:`; `TAKUMI_GUARD_TOKEN` is defined-but-empty job-wide so the npmrc reference stays expandable in tokenless steps.
- `wb` (`bunLockfile.ts`): `normalizeBunLockfile()` strips Guard `resolved` URLs from the root `bun.lock`, anchored to the `resolved` slot (`", ` prefix, mirroring reusable-workflows) so direct-tarball descriptors would survive; replaces the file atomically via a sibling temp file + rename, preserving permission bits against the process umask (`stat mode & 0o777` + chmod).
- Wired into the two points where wb knows an install just happened: `gen-code` (the wbfy-generated postinstall; resolves the repository root via `rootDirPath` so `apps/*` workspaces normalize the root lockfile, and runs before the "nothing to generate" early return) and `verify`'s install step (which now normalizes even when the install fails, since bun writes the lockfile before lifecycle scripts run).
- Only the Guard host is stripped; scoped registries such as Verdaccio legitimately keep their URLs.

## Why

- Guard integration previously lived only in the reusable-workflow callers, so self-contained repositories had the least protected install in the toolchain: lifecycle scripts ran unguarded straight off npmjs on every test, deploy, and release run.
- The existing lockfile normalization (pre-commit hook, autofix in reusable-workflows) fires only at commit time; everything before that — bypassed hooks, hook-less tools, every `git diff` a human or agent reads — saw the rewritten lockfile (1058 lines in one real no-op install).

## Testing

- New wbfy unit test: token step-scoped to the credentialed install, absent from the replay, `.npmrc` cleanup ordered after the replay (`selfContainedWorkflow.test.ts`, 9 passed).
- New wb unit test: Guard URLs emptied, Verdaccio URLs preserved, idempotent, no-op without `bun.lock` (`bunLockfile.test.ts`).
- Manual repros: failed-install normalization (postinstall `exit 1` + injected Guard URL → stripped, red failure line, no later steps), `apps/*` workspace postinstall normalizing the root lockfile, 0664 lockfile staying 0664 under `umask 022`.
- `bun verify`: clean. CI: all workflows green.
- The generated Guard steps can only be exercised end-to-end on real GitHub Actions, so the first `test.yml` run in a consuming repository is the actual smoke test.

## Notes

- Multi-agent review (Codex / Claude Code / Antigravity, 4 rounds) plus Gemini review converged with no remaining findings; the unanchored sed pattern in the pre-existing `lefthook.ts` generator is a known follow-up outside this PR's scope.
