### PR TITLE
feat(wb): strip Takumi Guard proxy URLs from bun.lock after an install

### DIFF
--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -9,6 +9,7 @@ import { findDescendantProjects } from '../project.js';
 import { findDrizzleConfig, wrapWithDrizzleConfigDir } from '../scripts/drizzleScripts.js';
 import { prismaScripts } from '../scripts/prismaScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
+import { normalizeBunLockfile } from '../utils/bunLockfile.js';
 import { writeWorkerTypesEnvStub } from '../utils/workerTypesEnv.js';
 
 const builder = {} as const;
@@ -27,6 +28,13 @@ export const genCodeCommand: CommandModule = {
     if (!projects) {
       console.error(chalk.red('No project found.'));
       process.exit(1);
+    }
+
+    // Before the early return below: `gen-code` is the `postinstall` script wbfy generates, making
+    // this the first wb code that runs after bun may have rewritten the lockfile, and a repository
+    // with nothing to generate needs the normalization just as much.
+    if (!argv.dryRun) {
+      normalizeBunLockfile(projects.root.dirPath);
     }
 
     const genCodeTargets = projects.descendants

--- a/packages/wb/src/commands/verifyCode.ts
+++ b/packages/wb/src/commands/verifyCode.ts
@@ -9,6 +9,7 @@ import type { Project } from '../project.js';
 import { findDescendantProjects, findRootAndSelfProjects, findSelfProject } from '../project.js';
 import { configureEnv } from '../scripts/run.js';
 import type { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
+import { normalizeBunLockfile } from '../utils/bunLockfile.js';
 
 import { buildLintCommand, lint, type LintCommandArgv } from './lint.js';
 import { test, type TestCommandArgv, withDefaultTestCascadeEnv } from './test.js';
@@ -80,6 +81,11 @@ async function verifyCode(project: Project, argv: VerifyCodeCommandArgv, steps: 
   await runStep(steps, { detail: installCommand, name: 'install' }, () =>
     runPackageCommand(installCommand, project, argv)
   );
+  // The repository may have no `gen-code` script (where the same normalization runs at postinstall),
+  // and `verify` is the command a developer runs before committing.
+  if (!argv.dryRun) {
+    normalizeBunLockfile(project.rootDirPath);
+  }
   if (project.packageJson.scripts?.['gen-code']) {
     const genCodeCommand = `${project.packageManagerCommand} gen-code`;
     await runStep(steps, { detail: genCodeCommand, name: 'gen-code' }, () =>

--- a/packages/wb/src/utils/bunLockfile.ts
+++ b/packages/wb/src/utils/bunLockfile.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import chalk from 'chalk';
+
+/** A Takumi Guard URL can only appear in bun.lock as a package's `resolved` value. */
+const guardResolvedUrlPattern = /"https:\/\/npm\.flatt\.tech\/[^"]*"/g;
+
+/**
+ * Strip Takumi Guard proxy URLs from the root `bun.lock`, returning whether the file changed.
+ *
+ * bun records an absolute `resolved` URL for an already-locked package whenever the configured
+ * registry does not serve the tarball host named in the package metadata — which is exactly what
+ * the Takumi Guard proxy does. So any install run with Guard as the DEFAULT registry (CI, or a
+ * developer who put it in ~/.npmrc) bakes npm.flatt.tech URLs into the lockfile, and committing
+ * them pins a SHARED lockfile to one environment's mirror: every later install downloads through
+ * the proxy, and a cold-cache install fails outright with 401 for anyone whose npmrc carries a
+ * registry.npmjs.org token, because bun sends the default registry's credentials to whatever host
+ * the lockfile names. Guard coverage does not depend on these URLs — with an empty `resolved`, bun
+ * derives the download URL from the configured registry — so they are pure damage.
+ *
+ * wbfy generates a pre-commit hook that strips the same URLs, but that only fires at `git commit`.
+ * Running this right after an install closes the window in between, where the rewritten lockfile is
+ * simply the working tree's state: a bypassed hook, a commit from a tool that does not run hooks,
+ * or a diff read by a human or an agent all see it. Only the Guard host is stripped; a scoped
+ * registry such as Verdaccio legitimately records its own URL for private packages.
+ */
+export function normalizeBunLockfile(rootDirPath: string): boolean {
+  const lockfilePath = path.join(rootDirPath, 'bun.lock');
+  let content: string;
+  try {
+    content = fs.readFileSync(lockfilePath, 'utf8');
+  } catch {
+    // A yarn/npm project, or a repository whose lockfile is gitignored: nothing to normalize.
+    return false;
+  }
+
+  const normalizedContent = content.replaceAll(guardResolvedUrlPattern, '""');
+  if (normalizedContent === content) return false;
+
+  fs.writeFileSync(lockfilePath, normalizedContent);
+  console.info(chalk.green(`Removed Takumi Guard proxy URLs from ${lockfilePath} to keep it registry-agnostic.`));
+  return true;
+}

--- a/packages/wb/test/unit/bunLockfile.test.ts
+++ b/packages/wb/test/unit/bunLockfile.test.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { normalizeBunLockfile } from '../../src/utils/bunLockfile.js';
+
+describe('normalizeBunLockfile', () => {
+  it('empties every Takumi Guard resolved URL and leaves other registries alone', async () => {
+    await withTempDir(async (dirPath) => {
+      const lockfilePath = path.join(dirPath, 'bun.lock');
+      await fs.writeFile(
+        lockfilePath,
+        `{
+  "packages": {
+    "chalk": ["chalk@5.6.2", "https://npm.flatt.tech/chalk/-/chalk-5.6.2.tgz", {}, "sha512-a"],
+    "cosmiconfig": ["cosmiconfig@9.0.0", "", {}, "sha512-b"],
+    "@willbooster-private/x": ["@willbooster-private/x@1.0.0", "https://verdaccio-production-e389.up.railway.app/@willbooster-private/x/-/x-1.0.0.tgz", {}, "sha512-c"]
+  }
+}
+`
+      );
+
+      expect(normalizeBunLockfile(dirPath)).toBe(true);
+      const content = await fs.readFile(lockfilePath, 'utf8');
+      expect(content).not.toContain('npm.flatt.tech');
+      expect(content).toContain('["chalk@5.6.2", "", {}, "sha512-a"]');
+      // A scoped private registry legitimately records its own URL.
+      expect(content).toContain('https://verdaccio-production-e389.up.railway.app/');
+
+      // Idempotent: a clean lockfile is left byte-for-byte alone.
+      expect(normalizeBunLockfile(dirPath)).toBe(false);
+      expect(await fs.readFile(lockfilePath, 'utf8')).toBe(content);
+    });
+  });
+
+  it('does nothing without a bun.lock', async () => {
+    await withTempDir(async (dirPath) => {
+      expect(normalizeBunLockfile(dirPath)).toBe(false);
+    });
+  });
+});
+
+async function withTempDir(runTest: (dirPath: string) => Promise<void>): Promise<void> {
+  const dirPath = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'wb-bun-lockfile-')));
+  try {
+    await runTest(dirPath);
+  } finally {
+    await fs.rm(dirPath, { force: true, recursive: true });
+  }
+}


### PR DESCRIPTION
## Why

bun records an absolute `resolved` URL for an already-locked package whenever the configured registry does not serve the tarball host named in the package metadata — exactly what the Takumi Guard proxy does. Any install run with Guard as the default registry (CI, or a developer who put it in `~/.npmrc`) bakes `npm.flatt.tech` URLs into `bun.lock`, and committing them pins a **shared** lockfile to one environment's mirror: a cold-cache install then fails with 401 for anyone whose npmrc carries a `registry.npmjs.org` token, because bun sends the default registry's credentials to whatever host the lockfile names.

wbfy already generates a `normalize-bun-lockfile` pre-commit hook (shared#1095) and reusable-workflows#479 normalizes before the autofix commit. Both fire at commit time. Everything before that still sees the rewritten lockfile:

- a hook bypassed with `git commit -n`, or a commit from a tool that runs no hooks;
- a repository where lefthook was never installed;
- every `git diff` a human or an agent reads in between — this is not cosmetic, a single no-op `bun install` in a real repository rewrote **1058** lines.

## What

`normalizeBunLockfile()` strips the Guard URLs from the root `bun.lock`, called at the two points where wb already knows an install just happened:

- **`gen-code`** — the `postinstall` script wbfy generates, so this is the first wb code that runs after bun may have rewritten the lockfile. Deliberately placed before the "nothing to generate" early return.
- **`verify`'s install step** — for repositories with no `gen-code` script, and because `verify` is what a developer runs before committing.

Only the Guard host is stripped, matching the pre-commit hook: a scoped registry such as Verdaccio legitimately records its own URL for private packages, and those are left untouched.

## Testing

- New unit test: Guard URLs emptied, Verdaccio URLs preserved, idempotent on a clean lockfile, no-op without a `bun.lock`.
- `bun wb test` in `packages/wb`: 231 passed, 1 skipped.
- `bun verify`: clean.
