### PR TITLE
fix(wbfy): anchor the pre-commit lockfile normalization to the resolved slot

### DIFF
--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -111,7 +111,10 @@ for file in {staged_files}; do
   normalized="$(mktemp "$file.wbfy-normalizing.XXXXXX")"
   trap 'rm -f "$normalized"' EXIT
   cp -p "$file" "$normalized"
-  sed -E 's#"https://npm\\.flatt\\.tech/[^"]*"#""#g' "$file" > "$normalized"
+  # Anchored to \`", \` so only a registry entry's \`resolved\` slot is cleared (mirroring
+  # reusable-workflows and wb's normalizeBunLockfile): a DIRECT tarball dependency carries the same
+  # host in the workspace descriptor and the package tuple's first element, which must survive.
+  sed -E 's#(", )"https://npm\\.flatt\\.tech/[^"]*"#\\1""#g' "$file" > "$normalized"
   if ! cmp -s "$file" "$normalized"; then
     mv "$normalized" "$file"
     echo "Removed Takumi Guard proxy URLs from $file so the lockfile stays registry-agnostic."


### PR DESCRIPTION
## Customer Summary

- The wbfy-generated pre-commit hook that strips Takumi Guard proxy URLs from `bun.lock` now edits only the intended field, so a project that ever declares a dependency directly by its Guard tarball URL would no longer have that declaration silently emptied at commit time.
- No behavior change for existing repositories: for lockfiles bun writes in wbfy-managed repos, the anchored pattern clears exactly the same URLs as before.

## Technical Summary

- `packages/wbfy/src/generators/lefthook.ts`: the `normalize-bun-lockfile` hook's sed pattern is now anchored to `", ` (`s#(", )"https://npm\.flatt\.tech/[^"]*"#\1""#g`), matching the reference implementation in reusable-workflows and `wb`'s `normalizeBunLockfile()` (PR #1116). Only a registry entry's `resolved` slot is cleared; a direct tarball dependency's workspace descriptor (`"pkg": "https://…"`) and package-tuple first element (`"pkg@https://…"`) survive.
- A comment in the generated hook documents the anchoring rationale.

## Why

- PR #1116 anchored `wb`'s runtime normalizer and cited reusable-workflows' anchored sed as the reference, leaving this pre-existing generator as the only unanchored copy of the pattern. The three implementations of the same normalization now agree, so the pre-commit hook and the runtime normalizer cannot diverge on the same lockfile.

## Testing

- Manual: ran the exact generated sed against a lockfile containing a Guard `resolved` URL, a direct Guard tarball descriptor (workspace + tuple forms), and a Verdaccio URL — only the `resolved` slot was emptied.
- `bun run vitest run` in `packages/wbfy`: 308 passed.
- `bun verify`: clean.
