### PR TITLE
feat(wbfy): warn before dropping unmanaged minimumReleaseAgeExcludes entries

### DIFF
--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -15,6 +15,7 @@ interface BunfigToml {
     exact?: boolean;
     linker?: string;
     minimumReleaseAge?: number;
+    minimumReleaseAgeExcludes?: string[];
   };
 }
 
@@ -216,6 +217,21 @@ const newContent = (
     ]),
   ].toSorted();
   const repoSpecificExcludeSet = new Set(repoSpecificExcludes);
+  // Marker-less entries wbfy does not manage are dropped by design (see the provenance comment
+  // above), but dropping them SILENTLY loses deliberate repository policy unnoticed — e.g. a
+  // hand-added exemption for a fast-moving pre-release dependency disappears on the first wbfy
+  // run. Warn with the exact re-add instruction instead of preserving them automatically, so
+  // retired managed entries still cannot masquerade as repository policy.
+  const managedExcludeSet = new Set(managedExcludes);
+  const droppedExcludes = (bunfigToml?.install?.minimumReleaseAgeExcludes ?? []).filter(
+    (packageName) => !managedExcludeSet.has(packageName) && !repoSpecificExcludeSet.has(packageName)
+  );
+  if (droppedExcludes.length > 0) {
+    console.warn(
+      `Dropping minimumReleaseAgeExcludes entries wbfy does not manage: ${droppedExcludes.join(', ')}. ` +
+        `If they are repository policy, re-add them below the "# ---------- repository-specific entries ----------" marker in bunfig.toml.`
+    );
+  }
   const minimumReleaseAgeExcludes = [
     ...managedExcludes
       .filter((packageName) => !repoSpecificExcludeSet.has(packageName))

--- a/packages/wbfy/test/unit/bunfig.test.ts
+++ b/packages/wbfy/test/unit/bunfig.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { extractRawTestSections, generateBunfigToml } from '../../src/generators/bunfig.js';
 import { promisePool } from '../../src/utils/promisePool.js';
@@ -99,6 +99,40 @@ minimumReleaseAgeExcludes = [
     // A marker entry that is not a plain npm package name is dead configuration and is dropped.
     expect(content).not.toContain('not@a@name');
   } finally {
+    fs.rmSync(tempDirPath, { force: true, recursive: true });
+  }
+});
+
+test('warns about marker-less exclude entries wbfy does not manage before dropping them', async () => {
+  const tempDirPath = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'wbfig-dropped-')));
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    fs.writeFileSync(
+      path.join(tempDirPath, 'bunfig.toml'),
+      `[install]
+minimumReleaseAgeExcludes = [
+    "react",
+    "vinext",
+    "@vinext/cloudflare",
+    # ---------- repository-specific entries ----------
+    "my-repo-specific-package",
+]
+`
+    );
+    await generateBunfigToml(createConfig({ dirPath: tempDirPath }));
+    await promisePool.promiseAll();
+    const content = fs.readFileSync(path.join(tempDirPath, 'bunfig.toml'), 'utf8');
+    // The drop itself is by design; the warning is the safety net.
+    expect(content).not.toContain('"vinext",');
+    const warning = warnSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(warning).toContain('vinext');
+    expect(warning).toContain('@vinext/cloudflare');
+    expect(warning).toContain('repository-specific entries');
+    // Managed and marker-tagged entries must not be reported as dropped.
+    expect(warning).not.toContain('react');
+    expect(warning).not.toContain('my-repo-specific-package');
+  } finally {
+    warnSpy.mockRestore();
     fs.rmSync(tempDirPath, { force: true, recursive: true });
   }
 });


### PR DESCRIPTION
## Technical Summary

- `bunfig.toml` 再生成時に、wbfy 管理外かつ repository-specific マーカー外の `minimumReleaseAgeExcludes` エントリを黙って削除していたのを、削除対象のエントリ名とマーカー配下への再追加手順を `console.warn` で表示するように変更。
- マーカー方式の provenance 設計（retired managed entry を repo policy に昇格させない）はそのまま維持し、自動保持はしない。
- ユニットテスト追加: 管理外エントリのみが警告に含まれ、管理エントリ・マーカー配下エントリは含まれないことを検証。

## Why

- exKAZUu-Dev/tomatrillion への初回 wbfy 適用で、リポジトリが意図して追加していた `vinext` / `@vinext/cloudflare` の除外エントリが無警告で消え、レビューで初めて発覚したため。

## Testing

- `bun run vitest run test/unit`（wbfy: 319 tests passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
