### PR TITLE
feat(wbfy)!: prohibit repository-specific minimumReleaseAgeExcludes entries

### DIFF
--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -5,7 +5,6 @@ import { parse } from 'smol-toml';
 
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
-import { isLiteralNpmPackageName, type YarnReleaseAgeSettings } from './removeYarnFiles.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { doesContainJava } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
@@ -17,10 +16,6 @@ interface BunfigToml {
     minimumReleaseAge?: number;
   };
 }
-
-// Everything after this marker inside minimumReleaseAgeExcludes is repository policy (e.g.
-// migrated from .yarnrc.yml npmPreapprovedPackages) and is preserved across regenerations.
-const repoSpecificExcludesMarker = '    # ---------- repository-specific entries ----------';
 
 export const bunMinimumReleaseAgeSeconds = 432_000;
 
@@ -175,12 +170,12 @@ export function readBunLinker(rootDirPath: string): BunLinker | undefined {
 export async function generateBunfigToml(
   config: PackageConfig,
   linker: BunLinker = 'isolated',
-  yarnReleaseAgeSettings?: YarnReleaseAgeSettings
+  yarnMinimumReleaseAgeSeconds?: number
 ): Promise<void> {
   return logger.functionIgnoringException('generateBunfigToml', async () => {
     const filePath = path.resolve(config.dirPath, 'bunfig.toml');
     const existingContent = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
-    const content = newContent(existingContent, linker, config, yarnReleaseAgeSettings);
+    const content = newContent(existingContent, linker, config, yarnMinimumReleaseAgeSeconds);
     await promisePool.run(() => fsUtil.generateFile(filePath, content));
   });
 }
@@ -189,7 +184,7 @@ const newContent = (
   existingContent: string | undefined,
   linker: BunLinker,
   config: PackageConfig,
-  yarnReleaseAgeSettings?: YarnReleaseAgeSettings
+  yarnMinimumReleaseAgeSeconds?: number
 ): string => {
   const bunfigToml = parseBunfigToml(existingContent);
   // Only Java repositories still depend on @willbooster/prettier-config (wbfy installs it with
@@ -199,35 +194,15 @@ const newContent = (
   const managedExcludes = doesContainJava(config)
     ? bunMinimumReleaseAgeExcludes
     : bunMinimumReleaseAgeExcludes.filter((packageName) => packageName !== '@willbooster/prettier-config');
-  // The repository's own release-age policy must survive every run, not just the migration one:
-  // repo-specific npmPreapprovedPackages entries (pre-filtered to literal names — Bun matches
-  // these literally) AND the entries under the repository-specific marker of the existing
-  // bunfig.toml are merged after the managed list, and a custom npmMinimalAgeGate (or an
-  // already-customized minimumReleaseAge) is carried over. Only marker-tagged entries count as
-  // repo-specific — provenance stays explicit in the file itself, so entries an older wbfy
-  // version managed and later retired can never masquerade as repository policy. An explicit
-  // repository preapproval that ALSO appears in the managed list is emitted once, under the
-  // marker: the effective exclusion set is identical, but the repository-policy provenance
-  // survives even if wbfy later retires that managed entry.
-  const repoSpecificExcludes = [
-    ...new Set([
-      ...(yarnReleaseAgeSettings?.minimumReleaseAgeExcludes ?? []),
-      ...readRepoSpecificExcludes(existingContent),
-    ]),
-  ].toSorted();
-  const repoSpecificExcludeSet = new Set(repoSpecificExcludes);
-  const minimumReleaseAgeExcludes = [
-    ...managedExcludes
-      .filter((packageName) => !repoSpecificExcludeSet.has(packageName))
-      .map((packageName) => `    "${packageName}",`),
-    ...(repoSpecificExcludes.length > 0
-      ? [repoSpecificExcludesMarker, ...repoSpecificExcludes.map((packageName) => `    "${packageName}",`)]
-      : []),
-  ];
+  // minimumReleaseAgeExcludes is org policy, never repository policy: every entry comes from
+  // bunMinimumReleaseAgeExcludes, and any hand-added (or previously migrated) repository-specific
+  // entry is dropped on regeneration. Dropping is fail-safe — an uncovered package becomes
+  // age-gated and surfaces at install time instead of weakening the gate. A repository that
+  // genuinely needs an exclusion must add it to bunMinimumReleaseAgeExcludes in wbfy so all
+  // repositories share the same vetted list. The custom npmMinimalAgeGate (or an
+  // already-customized minimumReleaseAge) is still carried over — only the excludes are locked.
   const minimumReleaseAgeSeconds =
-    yarnReleaseAgeSettings?.minimumReleaseAgeSeconds ??
-    bunfigToml?.install?.minimumReleaseAge ??
-    bunMinimumReleaseAgeSeconds;
+    yarnMinimumReleaseAgeSeconds ?? bunfigToml?.install?.minimumReleaseAge ?? bunMinimumReleaseAgeSeconds;
   // No `[run] bun = true`: its node->bun PATH shim leaks into every child process and breaks
   // tools requiring real Node.js (Playwright, wrangler, vinext); any existing setting is dropped.
   return `env = false
@@ -246,35 +221,14 @@ ${
     : 'linker = "hoisted"'
 }
 minimumReleaseAge = ${minimumReleaseAgeSeconds}${minimumReleaseAgeSeconds === bunMinimumReleaseAgeSeconds ? ' # 5 days' : ` # repository-specific override (org default: ${bunMinimumReleaseAgeSeconds} = 5 days)`}
+# Managed by wbfy — repository-specific entries are prohibited and removed on every run.
+# To exclude a package, add it to bunMinimumReleaseAgeExcludes in WillBooster/shared-2
+# (packages/wbfy/src/generators/bunfig.ts) so every repository shares the same vetted list.
 minimumReleaseAgeExcludes = [
-${minimumReleaseAgeExcludes.join('\n')}
+${managedExcludes.map((packageName) => `    "${packageName}",`).join('\n')}
 ]
 `;
 };
-
-function readRepoSpecificExcludes(content: string | undefined): string[] {
-  if (!content) return [];
-  const lines = content.split('\n');
-  const markerIndex = lines.findIndex((line) => line.trim() === repoSpecificExcludesMarker.trim());
-  if (markerIndex === -1) return [];
-  const excludes: string[] = [];
-  for (const line of lines.slice(markerIndex + 1)) {
-    const trimmed = line.trim();
-    // The section ends at the array's closing bracket; hand-added comments and blank lines
-    // between entries must not truncate the repository-policy list (though only the entries
-    // themselves survive regeneration).
-    if (trimmed.startsWith(']')) break;
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    // wbfy writes one double-quoted entry per line. A line this parser cannot read could hide
-    // further entries, so stop instead of guessing.
-    const entry = /^"([^"]+)",?$/u.exec(trimmed)?.[1];
-    if (!entry) break;
-    // Hand-edited entries pass the same strict name gate as migrated ones: anything else would
-    // be dead configuration for Bun and could even break the generated TOML when interpolated.
-    if (isLiteralNpmPackageName(entry)) excludes.push(entry);
-  }
-  return excludes;
-}
 
 /**
  * Preserve the project's `[test]` sections (e.g. preload scripts swapping a Cloudflare D1 client

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -221,8 +221,9 @@ ${
     : 'linker = "hoisted"'
 }
 minimumReleaseAge = ${minimumReleaseAgeSeconds}${minimumReleaseAgeSeconds === bunMinimumReleaseAgeSeconds ? ' # 5 days' : ` # repository-specific override (org default: ${bunMinimumReleaseAgeSeconds} = 5 days)`}
-# Managed by wbfy — repository-specific entries are prohibited and removed on every run.
-# To exclude a package, add it to bunMinimumReleaseAgeExcludes in WillBooster/shared
+# minimumReleaseAgeExcludes is managed by wbfy — repository-specific entries are prohibited and
+# removed on every run (the minimumReleaseAge above may still be repository-specific). To exclude
+# a package, add it to bunMinimumReleaseAgeExcludes in WillBooster/shared
 # (packages/wbfy/src/generators/bunfig.ts) so every repository shares the same vetted list.
 minimumReleaseAgeExcludes = [
 ${managedExcludes.map((packageName) => `    "${packageName}",`).join('\n')}

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -222,7 +222,7 @@ ${
 }
 minimumReleaseAge = ${minimumReleaseAgeSeconds}${minimumReleaseAgeSeconds === bunMinimumReleaseAgeSeconds ? ' # 5 days' : ` # repository-specific override (org default: ${bunMinimumReleaseAgeSeconds} = 5 days)`}
 # Managed by wbfy — repository-specific entries are prohibited and removed on every run.
-# To exclude a package, add it to bunMinimumReleaseAgeExcludes in WillBooster/shared-2
+# To exclude a package, add it to bunMinimumReleaseAgeExcludes in WillBooster/shared
 # (packages/wbfy/src/generators/bunfig.ts) so every repository shares the same vetted list.
 minimumReleaseAgeExcludes = [
 ${managedExcludes.map((packageName) => `    "${packageName}",`).join('\n')}

--- a/packages/wbfy/src/generators/removeYarnFiles.ts
+++ b/packages/wbfy/src/generators/removeYarnFiles.ts
@@ -17,10 +17,9 @@ import { getWorkspacePackageJsonPaths } from '../utils/workspaceUtil.js';
 // approvedGitRepositories has no Bun counterpart because Bun does not restrict git dependencies,
 // so dropping it cannot change the install graph — org-level git-dependency policy is instead
 // enforced on every wbfy run by assertSafeDependencySources, the trade-off explicitly chosen in
-// #1014). Anything else
-// (registries, auth, scopes, packageExtensions,
-// patchFolder, proxies, supportedArchitectures, ...) affects dependency resolution or install
-// behavior and requires manual migration.
+// #1014). Anything else (registries, auth, scopes, packageExtensions, patchFolder, proxies,
+// supportedArchitectures, ...) affects dependency resolution or install behavior and requires
+// manual migration.
 const safeYarnrcSettings = new Set([
   'approvedGitRepositories',
   'checksumBehavior',
@@ -196,7 +195,7 @@ function isMigratableYarnrcSetting(key: string, value: unknown): boolean {
 export function readYarnrcMinimumReleaseAgeSeconds(dirPath: string): number | undefined {
   const parsed = readYarnrcYml(dirPath);
   if (!parsed || parsed === unparsableYarnrc) return undefined;
-  return parseYarnDurationAsSeconds((parsed as { npmMinimalAgeGate?: unknown }).npmMinimalAgeGate);
+  return parseYarnDurationAsSeconds(parsed.npmMinimalAgeGate);
 }
 
 function parseYarnDurationAsSeconds(value: unknown): number | undefined {

--- a/packages/wbfy/src/generators/removeYarnFiles.ts
+++ b/packages/wbfy/src/generators/removeYarnFiles.ts
@@ -10,12 +10,14 @@ import { promisePool } from '../utils/promisePool.js';
 import { getWorkspacePackageJsonPaths } from '../utils/workspaceUtil.js';
 
 // Yarn settings wbfy can safely drop when migrating to Bun: tooling and cosmetics that do not
-// change what gets installed, plus the org-standard release-age-gate settings that have a Bun
-// translation (npmMinimalAgeGate / npmPreapprovedPackages are reflected into the generated
-// bunfig.toml's minimumReleaseAge / minimumReleaseAgeExcludes, and approvedGitRepositories has
-// no Bun counterpart because Bun does not restrict git dependencies, so dropping it cannot
-// change the install graph — org-level git-dependency policy is instead enforced on every wbfy
-// run by assertSafeDependencySources, the trade-off explicitly chosen in #1014). Anything else
+// change what gets installed, plus the org-standard release-age-gate settings (npmMinimalAgeGate
+// is reflected into the generated bunfig.toml's minimumReleaseAge; npmPreapprovedPackages is
+// deliberately DROPPED because minimumReleaseAgeExcludes is org policy managed solely by wbfy's
+// bunMinimumReleaseAgeExcludes — dropping is fail-safe, packages become age-gated; and
+// approvedGitRepositories has no Bun counterpart because Bun does not restrict git dependencies,
+// so dropping it cannot change the install graph — org-level git-dependency policy is instead
+// enforced on every wbfy run by assertSafeDependencySources, the trade-off explicitly chosen in
+// #1014). Anything else
 // (registries, auth, scopes, packageExtensions,
 // patchFolder, proxies, supportedArchitectures, ...) affects dependency resolution or install
 // behavior and requires manual migration.
@@ -58,20 +60,6 @@ const yarnDurationUnitsInSeconds: Record<string, number> = {
 };
 
 const unparsableYarnrc = Symbol('unparsableYarnrc');
-
-/**
- * Whether the value is a plain (optionally scoped) npm package name. Anything else — globs,
- * versioned descriptors, or names with characters npm forbids — is not a usable
- * minimumReleaseAgeExcludes entry, and the strict character set also guarantees the value can be
- * interpolated into a double-quoted TOML string without escaping.
- */
-export function isLiteralNpmPackageName(value: string): boolean {
-  // Mirrors validate-npm-package-name (verified 7.0.2): both parts of a SCOPED name may contain
-  // any URL-safe character including leading `.`/`_` (e.g. `@_scope/pkg`, `@scope/_private`),
-  // while an UNSCOPED name must not start with `.`, `_`, or `-`; legacy uppercase names remain
-  // installable and are accepted too. Every accepted character is TOML-safe.
-  return /^(?:@[\w.~-]+\/[\w.~-]+|[A-Za-z0-9~][\w.~-]*)$/u.test(value);
-}
 
 /**
  * Detects Yarn configuration that has no automatic Bun translation. Must run as a read-only
@@ -196,38 +184,18 @@ function isMigratableYarnrcSetting(key: string, value: unknown): boolean {
   return safeYarnrcSettings.has(key);
 }
 
-export interface YarnReleaseAgeSettings {
-  /** Undefined when .yarnrc.yml declares no (parsable) npmMinimalAgeGate. */
-  minimumReleaseAgeSeconds?: number;
-  minimumReleaseAgeExcludes: string[];
-}
-
 /**
- * Reads the release-age-gate settings from .yarnrc.yml so the generated bunfig.toml can keep
- * their behavior (minimumReleaseAge / minimumReleaseAgeExcludes). Must run BEFORE removeYarnFiles
- * deletes .yarnrc.yml.
+ * Reads the release-age gate from .yarnrc.yml so the generated bunfig.toml can keep its behavior
+ * (minimumReleaseAge). Must run BEFORE removeYarnFiles deletes .yarnrc.yml. npmPreapprovedPackages
+ * is deliberately NOT read: minimumReleaseAgeExcludes is org policy managed solely by wbfy's
+ * bunMinimumReleaseAgeExcludes, and dropping repository preapprovals is fail-safe (the packages
+ * become age-gated, which surfaces at install time instead of weakening the gate).
+ * @return The gate in seconds, or undefined when .yarnrc.yml declares no (parsable) npmMinimalAgeGate.
  */
-export function readYarnrcReleaseAgeSettings(dirPath: string): YarnReleaseAgeSettings {
-  const settings: YarnReleaseAgeSettings = { minimumReleaseAgeExcludes: [] };
+export function readYarnrcMinimumReleaseAgeSeconds(dirPath: string): number | undefined {
   const parsed = readYarnrcYml(dirPath);
-  if (!parsed || parsed === unparsableYarnrc) return settings;
-
-  const { npmMinimalAgeGate, npmPreapprovedPackages } = parsed as {
-    npmMinimalAgeGate?: unknown;
-    npmPreapprovedPackages?: unknown;
-  };
-  settings.minimumReleaseAgeSeconds = parseYarnDurationAsSeconds(npmMinimalAgeGate);
-  if (Array.isArray(npmPreapprovedPackages)) {
-    settings.minimumReleaseAgeExcludes = npmPreapprovedPackages.filter(
-      // Bun matches minimumReleaseAgeExcludes entries literally as package NAMES, so Yarn glob
-      // patterns (e.g. `@willbooster/*`) and package descriptors (e.g. `is-number@npm:7.0.0`)
-      // would be dead configuration and are dropped. Dropping is fail-safe (an uncovered package
-      // becomes age-gated, which surfaces at install time instead of weakening the gate), and
-      // the org-standard globs are already covered literally by bunMinimumReleaseAgeExcludes.
-      (entry): entry is string => typeof entry === 'string' && isLiteralNpmPackageName(entry)
-    );
-  }
-  return settings;
+  if (!parsed || parsed === unparsableYarnrc) return undefined;
+  return parseYarnDurationAsSeconds((parsed as { npmMinimalAgeGate?: unknown }).npmMinimalAgeGate);
 }
 
 function parseYarnDurationAsSeconds(value: unknown): number | undefined {

--- a/packages/wbfy/src/generators/removeYarnFiles.ts
+++ b/packages/wbfy/src/generators/removeYarnFiles.ts
@@ -178,8 +178,9 @@ function isMigratableYarnrcSetting(key: string, value: unknown): boolean {
   if (key === 'enableScripts') return value === false;
   // A gate value the translation cannot parse (e.g. Yarn's `${ENV_VAR:-14d}` expansion syntax)
   // would silently fall back to the 5-day org default and could WEAKEN the repository's policy,
-  // so only literally parsable durations are migratable. Untranslatable npmPreapprovedPackages
-  // entries need no such gate: dropping them is fail-safe (packages become age-gated).
+  // so only literally parsable durations are migratable. npmPreapprovedPackages needs no such
+  // gate: ALL its entries are dropped unconditionally (minimumReleaseAgeExcludes is org policy
+  // managed solely by bunMinimumReleaseAgeExcludes), which is fail-safe — packages become age-gated.
   if (key === 'npmMinimalAgeGate') return parseYarnDurationAsSeconds(value) !== undefined;
   return safeYarnrcSettings.has(key);
 }

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -45,9 +45,8 @@ import { generateWorkflows, isReusableWorkflowsRepo } from './generators/workflo
 import { generateMiseToml, minimumBunVersion } from './generators/miseToml.js';
 import {
   findUnmigratableYarnSettings,
-  readYarnrcReleaseAgeSettings,
+  readYarnrcMinimumReleaseAgeSeconds,
   removeYarnFiles,
-  type YarnReleaseAgeSettings,
 } from './generators/removeYarnFiles.js';
 import { setupLabels } from './github/label.js';
 import { setupRepositoryRulesets } from './github/ruleset.js';
@@ -245,13 +244,14 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
     // and skips the probe (and its node_modules cleanup) entirely.
     const previousBunLinker = readBunLinker(rootDirPath);
     // Read BEFORE removeYarnFiles deletes .yarnrc.yml: the generated bunfig.toml keeps the
-    // repository's release-age-gate behavior (npmMinimalAgeGate / npmPreapprovedPackages).
-    const yarnReleaseAgeSettings = readYarnrcReleaseAgeSettings(rootDirPath);
+    // repository's release-age gate (npmMinimalAgeGate). npmPreapprovedPackages is dropped —
+    // minimumReleaseAgeExcludes is org policy managed solely by bunMinimumReleaseAgeExcludes.
+    const yarnMinimumReleaseAgeSeconds = readYarnrcMinimumReleaseAgeSeconds(rootDirPath);
     await removeYarnFiles(rootConfig);
     await generateBunfigToml(
       rootConfig,
       skipDeps ? (previousBunLinker ?? 'isolated') : 'isolated',
-      yarnReleaseAgeSettings
+      yarnMinimumReleaseAgeSeconds
     );
     await generateMiseToml(rootConfig, bunVersion);
     await generateFnoxToml(rootConfig);
@@ -270,7 +270,7 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
     // install would silently drop every managed dependency update for the rest of the run.
     if (
       !skipDeps &&
-      !(await ensureInstallableBunLinker(rootDirPath, rootConfig, previousBunLinker, yarnReleaseAgeSettings))
+      !(await ensureInstallableBunLinker(rootDirPath, rootConfig, previousBunLinker, yarnMinimumReleaseAgeSeconds))
     ) {
       // Do not fail the run here: the probe observes the pre-migration lifecycle scripts (e.g.
       // still-Yarn-based postinstall commands that generatePackageJson converts later), so both
@@ -384,7 +384,7 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
 
     // Refresh lock files
     try {
-      await refreshBunLock(rootDirPath, rootConfig, yarnReleaseAgeSettings);
+      await refreshBunLock(rootDirPath, rootConfig, yarnMinimumReleaseAgeSeconds);
       // Now that bun.lock exists (migrated from yarn.lock when there was none), the Yarn lockfile
       // that removeYarnFiles intentionally preserved for the migration can be removed.
       fs.rmSync(path.resolve(rootDirPath, 'yarn.lock'), { force: true });
@@ -410,7 +410,7 @@ async function ensureInstallableBunLinker(
   rootDirPath: string,
   rootConfig: PackageConfig,
   previousLinker: BunLinker | undefined,
-  yarnReleaseAgeSettings: YarnReleaseAgeSettings
+  yarnMinimumReleaseAgeSeconds: number | undefined
 ): Promise<boolean> {
   // A layout switch must probe from a clean tree: `bun install` does not remove packages the
   // previous layout left behind, so e.g. still-hoisted phantom dependencies can make the isolated
@@ -423,7 +423,7 @@ async function ensureInstallableBunLinker(
   if (spawnSyncAndReturnStatus('bun', ['install'], rootDirPath, 1) === 0) return true;
 
   console.warn('bun install failed with the isolated linker; falling back to the hoisted linker.');
-  await generateBunfigToml(rootConfig, 'hoisted', yarnReleaseAgeSettings);
+  await generateBunfigToml(rootConfig, 'hoisted', yarnMinimumReleaseAgeSeconds);
   await promisePool.promiseAll();
   // The failed isolated attempt may have left a partial isolated tree behind.
   removeNodeModules(rootDirPath, rootConfig);
@@ -434,7 +434,7 @@ async function ensureInstallableBunLinker(
   // Both layouts failed, so the failure is not linker-specific; keep the default isolated
   // configuration instead of persisting a downgrade that the failed install never justified.
   // Clean up the failed hoisted attempt too, so later installs do not run on a polluted tree.
-  await generateBunfigToml(rootConfig, 'isolated', yarnReleaseAgeSettings);
+  await generateBunfigToml(rootConfig, 'isolated', yarnMinimumReleaseAgeSeconds);
   await promisePool.promiseAll();
   removeNodeModules(rootDirPath, rootConfig);
   return false;
@@ -467,7 +467,7 @@ function removeNodeModules(rootDirPath: string, rootConfig: PackageConfig): void
 async function refreshBunLock(
   rootDirPath: string,
   rootConfig: PackageConfig,
-  yarnReleaseAgeSettings: YarnReleaseAgeSettings
+  yarnMinimumReleaseAgeSeconds: number | undefined
 ): Promise<void> {
   // wbfy should update only the packages it explicitly manages through bun add.
   // Running bun update here refreshes unrelated application dependencies and
@@ -480,14 +480,14 @@ async function refreshBunLock(
   // run fails — e.g. a converted script may exercise a phantom dependency only hoisting provides.
   if (readBunLinker(rootDirPath) === 'isolated') {
     console.warn('bun install failed with the isolated linker after migration; retrying with the hoisted linker.');
-    await generateBunfigToml(rootConfig, 'hoisted', yarnReleaseAgeSettings);
+    await generateBunfigToml(rootConfig, 'hoisted', yarnMinimumReleaseAgeSeconds);
     await promisePool.promiseAll();
     removeNodeModules(rootDirPath, rootConfig);
     status = spawnSyncAndReturnStatus('bun', ['install'], rootDirPath, 1);
     if (status === 0) return;
     // Both layouts failed after conversion; restore the default isolated configuration and clean
     // up the failed hoisted attempt so the next run does not probe on a polluted tree.
-    await generateBunfigToml(rootConfig, 'isolated', yarnReleaseAgeSettings);
+    await generateBunfigToml(rootConfig, 'isolated', yarnMinimumReleaseAgeSeconds);
     await promisePool.promiseAll();
     removeNodeModules(rootDirPath, rootConfig);
   }

--- a/packages/wbfy/test/unit/bunfig.test.ts
+++ b/packages/wbfy/test/unit/bunfig.test.ts
@@ -37,43 +37,32 @@ test('returns an empty string when there is no [test] section', () => {
   expect(extractRawTestSections('env = false\n\n[install]\nexact = true\n')).toBe('');
 });
 
-test('keeps the migrated .yarnrc.yml release-age-gate behavior in the generated bunfig.toml', async () => {
+test('keeps a migrated .yarnrc.yml npmMinimalAgeGate across regenerations', async () => {
   const tempDirPath = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-bunfig-')));
   try {
-    await generateBunfigToml(createConfig({ dirPath: tempDirPath }), 'isolated', {
-      minimumReleaseAgeSeconds: 172_800,
-      minimumReleaseAgeExcludes: ['@willbooster/prettier-config', 'my-repo-specific-package', 'react'],
-    });
+    await generateBunfigToml(createConfig({ dirPath: tempDirPath }), 'isolated', 172_800);
     await promisePool.promiseAll();
     const content = fs.readFileSync(path.join(tempDirPath, 'bunfig.toml'), 'utf8');
     expect(content).toContain('minimumReleaseAge = 172800');
-    expect(content).toContain('"my-repo-specific-package",');
-    // An entry that overlaps the managed list is emitted exactly once — under the marker, so its
-    // repository-policy provenance survives even if the managed list later retires it.
-    expect(content.match(/^\s+"react",$/gmu)).toHaveLength(1);
-    expect(content.indexOf('"react",')).toBeGreaterThan(content.indexOf('# ---------- repository-specific entries'));
-    // An explicit preapproval the managed list omits for this (non-Java) repository is
-    // repository policy too and must survive under the marker.
-    expect(content).toContain('"@willbooster/prettier-config",');
 
     // A later run has no .yarnrc.yml to read anymore (removeYarnFiles deleted it), so the
-    // repo-specific policy must survive via the existing bunfig.toml.
+    // repository's gate must survive via the existing bunfig.toml.
     await generateBunfigToml(createConfig({ dirPath: tempDirPath }));
     await promisePool.promiseAll();
     const regenerated = fs.readFileSync(path.join(tempDirPath, 'bunfig.toml'), 'utf8');
     expect(regenerated).toContain('minimumReleaseAge = 172800');
-    expect(regenerated).toContain('"my-repo-specific-package",');
-    expect(regenerated.match(/^\s+"react",$/gmu)).toHaveLength(1);
   } finally {
     fs.rmSync(tempDirPath, { force: true, recursive: true });
   }
 });
 
-test('drops managed exclude entries retired from the managed list instead of keeping them as repo policy', async () => {
-  const tempDirPath = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'wbfig-retired-')));
+test('removes repository-specific minimumReleaseAgeExcludes entries — the list is org policy', async () => {
+  const tempDirPath = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'wbfig-excludes-')));
   try {
-    // An entry an older wbfy version managed (e.g. @next/eslint-plugin-next) sits ABOVE the
-    // repository-specific marker, so a regeneration must not preserve it.
+    // Both entries an older wbfy version managed (e.g. @next/eslint-plugin-next) and entries a
+    // repository added for itself (including ones an older wbfy preserved under its
+    // repository-specific marker) must disappear: exclusions may only come from
+    // bunMinimumReleaseAgeExcludes so every repository shares the same vetted list.
     fs.writeFileSync(
       path.join(tempDirPath, 'bunfig.toml'),
       `[install]
@@ -83,10 +72,6 @@ minimumReleaseAgeExcludes = [
     "react",
     # ---------- repository-specific entries ----------
     "my-repo-specific-package",
-
-    # a hand-added comment must not truncate the repository-policy list
-    "another-repo-specific-package",
-    "not@a@name",
 ]
 `
     );
@@ -94,10 +79,10 @@ minimumReleaseAgeExcludes = [
     await promisePool.promiseAll();
     const content = fs.readFileSync(path.join(tempDirPath, 'bunfig.toml'), 'utf8');
     expect(content).not.toContain('@next/eslint-plugin-next');
-    expect(content).toContain('"my-repo-specific-package",');
-    expect(content).toContain('"another-repo-specific-package",');
-    // A marker entry that is not a plain npm package name is dead configuration and is dropped.
-    expect(content).not.toContain('not@a@name');
+    expect(content).not.toContain('my-repo-specific-package');
+    expect(content).not.toContain('---------- repository-specific entries');
+    // Managed entries stay, each exactly once.
+    expect(content.match(/^\s+"react",$/gmu)).toHaveLength(1);
   } finally {
     fs.rmSync(tempDirPath, { force: true, recursive: true });
   }

--- a/packages/wbfy/test/unit/removeYarnFiles.test.ts
+++ b/packages/wbfy/test/unit/removeYarnFiles.test.ts
@@ -4,7 +4,10 @@ import path from 'node:path';
 
 import { expect, test } from 'vitest';
 
-import { findUnmigratableYarnSettings, readYarnrcReleaseAgeSettings } from '../../src/generators/removeYarnFiles.js';
+import {
+  findUnmigratableYarnSettings,
+  readYarnrcMinimumReleaseAgeSeconds,
+} from '../../src/generators/removeYarnFiles.js';
 
 // The .yarnrc.yml shape the org standard (yarn-plugin-auto-install era) rolls out to apps.
 const orgStandardYarnrc = `approvedGitRepositories:
@@ -128,37 +131,24 @@ test('detects patch: dependencies declared in workspace manifests, not only the 
   });
 });
 
-test('reads release-age settings, dropping globs and descriptors Bun would match literally', async () => {
+test('reads the release-age gate and ignores npmPreapprovedPackages (excludes are org policy)', async () => {
   await withTempDir(async (tempDirPath) => {
     fs.writeFileSync(path.join(tempDirPath, '.yarnrc.yml'), orgStandardYarnrc);
-    // The glob, the versioned descriptor, and the TOML-unsafe name are dropped: only plain
-    // (optionally scoped) npm package names are usable Bun exclude entries.
-    // Scoped names may start any part with `_` and unscoped names may contain `_`
-    // (mirrors validate-npm-package-name).
-    expect(readYarnrcReleaseAgeSettings(tempDirPath)).toEqual({
-      minimumReleaseAgeSeconds: 432_000,
-      minimumReleaseAgeExcludes: [
-        '@scope/_private',
-        '@_scope/pkg',
-        'string_decoder',
-        'one-way-git-sync',
-        'my-repo-specific-package',
-      ],
-    });
+    expect(readYarnrcMinimumReleaseAgeSeconds(tempDirPath)).toBe(432_000);
   });
 });
 
 test('parses Yarn duration variants (bare numbers mean minutes)', async () => {
   await withTempDir(async (tempDirPath) => {
     fs.writeFileSync(path.join(tempDirPath, '.yarnrc.yml'), 'npmMinimalAgeGate: 36h\n');
-    expect(readYarnrcReleaseAgeSettings(tempDirPath).minimumReleaseAgeSeconds).toBe(129_600);
+    expect(readYarnrcMinimumReleaseAgeSeconds(tempDirPath)).toBe(129_600);
 
     fs.writeFileSync(path.join(tempDirPath, '.yarnrc.yml'), 'npmMinimalAgeGate: 30\n');
-    expect(readYarnrcReleaseAgeSettings(tempDirPath).minimumReleaseAgeSeconds).toBe(1800);
+    expect(readYarnrcMinimumReleaseAgeSeconds(tempDirPath)).toBe(1800);
 
     // Fractional seconds round up so a tiny gate stays a gate instead of becoming 0 (disabled).
     fs.writeFileSync(path.join(tempDirPath, '.yarnrc.yml'), 'npmMinimalAgeGate: 1ms\n');
-    expect(readYarnrcReleaseAgeSettings(tempDirPath).minimumReleaseAgeSeconds).toBe(1);
+    expect(readYarnrcMinimumReleaseAgeSeconds(tempDirPath)).toBe(1);
   });
 });
 
@@ -171,9 +161,9 @@ test('blocks on a negative npmMinimalAgeGate, which Bun would reject', async () 
   });
 });
 
-test('returns empty settings without a .yarnrc.yml', async () => {
+test('returns undefined without a .yarnrc.yml', async () => {
   await withTempDir(async (tempDirPath) => {
-    expect(readYarnrcReleaseAgeSettings(tempDirPath)).toEqual({ minimumReleaseAgeExcludes: [] });
+    expect(readYarnrcMinimumReleaseAgeSeconds(tempDirPath)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Customer Summary

- Package release-age exclusions (`minimumReleaseAgeExcludes` in `bunfig.toml`) are now a single organization-wide list: individual repositories can no longer keep their own exclusions.
- Any hand-added or previously migrated repository-specific exclusion is removed the next time wbfy runs; the affected packages simply become subject to the standard 5-day release-age gate again (fail-safe — nothing installs an unvetted version).
- To exclude a package for a repository, add it to wbfy's shared list so every repository gets the same vetted change; the generated `bunfig.toml` now carries a comment explaining this process.
- Repository-specific `minimumReleaseAge` gate values (e.g. migrated from Yarn's `npmMinimalAgeGate`) are still preserved.

## Technical Summary

- `packages/wbfy/src/generators/bunfig.ts`: removed the `# ---------- repository-specific entries ----------` marker preservation (`repoSpecificExcludesMarker`, `readRepoSpecificExcludes`) — the excludes array is now always emitted solely from `bunMinimumReleaseAgeExcludes` (minus `@willbooster/prettier-config` for non-Java repos), with a policy comment scoped to the excludes key.
- `packages/wbfy/src/generators/removeYarnFiles.ts`: `readYarnrcReleaseAgeSettings` is simplified to `readYarnrcMinimumReleaseAgeSeconds` (returns only the parsed `npmMinimalAgeGate`); `npmPreapprovedPackages` is dropped unconditionally, and the now-unused `isLiteralNpmPackageName` and `YarnReleaseAgeSettings` are deleted. `npmPreapprovedPackages` stays in `safeYarnrcSettings` so declaring it never blocks a migration.
- `packages/wbfy/src/index.ts`: threads a plain `number | undefined` gate value instead of the settings object.
- Unit tests updated: repo-specific entries, old marker sections, and retired managed entries all disappear on regeneration; the `npmMinimalAgeGate` carry-over is still covered.

## Why

- Repository-specific exclusions weaken the supply-chain release-age gate invisibly and drift per repository. Making wbfy's shared list the only source forces every exclusion through a single reviewed change that all repositories then share.

## Testing

- `bun verify-full` passed locally (install, lint, typecheck, and unit tests for all workspaces).
- Verified fail-safety on Bun 1.3.14: `bun install` against an existing `bun.lock` does not re-apply the age gate, so dropping an exclusion can only affect new resolutions (`bun add` / `bun update` / lockfile-absent deps).

## Notes

- Breaking for repositories relying on repo-specific excludes: after the next wbfy run their entries are removed and gated again. The companion guideline update is WillBooster/agentic-workflows#470.
