### PR TITLE
fix(wbfy): replace the single-server-instance agent rule for Cloudflare Workers repos

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -180,7 +180,16 @@ ${
   allConfigs.some((c) => c.depending.next || c.depending.vinext)
     ? `
 - This project uses the React Compiler, so \`useCallback\` and \`useMemo\` are unnecessary for performance.
-- Assume a single server instance.
+${
+  // Cloudflare Workers execute across many ephemeral isolates with no shared memory, and two
+  // requests are not guaranteed to hit the same instance — the single-instance simplification
+  // (module-level mutable state, in-process caches or locks) silently loses state there.
+  // doesContainWranglerConfig is the accurate Workers signal (isCloudflare also matches a mere
+  // wrangler mention in a script or workflow).
+  allConfigs.some((c) => c.doesContainWranglerConfig)
+    ? '- The app runs on Cloudflare Workers across multiple ephemeral isolates: never keep state in module-level variables or in-process caches; persist anything shared between requests in bindings (D1, KV, R2, Durable Objects).'
+    : '- Assume a single server instance.'
+}
 `
     : ''
 }

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -146,6 +146,27 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
   const osCompatibilityInstruction = hasDesktopApp
     ? '- Server and CLI code targets macOS and Linux; the Tauri desktop app additionally supports Windows, so keep its Windows-specific code working.'
     : '- Ensure compatibility only with macOS and Linux; do not include Windows-specific code.';
+  // Cloudflare Workers execute across many ephemeral isolates and two requests are not guaranteed
+  // to hit the same instance, so the single-instance simplification silently loses state there —
+  // but Workers deliberately reuse execution contexts, so best-effort isolate-local caches stay
+  // legitimate (https://developers.cloudflare.com/workers/reference/how-workers-works/). The
+  // signals are correlated PER PACKAGE: a monorepo can host a single-instance server app next to
+  // an unrelated Worker, and neither may override the other's rule. doesContainWranglerConfig is
+  // the accurate Workers signal (isCloudflare also matches a mere wrangler mention in a script or
+  // workflow).
+  const hasWorkersApp = allConfigs.some((c) => c.doesContainWranglerConfig);
+  const hasSingleInstanceServerApp = allConfigs.some(
+    (c) => (c.depending.next || c.depending.vinext) && !c.doesContainWranglerConfig
+  );
+  const workersInstruction =
+    '- Cloudflare Workers run across multiple ephemeral isolates and two requests may hit different instances: never let correctness depend on module-level mutable state; persist authoritative shared state in bindings (D1, KV, R2, Durable Objects). Best-effort isolate-local caches of non-request-scoped data are fine.';
+  const serverInstanceInstruction = hasWorkersApp
+    ? hasSingleInstanceServerApp
+      ? `${workersInstruction} This applies only to packages with a wrangler configuration; assume a single server instance for the other server apps.`
+      : workersInstruction
+    : hasSingleInstanceServerApp
+      ? '- Assume a single server instance.'
+      : '';
   // Keep top-down ordering guidance function-only because classes are not hoisted and can fail when inheritance or top-level instantiation depends on declaration order.
   return `
 ## Coding Style
@@ -176,23 +197,14 @@ ${
 }
 ${
   // vinext is the org's current web-app framework and enables the React Compiler just as Next.js
-  // does, so it must not miss these rules.
+  // does, so it must not miss this rule.
   allConfigs.some((c) => c.depending.next || c.depending.vinext)
     ? `
 - This project uses the React Compiler, so \`useCallback\` and \`useMemo\` are unnecessary for performance.
-${
-  // Cloudflare Workers execute across many ephemeral isolates with no shared memory, and two
-  // requests are not guaranteed to hit the same instance — the single-instance simplification
-  // (module-level mutable state, in-process caches or locks) silently loses state there.
-  // doesContainWranglerConfig is the accurate Workers signal (isCloudflare also matches a mere
-  // wrangler mention in a script or workflow).
-  allConfigs.some((c) => c.doesContainWranglerConfig)
-    ? '- The app runs on Cloudflare Workers across multiple ephemeral isolates: never keep state in module-level variables or in-process caches; persist anything shared between requests in bindings (D1, KV, R2, Durable Objects).'
-    : '- Assume a single server instance.'
-}
 `
     : ''
 }
+${serverInstanceInstruction}
 `
     .replaceAll(/\.\n\n+-/g, '.\n-')
     .replaceAll(/\n{3,}/g, '\n\n')

--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -162,7 +162,7 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
     '- Cloudflare Workers run across multiple ephemeral isolates and two requests may hit different instances: never let correctness depend on module-level mutable state; persist authoritative shared state in bindings (D1, KV, R2, Durable Objects). Best-effort isolate-local caches of non-request-scoped data are fine.';
   const serverInstanceInstruction = hasWorkersApp
     ? hasSingleInstanceServerApp
-      ? `${workersInstruction} This applies only to packages with a wrangler configuration; assume a single server instance for the other server apps.`
+      ? `${workersInstruction} This applies to all code that runs on Cloudflare Workers (the wrangler-configured packages and any workspace package they import); assume a single server instance for the other server apps.`
       : workersInstruction
     : hasSingleInstanceServerApp
       ? '- Assume a single server instance.'

--- a/packages/wbfy/test/unit/agents.test.ts
+++ b/packages/wbfy/test/unit/agents.test.ts
@@ -26,14 +26,29 @@ test('scopes the OS compatibility rule when a workspace package contains a Tauri
   expect(content).toContain('the Tauri desktop app additionally supports Windows');
 });
 
-test('replaces the single-server-instance rule with a multi-isolate rule for Cloudflare Workers repos', () => {
-  const base = { depending: { ...createConfig().depending, vinext: true } };
-  const workersConfig = createConfig({ ...base, doesContainWranglerConfig: true });
-  const workersStyle = generateAgentCodingStyle([workersConfig]);
+test('correlates the server-instance rule with each package deployment target', () => {
+  const vinextDepending = { ...createConfig().depending, vinext: true };
+
+  // A vinext app that IS the Worker gets the multi-isolate rule, not the single-instance one.
+  const workersApp = createConfig({ depending: vinextDepending, doesContainWranglerConfig: true });
+  const workersStyle = generateAgentCodingStyle([workersApp]);
   expect(workersStyle).toContain('multiple ephemeral isolates');
   expect(workersStyle).not.toContain('Assume a single server instance.');
 
-  const serverConfig = createConfig(base);
-  const serverStyle = generateAgentCodingStyle([serverConfig]);
+  // A Worker-only repository (e.g. a Hono API) needs the multi-isolate rule too.
+  const workerOnly = createConfig({ doesContainWranglerConfig: true });
+  const workerOnlyStyle = generateAgentCodingStyle([workerOnly]);
+  expect(workerOnlyStyle).toContain('multiple ephemeral isolates');
+  expect(workerOnlyStyle).not.toContain('Assume a single server instance.');
+
+  // A server-hosted vinext app keeps the single-instance simplification.
+  const serverApp = createConfig({ depending: vinextDepending });
+  const serverStyle = generateAgentCodingStyle([serverApp]);
   expect(serverStyle).toContain('Assume a single server instance.');
+  expect(serverStyle).not.toContain('ephemeral isolates');
+
+  // A monorepo mixing both must not let the unrelated Worker suppress the server app's rule.
+  const mixedStyle = generateAgentCodingStyle([serverApp, workerOnly]);
+  expect(mixedStyle).toContain('multiple ephemeral isolates');
+  expect(mixedStyle).toContain('assume a single server instance for the other server apps');
 });

--- a/packages/wbfy/test/unit/agents.test.ts
+++ b/packages/wbfy/test/unit/agents.test.ts
@@ -25,3 +25,15 @@ test('scopes the OS compatibility rule when a workspace package contains a Tauri
 
   expect(content).toContain('the Tauri desktop app additionally supports Windows');
 });
+
+test('replaces the single-server-instance rule with a multi-isolate rule for Cloudflare Workers repos', () => {
+  const base = { depending: { ...createConfig().depending, vinext: true } };
+  const workersConfig = createConfig({ ...base, doesContainWranglerConfig: true });
+  const workersStyle = generateAgentCodingStyle([workersConfig]);
+  expect(workersStyle).toContain('multiple ephemeral isolates');
+  expect(workersStyle).not.toContain('Assume a single server instance.');
+
+  const serverConfig = createConfig(base);
+  const serverStyle = generateAgentCodingStyle([serverConfig]);
+  expect(serverStyle).toContain('Assume a single server instance.');
+});


### PR DESCRIPTION
## Technical Summary

- `generateAgentCodingStyle` の「Assume a single server instance.」を配置先ごとに切り替え:
  - wrangler 設定を持つパッケージがあるリポジトリには「複数の短命な isolate で動くため、正しさをモジュールレベルの可変状態に依存させず、共有すべき正式な状態は bindings（D1 / KV / R2 / Durable Objects）へ永続化する。リクエスト外データのベストエフォートな isolate ローカルキャッシュは可」というルールを生成（Worker のみのリポジトリにも適用）。
  - 判定はパッケージ単位で相関させ、サーバーホストの next/vinext アプリと無関係な Worker が混在するモノレポでは両方のルールを実行対象基準（Worker が import する共有パッケージも含む文言）で出し分け。
  - 非 Workers の next/vinext リポジトリは従来どおり「Assume a single server instance.」。
- 判定は `doesContainWranglerConfig`（`isCloudflare` は script/workflow 中の wrangler 言及だけでも真になるため不使用）。
- ユニットテスト追加（Workers 専用 / vinext-on-Workers / 非 Workers / 混在モノレポの 4 ケース）。

## Why

- Cloudflare Workers は多数の短命な isolate で実行され、2 つのリクエストが同じインスタンスに到達する保証がない（https://developers.cloudflare.com/workers/reference/how-workers-works/）。Workers リポジトリに単一サーバー前提の指示を生成すると、エージェントに lost state / 競合バグを作らせる恐れがあると exKAZUu-Dev/tomatrillion PR #23 のレビューで指摘されたため。

## Testing

- `bun run vitest run test/unit`（wbfy 全件 pass）、`bun run tsc --noEmit` エラーなし、CI green。
- マルチエージェントレビュー 3 ラウンドを実施し、全指摘（モノレポ相関・Worker-only 適用漏れ・キャッシュ全面禁止の緩和・共有パッケージ文言）を修正のうえ全エージェント No concern で収束。
