### PR TITLE
fix(wb): restore minimal Blitz/Prisma support for yarn-era Blitz repositories

### DIFF
--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -78,6 +78,14 @@ export function getGenCodeScripts(project: Project): string[] {
     // below fail (e.g. "Property 'AUTH_SECRET' does not exist on type 'Env'").
     scripts.push(`${wranglerTypesScript} --env-file ${workerTypesEnvPath}`);
   }
+  // Yarn-era Blitz repositories need `blitz codegen` for the route manifest (node_modules/.blitz)
+  // that @blitzjs/next's type declarations re-export; install scripts do not run it
+  // (enableScripts: false). Never under Bun: the blitz CLI patches the installed next package in
+  // place, which must not happen in Bun's shared global store (Bun-era Blitz repositories generate
+  // the manifest with their own scripts instead).
+  if (!project.usesBunPackageManager && project.hasOwnDependency('blitz') && project.hasSourceCode) {
+    scripts.push('YARN blitz codegen');
+  }
   const prismaGenerateScript = getPrismaGenerateScript(project);
   if (prismaGenerateScript) {
     scripts.push(prismaGenerateScript);

--- a/packages/wb/src/commands/genCode.ts
+++ b/packages/wb/src/commands/genCode.ts
@@ -82,7 +82,10 @@ export function getGenCodeScripts(project: Project): string[] {
   // that @blitzjs/next's type declarations re-export; install scripts do not run it
   // (enableScripts: false). Never under Bun: the blitz CLI patches the installed next package in
   // place, which must not happen in Bun's shared global store (Bun-era Blitz repositories generate
-  // the manifest with their own scripts instead).
+  // the manifest with their own scripts instead). On a fresh install `blitz codegen` also
+  // generates the Prisma client itself, making the PRISMA generate step below redundant once —
+  // keeping both is deliberate: after schema-only changes blitz's already-generated guard skips
+  // its internal generate, so the explicit step is still what regenerates the client.
   if (!project.usesBunPackageManager && project.hasOwnDependency('blitz') && project.hasSourceCode) {
     scripts.push('YARN blitz codegen');
   }

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -8,7 +8,7 @@ import type { CommandModule, InferredOptionTypes } from 'yargs';
 import type { DatabaseOrm, Project } from '../project.js';
 import { findDescendantProjects, getAbsoluteFileDatabaseUrlPath, isProjectEnvironment } from '../project.js';
 import { buildDrizzleKitCommand, drizzleScripts } from '../scripts/drizzleScripts.js';
-import { getPrismaDatabaseDirName, prismaScripts } from '../scripts/prismaScripts.js';
+import { prismaScripts } from '../scripts/prismaScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
 import { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { isDockerEnabled } from '../utils/ci.js';
@@ -309,7 +309,7 @@ const studioCommand: CommandModule<unknown, InferredOptionTypes<typeof studioBui
       // Resolved against the project directory because prismaScripts.studio resolves a relative
       // path against the CLI process directory, which differs for workspace descendants.
       const dbUrlOrPath = argv.restored
-        ? path.resolve(project.dirPath, getPrismaDatabaseDirName(project), 'restored.sqlite3')
+        ? path.resolve(project.dirPath, project.prismaDirName, 'restored.sqlite3')
         : argv.dbUrlOrPath?.toString();
       await runWithSpawn(
         withLocalD1IfNeeded(orm, project, getDatabaseOrmScripts(orm).studio(project, dbUrlOrPath, unknownOptions)),
@@ -390,13 +390,13 @@ dbs:
 }
 
 function getDefaultRestoreOutput(project: Project, orm: DatabaseOrm): string {
-  if (orm === 'prisma') return `${getPrismaDatabaseDirName(project)}/restored.sqlite3`;
+  if (orm === 'prisma') return `${project.prismaDirName}/restored.sqlite3`;
   return 'drizzle/restored.sqlite3';
 }
 
 function getLitestreamDbPath(project: Project, orm: DatabaseOrm): string {
   if (orm === 'prisma') {
-    return `${getPrismaDatabaseDirName(project)}/mount/prod.sqlite3`;
+    return `${project.prismaDirName}/mount/prod.sqlite3`;
   }
 
   const dbPath = getAbsoluteFileDatabaseUrlPath(project);

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
 import type { EnvReaderOptions } from '@willbooster/shared-lib-node/src';
 import chalk from 'chalk';
@@ -305,8 +306,10 @@ const studioCommand: CommandModule<unknown, InferredOptionTypes<typeof studioBui
     const allProjects = await findDatabaseOrmProjects(argv);
     const unknownOptions = extractUnknownOptions(argv, ['db-url-or-path', 'restored']);
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db studio', allProjects)) {
+      // Resolved against the project directory because prismaScripts.studio resolves a relative
+      // path against the CLI process directory, which differs for workspace descendants.
       const dbUrlOrPath = argv.restored
-        ? `${getPrismaDatabaseDirName(project)}/restored.sqlite3`
+        ? path.resolve(project.dirPath, getPrismaDatabaseDirName(project), 'restored.sqlite3')
         : argv.dbUrlOrPath?.toString();
       await runWithSpawn(
         withLocalD1IfNeeded(orm, project, getDatabaseOrmScripts(orm).studio(project, dbUrlOrPath, unknownOptions)),

--- a/packages/wb/src/commands/prisma.ts
+++ b/packages/wb/src/commands/prisma.ts
@@ -7,7 +7,7 @@ import type { CommandModule, InferredOptionTypes } from 'yargs';
 import type { DatabaseOrm, Project } from '../project.js';
 import { findDescendantProjects, getAbsoluteFileDatabaseUrlPath, isProjectEnvironment } from '../project.js';
 import { buildDrizzleKitCommand, drizzleScripts } from '../scripts/drizzleScripts.js';
-import { prismaScripts } from '../scripts/prismaScripts.js';
+import { getPrismaDatabaseDirName, prismaScripts } from '../scripts/prismaScripts.js';
 import { runWithSpawn } from '../scripts/run.js';
 import { sharedOptionsBuilder } from '../sharedOptionsBuilder.js';
 import { isDockerEnabled } from '../utils/ci.js';
@@ -305,7 +305,9 @@ const studioCommand: CommandModule<unknown, InferredOptionTypes<typeof studioBui
     const allProjects = await findDatabaseOrmProjects(argv);
     const unknownOptions = extractUnknownOptions(argv, ['db-url-or-path', 'restored']);
     for (const { orm, project } of prepareForRunningDatabaseOrmCommand('db studio', allProjects)) {
-      const dbUrlOrPath = argv.restored ? 'prisma/restored.sqlite3' : argv.dbUrlOrPath?.toString();
+      const dbUrlOrPath = argv.restored
+        ? `${getPrismaDatabaseDirName(project)}/restored.sqlite3`
+        : argv.dbUrlOrPath?.toString();
       await runWithSpawn(
         withLocalD1IfNeeded(orm, project, getDatabaseOrmScripts(orm).studio(project, dbUrlOrPath, unknownOptions)),
         project,
@@ -385,14 +387,13 @@ dbs:
 }
 
 function getDefaultRestoreOutput(project: Project, orm: DatabaseOrm): string {
-  if (orm === 'prisma') return 'prisma/restored.sqlite3';
+  if (orm === 'prisma') return `${getPrismaDatabaseDirName(project)}/restored.sqlite3`;
   return 'drizzle/restored.sqlite3';
 }
 
 function getLitestreamDbPath(project: Project, orm: DatabaseOrm): string {
   if (orm === 'prisma') {
-    const dirName = 'prisma';
-    return `${dirName}/mount/prod.sqlite3`;
+    return `${getPrismaDatabaseDirName(project)}/mount/prod.sqlite3`;
   }
 
   const dbPath = getAbsoluteFileDatabaseUrlPath(project);

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -18,7 +18,7 @@ import type { PackageJson } from 'type-fest';
 import { prependNodeModulesBinToPath } from './utils/binPath.js';
 import { isCI } from './utils/ci.js';
 import { selectFnoxSourcedKeys } from './utils/envSources.js';
-import { hasBunDirectoryMarker, isBunPackageManager } from './utils/runtime.js';
+import { hasBunDirectoryMarker, isBunPackageManager, isExplicitNonBunPackageManager } from './utils/runtime.js';
 import { clearTestStructureCache } from './utils/testStructure.js';
 import { findWranglerConfigPath } from './utils/wrangler.js';
 
@@ -65,12 +65,7 @@ export class Project {
     // Some repositories rely on the lockfile or packageManager field instead of mise.
     // Docker optimization must follow the target project, not the runtime that launched wb.
     const packageManager = this.rootPackageJson?.packageManager ?? this.packageJson.packageManager;
-    // An explicit non-Bun declaration wins over the directory markers: yarn-era repositories may
-    // pin bun in mise.toml solely for `bunx`-based helpers (e.g. `wb railway-env`), and Bun-managed
-    // repositories never declare a non-Bun packageManager.
-    if (typeof packageManager === 'string' && packageManager.trim() && !isBunPackageManager(packageManager)) {
-      return false;
-    }
+    if (isExplicitNonBunPackageManager(packageManager)) return false;
     if (hasBunDirectoryMarker(this.rootDirPath)) return true;
     return isBunPackageManager(packageManager);
   }

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -310,6 +310,12 @@ export class Project {
     return !!this.getOwnDependencyVersion('prisma');
   }
 
+  /** Blitz repositories keep their Prisma schema and SQLite databases under db/ instead of prisma/. */
+  @memoizeOne
+  get prismaDirName(): string {
+    return fs.existsSync(path.join(this.dirPath, 'db', 'schema.prisma')) ? 'db' : 'prisma';
+  }
+
   @memoizeOne
   get hasDrizzle(): boolean {
     return !!this.getOwnDependencyVersion('drizzle-orm');

--- a/packages/wb/src/project.ts
+++ b/packages/wb/src/project.ts
@@ -64,8 +64,15 @@ export class Project {
   get usesBunPackageManager(): boolean {
     // Some repositories rely on the lockfile or packageManager field instead of mise.
     // Docker optimization must follow the target project, not the runtime that launched wb.
+    const packageManager = this.rootPackageJson?.packageManager ?? this.packageJson.packageManager;
+    // An explicit non-Bun declaration wins over the directory markers: yarn-era repositories may
+    // pin bun in mise.toml solely for `bunx`-based helpers (e.g. `wb railway-env`), and Bun-managed
+    // repositories never declare a non-Bun packageManager.
+    if (typeof packageManager === 'string' && packageManager.trim() && !isBunPackageManager(packageManager)) {
+      return false;
+    }
     if (hasBunDirectoryMarker(this.rootDirPath)) return true;
-    return isBunPackageManager(this.rootPackageJson?.packageManager ?? this.packageJson.packageManager);
+    return isBunPackageManager(packageManager);
   }
 
   @memoizeOne

--- a/packages/wb/src/scripts/prismaScripts.ts
+++ b/packages/wb/src/scripts/prismaScripts.ts
@@ -82,6 +82,13 @@ class PrismaScripts {
   }
 
   seed(project: Project, scriptPath?: string): string {
+    // Blitz seed modules default-export the seed function without calling it, so only
+    // `blitz db seed` (whose loader invokes the export) actually populates the database.
+    // Bun-era Blitz repositories declare prisma.seed instead and must avoid the blitz CLI,
+    // which patches the installed next package inside Bun's shared global store.
+    if (!project.usesBunPackageManager && project.hasOwnDependency('blitz')) {
+      return `YARN blitz db seed${scriptPath ? ` -f ${scriptPath}` : ''}`;
+    }
     if (scriptPath) return `BUN build-ts run ${scriptPath}`;
     if ((project.packageJson.prisma as Record<string, string> | undefined)?.seed) return `YARN prisma db seed`;
     const seedsPath = `${getPrismaDatabaseDirName(project)}/seeds.ts`;

--- a/packages/wb/src/scripts/prismaScripts.ts
+++ b/packages/wb/src/scripts/prismaScripts.ts
@@ -5,14 +5,21 @@ import type { Project } from '../project.js';
 import { FILE_SCHEMA, getFileDatabaseUrlPath } from '../project.js';
 import { getLitestreamConfigOption } from './litestream.js';
 
-/** Where the Prisma SQLite database is mounted, relative to the project directory. */
-const databaseDirPath = 'prisma/mount';
-
 const POSSIBLE_PRISMA_PATHS = [
   { schemaPath: path.join('prisma', 'schema.prisma'), dbPath: 'prisma' },
   { schemaPath: path.join('prisma', 'schema'), dbPath: path.join('prisma', 'schema') },
   { schemaPath: path.join('db', 'schema.prisma'), dbPath: 'db' },
 ];
+
+/** Blitz repositories keep their Prisma schema and SQLite databases under db/ instead of prisma/. */
+export function getPrismaDatabaseDirName(project: Project): string {
+  return fs.existsSync(path.resolve(project.dirPath, 'db', 'schema.prisma')) ? 'db' : 'prisma';
+}
+
+/** Where the Litestream-replicated SQLite database is mounted, relative to the project directory. */
+function getMountDirPath(project: Project): string {
+  return `${getPrismaDatabaseDirName(project)}/mount`;
+}
 
 /**
  * A collection of scripts for executing Prisma commands.
@@ -20,8 +27,8 @@ const POSSIBLE_PRISMA_PATHS = [
  * and `YARN zzz` is replaced with `yarn zzz` or `node_modules/.bin/zzz`.
  */
 class PrismaScripts {
-  cleanUpLitestream(_: Project): string {
-    const dirPath = databaseDirPath;
+  cleanUpLitestream(project: Project): string {
+    const dirPath = getMountDirPath(project);
     const cleanUpCommand = buildWalCheckpointAndRemoveSqliteSidecarFilesCommand(`${dirPath}/prod.sqlite3`);
     // Cleanup existing artifacts to avoid issues with Litestream replication.
     // Note that don't merge multiple rm commands into one, because if one fails, the subsequent ones won't run.
@@ -37,7 +44,7 @@ class PrismaScripts {
   }
 
   deployForce(project: Project): string {
-    const dirPath = databaseDirPath;
+    const dirPath = getMountDirPath(project);
     const removeDbCommand = buildRemoveSqliteDbCommand(`${dirPath}/prod.sqlite3`);
     const litestreamConfigOption = getLitestreamConfigOption(project);
     // `prisma migrate reset` can fail depending on the state of the existing database, so we remove it first.
@@ -47,7 +54,7 @@ class PrismaScripts {
   }
 
   listBackups(project: Project, configPath?: string): string {
-    const dirPath = databaseDirPath;
+    const dirPath = getMountDirPath(project);
     return `litestream ltx ${getLitestreamConfigOption(project, configPath)} ${dirPath}/prod.sqlite3`;
   }
 
@@ -70,14 +77,15 @@ class PrismaScripts {
   }
 
   restore(project: Project, outputPath: string, configPath?: string): string {
-    const dirPath = databaseDirPath;
+    const dirPath = getMountDirPath(project);
     return `rm -Rf ${outputPath}*; litestream restore ${getLitestreamConfigOption(project, configPath)} -o ${outputPath} ${dirPath}/prod.sqlite3`;
   }
 
   seed(project: Project, scriptPath?: string): string {
     if (scriptPath) return `BUN build-ts run ${scriptPath}`;
     if ((project.packageJson.prisma as Record<string, string> | undefined)?.seed) return `YARN prisma db seed`;
-    return `if [ -e "prisma/seeds.ts" ]; then BUN build-ts run prisma/seeds.ts; fi`;
+    const seedsPath = `${getPrismaDatabaseDirName(project)}/seeds.ts`;
+    return `if [ -e "${seedsPath}" ]; then BUN build-ts run ${seedsPath}; fi`;
   }
 
   studio(project: Project, dbUrlOrPath?: string, additionalOptions = ''): string {

--- a/packages/wb/src/scripts/prismaScripts.ts
+++ b/packages/wb/src/scripts/prismaScripts.ts
@@ -11,11 +11,6 @@ const POSSIBLE_PRISMA_PATHS = [
   { schemaPath: path.join('db', 'schema.prisma'), dbPath: 'db' },
 ];
 
-/** Where the Litestream-replicated SQLite database is mounted, relative to the project directory. */
-function getMountDirPath(project: Project): string {
-  return `${project.prismaDirName}/mount`;
-}
-
 /**
  * A collection of scripts for executing Prisma commands.
  * Note that `PRISMA` is replaced with `YARN prisma`
@@ -110,6 +105,11 @@ class PrismaScripts {
     }
     return `${prefix}PRISMA studio ${additionalOptions}`;
   }
+}
+
+/** Where the Litestream-replicated SQLite database is mounted, relative to the project directory. */
+function getMountDirPath(project: Project): string {
+  return `${project.prismaDirName}/mount`;
 }
 
 function getPrismaBaseDir(project: Project): string | undefined {

--- a/packages/wb/src/scripts/prismaScripts.ts
+++ b/packages/wb/src/scripts/prismaScripts.ts
@@ -11,14 +11,9 @@ const POSSIBLE_PRISMA_PATHS = [
   { schemaPath: path.join('db', 'schema.prisma'), dbPath: 'db' },
 ];
 
-/** Blitz repositories keep their Prisma schema and SQLite databases under db/ instead of prisma/. */
-export function getPrismaDatabaseDirName(project: Project): string {
-  return fs.existsSync(path.resolve(project.dirPath, 'db', 'schema.prisma')) ? 'db' : 'prisma';
-}
-
 /** Where the Litestream-replicated SQLite database is mounted, relative to the project directory. */
 function getMountDirPath(project: Project): string {
-  return `${getPrismaDatabaseDirName(project)}/mount`;
+  return `${project.prismaDirName}/mount`;
 }
 
 /**
@@ -91,7 +86,7 @@ class PrismaScripts {
     }
     if (scriptPath) return `BUN build-ts run ${scriptPath}`;
     if ((project.packageJson.prisma as Record<string, string> | undefined)?.seed) return `YARN prisma db seed`;
-    const seedsPath = `${getPrismaDatabaseDirName(project)}/seeds.ts`;
+    const seedsPath = `${project.prismaDirName}/seeds.ts`;
     return `if [ -e "${seedsPath}" ]; then BUN build-ts run ${seedsPath}; fi`;
   }
 

--- a/packages/wb/src/utils/runtime.ts
+++ b/packages/wb/src/utils/runtime.ts
@@ -2,15 +2,20 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 export function usesBunRuntime(dirPath: string): boolean {
+  // Mirrors Project.usesBunPackageManager: the outermost packageManager declaration (the
+  // workspace root's) takes precedence over nested ones, and an explicit non-Bun declaration
+  // wins over the directory markers. The walk therefore collects signals up to the repository
+  // root instead of deciding at the first hit, so a child workspace cannot override the root.
+  let outermostPackageManager: unknown;
+  let hasSomeBunDirectoryMarker = false;
   for (let currentPath = path.resolve(dirPath); ; currentPath = path.dirname(currentPath)) {
     const packageManager = readPackageManagerField(path.join(currentPath, 'package.json'));
-    if (isExplicitNonBunPackageManager(packageManager)) return false;
-    if (hasBunDirectoryMarker(currentPath) || isBunPackageManager(packageManager)) {
-      return true;
+    if (packageManager !== undefined) outermostPackageManager = packageManager;
+    hasSomeBunDirectoryMarker ||= hasBunDirectoryMarker(currentPath);
+    if (fs.existsSync(path.join(currentPath, '.git')) || path.dirname(currentPath) === currentPath) {
+      if (isExplicitNonBunPackageManager(outermostPackageManager)) return false;
+      return hasSomeBunDirectoryMarker || isBunPackageManager(outermostPackageManager);
     }
-    if (fs.existsSync(path.join(currentPath, '.git'))) return false;
-    const parentPath = path.dirname(currentPath);
-    if (parentPath === currentPath) return false;
   }
 }
 

--- a/packages/wb/src/utils/runtime.ts
+++ b/packages/wb/src/utils/runtime.ts
@@ -3,10 +3,9 @@ import path from 'node:path';
 
 export function usesBunRuntime(dirPath: string): boolean {
   for (let currentPath = path.resolve(dirPath); ; currentPath = path.dirname(currentPath)) {
-    if (
-      hasBunDirectoryMarker(currentPath) ||
-      isBunPackageManager(readPackageManagerField(path.join(currentPath, 'package.json')))
-    ) {
+    const packageManager = readPackageManagerField(path.join(currentPath, 'package.json'));
+    if (isExplicitNonBunPackageManager(packageManager)) return false;
+    if (hasBunDirectoryMarker(currentPath) || isBunPackageManager(packageManager)) {
       return true;
     }
     if (fs.existsSync(path.join(currentPath, '.git'))) return false;
@@ -20,7 +19,8 @@ export function usesBunRuntime(dirPath: string): boolean {
  * `.tool-versions` bun entry. wbfy migrates .tool-versions into mise.toml, so a mise-pinned bun
  * must count as well: repos that gitignore bun.lock and have no packageManager field rely on the
  * tool manifest. This is the single signal list deciding bun-vs-yarn; `Project.usesBunPackageManager`
- * shares it so the two detections cannot drift.
+ * and `usesBunRuntime` share it — and both give an explicit non-Bun packageManager declaration
+ * precedence over it (see isExplicitNonBunPackageManager) — so the two detections cannot drift.
  */
 export function hasBunDirectoryMarker(dirPath: string): boolean {
   return (
@@ -34,6 +34,16 @@ export function hasBunDirectoryMarker(dirPath: string): boolean {
 
 export function isBunPackageManager(packageManager: unknown): boolean {
   return typeof packageManager === 'string' && packageManager.startsWith('bun@');
+}
+
+/**
+ * An explicit non-Bun packageManager declaration (e.g. `yarn@4.17.0`) overrides the directory
+ * markers: yarn-era repositories may pin bun in mise.toml solely for `bunx`-based helpers
+ * (e.g. `wb railway-env`), and Bun-managed repositories never declare a non-Bun packageManager
+ * (wbfy deletes the field).
+ */
+export function isExplicitNonBunPackageManager(packageManager: unknown): boolean {
+  return typeof packageManager === 'string' && !!packageManager.trim() && !isBunPackageManager(packageManager);
 }
 
 function readPackageManagerField(packageJsonPath: string): unknown {

--- a/packages/wb/src/utils/runtime.ts
+++ b/packages/wb/src/utils/runtime.ts
@@ -37,10 +37,6 @@ export function hasBunDirectoryMarker(dirPath: string): boolean {
   );
 }
 
-export function isBunPackageManager(packageManager: unknown): boolean {
-  return typeof packageManager === 'string' && packageManager.startsWith('bun@');
-}
-
 /**
  * An explicit non-Bun packageManager declaration (e.g. `yarn@4.17.0`) overrides the directory
  * markers: yarn-era repositories may pin bun in mise.toml solely for `bunx`-based helpers
@@ -49,6 +45,10 @@ export function isBunPackageManager(packageManager: unknown): boolean {
  */
 export function isExplicitNonBunPackageManager(packageManager: unknown): boolean {
   return typeof packageManager === 'string' && !!packageManager.trim() && !isBunPackageManager(packageManager);
+}
+
+export function isBunPackageManager(packageManager: unknown): boolean {
+  return typeof packageManager === 'string' && packageManager.startsWith('bun@');
 }
 
 function readPackageManagerField(packageJsonPath: string): unknown {

--- a/packages/wb/test/unit/genCode.test.ts
+++ b/packages/wb/test/unit/genCode.test.ts
@@ -204,6 +204,38 @@ describe('getGenCodeScripts', () => {
     }
   });
 
+  it('runs blitz codegen before prisma generate for yarn-era Blitz repositories', async () => {
+    const dirPath = await createProject({
+      packageManager: 'yarn@4.17.0',
+      dependencies: { blitz: '2.2.4', prisma: '6.0.0' },
+    });
+    await fs.mkdir(path.join(dirPath, 'src'));
+    await fs.mkdir(path.join(dirPath, 'db'));
+    await fs.writeFile(path.join(dirPath, 'db', 'schema.prisma'), '');
+
+    try {
+      const scripts = getGenCodeScripts(new Project(dirPath, {}, false));
+      expect(scripts).toContain('YARN blitz codegen');
+      expect(scripts.indexOf('YARN blitz codegen')).toBeLessThan(scripts.indexOf('PRISMA generate'));
+    } finally {
+      await fs.rm(dirPath, { force: true, recursive: true });
+    }
+  });
+
+  it('does not run blitz codegen for Bun-managed Blitz repositories', async () => {
+    // The blitz CLI patches the installed next package in place, which must never happen in
+    // Bun's shared global store; Bun-era Blitz repositories generate the manifest themselves.
+    const dirPath = await createProject({ dependencies: { blitz: '2.2.4' } });
+    await fs.mkdir(path.join(dirPath, 'src'));
+    await fs.writeFile(path.join(dirPath, 'bun.lock'), '');
+
+    try {
+      expect(getGenCodeScripts(new Project(dirPath, {}, false))).not.toContain('YARN blitz codegen');
+    } finally {
+      await fs.rm(dirPath, { force: true, recursive: true });
+    }
+  });
+
   it('does not run prisma generate without a schema', async () => {
     const dirPath = await createProject({
       dependencies: {

--- a/packages/wb/test/unit/project.test.ts
+++ b/packages/wb/test/unit/project.test.ts
@@ -12,6 +12,7 @@ import {
   getAbsoluteFileDatabaseUrlPath,
 } from '../../src/project.js';
 
+import { usesBunRuntime } from '../../src/utils/runtime.js';
 import { initializeProjectDirectory, tempDir } from '../helpers/shared.js';
 
 describe('project', () => {
@@ -84,6 +85,8 @@ describe('project', () => {
 
       const project = findSelfProject({}, false, dirPath);
       expect(project?.usesBunPackageManager).toBe(false);
+      // `wb run` must agree: the same precedence applies to the runtime detection.
+      expect(usesBunRuntime(dirPath)).toBe(false);
     } finally {
       await fs.promises.rm(dirPath, { recursive: true, force: true });
     }

--- a/packages/wb/test/unit/project.test.ts
+++ b/packages/wb/test/unit/project.test.ts
@@ -92,6 +92,30 @@ describe('project', () => {
     }
   });
 
+  it('keeps the workspace root packageManager authoritative for the runtime detection', async () => {
+    // A child workspace declaring its own non-Bun packageManager must not override the Bun root:
+    // Project.usesBunPackageManager prefers the root declaration, and `wb run` must agree.
+    const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-bun-workspace-'));
+    try {
+      await fs.promises.mkdir(path.join(dirPath, '.git'));
+      await fs.promises.writeFile(
+        path.join(dirPath, 'package.json'),
+        JSON.stringify({ name: 'root', packageManager: 'bun@1.3.14', workspaces: ['packages/*'] })
+      );
+      await fs.promises.writeFile(path.join(dirPath, 'bun.lock'), '');
+      const childDirPath = path.join(dirPath, 'packages', 'child');
+      await fs.promises.mkdir(childDirPath, { recursive: true });
+      await fs.promises.writeFile(
+        path.join(childDirPath, 'package.json'),
+        JSON.stringify({ name: 'child', packageManager: 'yarn@4.17.0' })
+      );
+
+      expect(usesBunRuntime(childDirPath)).toBe(true);
+    } finally {
+      await fs.promises.rm(dirPath, { recursive: true, force: true });
+    }
+  });
+
   it('uses oxlint when declared', async () => {
     const dirPath = path.join(tempDir, 'app');
     await initializeProjectDirectory(dirPath);

--- a/packages/wb/test/unit/project.test.ts
+++ b/packages/wb/test/unit/project.test.ts
@@ -71,6 +71,24 @@ describe('project', () => {
     expect(project?.isBunAvailable).toBe(true);
   });
 
+  it('prefers an explicit yarn packageManager over a mise.toml bun pin', async () => {
+    // Yarn-era repositories may pin bun in mise.toml solely for `bunx`-based helpers
+    // (e.g. `wb railway-env`); the explicit packageManager declaration must win.
+    const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-yarn-pm-'));
+    try {
+      await fs.promises.writeFile(
+        path.join(dirPath, 'package.json'),
+        JSON.stringify({ name: 'app', packageManager: 'yarn@4.17.0' })
+      );
+      await fs.promises.writeFile(path.join(dirPath, 'mise.toml'), '[tools]\nbun = "latest"\n');
+
+      const project = findSelfProject({}, false, dirPath);
+      expect(project?.usesBunPackageManager).toBe(false);
+    } finally {
+      await fs.promises.rm(dirPath, { recursive: true, force: true });
+    }
+  });
+
   it('uses oxlint when declared', async () => {
     const dirPath = path.join(tempDir, 'app');
     await initializeProjectDirectory(dirPath);

--- a/packages/wb/test/unit/scripts/prismaScripts.test.ts
+++ b/packages/wb/test/unit/scripts/prismaScripts.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { Project } from '../../../src/project.js';
+import { Project } from '../../../src/project.js';
 import { cleanUpSqliteDbIfNeeded, prismaScripts } from '../../../src/scripts/prismaScripts.js';
 
 const createdDirs: string[] = [];
@@ -75,6 +75,7 @@ describe('prismaScripts.reset', () => {
       dirPath,
       env: {},
       packageJson: { dependencies: {} },
+      prismaDirName: 'prisma',
     } as unknown as Project;
     const command = prismaScripts.cleanUpLitestream(project);
 
@@ -105,13 +106,12 @@ describe('prismaScripts.reset', () => {
 
   it('resolves database paths under db/ for the Blitz layout (db/schema.prisma)', () => {
     const dirPath = createProjectDir({ blitzLayout: true });
-    const project = {
-      dirPath,
-      env: {},
-      hasOwnDependency: (name: string) => name === 'blitz',
-      packageJson: { dependencies: { blitz: '2.2.4' } },
-      usesBunPackageManager: false,
-    } as unknown as Project;
+    // A real Project so prismaDirName's db/schema.prisma detection is exercised end-to-end.
+    fs.writeFileSync(
+      path.join(dirPath, 'package.json'),
+      JSON.stringify({ name: 'blitz-app', dependencies: { blitz: '2.2.4' } })
+    );
+    const project = new Project(dirPath, {}, false);
 
     expect(prismaScripts.deployForce(project)).toContain('rm -Rf "db/mount/prod.sqlite3"*');
     expect(prismaScripts.cleanUpLitestream(project)).toContain(
@@ -130,6 +130,7 @@ describe('prismaScripts.reset', () => {
       dirPath: '/tmp/dummy',
       env: {},
       packageJson: { dependencies: {} },
+      prismaDirName: 'prisma',
     } as unknown as Project;
 
     const command = prismaScripts.deployForce(project);

--- a/packages/wb/test/unit/scripts/prismaScripts.test.ts
+++ b/packages/wb/test/unit/scripts/prismaScripts.test.ts
@@ -103,6 +103,24 @@ describe('prismaScripts.reset', () => {
     expect(introspectedSchema).toContain('model t');
   }, 120_000);
 
+  it('resolves database paths under db/ for the Blitz layout (db/schema.prisma)', () => {
+    const dirPath = createProjectDir({ blitzLayout: true });
+    const project = {
+      dirPath,
+      env: {},
+      packageJson: { dependencies: { blitz: '2.2.4' } },
+    } as unknown as Project;
+
+    expect(prismaScripts.deployForce(project)).toContain('rm -Rf "db/mount/prod.sqlite3"*');
+    expect(prismaScripts.cleanUpLitestream(project)).toContain(
+      'rm -f "db/mount/prod.sqlite3".* "db/mount/prod.sqlite3"-*'
+    );
+    expect(prismaScripts.restore(project, 'db/restored.sqlite3')).toContain(
+      '-o db/restored.sqlite3 db/mount/prod.sqlite3'
+    );
+    expect(prismaScripts.seed(project)).toBe('if [ -e "db/seeds.ts" ]; then BUN build-ts run db/seeds.ts; fi');
+  });
+
   it('uses wal checkpoint in deployForce cleanup command', () => {
     const project = {
       dirPath: '/tmp/dummy',
@@ -117,12 +135,13 @@ describe('prismaScripts.reset', () => {
   });
 });
 
-function createProjectDir(): string {
+function createProjectDir(options?: { blitzLayout?: boolean }): string {
   const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wb-prisma-scripts-'));
   createdDirs.push(dirPath);
-  fs.mkdirSync(path.join(dirPath, 'prisma'), { recursive: true });
+  const schemaDirName = options?.blitzLayout ? 'db' : 'prisma';
+  fs.mkdirSync(path.join(dirPath, schemaDirName), { recursive: true });
   fs.writeFileSync(
-    path.join(dirPath, 'prisma', 'schema.prisma'),
+    path.join(dirPath, schemaDirName, 'schema.prisma'),
     [
       'datasource db {',
       '  provider = "sqlite"',

--- a/packages/wb/test/unit/scripts/prismaScripts.test.ts
+++ b/packages/wb/test/unit/scripts/prismaScripts.test.ts
@@ -108,7 +108,9 @@ describe('prismaScripts.reset', () => {
     const project = {
       dirPath,
       env: {},
+      hasOwnDependency: (name: string) => name === 'blitz',
       packageJson: { dependencies: { blitz: '2.2.4' } },
+      usesBunPackageManager: false,
     } as unknown as Project;
 
     expect(prismaScripts.deployForce(project)).toContain('rm -Rf "db/mount/prod.sqlite3"*');
@@ -118,7 +120,9 @@ describe('prismaScripts.reset', () => {
     expect(prismaScripts.restore(project, 'db/restored.sqlite3')).toContain(
       '-o db/restored.sqlite3 db/mount/prod.sqlite3'
     );
-    expect(prismaScripts.seed(project)).toBe('if [ -e "db/seeds.ts" ]; then BUN build-ts run db/seeds.ts; fi');
+    // Blitz seed modules default-export the seed function; only the blitz CLI's loader invokes it.
+    expect(prismaScripts.seed(project)).toBe('YARN blitz db seed');
+    expect(prismaScripts.seed(project, 'db/genUserCsv')).toBe('YARN blitz db seed -f db/genUserCsv');
   });
 
   it('uses wal checkpoint in deployForce cleanup command', () => {

--- a/packages/wbfy/src/generators/lefthook.ts
+++ b/packages/wbfy/src/generators/lefthook.ts
@@ -408,10 +408,10 @@ function generatePostMergeCommands(config: PackageConfig, allConfigs: PackageCon
   }
   // Blitz repositories deliberately get the same wb-driven prisma commands as everyone else:
   // the blitz CLI's codegen patches the installed next package in place, which must never run
-  // under Bun's shared global store (blitz repos migrated to bun run without the blitz CLI, and
-  // yarn-era ones regenerate the route manifest via `blitz dev` anyway). wb routes `wb prisma`
-  // through the blitz CLI only on wb <= 15 yarn-era repos, where in-place patching was already
-  // the status quo.
+  // under Bun's shared global store. Yarn-era Blitz repos get their route manifest from
+  // `wb gen-code`'s `blitz codegen` step, and current wb routes only `wb prisma seed` through
+  // the blitz CLI, only for non-Bun repos (see packages/wb/src/scripts/prismaScripts.ts); the
+  // post-merge hooks stay wb-driven because `prisma deploy`/`generate` need no blitz loader.
   if (config.depending.prisma) {
     postMergeCommands.push(
       String.raw`run_if_changed ".*\.prisma" "node node_modules/.bin/wb prisma deploy"`,


### PR DESCRIPTION
## Customer Summary

- 開発者向けツール(wb)の修正で、Blitz 製アプリのリポジトリ(WillBooster/survey-system, WillBooster/chofu-walking, WillBooster/literacy-test)で `wb` の DB・コード生成・スクリプト実行コマンドが再び正しく動作するようにします。アプリ利用者への影響はありません。

## Technical Summary

- **`db/` レイアウト対応の復元**: Prisma の SQLite データベースディレクトリを `Project.prismaDirName`(`db/schema.prisma` の有無で `db`/`prisma` を返すメモ化 getter)から解決し、`wb prisma restore` / `studio --restored` / `deploy-force` / `list-backups` と Litestream のクリーンアップ・設定生成パスを修正(従来は `prisma/mount` 固定)。`studio --restored` の既定パスはプロジェクトディレクトリ基準の絶対パスで解決し、ワークスペース子パッケージでも正しい DB を開く。
- **`wb gen-code` に `blitz codegen` を復元(yarn 世代限定)**: `@blitzjs/next` の型宣言は生成物 `node_modules/.blitz` を再エクスポートしており、yarn 世代は `enableScripts: false` のため install では生成されない。Bun 管理リポジトリでは実行しない(blitz CLI が共有グローバルストア内の next を書き換えるため)。フレッシュインストール時の `prisma generate` 二重実行は意図的(スキーマ変更のみの再実行時は blitz 側がスキップするため明示ステップが必要)としてコメントに記録。
- **`wb prisma seed` を yarn 世代 Blitz では `blitz db seed` にルーティング**: Blitz の seed モジュールは default export を呼び出さないため、`build-ts run` では無言の no-op になる。blitz CLI のローダーのみが実際に DB を投入する。
- **パッケージマネージャ判定の優先順位修正**: 明示的な非 Bun の `packageManager` 宣言(例 `yarn@4.17.0`)を mise.toml の bun ピン等のディレクトリマーカーより優先(共有ヘルパー `isExplicitNonBunPackageManager`)。`wb run` の bun/node 判定(`usesBunRuntime`)も同じ優先順位を共有し、ワークスペースルートの宣言が子パッケージより優先されるようリポジトリルートまでシグナルを収集して判定。
- wbfy はコード変更なし(lefthook 生成コメントの記述更新のみ)。survey-system / literacy-test には正常適用され、chofu-walking は設計どおり「yarn patch 使用のため手動で Bun へ移行が必要」と明示して安全にスキップする(exit 0)ことを確認。

## Why

- #1052 で wb から Blitz サポートが削除されたが、上記 3 リポジトリは現役の Blitz アプリ。Bun 世代の survey-system / literacy-test は現行 wb で動作する(`prisma/` レイアウト + `prisma.seed` 設定 + #1108 の dev サーバー対応)一方、yarn 世代の chofu-walking(Blitz 標準の `db/` レイアウト)には共有ツール側でしか直せないギャップが残っていた。
- chofu-walking が `wb railway-env` のために mise.toml へ bun をピンすると全コマンドが `bun run` に反転する問題も、同リポジトリの fnox 移行作業で実際に顕在化していた。

## Testing

- `bun verify-full`(全パッケージ)パス。
- 3 リポジトリすべてで `wb start` / `test` / `test-on-ci` / `gen-code` / `run` / `prisma migrate|reset|seed|restore|studio --restored|deploy-force` を `--dry-run` 検証し、chofu-walking が `db/` パス + `yarn blitz codegen` + `yarn blitz db seed` + yarn/node コマンド、survey-system / literacy-test が従来どおりの `prisma/` パス + bun コマンドになることを確認。
- chofu-walking で `wb gen-code` を実実行し、Routes manifest 生成と `db/schema.prisma` からの Prisma クライアント生成を確認。
- ワークスペース構成のフィクスチャで `studio --restored` が子パッケージの DB パスに解決されることを確認。
- ローカル wbfy を 3 リポジトリのコピーに適用し、wbfy の挙動を確認。
- 新挙動(db/ レイアウトのパス解決、yarn 世代のみの blitz codegen / blitz db seed、packageManager 優先、ワークスペースルート優先の runtime 判定)にユニットテストを追加。

## Notes

- マルチエージェントレビュー(Codex / Claude Code / Antigravity)を3ラウンド実施し、検出された6件(usesBunRuntime のドリフト、Blitz seed の無言 no-op、子ワークスペースの packageManager 上書き、studio --restored の相対パス解決、gen-code コメント、wbfy lefthook コメント)をすべて修正。Gemini レビュー指摘(prismaDirName の Project への移動、トップダウン順)も適用済み。
- Drizzle プロジェクトの `studio --restored` 既定パス不一致は本 PR 以前からの既存バグでスコープ外(レビュー facts に記録済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
