### PR TITLE
fix(wbfy): keep the test script of non-JavaScript packages

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -2257,6 +2257,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
   if (config.isRoot) {
     applyTestOnCiScript(scripts, oldScripts);
   }
+  applyTestScript(config, scripts, oldScripts);
   applyDatabaseScripts(config, scripts, oldScripts, `bun ${getWbDatabaseCommand(config)}`);
   applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
   if (!hasTypecheck) {
@@ -2288,6 +2289,36 @@ function applyTestOnCiScript(scripts: Record<string, string>, oldScripts: Packag
  */
 function isGeneratedTestOnCiScript(script: string): boolean {
   return /^(?:(?:bun(?:[ \t]+--bun)?|yarn|npx)[ \t]+)?wb[ \t]+test-on-ci$/u.test(script.trim());
+}
+
+/**
+ * `wb test` runs JavaScript/TypeScript test runners only, so replacing the `test` script of a
+ * package written in another language (e.g. a Maven or an RSpec package in a polyglot monorepo)
+ * silently drops its whole suite: the generated script then succeeds without running anything.
+ * Such a package keeps its own `test` script; JS/TS packages are standardized as usual.
+ */
+function applyTestScript(
+  config: PackageConfig,
+  scripts: Record<string, string>,
+  oldScripts: PackageJson.Scripts
+): void {
+  const oldScript = oldScripts.test?.trim();
+  if (
+    !oldScript ||
+    config.doesContainJavaScript ||
+    config.doesContainTypeScript ||
+    config.doesContainJavaScriptInPackages ||
+    config.doesContainTypeScriptInPackages
+  ) {
+    return;
+  }
+  if (isGeneratedTestScript(oldScript)) return;
+  scripts.test = oldScript;
+}
+
+/** Whether a script body is one of the KNOWN generated `wb test` invocations. */
+function isGeneratedTestScript(script: string): boolean {
+  return /^(?:(?:bun(?:[ \t]+--bun)?|yarn|npx)[ \t]+)?wb[ \t]+test$/u.test(script.trim());
 }
 
 function applyDatabaseScripts(


### PR DESCRIPTION
## Problem

`generateScripts` sets `test: 'bun wb test'` unconditionally, but `wb test` only runs JavaScript/TypeScript test runners. In a polyglot monorepo, a package whose tests belong to another toolchain loses its whole suite: the generated script exits 0 without running anything.

Found while migrating WillBooster/investment-helper to Bun + fnox, where wbfy replaced `bash -c 'mvn test -q'` (Maven) and `bash -c 'bundle && bundle exec rspec'` (RSpec) with `bun wb test`.

## Fix

A package that contains no JavaScript/TypeScript — neither itself nor in its workspaces — keeps its existing `test` script, unless that script is a known generated `wb test` invocation (mirroring the existing `applyTestOnCiScript` / `isGeneratedTestOnCiScript` pattern). JS/TS packages are standardized exactly as before.

## Verification

Ran the local checkout against WillBooster/investment-helper: the Maven and RSpec `test` scripts survive, and every other generated script is unchanged.
