### PR TITLE
feat(wbfy): grant aries scoped fnox access

### DIFF
--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -59,6 +59,23 @@ export const FNOX_AGE_PRINCIPALS = [
     publicKeys: ['age1mw4pz9dujy9dmhk0palqawjkj7m4k7zx78yr9fjt63sa5l3e43uq6nw004'],
     repositoryScope: { organizations: ['WillBooster', 'WillBoosterLab'] },
   },
+  {
+    name: 'aries',
+    publicKeys: ['age1nn0ehyaenyq8kmnq4294kzzgxv5dnf6pep2cdkraxzfqlk7xgsrqqn6nn9'],
+    repositoryScope: {
+      repositories: [
+        'WillBooster/agent-challenges',
+        'WillBooster/agentic-workflows',
+        'WillBooster/agentic-workflows-dashboard',
+        'WillBooster/cheerlings',
+        'WillBooster/chofu-walking',
+        'WillBooster/prompt-study',
+        'WillBoosterLab/exercode',
+        'WillBoosterLab/exercode-employee-courses',
+        'WillBoosterLab/judge',
+      ],
+    },
+  },
 ] as const satisfies readonly FnoxAgePrincipal[];
 
 interface FnoxToml {

--- a/packages/wbfy/test/unit/fnoxToml.test.ts
+++ b/packages/wbfy/test/unit/fnoxToml.test.ts
@@ -44,6 +44,34 @@ test('matches fnox repository scopes by organization or exact repository', () =>
   expect(matchesFnoxRepositoryScope(scope, createConfig({ repository: undefined }))).toBe(false);
 });
 
+test('grants aries fnox access only to the selected repositories', () => {
+  const ariesRecipient = {
+    name: 'aries',
+    publicKey: 'age1nn0ehyaenyq8kmnq4294kzzgxv5dnf6pep2cdkraxzfqlk7xgsrqqn6nn9',
+  };
+  const selectedRepositories = [
+    'WillBooster/agent-challenges',
+    'WillBooster/agentic-workflows',
+    'WillBooster/agentic-workflows-dashboard',
+    'WillBooster/cheerlings',
+    'WillBooster/chofu-walking',
+    'WillBooster/prompt-study',
+    'WillBoosterLab/exercode',
+    'WillBoosterLab/exercode-employee-courses',
+    'WillBoosterLab/judge',
+  ];
+
+  for (const repository of selectedRepositories) {
+    expect(getFnoxAgeRecipients(createConfig({ repository: `github:${repository}` }))).toContainEqual(ariesRecipient);
+  }
+  expect(getFnoxAgeRecipients(createConfig({ repository: 'github:WillBooster/shared' }))).not.toContainEqual(
+    ariesRecipient
+  );
+  expect(getFnoxAgeRecipients(createConfig({ repository: 'github:WillBoosterLab/example' }))).not.toContainEqual(
+    ariesRecipient
+  );
+});
+
 test('keeps the age recipients of a repository outside the WillBooster organizations', async () => {
   const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-fnox-'));
   try {


### PR DESCRIPTION
## Customer Summary

- Grant aries access to fnox-managed secrets in the nine requested repositories.
- Keep every other WillBooster and WillBoosterLab repository outside aries's access scope.
- The target repositories receive the new recipient when they are regenerated with the released wbfy version.

## Technical Summary

- Add the aries age public key as an fnox principal with an exact repository allowlist.
- Cover all nine allowed repositories and representative denied repositories from both organizations in the scope test.

## Why

aries needs fnox access to a limited set of repositories without receiving organization-wide decryption access.

## Testing

- `bun test test/unit/fnoxToml.test.ts`
- `bun test` in `packages/wbfy` (323 passed)
- `bun verify`
- `bun verify-full` (stopped in the existing `packages/wb` Docker test because Docker Desktop reported `no space left on device`; fnox tests, all wbfy tests, lint, formatting, and type checking passed independently)
