### PR TITLE
fix(wbfy): keep scripts that chain extra commands onto the generated ones

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -2329,15 +2329,24 @@ function keepGeneratedScriptWrappers(
     const oldScript = oldScripts[scriptName]?.trim();
     const generatedScript = scripts[scriptName];
     if (!oldScript || !generatedScript || oldScript === generatedScript) continue;
-    // The stored wrapper may carry a legacy runner prefix (e.g. `yarn wb test && ...`), so compare
-    // the command core and accept any of the historical prefixes.
+    // The stored wrapper may lead with a legacy runner prefix (`yarn wb test && ...`) or with the
+    // `bun run wb test && ...` that convertYarnCommandsToBun produces from it later in this very
+    // run, so accept those prefixes and REWRITE the matched head to the generated command. Keeping
+    // the old head verbatim would freeze a stale prefix — notably `--bun`, whose node->bun PATH
+    // shim breaks Node-based tools — and leave a body the next run no longer recognizes as a
+    // wrapper, silently dropping the chained commands one run later.
     const generatedCore = generatedScript.replace(/^bun[ \t]+/u, '');
-    const wrapperRegExp = new RegExp(
-      `^(?:(?:bun(?:[ \\t]+--bun)?|yarn|npx)[ \\t]+)?${escapeRegExp(generatedCore)}[ \\t]*(?:&&|\\|\\||;)`,
+    const headRegExp = new RegExp(
+      `^(?:(?:bun(?:[ \\t]+--bun)?|yarn|npx)(?:[ \\t]+run)?[ \\t]+)?${escapeRegExp(generatedCore).replaceAll(
+        ' ',
+        String.raw`[ \t]+`
+      )}(?=[ \\t]*(?:&&|\\|\\||;|\\n))`,
       'u'
     );
-    if (wrapperRegExp.test(oldScript)) {
-      scripts[scriptName] = oldScript;
+    // A newline separates shell commands just like &&, || and ;, matching isGeneratedDatabaseScript.
+    if (headRegExp.test(oldScript)) {
+      // A function replacement keeps `$`-shaped characters in the generated command literal.
+      scripts[scriptName] = oldScript.replace(headRegExp, () => generatedScript);
     }
   }
 }

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -2258,6 +2258,7 @@ export function generateScripts(config: PackageConfig, oldScripts: PackageJson.S
     applyTestOnCiScript(scripts, oldScripts);
   }
   applyTestScript(config, scripts, oldScripts);
+  keepGeneratedScriptWrappers(scripts, oldScripts, ['test', 'verify-full']);
   applyDatabaseScripts(config, scripts, oldScripts, `bun ${getWbDatabaseCommand(config)}`);
   applyMiseTaskScripts(config, scripts, oldScripts, ['build', 'dev', 'start', 'test', 'typecheck']);
   if (!hasTypecheck) {
@@ -2303,22 +2304,42 @@ function applyTestScript(
   oldScripts: PackageJson.Scripts
 ): void {
   const oldScript = oldScripts.test?.trim();
-  if (
-    !oldScript ||
-    config.doesContainJavaScript ||
-    config.doesContainTypeScript ||
-    config.doesContainJavaScriptInPackages ||
-    config.doesContainTypeScriptInPackages
-  ) {
-    return;
-  }
-  if (isGeneratedTestScript(oldScript)) return;
+  if (!oldScript || doesContainJsOrTs(config) || isGeneratedTestScript(oldScript)) return;
   scripts.test = oldScript;
 }
 
 /** Whether a script body is one of the KNOWN generated `wb test` invocations. */
 function isGeneratedTestScript(script: string): boolean {
   return /^(?:(?:bun(?:[ \t]+--bun)?|yarn|npx)[ \t]+)?wb[ \t]+test$/u.test(script.trim());
+}
+
+/**
+ * Keeps a script that CHAINS extra commands onto the generated one (e.g. a polyglot monorepo
+ * appending its Maven and RSpec suites to `wb test`, which runs JavaScript/TypeScript runners
+ * only). Such a wrapper still runs the generated command, so replacing it would silently drop the
+ * repository's own steps — the same reasoning as `applyTestOnCiScript`. A script that starts with
+ * anything else is standardized as usual.
+ */
+function keepGeneratedScriptWrappers(
+  scripts: Record<string, string>,
+  oldScripts: PackageJson.Scripts,
+  scriptNames: string[]
+): void {
+  for (const scriptName of scriptNames) {
+    const oldScript = oldScripts[scriptName]?.trim();
+    const generatedScript = scripts[scriptName];
+    if (!oldScript || !generatedScript || oldScript === generatedScript) continue;
+    // The stored wrapper may carry a legacy runner prefix (e.g. `yarn wb test && ...`), so compare
+    // the command core and accept any of the historical prefixes.
+    const generatedCore = generatedScript.replace(/^bun[ \t]+/u, '');
+    const wrapperRegExp = new RegExp(
+      `^(?:(?:bun(?:[ \\t]+--bun)?|yarn|npx)[ \\t]+)?${escapeRegExp(generatedCore)}[ \\t]*(?:&&|\\|\\||;)`,
+      'u'
+    );
+    if (wrapperRegExp.test(oldScript)) {
+      scripts[scriptName] = oldScript;
+    }
+  }
 }
 
 function applyDatabaseScripts(

--- a/packages/wbfy/test/unit/packageJson.test.ts
+++ b/packages/wbfy/test/unit/packageJson.test.ts
@@ -1208,6 +1208,50 @@ test('does not generate test/ci in a workspace package', async () => {
   expect(packageJson.scripts?.['test/ci']).toBeUndefined();
 });
 
+const jsRootConfig = { doesContainTypeScript: true, isRoot: true } as const;
+
+test('keeps commands chained onto the generated test and verify-full scripts', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      scripts: {
+        test: 'bun wb test && bun run test/analyzers',
+        'verify-full': 'bun wb verify --full && bun run test/analyzers',
+      },
+    },
+    jsRootConfig
+  );
+
+  expect(packageJson.scripts).toMatchObject({
+    test: 'bun wb test && bun run test/analyzers',
+    'verify-full': 'bun wb verify --full && bun run test/analyzers',
+  });
+});
+
+test('normalizes the runner prefix of a chained test script instead of freezing it', async () => {
+  // `bun run wb test` is what convertYarnCommandsToBun leaves behind for a `yarn wb test` wrapper,
+  // and `--bun` breaks Node-based tools; both must converge on the generated command so that the
+  // next run still recognizes the body as a wrapper.
+  const packageJson = await generatePackageJsonFrom(
+    { scripts: { test: 'bun run wb test && mvn test', 'verify-full': 'bun --bun wb verify --full; mvn test' } },
+    jsRootConfig
+  );
+
+  expect(packageJson.scripts).toMatchObject({
+    test: 'bun wb test && mvn test',
+    'verify-full': 'bun wb verify --full; mvn test',
+  });
+});
+
+test('keeps a command chained onto the generated test script with a newline', async () => {
+  const packageJson = await generatePackageJsonFrom({ scripts: { test: 'bun wb test\nmvn test' } }, jsRootConfig);
+  expect(packageJson.scripts?.test).toBe('bun wb test\nmvn test');
+});
+
+test('replaces a plain generated test script body', async () => {
+  const packageJson = await generatePackageJsonFrom({ scripts: { test: 'yarn wb test' } }, jsRootConfig);
+  expect(packageJson.scripts?.test).toBe('bun wb test');
+});
+
 async function generatePackageJsonFrom(
   initialPackageJson: Record<string, unknown>,
   configOverrides: Parameters<typeof createConfig>[0] = {},


### PR DESCRIPTION
Follow-up to #1132.

## Problem

`generateScripts` regenerates `test` and `verify-full` wholesale, so a repository that CHAINS extra commands onto the generated command loses them on every wbfy run. WillBooster/investment-helper needs exactly that: `wb test` runs JavaScript/TypeScript runners only, so its root scripts append the Maven and RSpec suites (`bun wb test && bun run test/analyzers`). #1132 protects those suites' own package scripts, but the root wrappers that invoke them were still wiped.

## Fix

`keepGeneratedScriptWrappers` keeps a `test` / `verify-full` script whose head is the generated command followed by a chaining operator — the same "custom wrappers are preserved" reasoning `applyTestOnCiScript` already applies to `test/ci`. A script that starts with anything else (e.g. a legacy bare `vitest`) is still standardized.

The head is REWRITTEN to the generated command rather than copied verbatim, which keeps the operation idempotent and normalizing:

- `convertYarnCommandsToBun` (called later in the same `generatePackageJson` run) turns a preserved `yarn wb test && …` into `bun run wb test && …`. A verbatim copy plus a prefix pattern that does not accept `bun run` would stop matching on the NEXT run and silently drop the chained commands one run later — the shape this PR exists to prevent.
- A `bun --bun` prefix would otherwise be frozen into the script, re-blessing the node->bun PATH shim that the generated command's comment explicitly avoids.

A newline is accepted as a chaining operator too, matching the reasoning already documented on `isGeneratedDatabaseScript`.

## Verification

- Four unit tests in `packages/wbfy/test/unit/packageJson.test.ts`; the two behavioral ones (`normalizes the runner prefix …`, `keeps a command chained … with a newline`) fail with assertion errors against the previous verbatim-copy implementation and pass with this one. Full file: 82 passed.
- Ran the local checkout twice against WillBooster/investment-helper: `test`, `test/ci`, `test/analyzers`, and `verify-full` come out byte-identical on both runs, and every other generated script is unchanged.
- `bun wb typecheck` and `bun wb lint` pass.
