### PR TITLE
fix: remove unused aries fnox scopes

### DIFF
--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -65,13 +65,11 @@ export const FNOX_AGE_PRINCIPALS = [
     repositoryScope: {
       repositories: [
         'WillBooster/agent-challenges',
-        'WillBooster/agentic-workflows',
         'WillBooster/agentic-workflows-dashboard',
         'WillBooster/cheerlings',
         'WillBooster/chofu-walking',
         'WillBooster/prompt-study',
         'WillBoosterLab/exercode',
-        'WillBoosterLab/exercode-employee-courses',
         'WillBoosterLab/judge',
       ],
     },

--- a/packages/wbfy/test/unit/fnoxToml.test.ts
+++ b/packages/wbfy/test/unit/fnoxToml.test.ts
@@ -51,13 +51,11 @@ test('grants aries fnox access only to the selected repositories', () => {
   };
   const selectedRepositories = [
     'WillBooster/agent-challenges',
-    'WillBooster/agentic-workflows',
     'WillBooster/agentic-workflows-dashboard',
     'WillBooster/cheerlings',
     'WillBooster/chofu-walking',
     'WillBooster/prompt-study',
     'WillBoosterLab/exercode',
-    'WillBoosterLab/exercode-employee-courses',
     'WillBoosterLab/judge',
   ];
 


### PR DESCRIPTION
## Customer Summary

- Stop pre-authorizing aries for repositories that do not use fnox.
- Keep aries access unchanged for the seven repositories currently using fnox.

## Technical Summary

- Remove `WillBooster/agentic-workflows` from the aries repository scope.
- Remove `WillBoosterLab/exercode-employee-courses` from the aries repository scope.
- Update the existing selected-repository test data to match the reduced scope without adding a new test case.

## Why

Both repositories currently have no operational `fnox.toml`. Keeping them in the whitelist would grant aries access automatically if fnox were introduced later, which is broader than the currently approved scope.

## Testing

- `bun verify-full`
