### PR TITLE
feat(wbfy): use a dedicated fnox CI identity for public repositories

### DIFF
--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -25,6 +25,10 @@ interface FnoxAgePrincipal {
   name: string;
   publicKeys: readonly string[];
   repositoryScope: FnoxRepositoryScope;
+  // Marks the principal as a CI identity. Every fnox-managed repository must resolve at least one
+  // (generateFnoxToml fails closed otherwise): a roster without a CI recipient would re-encrypt
+  // secrets that CI can never decrypt again.
+  isCiIdentity?: true;
 }
 
 interface FnoxAgeRecipient {
@@ -61,15 +65,19 @@ export const FNOX_AGE_PRINCIPALS = [
     name: 'ci',
     publicKeys: ['age1a2c6ef6ahl6mmkhgqtxg0mgtd7ysspntq7rxusv26efxhnuhlcdsr9dpak'],
     repositoryScope: { organizations: ['WillBooster', 'WillBoosterLab'], visibility: 'private' },
+    isCiIdentity: true,
   },
   {
     // The CI identity dedicated to public repositories (the PUBLIC_FNOX_AGE_KEY organization
-    // secret / ~/.config/fnox/age-ci-wb-public.txt). Public repositories exist only in the
-    // WillBooster organization: WillBoosterLab is on GitHub Free, where organization secrets
-    // cannot reach private repos, and hosts private repositories exclusively.
+    // secret / ~/.config/fnox/age-ci-wb-public.txt). Scoped to WillBooster only because the
+    // PUBLIC_FNOX_AGE_KEY secret is registered in that organization alone; a public
+    // WillBoosterLab repository resolves NO CI identity and generateFnoxToml fails closed on it
+    // (WillBoosterLab does own public repositories, e.g. its reusable-workflows sync mirror, but
+    // none of them use fnox — register the secret there and extend this scope if one ever does).
     name: 'ci-public',
     publicKeys: ['age1fhea85xjwp89lwq3jcnwj32swh3v24pwparqh5l7qkgvc4ax3p0ql6du36'],
     repositoryScope: { organizations: ['WillBooster'], visibility: 'public' },
+    isCiIdentity: true,
   },
   {
     name: 'remin',
@@ -158,6 +166,21 @@ export async function generateFnoxToml(rootConfig: PackageConfig): Promise<void>
     if (!rootConfig.isRepoVisibilityKnown && doesFnoxRecipientSetDependOnVisibility(rootConfig)) {
       failFnoxSync(
         `Failed to synchronize fnox age recipients because the visibility of ${rootConfig.repoAuthor}/${rootConfig.repoName} could not be determined (GitHub lookup failed) and the CI recipient depends on it. Check network and gh authentication, then rerun wbfy.`
+      );
+      return;
+    }
+    // Both CI identities are visibility-constrained, so a repository can fall through BOTH (e.g. a
+    // public WillBoosterLab repository, whose organization has no PUBLIC_FNOX_AGE_KEY secret).
+    // Re-encrypting for a roster without a CI identity would leave CI unable to decrypt anything,
+    // failing only at runtime in Actions; fail loudly here instead.
+    if (
+      !FNOX_AGE_PRINCIPALS.some(
+        (principal: FnoxAgePrincipal) =>
+          principal.isCiIdentity && matchesFnoxRepositoryScope(principal.repositoryScope, rootConfig)
+      )
+    ) {
+      failFnoxSync(
+        `Failed to synchronize fnox age recipients because no CI identity is scoped to ${rootConfig.repoAuthor}/${rootConfig.repoName} (public repositories are supported only in the WillBooster organization). Provision the matching organization secret and extend the CI scopes in wbfy first.`
       );
       return;
     }

--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -15,6 +15,10 @@ type RepositoryFullName = `${WillBoosterOrganization}/${string}`;
 export interface FnoxRepositoryScope {
   organizations?: readonly WillBoosterOrganization[];
   repositories?: readonly RepositoryFullName[];
+  // Restricts the scope to repositories of the given visibility. Public repositories publish their
+  // ciphertexts to the world, so they must use a CI identity separate from the org-internal one:
+  // leaking either CI key must not expose the other side's secrets.
+  visibility?: 'public' | 'private';
 }
 
 interface FnoxAgePrincipal {
@@ -32,9 +36,12 @@ interface FnoxAgeRecipient {
 // principal's public keys and repository scope here. Organization scopes include every current and
 // future repository in that organization; use repositories for exact owner/repository grants. The
 // next wbfy run on each matching repository rewrites every managed fnox.toml and re-encrypts its
-// committed secrets for the resulting recipient set. Removing a scope cannot revoke ciphertext
+// committed secrets for the resulting recipient set. A scope's optional visibility constraint
+// selects only public or only private repositories (used to keep the org-internal and the
+// public-repository CI identities apart). Removing a scope cannot revoke ciphertext
 // already available from Git history, so rotate the secret values that principal could decrypt.
-// Only public keys may appear here; CI's private key supplies the FNOX_AGE_KEY secret.
+// Only public keys may appear here; a CI identity's private key supplies the FNOX_AGE_KEY (or,
+// for public repositories, PUBLIC_FNOX_AGE_KEY) organization secret.
 export const FNOX_AGE_PRINCIPALS = [
   {
     name: 'exkazuu',
@@ -50,9 +57,19 @@ export const FNOX_AGE_PRINCIPALS = [
     repositoryScope: { organizations: ['WillBooster', 'WillBoosterLab'] },
   },
   {
+    // The org-internal CI identity (the FNOX_AGE_KEY organization secret / ~/.config/fnox/age-ci-wb.txt).
     name: 'ci',
     publicKeys: ['age1a2c6ef6ahl6mmkhgqtxg0mgtd7ysspntq7rxusv26efxhnuhlcdsr9dpak'],
-    repositoryScope: { organizations: ['WillBooster', 'WillBoosterLab'] },
+    repositoryScope: { organizations: ['WillBooster', 'WillBoosterLab'], visibility: 'private' },
+  },
+  {
+    // The CI identity dedicated to public repositories (the PUBLIC_FNOX_AGE_KEY organization
+    // secret / ~/.config/fnox/age-ci-wb-public.txt). Public repositories exist only in the
+    // WillBooster organization: WillBoosterLab is on GitHub Free, where organization secrets
+    // cannot reach private repos, and hosts private repositories exclusively.
+    name: 'ci-public',
+    publicKeys: ['age1fhea85xjwp89lwq3jcnwj32swh3v24pwparqh5l7qkgvc4ax3p0ql6du36'],
+    repositoryScope: { organizations: ['WillBooster'], visibility: 'public' },
   },
   {
     name: 'remin',
@@ -133,6 +150,15 @@ export async function generateFnoxToml(rootConfig: PackageConfig): Promise<void>
           `Failed to check for nested fnox configs due to: ${(error as Error | undefined)?.message ?? error}`
         );
       }
+      return;
+    }
+    // A failed visibility lookup collapses isPublicRepo to false, which would silently re-encrypt
+    // a public repository's world-readable ciphertexts to the org-internal CI identity (and vice
+    // versa drop the public one). Fail instead of guessing whenever visibility changes the roster.
+    if (!rootConfig.isRepoVisibilityKnown && doesFnoxRecipientSetDependOnVisibility(rootConfig)) {
+      failFnoxSync(
+        `Failed to synchronize fnox age recipients because the visibility of ${rootConfig.repoAuthor}/${rootConfig.repoName} could not be determined (GitHub lookup failed) and the CI recipient depends on it. Check network and gh authentication, then rerun wbfy.`
+      );
       return;
     }
     // The migration is transactional over every managed fnox.toml: reruns must retry from the
@@ -411,7 +437,20 @@ export function readFnoxAgeRecipients(fnoxTomlContent: string): Set<string> | un
   }
 }
 
-export function getFnoxAgeRecipients(rootConfig: Pick<PackageConfig, 'repoAuthor' | 'repoName'>): FnoxAgeRecipient[] {
+type FnoxRepositoryIdentity = Pick<PackageConfig, 'repoAuthor' | 'repoName' | 'isPublicRepo' | 'isRepoVisibilityKnown'>;
+
+/** Whether the recipient set differs between the public and private reading of the repository. */
+export function doesFnoxRecipientSetDependOnVisibility(
+  rootConfig: Pick<PackageConfig, 'repoAuthor' | 'repoName'>
+): boolean {
+  const publicKeysFor = (isPublicRepo: boolean): string =>
+    getFnoxAgeRecipients({ ...rootConfig, isPublicRepo, isRepoVisibilityKnown: true })
+      .map(({ publicKey }) => publicKey)
+      .join('\n');
+  return publicKeysFor(true) !== publicKeysFor(false);
+}
+
+export function getFnoxAgeRecipients(rootConfig: FnoxRepositoryIdentity): FnoxAgeRecipient[] {
   return FNOX_AGE_PRINCIPALS.filter((principal) =>
     matchesFnoxRepositoryScope(principal.repositoryScope, rootConfig)
   ).flatMap((principal) =>
@@ -422,13 +461,19 @@ export function getFnoxAgeRecipients(rootConfig: Pick<PackageConfig, 'repoAuthor
   );
 }
 
-export function matchesFnoxRepositoryScope(
-  scope: FnoxRepositoryScope,
-  repository: Pick<PackageConfig, 'repoAuthor' | 'repoName'>
-): boolean {
+export function matchesFnoxRepositoryScope(scope: FnoxRepositoryScope, repository: FnoxRepositoryIdentity): boolean {
   const owner = repository.repoAuthor?.toLowerCase();
   const name = repository.repoName?.toLowerCase();
   if (!owner || !name) return false;
+
+  // An unknown visibility (failed GitHub lookup) matches no visibility-constrained scope: callers
+  // that would rewrite recipients fail instead of encrypting to the wrong CI identity.
+  if (
+    scope.visibility &&
+    (!repository.isRepoVisibilityKnown || (scope.visibility === 'public') !== repository.isPublicRepo)
+  ) {
+    return false;
+  }
 
   return (
     (scope.organizations?.some((organization) => organization.toLowerCase() === owner) ?? false) ||

--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -25,10 +25,12 @@ interface FnoxAgePrincipal {
   name: string;
   publicKeys: readonly string[];
   repositoryScope: FnoxRepositoryScope;
-  // Marks the principal as a CI identity. Every fnox-managed repository must resolve at least one
-  // (generateFnoxToml fails closed otherwise): a roster without a CI recipient would re-encrypt
-  // secrets that CI can never decrypt again.
-  isCiIdentity?: true;
+  // Marks the principal as a CI identity and names the GitHub secret holding its private key.
+  // Every fnox-managed repository must resolve one (generateFnoxToml fails closed otherwise: a
+  // roster without a CI recipient would re-encrypt secrets that CI can never decrypt again), and
+  // the workflow generator derives its caller mappings from the same resolution so the two can
+  // never disagree on which CI identity applies.
+  ciAgeKeySecretName?: 'FNOX_AGE_KEY' | 'PUBLIC_FNOX_AGE_KEY';
 }
 
 interface FnoxAgeRecipient {
@@ -65,7 +67,7 @@ export const FNOX_AGE_PRINCIPALS = [
     name: 'ci',
     publicKeys: ['age1a2c6ef6ahl6mmkhgqtxg0mgtd7ysspntq7rxusv26efxhnuhlcdsr9dpak'],
     repositoryScope: { organizations: ['WillBooster', 'WillBoosterLab'], visibility: 'private' },
-    isCiIdentity: true,
+    ciAgeKeySecretName: 'FNOX_AGE_KEY',
   },
   {
     // The CI identity dedicated to public repositories (the PUBLIC_FNOX_AGE_KEY organization
@@ -77,7 +79,7 @@ export const FNOX_AGE_PRINCIPALS = [
     name: 'ci-public',
     publicKeys: ['age1fhea85xjwp89lwq3jcnwj32swh3v24pwparqh5l7qkgvc4ax3p0ql6du36'],
     repositoryScope: { organizations: ['WillBooster'], visibility: 'public' },
-    isCiIdentity: true,
+    ciAgeKeySecretName: 'PUBLIC_FNOX_AGE_KEY',
   },
   {
     name: 'remin',
@@ -173,12 +175,7 @@ export async function generateFnoxToml(rootConfig: PackageConfig): Promise<void>
     // public WillBoosterLab repository, whose organization has no PUBLIC_FNOX_AGE_KEY secret).
     // Re-encrypting for a roster without a CI identity would leave CI unable to decrypt anything,
     // failing only at runtime in Actions; fail loudly here instead.
-    if (
-      !FNOX_AGE_PRINCIPALS.some(
-        (principal: FnoxAgePrincipal) =>
-          principal.isCiIdentity && matchesFnoxRepositoryScope(principal.repositoryScope, rootConfig)
-      )
-    ) {
+    if (!resolveFnoxCiAgeKeySecretName(rootConfig)) {
       failFnoxSync(
         `Failed to synchronize fnox age recipients because no CI identity is scoped to ${rootConfig.repoAuthor}/${rootConfig.repoName} (public repositories are supported only in the WillBooster organization). Provision the matching organization secret and extend the CI scopes in wbfy first.`
       );
@@ -461,6 +458,21 @@ export function readFnoxAgeRecipients(fnoxTomlContent: string): Set<string> | un
 }
 
 type FnoxRepositoryIdentity = Pick<PackageConfig, 'repoAuthor' | 'repoName' | 'isPublicRepo' | 'isRepoVisibilityKnown'>;
+
+/**
+ * The GitHub secret holding the private key of the CI identity scoped to the repository, or
+ * undefined when none is (an unknown visibility, or a repository no CI scope covers). The single
+ * source of truth shared by the recipient sync and the workflow generator's caller mappings.
+ */
+export function resolveFnoxCiAgeKeySecretName(
+  config: FnoxRepositoryIdentity
+): 'FNOX_AGE_KEY' | 'PUBLIC_FNOX_AGE_KEY' | undefined {
+  const ciPrincipal: FnoxAgePrincipal | undefined = FNOX_AGE_PRINCIPALS.find(
+    (principal: FnoxAgePrincipal) =>
+      principal.ciAgeKeySecretName && matchesFnoxRepositoryScope(principal.repositoryScope, config)
+  );
+  return ciPrincipal?.ciAgeKeySecretName;
+}
 
 /** Whether the recipient set differs between the public and private reading of the repository. */
 export function doesFnoxRecipientSetDependOnVisibility(

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -1084,15 +1084,13 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
       // Public repositories commit world-readable ciphertexts, so they decrypt with a dedicated
       // CI identity (the PUBLIC_FNOX_AGE_KEY organization secret) instead of the org-internal
       // one; the callee still receives it under its declared FNOX_AGE_KEY name. When no CI
-      // identity resolves (see fnoxAgeKeyMapping), only fill in a MISSING mapping with the
-      // org-internal default: rewriting an EXISTING mapping on incomplete information would break
-      // an already-migrated repository's CI, and a fnox recipient sync failure does not stop this
-      // generator from writing files.
+      // identity resolves (see fnoxAgeKeyMapping), leave any existing mapping untouched and add
+      // none: creating or rewriting one on incomplete information would map a possibly-public
+      // repository to the wrong identity, and a fnox recipient sync failure does not stop this
+      // generator from writing files — the failed run's rerun fills the mapping in.
       const mapping = fnoxAgeKeyMapping(config);
       if (mapping) {
         secrets.FNOX_AGE_KEY = mapping;
-      } else {
-        secrets.FNOX_AGE_KEY ??= '${{ secrets.FNOX_AGE_KEY }}';
       }
       // fnox.toml replaced the .env files (wb no longer reads them), so the legacy inputs would
       // only keep dead configuration alive.

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -1047,7 +1047,8 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
     secrets.GH_TOKEN = '${{ secrets.GITHUB_TOKEN }}';
   }
 
-  // fnox.toml carries age-encrypted app secrets; CI decrypts them with the FNOX_AGE_KEY repository secret.
+  // fnox.toml carries age-encrypted app secrets; CI decrypts them with the FNOX_AGE_KEY (or, for
+  // public repositories, PUBLIC_FNOX_AGE_KEY) organization secret.
   // Key the injection on the *called* reusable workflow, not the caller's filename: callers may have
   // arbitrary names (e.g. scheduled run-script callers), and GitHub rejects passing a secret that the
   // callee does not declare. In a not-yet-migrated repository the legacy DOT_ENV pass-through is
@@ -1075,7 +1076,12 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
       delete secrets.VERDACCIO_TOKEN;
     }
     if (fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'))) {
-      secrets.FNOX_AGE_KEY = '${{ secrets.FNOX_AGE_KEY }}';
+      // Public repositories commit world-readable ciphertexts, so they decrypt with a dedicated
+      // CI identity (the PUBLIC_FNOX_AGE_KEY organization secret) instead of the org-internal
+      // one; the callee still receives it under its declared FNOX_AGE_KEY name. An unknown
+      // visibility keeps the org-internal mapping, matching the fnox recipient sync, which fails
+      // the run in that case anyway.
+      secrets.FNOX_AGE_KEY = config.isPublicRepo ? '${{ secrets.PUBLIC_FNOX_AGE_KEY }}' : '${{ secrets.FNOX_AGE_KEY }}';
       // fnox.toml replaced the .env files (wb no longer reads them), so the legacy inputs would
       // only keep dead configuration alive.
       delete secrets.DOT_ENV;

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -1040,7 +1040,11 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   job.with ??= {};
   // `secrets: inherit` (parsed by js-yaml as a plain string) already forwards every caller secret
   // including the ones injected below, so preserve it untouched — property assignments on the
-  // string would throw.
+  // string would throw. Caveat: `inherit` forwards secrets under their existing NAMES, so it can
+  // never feed PUBLIC_FNOX_AGE_KEY into the callee's declared FNOX_AGE_KEY; a hand-written
+  // inherit caller in a PUBLIC fnox repository must be converted to an explicit mapping manually
+  // (wbfy never generates the inherit form, and hand-written deviations are fixed in the target
+  // repository by policy).
   const secrets = job.secrets === 'inherit' ? undefined : (job.secrets = job.secrets ?? {});
 
   if (secrets && (kind === 'test' || kind === 'release')) {
@@ -1078,16 +1082,37 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
     if (fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'))) {
       // Public repositories commit world-readable ciphertexts, so they decrypt with a dedicated
       // CI identity (the PUBLIC_FNOX_AGE_KEY organization secret) instead of the org-internal
-      // one; the callee still receives it under its declared FNOX_AGE_KEY name. An unknown
-      // visibility keeps the org-internal mapping, matching the fnox recipient sync, which fails
-      // the run in that case anyway.
-      secrets.FNOX_AGE_KEY = config.isPublicRepo ? '${{ secrets.PUBLIC_FNOX_AGE_KEY }}' : '${{ secrets.FNOX_AGE_KEY }}';
+      // one; the callee still receives it under its declared FNOX_AGE_KEY name. When the
+      // visibility lookup failed (isPublicRepo collapses to false then), only fill in a MISSING
+      // mapping with the org-internal default: rewriting an existing PUBLIC_FNOX_AGE_KEY mapping
+      // on that guess would break an already-migrated public repository's CI, and the fnox
+      // recipient sync's own unknown-visibility failure does not stop this generator from
+      // writing files.
+      if (config.isRepoVisibilityKnown) {
+        secrets.FNOX_AGE_KEY = fnoxAgeKeySecretExpression(config);
+      } else {
+        secrets.FNOX_AGE_KEY ??= '${{ secrets.FNOX_AGE_KEY }}';
+      }
       // fnox.toml replaced the .env files (wb no longer reads them), so the legacy inputs would
       // only keep dead configuration alive.
       delete secrets.DOT_ENV;
       delete secrets.DOT_ENV_PRODUCTION;
       delete job.with.dot_env_path;
     }
+  }
+  // Callers pinned to a tag/SHA keep their secret SET untouched (the pinned revision's
+  // declarations may differ), but the fnox recipient sync migrates the repository's ciphertexts
+  // by visibility regardless of the caller's ref, so an already-present FNOX_AGE_KEY mapping must
+  // still be remapped to the CI identity that can actually decrypt them; only the mapped-from
+  // secret changes, never the declared FNOX_AGE_KEY name the pinned revision expects.
+  if (
+    secrets?.FNOX_AGE_KEY &&
+    orgWorkflowCall &&
+    !calledReusableWorkflow &&
+    config.isRepoVisibilityKnown &&
+    fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'))
+  ) {
+    secrets.FNOX_AGE_KEY = fnoxAgeKeySecretExpression(config);
   }
   // reusable-workflows replaced the NPM_TOKEN secret declaration with VERDACCIO_TOKEN; GitHub
   // rejects passing an undeclared secret to a reusable workflow with a startup_failure that emits
@@ -1171,6 +1196,10 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
       delete job.secrets;
     }
   }
+}
+
+function fnoxAgeKeySecretExpression(config: Pick<PackageConfig, 'isPublicRepo'>): string {
+  return config.isPublicRepo ? '${{ secrets.PUBLIC_FNOX_AGE_KEY }}' : '${{ secrets.FNOX_AGE_KEY }}';
 }
 
 async function writeYaml(newSettings: Workflow, filePath: string): Promise<void> {

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -9,6 +9,7 @@ import merge from 'deepmerge';
 import yaml from 'js-yaml';
 
 import { logger } from '../logger.js';
+import { hasFnoxSyncFailed, resolveFnoxCiAgeKeySecretName } from './fnoxToml.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { jsoncUtil } from '../utils/jsoncUtil.js';
 import type { PackageConfig } from '../packageConfig.js';
@@ -1082,14 +1083,14 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
     if (fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'))) {
       // Public repositories commit world-readable ciphertexts, so they decrypt with a dedicated
       // CI identity (the PUBLIC_FNOX_AGE_KEY organization secret) instead of the org-internal
-      // one; the callee still receives it under its declared FNOX_AGE_KEY name. When the
-      // visibility lookup failed (isPublicRepo collapses to false then), only fill in a MISSING
-      // mapping with the org-internal default: rewriting an existing PUBLIC_FNOX_AGE_KEY mapping
-      // on that guess would break an already-migrated public repository's CI, and the fnox
-      // recipient sync's own unknown-visibility failure does not stop this generator from
-      // writing files.
-      if (config.isRepoVisibilityKnown) {
-        secrets.FNOX_AGE_KEY = fnoxAgeKeySecretExpression(config);
+      // one; the callee still receives it under its declared FNOX_AGE_KEY name. When no CI
+      // identity resolves (see fnoxAgeKeyMapping), only fill in a MISSING mapping with the
+      // org-internal default: rewriting an EXISTING mapping on incomplete information would break
+      // an already-migrated repository's CI, and a fnox recipient sync failure does not stop this
+      // generator from writing files.
+      const mapping = fnoxAgeKeyMapping(config);
+      if (mapping) {
+        secrets.FNOX_AGE_KEY = mapping;
       } else {
         secrets.FNOX_AGE_KEY ??= '${{ secrets.FNOX_AGE_KEY }}';
       }
@@ -1109,10 +1110,12 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
     secrets?.FNOX_AGE_KEY &&
     orgWorkflowCall &&
     !calledReusableWorkflow &&
-    config.isRepoVisibilityKnown &&
     fs.existsSync(path.resolve(config.dirPath, 'fnox.toml'))
   ) {
-    secrets.FNOX_AGE_KEY = fnoxAgeKeySecretExpression(config);
+    const mapping = fnoxAgeKeyMapping(config);
+    if (mapping) {
+      secrets.FNOX_AGE_KEY = mapping;
+    }
   }
   // reusable-workflows replaced the NPM_TOKEN secret declaration with VERDACCIO_TOKEN; GitHub
   // rejects passing an undeclared secret to a reusable workflow with a startup_failure that emits
@@ -1198,8 +1201,17 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
   }
 }
 
-function fnoxAgeKeySecretExpression(config: Pick<PackageConfig, 'isPublicRepo'>): string {
-  return config.isPublicRepo ? '${{ secrets.PUBLIC_FNOX_AGE_KEY }}' : '${{ secrets.FNOX_AGE_KEY }}';
+/**
+ * The secret expression the caller maps into the callee's declared FNOX_AGE_KEY, or undefined
+ * when the repository state does not identify a usable CI identity — an unknown visibility, a
+ * repository no CI scope covers (deriving from the same principal roster as the recipient sync
+ * keeps the two from ever disagreeing), or a failed fnox recipient sync, whose ciphertexts may
+ * still target the previous identity. The caller must then preserve any existing mapping.
+ */
+function fnoxAgeKeyMapping(config: PackageConfig): string | undefined {
+  if (!config.isRepoVisibilityKnown || hasFnoxSyncFailed()) return undefined;
+  const secretName = resolveFnoxCiAgeKeySecretName(config);
+  return secretName && `\${{ secrets.${secretName} }}`;
 }
 
 async function writeYaml(newSettings: Workflow, filePath: string): Promise<void> {

--- a/packages/wbfy/test/helpers/callerWorkflow.ts
+++ b/packages/wbfy/test/helpers/callerWorkflow.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { load } from 'js-yaml';
+import { expect } from 'vitest';
+
+export interface CallerJob {
+  secrets?: Record<string, string>;
+}
+
+/** Runs the callback in a fresh temp repository containing a .github/workflows directory. */
+export async function withTempWorkflowsRepo(
+  prefix: string,
+  callback: (dirPath: string, workflowsPath: string) => Promise<void>
+): Promise<void> {
+  const tempRootPath = path.join(process.cwd(), '.tmp');
+  await fs.promises.mkdir(tempRootPath, { recursive: true });
+  const dirPath = await fs.promises.mkdtemp(path.join(tempRootPath, prefix));
+  try {
+    const workflowsPath = path.join(dirPath, '.github', 'workflows');
+    await fs.promises.mkdir(workflowsPath, { recursive: true });
+    await callback(dirPath, workflowsPath);
+  } finally {
+    await fs.promises.rm(dirPath, { recursive: true, force: true });
+  }
+}
+
+/** Reads the sole job of a generated caller workflow. */
+export function readCallerJob(workflowsPath: string, fileName = 'test.yml'): CallerJob {
+  const parsed = load(fs.readFileSync(path.join(workflowsPath, fileName), 'utf8')) as {
+    jobs: Record<string, CallerJob>;
+  };
+  const job = Object.values(parsed.jobs)[0];
+  expect(job).toBeDefined();
+  // The non-null assertion is checked by the expect above.
+  return job as CallerJob;
+}

--- a/packages/wbfy/test/unit/fnoxAgeKeyInjection.test.ts
+++ b/packages/wbfy/test/unit/fnoxAgeKeyInjection.test.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { load } from 'js-yaml';
+import { expect, test } from 'vitest';
+
+import { generateWorkflows } from '../../src/generators/workflow.js';
+import { promisePool } from '../../src/utils/promisePool.js';
+import { createConfig } from '../helpers/testConfig.js';
+
+// A public repository's committed ciphertexts are world-readable, so its caller workflows must
+// decrypt with the dedicated PUBLIC_FNOX_AGE_KEY organization secret; private repositories keep
+// the org-internal FNOX_AGE_KEY. The callee always receives it under its declared FNOX_AGE_KEY name.
+
+async function withTempRepo(callback: (dirPath: string, workflowsPath: string) => Promise<void>): Promise<void> {
+  const tempRootPath = path.join(process.cwd(), '.tmp');
+  await fs.promises.mkdir(tempRootPath, { recursive: true });
+  const dirPath = await fs.promises.mkdtemp(path.join(tempRootPath, 'wbfy-fnox-age-key-injection-'));
+  try {
+    const workflowsPath = path.join(dirPath, '.github', 'workflows');
+    await fs.promises.mkdir(workflowsPath, { recursive: true });
+    fs.writeFileSync(path.join(dirPath, 'package.json'), JSON.stringify({ name: 'plain' }));
+    fs.writeFileSync(path.join(dirPath, 'fnox.toml'), '[secrets]\n');
+    fs.writeFileSync(
+      path.join(workflowsPath, 'test.yml'),
+      `name: Test
+on:
+  pull_request:
+jobs:
+  test:
+    uses: WillBooster/reusable-workflows/.github/workflows/test.yml@main
+    secrets:
+      GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+`
+    );
+    await callback(dirPath, workflowsPath);
+  } finally {
+    await fs.promises.rm(dirPath, { recursive: true, force: true });
+  }
+}
+
+function readTestCallerFnoxAgeKey(workflowsPath: string): string | undefined {
+  const parsed = load(fs.readFileSync(path.join(workflowsPath, 'test.yml'), 'utf8')) as {
+    jobs: Record<string, { secrets?: Record<string, string> }>;
+  };
+  const job = Object.values(parsed.jobs)[0];
+  expect(job).toBeDefined();
+  return job?.secrets?.FNOX_AGE_KEY;
+}
+
+test('maps FNOX_AGE_KEY from PUBLIC_FNOX_AGE_KEY in a public repository', async () => {
+  await withTempRepo(async (dirPath, workflowsPath) => {
+    await generateWorkflows(createConfig({ dirPath, isRoot: true, isPublicRepo: true }));
+    await promisePool.promiseAll();
+
+    expect(readTestCallerFnoxAgeKey(workflowsPath)).toBe('${{ secrets.PUBLIC_FNOX_AGE_KEY }}');
+  });
+});
+
+test('maps FNOX_AGE_KEY from the org-internal secret in a private repository', async () => {
+  await withTempRepo(async (dirPath, workflowsPath) => {
+    await generateWorkflows(createConfig({ dirPath, isRoot: true, isPublicRepo: false }));
+    await promisePool.promiseAll();
+
+    expect(readTestCallerFnoxAgeKey(workflowsPath)).toBe('${{ secrets.FNOX_AGE_KEY }}');
+  });
+});

--- a/packages/wbfy/test/unit/fnoxAgeKeyInjection.test.ts
+++ b/packages/wbfy/test/unit/fnoxAgeKeyInjection.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { expect, test } from 'vitest';
 
+import { generateFnoxToml, hasFnoxSyncFailed } from '../../src/generators/fnoxToml.js';
 import { generateWorkflows } from '../../src/generators/workflow.js';
 import { promisePool } from '../../src/utils/promisePool.js';
 import { readCallerJob, withTempWorkflowsRepo } from '../helpers/callerWorkflow.js';
@@ -67,6 +68,20 @@ test('keeps an existing PUBLIC_FNOX_AGE_KEY mapping when the visibility lookup f
   });
 });
 
+test('keeps the org-internal mapping in a public WillBoosterLab repository', async () => {
+  await withTempWorkflowsRepo('wbfy-fnox-age-key-injection-', async (dirPath, workflowsPath) => {
+    writeFnoxRepoFixture(dirPath, workflowsPath, defaultCallerContent);
+    // No CI identity is scoped to public WillBoosterLab repositories (the recipient sync fails
+    // closed on them), so the caller must not be pointed at the nonexistent PUBLIC_FNOX_AGE_KEY.
+    await generateWorkflows(
+      createConfig({ dirPath, isRoot: true, isPublicRepo: true, repository: 'github:WillBoosterLab/example' })
+    );
+    await promisePool.promiseAll();
+
+    expect(readCallerJob(workflowsPath).secrets?.FNOX_AGE_KEY).toBe('${{ secrets.FNOX_AGE_KEY }}');
+  });
+});
+
 test('remaps an existing FNOX_AGE_KEY mapping of a pinned caller in a public repository', async () => {
   await withTempWorkflowsRepo('wbfy-fnox-age-key-injection-', async (dirPath, workflowsPath) => {
     writeFnoxRepoFixture(dirPath, workflowsPath, defaultCallerContent);
@@ -89,5 +104,34 @@ jobs:
     expect(job.secrets?.FNOX_AGE_KEY).toBe('${{ secrets.PUBLIC_FNOX_AGE_KEY }}');
     // The pinned revision's other secret declarations are unknown, so nothing else is injected.
     expect(job.secrets?.TAKUMI_GUARD_TOKEN).toBeUndefined();
+  });
+});
+
+test('does not remap FNOX_AGE_KEY while the fnox recipient sync failed', async () => {
+  await withTempWorkflowsRepo('wbfy-fnox-age-key-injection-', async (dirPath, workflowsPath) => {
+    writeFnoxRepoFixture(
+      dirPath,
+      workflowsPath,
+      defaultCallerContent.replace('GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}', 'FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}')
+    );
+    // generateFnoxToml refuses this fixture (its fnox.toml is invisible to git, and a leftover
+    // migration marker also marks an interrupted migration): the ciphertexts may still target the
+    // previous CI identity, so the workflow generator must not flip the key mapping either.
+    fs.mkdirSync(path.join(dirPath, '.tmp'), { recursive: true });
+    fs.writeFileSync(path.join(dirPath, '.tmp', 'wbfy-fnox-migration-marker'), '');
+    try {
+      const config = createConfig({ dirPath, isRoot: true, isPublicRepo: true });
+      await generateFnoxToml(config);
+      expect(hasFnoxSyncFailed()).toBe(true);
+      await generateWorkflows(config);
+      await promisePool.promiseAll();
+
+      expect(readCallerJob(workflowsPath).secrets?.FNOX_AGE_KEY).toBe('${{ secrets.FNOX_AGE_KEY }}');
+    } finally {
+      // failFnoxSync sets the process-global exit code; reset it so this test run's own status
+      // stays meaningful, and clear the module-level flag via a no-op non-WillBooster run.
+      process.exitCode = 0;
+      await generateFnoxToml(createConfig({ isWillBoosterRepo: false }));
+    }
   });
 });

--- a/packages/wbfy/test/unit/fnoxAgeKeyInjection.test.ts
+++ b/packages/wbfy/test/unit/fnoxAgeKeyInjection.test.ts
@@ -68,17 +68,18 @@ test('keeps an existing PUBLIC_FNOX_AGE_KEY mapping when the visibility lookup f
   });
 });
 
-test('keeps the org-internal mapping in a public WillBoosterLab repository', async () => {
+test('adds no mapping in a public WillBoosterLab repository', async () => {
   await withTempWorkflowsRepo('wbfy-fnox-age-key-injection-', async (dirPath, workflowsPath) => {
     writeFnoxRepoFixture(dirPath, workflowsPath, defaultCallerContent);
     // No CI identity is scoped to public WillBoosterLab repositories (the recipient sync fails
-    // closed on them), so the caller must not be pointed at the nonexistent PUBLIC_FNOX_AGE_KEY.
+    // closed on them), so the caller must not be pointed at the nonexistent PUBLIC_FNOX_AGE_KEY —
+    // or at any other secret this unsupported state cannot back.
     await generateWorkflows(
       createConfig({ dirPath, isRoot: true, isPublicRepo: true, repository: 'github:WillBoosterLab/example' })
     );
     await promisePool.promiseAll();
 
-    expect(readCallerJob(workflowsPath).secrets?.FNOX_AGE_KEY).toBe('${{ secrets.FNOX_AGE_KEY }}');
+    expect(readCallerJob(workflowsPath).secrets?.FNOX_AGE_KEY).toBeUndefined();
   });
 });
 

--- a/packages/wbfy/test/unit/fnoxAgeKeyInjection.test.ts
+++ b/packages/wbfy/test/unit/fnoxAgeKeyInjection.test.ts
@@ -1,29 +1,18 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { load } from 'js-yaml';
 import { expect, test } from 'vitest';
 
 import { generateWorkflows } from '../../src/generators/workflow.js';
 import { promisePool } from '../../src/utils/promisePool.js';
+import { readCallerJob, withTempWorkflowsRepo } from '../helpers/callerWorkflow.js';
 import { createConfig } from '../helpers/testConfig.js';
 
 // A public repository's committed ciphertexts are world-readable, so its caller workflows must
 // decrypt with the dedicated PUBLIC_FNOX_AGE_KEY organization secret; private repositories keep
 // the org-internal FNOX_AGE_KEY. The callee always receives it under its declared FNOX_AGE_KEY name.
 
-async function withTempRepo(callback: (dirPath: string, workflowsPath: string) => Promise<void>): Promise<void> {
-  const tempRootPath = path.join(process.cwd(), '.tmp');
-  await fs.promises.mkdir(tempRootPath, { recursive: true });
-  const dirPath = await fs.promises.mkdtemp(path.join(tempRootPath, 'wbfy-fnox-age-key-injection-'));
-  try {
-    const workflowsPath = path.join(dirPath, '.github', 'workflows');
-    await fs.promises.mkdir(workflowsPath, { recursive: true });
-    fs.writeFileSync(path.join(dirPath, 'package.json'), JSON.stringify({ name: 'plain' }));
-    fs.writeFileSync(path.join(dirPath, 'fnox.toml'), '[secrets]\n');
-    fs.writeFileSync(
-      path.join(workflowsPath, 'test.yml'),
-      `name: Test
+const defaultCallerContent = `name: Test
 on:
   pull_request:
 jobs:
@@ -31,37 +20,74 @@ jobs:
     uses: WillBooster/reusable-workflows/.github/workflows/test.yml@main
     secrets:
       GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
-`
-    );
-    await callback(dirPath, workflowsPath);
-  } finally {
-    await fs.promises.rm(dirPath, { recursive: true, force: true });
-  }
-}
+`;
 
-function readTestCallerFnoxAgeKey(workflowsPath: string): string | undefined {
-  const parsed = load(fs.readFileSync(path.join(workflowsPath, 'test.yml'), 'utf8')) as {
-    jobs: Record<string, { secrets?: Record<string, string> }>;
-  };
-  const job = Object.values(parsed.jobs)[0];
-  expect(job).toBeDefined();
-  return job?.secrets?.FNOX_AGE_KEY;
+function writeFnoxRepoFixture(dirPath: string, workflowsPath: string, callerContent: string): void {
+  fs.writeFileSync(path.join(dirPath, 'package.json'), JSON.stringify({ name: 'plain' }));
+  fs.writeFileSync(path.join(dirPath, 'fnox.toml'), '[secrets]\n');
+  fs.writeFileSync(path.join(workflowsPath, 'test.yml'), callerContent);
 }
 
 test('maps FNOX_AGE_KEY from PUBLIC_FNOX_AGE_KEY in a public repository', async () => {
-  await withTempRepo(async (dirPath, workflowsPath) => {
+  await withTempWorkflowsRepo('wbfy-fnox-age-key-injection-', async (dirPath, workflowsPath) => {
+    writeFnoxRepoFixture(dirPath, workflowsPath, defaultCallerContent);
     await generateWorkflows(createConfig({ dirPath, isRoot: true, isPublicRepo: true }));
     await promisePool.promiseAll();
 
-    expect(readTestCallerFnoxAgeKey(workflowsPath)).toBe('${{ secrets.PUBLIC_FNOX_AGE_KEY }}');
+    expect(readCallerJob(workflowsPath).secrets?.FNOX_AGE_KEY).toBe('${{ secrets.PUBLIC_FNOX_AGE_KEY }}');
   });
 });
 
 test('maps FNOX_AGE_KEY from the org-internal secret in a private repository', async () => {
-  await withTempRepo(async (dirPath, workflowsPath) => {
+  await withTempWorkflowsRepo('wbfy-fnox-age-key-injection-', async (dirPath, workflowsPath) => {
+    writeFnoxRepoFixture(dirPath, workflowsPath, defaultCallerContent);
     await generateWorkflows(createConfig({ dirPath, isRoot: true, isPublicRepo: false }));
     await promisePool.promiseAll();
 
-    expect(readTestCallerFnoxAgeKey(workflowsPath)).toBe('${{ secrets.FNOX_AGE_KEY }}');
+    expect(readCallerJob(workflowsPath).secrets?.FNOX_AGE_KEY).toBe('${{ secrets.FNOX_AGE_KEY }}');
+  });
+});
+
+test('keeps an existing PUBLIC_FNOX_AGE_KEY mapping when the visibility lookup failed', async () => {
+  await withTempWorkflowsRepo('wbfy-fnox-age-key-injection-', async (dirPath, workflowsPath) => {
+    // The exact shape a failed GitHub lookup produces for a public repository: rewriting the
+    // mapping to the org-internal secret on that guess would break the repository's CI.
+    writeFnoxRepoFixture(
+      dirPath,
+      workflowsPath,
+      defaultCallerContent.replace(
+        'GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}',
+        'FNOX_AGE_KEY: ${{ secrets.PUBLIC_FNOX_AGE_KEY }}'
+      )
+    );
+    await generateWorkflows(createConfig({ dirPath, isRoot: true, isPublicRepo: false, isRepoVisibilityKnown: false }));
+    await promisePool.promiseAll();
+
+    expect(readCallerJob(workflowsPath).secrets?.FNOX_AGE_KEY).toBe('${{ secrets.PUBLIC_FNOX_AGE_KEY }}');
+  });
+});
+
+test('remaps an existing FNOX_AGE_KEY mapping of a pinned caller in a public repository', async () => {
+  await withTempWorkflowsRepo('wbfy-fnox-age-key-injection-', async (dirPath, workflowsPath) => {
+    writeFnoxRepoFixture(dirPath, workflowsPath, defaultCallerContent);
+    fs.writeFileSync(
+      path.join(workflowsPath, 'scheduled.yml'),
+      `name: Scheduled
+on:
+  workflow_dispatch:
+jobs:
+  scheduled:
+    uses: WillBooster/reusable-workflows/.github/workflows/run-script.yml@91fa583a4ce3e298b1edba90f941bab29271f693
+    secrets:
+      FNOX_AGE_KEY: \${{ secrets.FNOX_AGE_KEY }}
+`
+    );
+    await generateWorkflows(createConfig({ dirPath, isRoot: true, isPublicRepo: true }));
+    await promisePool.promiseAll();
+
+    const job = readCallerJob(workflowsPath, 'scheduled.yml');
+    expect(job.secrets?.FNOX_AGE_KEY).toBe('${{ secrets.PUBLIC_FNOX_AGE_KEY }}');
+    // The pinned revision's other secret declarations are unknown, so nothing else is injected.
+    expect(job.secrets?.TAKUMI_GUARD_TOKEN).toBeUndefined();
   });
 });

--- a/packages/wbfy/test/unit/fnoxToml.test.ts
+++ b/packages/wbfy/test/unit/fnoxToml.test.ts
@@ -31,6 +31,13 @@ test('selects the CI identity by repository visibility', () => {
       ({ name }) => name
     )
   ).toEqual([...developerNames, 'ci-public', 'remin']);
+  // A public WillBoosterLab repository resolves NO CI identity (PUBLIC_FNOX_AGE_KEY is registered
+  // only in the WillBooster organization); generateFnoxToml fails closed on it.
+  expect(
+    getFnoxAgeRecipients(createConfig({ repository: 'github:WillBoosterLab/example', isPublicRepo: true })).map(
+      ({ name }) => name
+    )
+  ).toEqual([...developerNames, 'remin']);
   // An unknown visibility (failed GitHub lookup) grants NEITHER CI identity; generateFnoxToml
   // fails instead of rewriting recipients in that state.
   expect(

--- a/packages/wbfy/test/unit/fnoxToml.test.ts
+++ b/packages/wbfy/test/unit/fnoxToml.test.ts
@@ -13,15 +13,31 @@ import {
 } from '../../src/generators/fnoxToml.js';
 import { createConfig } from '../helpers/testConfig.js';
 
-test('keeps the existing age recipient roster for both WillBooster organizations', () => {
-  const recipientNames = ['exkazuu', 'ponharu1', 'ponharu2', 'ci', 'remin'];
+test('selects the CI identity by repository visibility', () => {
+  const developerNames = ['exkazuu', 'ponharu1', 'ponharu2'];
 
   expect(
-    getFnoxAgeRecipients(createConfig({ repository: 'github:WillBooster/example' })).map(({ name }) => name)
-  ).toEqual(recipientNames);
+    getFnoxAgeRecipients(createConfig({ repository: 'github:WillBooster/example', isPublicRepo: false })).map(
+      ({ name }) => name
+    )
+  ).toEqual([...developerNames, 'ci', 'remin']);
   expect(
-    getFnoxAgeRecipients(createConfig({ repository: 'github:WillBoosterLab/example' })).map(({ name }) => name)
-  ).toEqual(recipientNames);
+    getFnoxAgeRecipients(createConfig({ repository: 'github:WillBoosterLab/example', isPublicRepo: false })).map(
+      ({ name }) => name
+    )
+  ).toEqual([...developerNames, 'ci', 'remin']);
+  expect(
+    getFnoxAgeRecipients(createConfig({ repository: 'github:WillBooster/example', isPublicRepo: true })).map(
+      ({ name }) => name
+    )
+  ).toEqual([...developerNames, 'ci-public', 'remin']);
+  // An unknown visibility (failed GitHub lookup) grants NEITHER CI identity; generateFnoxToml
+  // fails instead of rewriting recipients in that state.
+  expect(
+    getFnoxAgeRecipients(
+      createConfig({ repository: 'github:WillBooster/example', isPublicRepo: false, isRepoVisibilityKnown: false })
+    ).map(({ name }) => name)
+  ).toEqual([...developerNames, 'remin']);
 });
 
 test('matches fnox repository scopes by organization or exact repository', () => {
@@ -42,6 +58,22 @@ test('matches fnox repository scopes by organization or exact repository', () =>
     )
   ).toBe(false);
   expect(matchesFnoxRepositoryScope(scope, createConfig({ repository: undefined }))).toBe(false);
+});
+
+test('matches visibility-constrained fnox repository scopes only when the visibility is known and agrees', () => {
+  const publicScope = { organizations: ['WillBooster'], visibility: 'public' } as const;
+  const privateScope = { organizations: ['WillBooster'], visibility: 'private' } as const;
+
+  expect(matchesFnoxRepositoryScope(publicScope, createConfig({ isPublicRepo: true }))).toBe(true);
+  expect(matchesFnoxRepositoryScope(publicScope, createConfig({ isPublicRepo: false }))).toBe(false);
+  expect(matchesFnoxRepositoryScope(privateScope, createConfig({ isPublicRepo: false }))).toBe(true);
+  expect(matchesFnoxRepositoryScope(privateScope, createConfig({ isPublicRepo: true }))).toBe(false);
+  expect(
+    matchesFnoxRepositoryScope(publicScope, createConfig({ isPublicRepo: true, isRepoVisibilityKnown: false }))
+  ).toBe(false);
+  expect(
+    matchesFnoxRepositoryScope(privateScope, createConfig({ isPublicRepo: false, isRepoVisibilityKnown: false }))
+  ).toBe(false);
 });
 
 test('grants aries fnox access only to the selected repositories', () => {

--- a/packages/wbfy/test/unit/verdaccioTokenInjection.test.ts
+++ b/packages/wbfy/test/unit/verdaccioTokenInjection.test.ts
@@ -1,46 +1,19 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { load } from 'js-yaml';
 import { expect, test } from 'vitest';
 
 import { generateWorkflows } from '../../src/generators/workflow.js';
 import { promisePool } from '../../src/utils/promisePool.js';
+import { readCallerJob, withTempWorkflowsRepo } from '../helpers/callerWorkflow.js';
 import { createConfig } from '../helpers/testConfig.js';
 
 // VERDACCIO_TOKEN flows into a reusable-workflow caller only when the repository actually
 // resolves @willbooster-private/* packages; TAKUMI_GUARD_TOKEN is passed unconditionally
 // (an unset secret expands to '' and the callee treats that as "feature off").
 
-async function withTempRepo(callback: (dirPath: string, workflowsPath: string) => Promise<void>): Promise<void> {
-  const tempRootPath = path.join(process.cwd(), '.tmp');
-  await fs.promises.mkdir(tempRootPath, { recursive: true });
-  const dirPath = await fs.promises.mkdtemp(path.join(tempRootPath, 'wbfy-verdaccio-injection-'));
-  try {
-    const workflowsPath = path.join(dirPath, '.github', 'workflows');
-    await fs.promises.mkdir(workflowsPath, { recursive: true });
-    await callback(dirPath, workflowsPath);
-  } finally {
-    await fs.promises.rm(dirPath, { recursive: true, force: true });
-  }
-}
-
-interface CallerJob {
-  secrets?: Record<string, string>;
-}
-
-function readTestCallerJob(workflowsPath: string): CallerJob {
-  const parsed = load(fs.readFileSync(path.join(workflowsPath, 'test.yml'), 'utf8')) as {
-    jobs: Record<string, CallerJob>;
-  };
-  const job = Object.values(parsed.jobs)[0];
-  expect(job).toBeDefined();
-  // The non-null assertion is checked by the expect above.
-  return job as CallerJob;
-}
-
 test('omits VERDACCIO_TOKEN and even removes an existing pass-through when no private package is used', async () => {
-  await withTempRepo(async (dirPath, workflowsPath) => {
+  await withTempWorkflowsRepo('wbfy-verdaccio-injection-', async (dirPath, workflowsPath) => {
     fs.writeFileSync(path.join(dirPath, 'package.json'), JSON.stringify({ name: 'plain' }));
     // A previously generated caller carries the pass-through; regeneration must strip it.
     fs.writeFileSync(
@@ -58,14 +31,14 @@ jobs:
     await generateWorkflows(createConfig({ dirPath, isRoot: true }));
     await promisePool.promiseAll();
 
-    const job = readTestCallerJob(workflowsPath);
+    const job = readCallerJob(workflowsPath);
     expect(job.secrets?.VERDACCIO_TOKEN).toBeUndefined();
     expect(job.secrets?.TAKUMI_GUARD_TOKEN).toBe('${{ secrets.TAKUMI_GUARD_TOKEN }}');
   });
 });
 
 test('passes VERDACCIO_TOKEN when a private package is depended upon', async () => {
-  await withTempRepo(async (dirPath, workflowsPath) => {
+  await withTempWorkflowsRepo('wbfy-verdaccio-injection-', async (dirPath, workflowsPath) => {
     fs.writeFileSync(
       path.join(dirPath, 'package.json'),
       JSON.stringify({ name: 'consumer', devDependencies: { '@willbooster-private/agentic-workflows': '1.0.0' } })
@@ -73,7 +46,7 @@ test('passes VERDACCIO_TOKEN when a private package is depended upon', async () 
     await generateWorkflows(createConfig({ dirPath, isRoot: true }));
     await promisePool.promiseAll();
 
-    const job = readTestCallerJob(workflowsPath);
+    const job = readCallerJob(workflowsPath);
     expect(job.secrets?.VERDACCIO_TOKEN).toBe('${{ secrets.VERDACCIO_TOKEN }}');
     expect(job.secrets?.TAKUMI_GUARD_TOKEN).toBe('${{ secrets.TAKUMI_GUARD_TOKEN }}');
   });


### PR DESCRIPTION
## Customer Summary

- Public repositories in the WillBooster organization now decrypt their fnox-committed secrets with a dedicated CI key (the `PUBLIC_FNOX_AGE_KEY` organization secret) instead of the org-internal one.
- Even if the org-internal CI key leaks, the world-readable ciphertexts committed in public repositories stay safe, and vice versa.
- Private repositories keep working exactly as before; the next wbfy run on a public fnox repository re-encrypts its secrets and updates its caller workflows automatically.

## Technical Summary

- `FnoxRepositoryScope` gains an optional `visibility: 'public' | 'private'` constraint, evaluated against `isPublicRepo`/`isRepoVisibilityKnown` in `matchesFnoxRepositoryScope`; an unknown visibility (failed GitHub lookup) matches no visibility-constrained scope.
- The CI principal is split: `ci` (org-internal, `FNOX_AGE_KEY`, private repositories in both organizations) and `ci-public` (`PUBLIC_FNOX_AGE_KEY`, public WillBooster repositories). Each carries `ciAgeKeySecretName`, and `resolveFnoxCiAgeKeySecretName` is the single source of truth shared by the recipient sync and the workflow generator, so the two can never disagree.
- `generateFnoxToml` fails closed when the visibility is unknown and the recipient set depends on it, and when no CI identity is scoped to the repository (e.g. a public WillBoosterLab repository — that organization owns public repositories but has no `PUBLIC_FNOX_AGE_KEY` secret).
- The workflow generator writes a caller's `FNOX_AGE_KEY` mapping only when a CI identity resolves for a successfully synchronized repository (`hasFnoxSyncFailed()` gate); otherwise it preserves any existing mapping and adds none. Already-present mappings of callers pinned to a tag/SHA are remapped too (only the mapped-from secret changes, never the declared name). `secrets: inherit` callers cannot receive the renamed secret; the limitation is documented at the preserve site (hand-written deviations are fixed in the target repository by policy).
- Test helpers for generated caller workflows are deduplicated into `packages/wbfy/test/helpers/callerWorkflow.ts`.

## Why

- Committed age ciphertexts in a public repository are downloadable by anyone forever, so encrypting them to the org-wide CI key makes that key a single point of failure for both public and private secrets. A dedicated key per visibility class limits the blast radius of either key leaking.
- The `PUBLIC_FNOX_AGE_KEY` organization secret has already been registered by an org admin; this PR wires wbfy's recipient sync and workflow generation to it.

## Testing

- `cd packages/wbfy && bun run vitest run test/unit` (330 tests passed, including new coverage: visibility-split recipient rosters, visibility-constrained scope matching, unknown-visibility exclusion, and caller-workflow mapping by visibility, for pinned callers, for public WillBoosterLab repositories, and under a failed recipient sync).
- `bun verify` (type checking and linting) passed; PR CI is green.
- Multi-agent review (Codex, Claude Code, Antigravity) ran for 4 rounds; all confirmed findings were fixed and the final round reported no concerns.

## Notes

- Rollout: run wbfy on each public fnox-migrated repository (currently only `WillBooster/build-ts`) to re-encrypt its secrets for `ci-public`; ciphertexts in git history remain decryptable by the org-internal CI key, so rotate already-committed public secret values if that separation matters for them.
- Confirm with an org admin that `PUBLIC_FNOX_AGE_KEY` is visible to public repositories (verifying it needs `admin:org`).
