### PR TITLE
fix(wbfy): allow wb >= 19 in repositories using neither fnox nor .env files

### DIFF
--- a/packages/wbfy/src/fixers/envFiles.ts
+++ b/packages/wbfy/src/fixers/envFiles.ts
@@ -3,17 +3,8 @@ import path from 'node:path';
 
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
+import { isRemovableEnvFileName } from '../utils/envFileName.js';
 import { spawnSyncAndReturnRawStdout, spawnSyncAndReturnStatus } from '../utils/spawnUtil.js';
-
-/**
- * `.env` cascade files (`.env`, `.env.local`, `.env.<mode>`, `.env.<mode>.local`, `.env.example`,
- * ...) are matched by name; `.env.cloudflare` is the deployment-credential sidecar that
- * untrackCloudflareEnv unlinks from git while keeping it on disk (a local `wb deploy` still needs
- * the real token in it), so it is excluded here.
- */
-function isRemovableEnvFileName(fileName: string): boolean {
-  return /^\.env(?:\.|$)/u.test(fileName) && !/^\.env\.cloudflare(?:\.|$)/u.test(fileName);
-}
 
 /**
  * Removes committed .env files from a repository that migrated to fnox (a root fnox.toml exists):

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -24,7 +24,7 @@ import { globIgnore } from '../utils/globUtil.js';
 import { combineMerge } from '../utils/mergeUtil.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
-import { spawnSync, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
+import { spawnSync, spawnSyncAndReturnRawStdout, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
 import { escapeRegExp } from '../utils/stringUtil.js';
 import { getTsconfigBaseDependencies, managedTsconfigBaseDependencies } from '../utils/tsconfigBase.js';
 import { parseSourceFile } from '../utils/typescriptApi.js';
@@ -2025,11 +2025,11 @@ function shouldUpdateExistingManagedDependency(
   if (isWorkspaceProtocolRange(currentVersion)) return true;
   if (!managedDependencyNames.has(dependency)) return false;
   const managedVersion = getManagedDependencyVersion(config, rootConfig, dependency);
-  // An existing fnox-only wb pin in a non-fnox repository is an incompatible state (wb >= 19
-  // ignores the repository's .env configuration), so the general no-downgrade rule below must
-  // not preserve it: rewrite it to the capped compatible release. Restricted to fnox-only
-  // MAJORS of the current pin so a merely-newer compatible pin (e.g. 18.0.2 while the registry
-  // lookup lags at 18.0.1) keeps the no-downgrade protection.
+  // An existing fnox-only wb pin in a repository still relying on the .env cascade without fnox
+  // is an incompatible state (wb >= 19 ignores the repository's .env configuration), so the
+  // general no-downgrade rule below must not preserve it: rewrite it to the capped compatible
+  // release. Restricted to fnox-only MAJORS of the current pin so a merely-newer compatible pin
+  // (e.g. 18.0.2 while the registry lookup lags at 18.0.1) keeps the no-downgrade protection.
   const currentValidVersion = semver.valid(currentVersion);
   if (
     dependency === wbDependency &&
@@ -2037,7 +2037,8 @@ function shouldUpdateExistingManagedDependency(
     semver.major(currentValidVersion) >= semver.major(minimumFnoxOnlyWbVersion) &&
     semver.valid(managedVersion) &&
     isNewerPackageVersion(currentVersion, managedVersion) &&
-    !hasFnoxConfigForRepository(rootConfig.dirPath)
+    !hasFnoxConfigForRepository(rootConfig.dirPath) &&
+    repositoryUsesEnvCascade(rootConfig.dirPath)
   ) {
     return true;
   }
@@ -2064,7 +2065,8 @@ function shouldUpdateExistingManagedDependency(
 
 // wb >= 19 reads environment variables exclusively from fnox (the .env cascade was removed), so
 // installing it into a repository that has not migrated (no root fnox.toml) would silently drop
-// every .env-configured variable from its builds, tests, and deploys.
+// every .env-configured variable from its builds, tests, and deploys. A repository that uses
+// neither fnox nor the .env cascade has nothing to migrate, so it gets the latest wb.
 const minimumFnoxOnlyWbVersion = '19.0.0';
 // The newest release below minimumFnoxOnlyWbVersion at the time this guard shipped; used only
 // when the registry lookup for the actual newest pre-fnox-only release fails.
@@ -2075,9 +2077,10 @@ const lastKnownPreV7TypescriptVersion = '6.0.3';
 
 /**
  * The version wbfy materializes for a managed dependency: the latest release, except that
- * `@willbooster/wb` is capped to the latest pre-fnox-only release for repositories without a
- * root fnox.toml (see minimumFnoxOnlyWbVersion). Capping at the version source covers every
- * path — upgrades of an existing pin, `*`/missing specifiers, and fresh installs.
+ * `@willbooster/wb` is capped to the latest pre-fnox-only release for repositories that still
+ * rely on the .env cascade without a root fnox.toml (see minimumFnoxOnlyWbVersion). Capping at
+ * the version source covers every path — upgrades of an existing pin, `*`/missing specifiers,
+ * and fresh installs.
  */
 function getManagedDependencyVersion(config: PackageConfig, rootConfig: PackageConfig, dependency: string): string {
   const latestVersion = getLatestDependencyVersion(config, dependency);
@@ -2095,7 +2098,7 @@ function getManagedDependencyVersion(config: PackageConfig, rootConfig: PackageC
   }
   if (dependency !== wbDependency) return latestVersion;
   return selectManagedWbVersion(
-    hasFnoxConfigForRepository(rootConfig.dirPath),
+    !hasFnoxConfigForRepository(rootConfig.dirPath) && repositoryUsesEnvCascade(rootConfig.dirPath),
     latestVersion,
     getLatestPreFnoxOnlyWbVersion,
     rootConfig.dirPath
@@ -2116,15 +2119,82 @@ export function hasFnoxConfigForRepository(rootDirPath: string): boolean {
   }
 }
 
+/** The nearest ancestor containing `.git` (the repository root), or the filesystem root. */
+function findGitRepositoryDirPath(dirPath: string): string {
+  for (let currentDirPath = path.resolve(dirPath); ; currentDirPath = path.dirname(currentDirPath)) {
+    if (fs.existsSync(path.join(currentDirPath, '.git')) || path.dirname(currentDirPath) === currentDirPath) {
+      return currentDirPath;
+    }
+  }
+}
+
+/**
+ * `.env` cascade file names (`.env`, `.env.local`, `.env.<mode>`, `.env.<mode>.local`, ...) count
+ * as env usage, `.env.example` included — it signals developer-local cascade files a fresh
+ * checkout cannot see. `.env.cloudflare` is the deployment-credential sidecar wb keeps reading
+ * regardless of fnox, so it does not count.
+ */
+function isEnvCascadeFileName(fileName: string): boolean {
+  return /^\.env(?:\.|$)/u.test(fileName) && !/^\.env\.cloudflare(?:\.|$)/u.test(fileName);
+}
+
+/**
+ * Whether the repository's .env cascade could still supply environment variables: a cascade file
+ * anywhere in the working tree — tracked, untracked, or gitignored, because a gitignored
+ * `.env.local` is a real configuration source on developer machines — or a legacy `DOT_ENV`
+ * secret wired into a workflow (CI materializes the cascade from it). The ignored-files listing
+ * collapses wholly ignored directories (`--directory`), so e.g. node_modules contents never
+ * count and the listing stays cheap. Like hasFnoxConfigForRepository, scan from the git
+ * repository root: wbfy may be invoked on a workspace CHILD whose cascade files and workflows
+ * live at the repository root.
+ */
+export function repositoryUsesEnvCascade(dirPath: string): boolean {
+  const rootDirPath = findGitRepositoryDirPath(dirPath);
+  // Three listings: tracked files, untracked non-ignored files, and ignored files (`--ignored`
+  // limits `--others` to ignored files, so plain untracked files need their own listing).
+  for (const extraArgs of [
+    [],
+    ['--others', '--exclude-standard', '--directory'],
+    ['--others', '--ignored', '--exclude-standard', '--directory'],
+  ]) {
+    // -z + core.quotePath=false: git C-quotes non-ASCII paths by default, which would break the
+    // basename filter below. Raw (untrimmed) stdout, because a leading whitespace byte belongs
+    // to the first file name.
+    const listedPaths = spawnSyncAndReturnRawStdout(
+      'git',
+      ['-c', 'core.quotePath=false', 'ls-files', '-z', ...extraArgs, '--', '.env*', '*/.env*'],
+      rootDirPath
+    ).split('\0');
+    // Collapsed directory entries end with '/'; a directory is not a cascade file.
+    if (
+      listedPaths.some(
+        (filePath) => filePath && !filePath.endsWith('/') && isEnvCascadeFileName(path.basename(filePath))
+      )
+    ) {
+      return true;
+    }
+  }
+  try {
+    const workflowsDirPath = path.join(rootDirPath, '.github', 'workflows');
+    for (const fileName of fs.readdirSync(workflowsDirPath)) {
+      const filePath = path.join(workflowsDirPath, fileName);
+      if (fs.statSync(filePath).isFile() && fs.readFileSync(filePath, 'utf8').includes('DOT_ENV')) return true;
+    }
+  } catch {
+    // No workflows directory.
+  }
+  return false;
+}
+
 const warnedPreFnoxOnlyWbRootDirPaths = new Set<string>();
 
 export function selectManagedWbVersion(
-  hasFnoxConfig: boolean,
+  needsFnoxMigration: boolean,
   latestVersion: string,
   getLatestPreFnoxVersion: () => string | undefined,
   rootDirPath: string
 ): string {
-  if (hasFnoxConfig) return latestVersion;
+  if (!needsFnoxMigration) return latestVersion;
   const validLatestVersion = semver.valid(latestVersion);
   // Compare majors so a 19.x PRE-release (semver-less-than 19.0.0) is capped too.
   if (validLatestVersion && semver.major(validLatestVersion) < semver.major(minimumFnoxOnlyWbVersion)) {
@@ -2138,7 +2208,7 @@ export function selectManagedWbVersion(
   if (!warnedPreFnoxOnlyWbRootDirPaths.has(rootDirPath)) {
     warnedPreFnoxOnlyWbRootDirPaths.add(rootDirPath);
     console.warn(
-      `Capped ${wbDependency} at ${preFnoxVersion} in ${rootDirPath}: wb >= ${minimumFnoxOnlyWbVersion} loads environment variables only from fnox, and this repository has no root fnox.toml. Migrate to fnox (see migrate-env-to-fnox), then rerun wbfy to upgrade.`
+      `Capped ${wbDependency} at ${preFnoxVersion} in ${rootDirPath}: wb >= ${minimumFnoxOnlyWbVersion} loads environment variables only from fnox, and this repository still relies on the .env cascade (or a DOT_ENV secret) without a root fnox.toml. Migrate to fnox (see migrate-env-to-fnox), then rerun wbfy to upgrade.`
     );
   }
   return preFnoxVersion;

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -25,7 +25,7 @@ import { combineMerge } from '../utils/mergeUtil.js';
 import { isEnvCascadeFileName } from '../utils/envFileName.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
-import { spawnSync, spawnSyncAndReturnRawStdout, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
+import { spawnSync, spawnSyncAndReturnStatusAndRawStdout, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
 import { escapeRegExp } from '../utils/stringUtil.js';
 import { getTsconfigBaseDependencies, managedTsconfigBaseDependencies } from '../utils/tsconfigBase.js';
 import { parseSourceFile } from '../utils/typescriptApi.js';
@@ -2120,14 +2120,7 @@ export function hasFnoxConfigForRepository(rootDirPath: string): boolean {
   }
 }
 
-/** The nearest ancestor containing `.git` (the repository root), or the filesystem root. */
-function findGitRepositoryDirPath(dirPath: string): string {
-  for (let currentDirPath = path.resolve(dirPath); ; currentDirPath = path.dirname(currentDirPath)) {
-    if (fs.existsSync(path.join(currentDirPath, '.git')) || path.dirname(currentDirPath) === currentDirPath) {
-      return currentDirPath;
-    }
-  }
-}
+const repositoryUsesEnvCascadeCache = new Map<string, boolean>();
 
 /**
  * Whether the repository's .env cascade could still supply environment variables: a cascade file
@@ -2154,7 +2147,14 @@ export function repositoryUsesEnvCascade(dirPath: string): boolean {
   return usesEnvCascade;
 }
 
-const repositoryUsesEnvCascadeCache = new Map<string, boolean>();
+/** The nearest ancestor containing `.git` (the repository root), or the filesystem root. */
+function findGitRepositoryDirPath(dirPath: string): string {
+  for (let currentDirPath = path.resolve(dirPath); ; currentDirPath = path.dirname(currentDirPath)) {
+    if (fs.existsSync(path.join(currentDirPath, '.git')) || path.dirname(currentDirPath) === currentDirPath) {
+      return currentDirPath;
+    }
+  }
+}
 
 function detectEnvCascadeUsage(rootDirPath: string): boolean {
   // Three listings: tracked files, untracked non-ignored files, and ignored files (`--ignored`
@@ -2167,11 +2167,16 @@ function detectEnvCascadeUsage(rootDirPath: string): boolean {
     // -z + core.quotePath=false: git C-quotes non-ASCII paths by default, which would break the
     // basename filter below. Raw (untrimmed) stdout, because a leading whitespace byte belongs
     // to the first file name.
-    const listedPaths = spawnSyncAndReturnRawStdout(
+    const [status, stdout] = spawnSyncAndReturnStatusAndRawStdout(
       'git',
       ['-c', 'core.quotePath=false', 'ls-files', '-z', ...extraArgs, '--', '.env*', '*/.env*'],
       rootDirPath
-    ).split('\0');
+    );
+    // Fail CLOSED: when git itself fails (a stale worktree gitdir link, a dubious-ownership
+    // refusal, a missing binary), an empty listing must not read as "no cascade files" — this
+    // guard exists to prevent silent env loss, so assume the cascade is in use and keep the cap.
+    if (status !== 0) return true;
+    const listedPaths = stdout.split('\0');
     // Collapsed directory entries end with '/'; a directory is not a cascade file.
     if (
       listedPaths.some(

--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -22,6 +22,7 @@ import { fsUtil } from '../utils/fsUtil.js';
 import { gitHubUtil } from '../utils/githubUtil.js';
 import { globIgnore } from '../utils/globUtil.js';
 import { combineMerge } from '../utils/mergeUtil.js';
+import { isEnvCascadeFileName } from '../utils/envFileName.js';
 import { doesContainJava, doesContainJsOrTs } from '../utils/packageCapabilities.js';
 import { promisePool } from '../utils/promisePool.js';
 import { spawnSync, spawnSyncAndReturnRawStdout, spawnSyncAndReturnStdout } from '../utils/spawnUtil.js';
@@ -2129,27 +2130,33 @@ function findGitRepositoryDirPath(dirPath: string): string {
 }
 
 /**
- * `.env` cascade file names (`.env`, `.env.local`, `.env.<mode>`, `.env.<mode>.local`, ...) count
- * as env usage, `.env.example` included — it signals developer-local cascade files a fresh
- * checkout cannot see. `.env.cloudflare` is the deployment-credential sidecar wb keeps reading
- * regardless of fnox, so it does not count.
- */
-function isEnvCascadeFileName(fileName: string): boolean {
-  return /^\.env(?:\.|$)/u.test(fileName) && !/^\.env\.cloudflare(?:\.|$)/u.test(fileName);
-}
-
-/**
  * Whether the repository's .env cascade could still supply environment variables: a cascade file
- * anywhere in the working tree — tracked, untracked, or gitignored, because a gitignored
- * `.env.local` is a real configuration source on developer machines — or a legacy `DOT_ENV`
- * secret wired into a workflow (CI materializes the cascade from it). The ignored-files listing
- * collapses wholly ignored directories (`--directory`), so e.g. node_modules contents never
- * count and the listing stays cheap. Like hasFnoxConfigForRepository, scan from the git
- * repository root: wbfy may be invoked on a workspace CHILD whose cascade files and workflows
- * live at the repository root.
+ * (isEnvCascadeFileName) anywhere in the working tree — tracked, untracked, or gitignored,
+ * because a gitignored `.env.local` is a real configuration source on developer machines — or a
+ * legacy `DOT_ENV` secret wired into a workflow (CI materializes the cascade from it). The
+ * ignored-files listing collapses wholly ignored directories (`--directory`), so e.g.
+ * node_modules contents never count and the listing stays cheap. Like hasFnoxConfigForRepository,
+ * scan from the git repository root: wbfy may be invoked on a workspace CHILD whose cascade files
+ * and workflows live at the repository root.
+ *
+ * The verdict is memoized per repository root, and index.ts primes it BEFORE removeEnvExample
+ * runs: on a fresh checkout a tracked `.env.example` may be the only visible signal that
+ * developers keep gitignored cascade files, and it must count even though this same wbfy run
+ * deletes it.
  */
 export function repositoryUsesEnvCascade(dirPath: string): boolean {
   const rootDirPath = findGitRepositoryDirPath(dirPath);
+  let usesEnvCascade = repositoryUsesEnvCascadeCache.get(rootDirPath);
+  if (usesEnvCascade === undefined) {
+    usesEnvCascade = detectEnvCascadeUsage(rootDirPath);
+    repositoryUsesEnvCascadeCache.set(rootDirPath, usesEnvCascade);
+  }
+  return usesEnvCascade;
+}
+
+const repositoryUsesEnvCascadeCache = new Map<string, boolean>();
+
+function detectEnvCascadeUsage(rootDirPath: string): boolean {
   // Three listings: tracked files, untracked non-ignored files, and ignored files (`--ignored`
   // limits `--others` to ignored files, so plain untracked files need their own listing).
   for (const extraArgs of [

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -28,7 +28,7 @@ import { generateGitignore } from './generators/gitignore.js';
 import { generateIdeaSettings } from './generators/idea.js';
 import { generateLefthookUpdatingPackageJson } from './generators/lefthook.js';
 import { generateLintstagedrc } from './generators/lintstagedrc.js';
-import { generatePackageJson, getWorkspacePackageDirs } from './generators/packageJson.js';
+import { generatePackageJson, getWorkspacePackageDirs, repositoryUsesEnvCascade } from './generators/packageJson.js';
 import { generateOxfmtConfig } from './generators/oxfmtConfig.js';
 import { generateOxlintConfig } from './generators/oxlintConfig.js';
 import { generatePrettierignore } from './generators/prettierignore.js';
@@ -237,6 +237,11 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
       }
     }
     assertSafeDependencySources(allPackageConfigs);
+    // Prime the cascade-usage memo BEFORE removeEnvExample deletes .env.example: on a fresh
+    // checkout that file may be the only visible signal that developers keep gitignored .env
+    // files, and generatePackageJson's wb version cap must still see it (see
+    // repositoryUsesEnvCascade).
+    repositoryUsesEnvCascade(rootConfig.dirPath);
     for (const config of allPackageConfigs) await removeEnvExample(config);
 
     // Managed repositories use Bun with mise (and optionally fnox); Yarn artifacts are removed.

--- a/packages/wbfy/src/utils/envFileName.ts
+++ b/packages/wbfy/src/utils/envFileName.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether wb's .env cascade could read a file named `fileName` (`.env`, `.env.local`,
+ * `.env.<mode>`, `.env.<mode>.local`, ...), `.env.example` included — it signals developer-local
+ * cascade files a fresh checkout cannot see. Only the exact `.env.cloudflare` name is excluded:
+ * wb's deploy reads that sidecar directly regardless of fnox (readCloudflareEnvFiles), while a
+ * `.env.cloudflare.*` variant is NOT the sidecar and conservatively counts as cascade usage
+ * (wb 18's `--cascade-env` accepts arbitrary names, so e.g. `.env.cloudflare.local` is loadable).
+ */
+export function isEnvCascadeFileName(fileName: string): boolean {
+  return /^\.env(?:\.|$)/u.test(fileName) && fileName !== '.env.cloudflare';
+}
+
+/**
+ * Whether removeEnvFiles may delete a file named `fileName` from a fnox-migrated repository.
+ * Unlike isEnvCascadeFileName, the whole `.env.cloudflare*` family is kept: `.env.cloudflare` is
+ * the deployment-credential sidecar that untrackCloudflareEnv unlinks from git while keeping it
+ * on disk (a local `wb deploy` still needs the real token in it), and deleting a sibling local
+ * variant would likewise destroy a developer-local credential file.
+ */
+export function isRemovableEnvFileName(fileName: string): boolean {
+  return /^\.env(?:\.|$)/u.test(fileName) && !/^\.env\.cloudflare(?:\.|$)/u.test(fileName);
+}

--- a/packages/wbfy/src/utils/spawnUtil.ts
+++ b/packages/wbfy/src/utils/spawnUtil.ts
@@ -22,14 +22,24 @@ export function spawnSyncAndReturnStatus(command: string, args: string[], cwd: s
  * `git ls-files -z`) where a leading/trailing whitespace byte belongs to a file name.
  */
 export function spawnSyncAndReturnRawStdout(command: string, args: string[], cwd: string): string {
+  return spawnSyncAndReturnStdoutInternal(command, args, cwd, false)[1];
+}
+
+/** Like spawnSyncAndReturnRawStdout, but also exposes the exit status so callers can fail closed. */
+export function spawnSyncAndReturnStatusAndRawStdout(command: string, args: string[], cwd: string): [number, string] {
   return spawnSyncAndReturnStdoutInternal(command, args, cwd, false);
 }
 
 export function spawnSyncAndReturnStdout(command: string, args: string[], cwd: string): string {
-  return spawnSyncAndReturnStdoutInternal(command, args, cwd, true);
+  return spawnSyncAndReturnStdoutInternal(command, args, cwd, true)[1];
 }
 
-function spawnSyncAndReturnStdoutInternal(command: string, args: string[], cwd: string, trims: boolean): string {
+function spawnSyncAndReturnStdoutInternal(
+  command: string,
+  args: string[],
+  cwd: string,
+  trims: boolean
+): [number, string] {
   const [newCmd, newArgs, options] = getSpawnSyncArgs(command, args, cwd);
   options.stdio = 'pipe';
   const proc = child_process.spawnSync(newCmd, newArgs, options);
@@ -46,7 +56,7 @@ function spawnSyncAndReturnStdoutInternal(command: string, args: string[], cwd: 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- spawnSync returns null stdout on ENOENT.
   const stdout = proc.stdout ?? '';
   const stdoutText = typeof stdout === 'string' ? stdout : stdout.toString();
-  return trims ? stdoutText.trim() : stdoutText;
+  return [proc.status ?? 1, trims ? stdoutText.trim() : stdoutText];
 }
 
 export function getSpawnSyncArgs(command: string, args: string[], cwd: string): [string, string[], SpawnSyncOptions] {

--- a/packages/wbfy/test/unit/managedWbVersion.test.ts
+++ b/packages/wbfy/test/unit/managedWbVersion.test.ts
@@ -1,19 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
+import child_process from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { hasFnoxConfigForRepository, selectManagedWbVersion } from '../../src/generators/packageJson.js';
+import {
+  hasFnoxConfigForRepository,
+  repositoryUsesEnvCascade,
+  selectManagedWbVersion,
+} from '../../src/generators/packageJson.js';
 
 // wb >= 19 loads environment variables only from fnox, so wbfy must not materialize such a
-// version for repositories without a root fnox.toml (fresh installs, `*`, and upgrades all flow
-// through this selection).
+// version for repositories that still rely on the .env cascade without a root fnox.toml (fresh
+// installs, `*`, and upgrades all flow through this selection). Repositories using neither fnox
+// nor .env files have nothing to migrate and get the latest wb.
 describe('selectManagedWbVersion', () => {
-  it('keeps the latest version for fnox repositories', () => {
+  it('keeps the latest version for repositories not needing the fnox migration', () => {
     expect(
       selectManagedWbVersion(
-        true,
+        false,
         '19.0.0',
         () => {
           throw new Error('must not be called');
@@ -23,18 +29,18 @@ describe('selectManagedWbVersion', () => {
     ).toBe('19.0.0');
   });
 
-  it('caps a fnox-only latest version to the latest pre-fnox-only release for non-fnox repositories', () => {
-    expect(selectManagedWbVersion(false, '19.1.0', () => '18.0.1', '/repo')).toBe('18.0.1');
+  it('caps a fnox-only latest version to the latest pre-fnox-only release for repositories needing the migration', () => {
+    expect(selectManagedWbVersion(true, '19.1.0', () => '18.0.1', '/repo')).toBe('18.0.1');
   });
 
-  it('caps a fnox-only PRE-release version for non-fnox repositories', () => {
-    expect(selectManagedWbVersion(false, '19.0.0-alpha.0', () => '18.0.1', '/repo')).toBe('18.0.1');
+  it('caps a fnox-only PRE-release version for repositories needing the migration', () => {
+    expect(selectManagedWbVersion(true, '19.0.0-alpha.0', () => '18.0.1', '/repo')).toBe('18.0.1');
   });
 
-  it('keeps a pre-fnox-only latest version for non-fnox repositories', () => {
+  it('keeps a pre-fnox-only latest version for repositories needing the migration', () => {
     expect(
       selectManagedWbVersion(
-        false,
+        true,
         '18.0.1',
         () => {
           throw new Error('must not be called');
@@ -45,18 +51,18 @@ describe('selectManagedWbVersion', () => {
   });
 
   it('falls back to the last known pre-fnox-only release when the lookup fails', () => {
-    expect(selectManagedWbVersion(false, '19.0.0', () => {}, '/repo')).toBe('18.0.1');
+    expect(selectManagedWbVersion(true, '19.0.0', () => {}, '/repo')).toBe('18.0.1');
   });
 
-  it('resolves a failed-lookup marker to a compatible release for non-fnox repositories', () => {
-    expect(selectManagedWbVersion(false, '*', () => '18.0.1', '/repo')).toBe('18.0.1');
-    expect(selectManagedWbVersion(false, '*', () => {}, '/repo')).toBe('18.0.1');
+  it('resolves a failed-lookup marker to a compatible release for repositories needing the migration', () => {
+    expect(selectManagedWbVersion(true, '*', () => '18.0.1', '/repo')).toBe('18.0.1');
+    expect(selectManagedWbVersion(true, '*', () => {}, '/repo')).toBe('18.0.1');
   });
 
-  it('passes through a failed-lookup marker for fnox repositories', () => {
+  it('passes through a failed-lookup marker for repositories not needing the migration', () => {
     expect(
       selectManagedWbVersion(
-        true,
+        false,
         '*',
         () => {
           throw new Error('must not be called');
@@ -83,6 +89,77 @@ describe('hasFnoxConfigForRepository', () => {
       expect(hasFnoxConfigForRepository(repoPath)).toBe(true);
     } finally {
       fs.rmSync(outerPath, { recursive: true, force: true });
+    }
+  });
+});
+
+function createGitRepository(): string {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-env-repo-'));
+  child_process.execFileSync('git', ['init', '--quiet'], { cwd: repoPath });
+  return repoPath;
+}
+
+describe('repositoryUsesEnvCascade', () => {
+  it('detects nothing in a repository without cascade files or DOT_ENV workflows', () => {
+    const repoPath = createGitRepository();
+    try {
+      fs.writeFileSync(path.join(repoPath, 'package.json'), '{}');
+      const workflowsPath = path.join(repoPath, '.github', 'workflows');
+      fs.mkdirSync(workflowsPath, { recursive: true });
+      fs.writeFileSync(path.join(workflowsPath, 'test.yml'), 'jobs: {}\n');
+      expect(repositoryUsesEnvCascade(repoPath)).toBe(false);
+    } finally {
+      fs.rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('detects tracked, untracked, and gitignored cascade files, also from a workspace child', () => {
+    const repoPath = createGitRepository();
+    try {
+      // Untracked root .env.
+      fs.writeFileSync(path.join(repoPath, '.env'), 'FOO=1\n');
+      expect(repositoryUsesEnvCascade(repoPath)).toBe(true);
+      fs.rmSync(path.join(repoPath, '.env'));
+
+      // Gitignored nested .env.local: a developer-local configuration source.
+      fs.writeFileSync(path.join(repoPath, '.gitignore'), '.env.local\n');
+      const childPath = path.join(repoPath, 'packages', 'app');
+      fs.mkdirSync(childPath, { recursive: true });
+      fs.writeFileSync(path.join(childPath, '.env.local'), 'FOO=1\n');
+      expect(repositoryUsesEnvCascade(repoPath)).toBe(true);
+      // Scanning starts from the repository root even when invoked on a workspace child.
+      expect(repositoryUsesEnvCascade(childPath)).toBe(true);
+    } finally {
+      fs.rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores the .env.cloudflare sidecar and files inside wholly ignored directories', () => {
+    const repoPath = createGitRepository();
+    try {
+      fs.writeFileSync(path.join(repoPath, '.env.cloudflare'), 'CLOUDFLARE_API_TOKEN=x\n');
+      fs.writeFileSync(path.join(repoPath, '.gitignore'), 'node_modules/\n');
+      const dependencyPath = path.join(repoPath, 'node_modules', 'some-pkg');
+      fs.mkdirSync(dependencyPath, { recursive: true });
+      fs.writeFileSync(path.join(dependencyPath, '.env'), 'FOO=1\n');
+      expect(repositoryUsesEnvCascade(repoPath)).toBe(false);
+    } finally {
+      fs.rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('detects a legacy DOT_ENV secret wired into a workflow', () => {
+    const repoPath = createGitRepository();
+    try {
+      const workflowsPath = path.join(repoPath, '.github', 'workflows');
+      fs.mkdirSync(workflowsPath, { recursive: true });
+      fs.writeFileSync(
+        path.join(workflowsPath, 'test.yml'),
+        'jobs:\n  test:\n    secrets:\n      DOT_ENV: ${{ secrets.DOT_ENV }}\n'
+      );
+      expect(repositoryUsesEnvCascade(repoPath)).toBe(true);
+    } finally {
+      fs.rmSync(repoPath, { recursive: true, force: true });
     }
   });
 });

--- a/packages/wbfy/test/unit/managedWbVersion.test.ts
+++ b/packages/wbfy/test/unit/managedWbVersion.test.ts
@@ -113,14 +113,34 @@ describe('repositoryUsesEnvCascade', () => {
     }
   });
 
-  it('detects tracked, untracked, and gitignored cascade files, also from a workspace child', () => {
+  it('detects a tracked cascade file', () => {
     const repoPath = createGitRepository();
     try {
-      // Untracked root .env.
-      fs.writeFileSync(path.join(repoPath, '.env'), 'FOO=1\n');
+      fs.writeFileSync(path.join(repoPath, '.env.production'), 'FOO=1\n');
+      child_process.execFileSync('git', ['add', '.env.production'], { cwd: repoPath });
       expect(repositoryUsesEnvCascade(repoPath)).toBe(true);
-      fs.rmSync(path.join(repoPath, '.env'));
+    } finally {
+      fs.rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
 
+  it('detects an untracked cascade file and memoizes the verdict across its deletion', () => {
+    const repoPath = createGitRepository();
+    try {
+      fs.writeFileSync(path.join(repoPath, '.env.example'), 'FOO=\n');
+      expect(repositoryUsesEnvCascade(repoPath)).toBe(true);
+      // The memoized verdict must survive removeEnvExample deleting the file mid-run (index.ts
+      // primes the memo before that fixer).
+      fs.rmSync(path.join(repoPath, '.env.example'));
+      expect(repositoryUsesEnvCascade(repoPath)).toBe(true);
+    } finally {
+      fs.rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('detects a gitignored cascade file, also from a workspace child', () => {
+    const repoPath = createGitRepository();
+    try {
       // Gitignored nested .env.local: a developer-local configuration source.
       fs.writeFileSync(path.join(repoPath, '.gitignore'), '.env.local\n');
       const childPath = path.join(repoPath, 'packages', 'app');
@@ -143,6 +163,18 @@ describe('repositoryUsesEnvCascade', () => {
       fs.mkdirSync(dependencyPath, { recursive: true });
       fs.writeFileSync(path.join(dependencyPath, '.env'), 'FOO=1\n');
       expect(repositoryUsesEnvCascade(repoPath)).toBe(false);
+    } finally {
+      fs.rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  it('detects a .env.cloudflare.local variant (only the exact sidecar name is excluded)', () => {
+    const repoPath = createGitRepository();
+    try {
+      // wb 18's `--cascade-env=cloudflare` loads `.env.cloudflare.local`; only the exact
+      // `.env.cloudflare` sidecar is read by wb regardless of fnox.
+      fs.writeFileSync(path.join(repoPath, '.env.cloudflare.local'), 'FOO=1\n');
+      expect(repositoryUsesEnvCascade(repoPath)).toBe(true);
     } finally {
       fs.rmSync(repoPath, { recursive: true, force: true });
     }

--- a/packages/wbfy/test/unit/managedWbVersion.test.ts
+++ b/packages/wbfy/test/unit/managedWbVersion.test.ts
@@ -168,6 +168,18 @@ describe('repositoryUsesEnvCascade', () => {
     }
   });
 
+  it('fails closed when git cannot run in the repository', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-env-broken-repo-'));
+    try {
+      // A stale worktree-style gitdir link makes every git command fail; an empty listing must
+      // not read as "no cascade files", so detection assumes the cascade is in use.
+      fs.writeFileSync(path.join(repoPath, '.git'), 'gitdir: /nonexistent/gitdir\n');
+      expect(repositoryUsesEnvCascade(repoPath)).toBe(true);
+    } finally {
+      fs.rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
   it('detects a .env.cloudflare.local variant (only the exact sidecar name is excluded)', () => {
     const repoPath = createGitRepository();
     try {


### PR DESCRIPTION
## Overview

The fnox-only wb cap (wb < 19 for repositories without a root `fnox.toml`) exists to protect repositories whose `.env` cascade would be silently dropped by wb >= 19. However, a repository that uses **neither** fnox **nor** any `.env` cascade file has nothing to migrate, yet was still capped at the last pre-fnox-only release (e.g. WillBooster/website — a Hugo site with no environment variables at all).

## Changes

- Added `repositoryUsesEnvCascade`: detects whether the `.env` cascade could still supply variables, by scanning
  - tracked, untracked, and gitignored `.env*` files anywhere in the working tree (a gitignored `.env.local` is a real configuration source on developer machines; wholly ignored directories such as `node_modules` stay collapsed via `--directory` and never count),
  - `.env.example` counts (it signals developer-local cascade files a fresh checkout cannot see); only the exact `.env.cloudflare` sidecar is excluded — `.env.cloudflare.*` variants count because wb 18's `--cascade-env` can load them,
  - legacy `DOT_ENV` secrets wired into `.github/workflows/` (CI materializes the cascade from them).
- The wb version cap and the fnox-only-pin downgrade override now apply only when the repository has no root `fnox.toml` **and** still uses the `.env` cascade.
- The verdict is memoized per repository root and primed in `index.ts` **before** `removeEnvExample`, so a tracked `.env.example` still counts within the same wbfy run that deletes it.
- Detection fails **closed**: any `git ls-files` failure (stale worktree gitdir link, dubious-ownership refusal, missing binary) returns "cascade in use", preserving the cap — an empty listing from a broken git must not uncap a repository that still relies on `.env` files.
- The cascade/removal file-name predicates are shared in `utils/envFileName.ts` (with the deliberate difference documented: removal keeps the whole `.env.cloudflare*` family).
- Scans start from the git repository root, so invoking wbfy on a workspace child behaves like `hasFnoxConfigForRepository`.

## Verification

- `bun verify` and `packages/wbfy` unit tests pass (tests cover tracked/untracked/gitignored detection, memoization across `.env.example` deletion, fail-closed on git failure, the `.env.cloudflare` exact-name exclusion and `.env.cloudflare.local` detection, `node_modules` exclusion, DOT_ENV workflows, and workspace-child invocation).
- Manual check: `repositoryUsesEnvCascade('<website>')` → `false` (would now get wb 19), `repositoryUsesEnvCascade('<shared>')` → `false`.

## Residual risk (accepted)

A repository whose `.env.example` was already deleted by a past wbfy run and whose only cascade files are gitignored developer-local `.env*` shows no signal on a fresh checkout and gets uncapped; DOT_ENV workflow secrets and tracked `.env*` files remain the durable signals. Accepted because wbfy removed `.env.example` support org-wide in #1068.
