### PR TITLE
feat(wbfy): add scoped fnox access for sunaga and ayame

### DIFF
--- a/packages/wbfy/src/generators/fnoxToml.ts
+++ b/packages/wbfy/src/generators/fnoxToml.ts
@@ -101,6 +101,20 @@ export const FNOX_AGE_PRINCIPALS = [
       ],
     },
   },
+  {
+    name: 'sunaga',
+    publicKeys: ['age1ulxzn6y68ku34cpx5fya5gf7rnrwz0uflnye6uxuhg34p2njhgkqmg73g4'],
+    repositoryScope: {
+      repositories: ['WillBoosterLab/exercode', 'WillBoosterLab/judge'],
+    },
+  },
+  {
+    name: 'ayame',
+    publicKeys: ['age1vxm2gs003ruwm8p6h3hv7xasju2s8k4mxmc34zm6grdwznrs09nq6xz5vz'],
+    repositoryScope: {
+      repositories: ['WillBooster/chofu-walking', 'WillBoosterLab/exercode', 'WillBoosterLab/judge'],
+    },
+  },
 ] as const satisfies readonly FnoxAgePrincipal[];
 
 interface FnoxToml {

--- a/packages/wbfy/test/unit/fnoxToml.test.ts
+++ b/packages/wbfy/test/unit/fnoxToml.test.ts
@@ -109,6 +109,33 @@ test('grants aries fnox access only to the selected repositories', () => {
   );
 });
 
+test('grants sunaga and ayame fnox access only to their selected repositories', () => {
+  const sunagaRecipient = {
+    name: 'sunaga',
+    publicKey: 'age1ulxzn6y68ku34cpx5fya5gf7rnrwz0uflnye6uxuhg34p2njhgkqmg73g4',
+  };
+  const ayameRecipient = {
+    name: 'ayame',
+    publicKey: 'age1vxm2gs003ruwm8p6h3hv7xasju2s8k4mxmc34zm6grdwznrs09nq6xz5vz',
+  };
+
+  for (const repository of ['WillBoosterLab/exercode', 'WillBoosterLab/judge']) {
+    const recipients = getFnoxAgeRecipients(createConfig({ repository: `github:${repository}` }));
+    expect(recipients).toContainEqual(sunagaRecipient);
+    expect(recipients).toContainEqual(ayameRecipient);
+  }
+
+  const chofuWalkingRecipients = getFnoxAgeRecipients(createConfig({ repository: 'github:WillBooster/chofu-walking' }));
+  expect(chofuWalkingRecipients).not.toContainEqual(sunagaRecipient);
+  expect(chofuWalkingRecipients).toContainEqual(ayameRecipient);
+
+  for (const repository of ['WillBooster/shared', 'WillBoosterLab/example']) {
+    const recipients = getFnoxAgeRecipients(createConfig({ repository: `github:${repository}` }));
+    expect(recipients).not.toContainEqual(sunagaRecipient);
+    expect(recipients).not.toContainEqual(ayameRecipient);
+  }
+});
+
 test('keeps the age recipients of a repository outside the WillBooster organizations', async () => {
   const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-fnox-'));
   try {


### PR DESCRIPTION
## Customer Summary

- sunagaさんが `WillBoosterLab/exercode` と `WillBoosterLab/judge` のfnox secretsを利用できるようにします。
- ayameさんが上記2リポジトリと `WillBooster/chofu-walking` のfnox secretsを利用できるようにします。
- 指定外のリポジトリにはアクセスを付与しません。
- 各対象リポジトリで次回wbfyを実行すると、更新されたrecipient一覧でsecretsが再暗号化されます。

## Technical Summary

- `FNOX_AGE_PRINCIPALS` にsunagaさんとayameさんのage公開鍵を追加しました。
- `organizations` は使用せず、`repositories` による完全一致スコープを設定しました。
- 共通対象、ayameさん固有の対象、対象外リポジトリのrecipient判定をテストしました。

## Why

fnox secretsへのアクセスを必要なリポジトリだけに限定し、最小権限で2名へ付与するためです。

## Testing

- `bun test packages/wbfy/test/unit/fnoxToml.test.ts`
- `bun verify`
