### PR TITLE
feat(shared-lib): add getAppEnv to read WB_ENV with the standardized domain

### DIFF
--- a/packages/shared-lib/src/appEnv.ts
+++ b/packages/shared-lib/src/appEnv.ts
@@ -1,0 +1,18 @@
+export type AppEnv = 'development' | 'test' | 'staging' | 'production';
+
+/**
+ * The runtime `WB_ENV` widened to the full domain wb standardizes.
+ *
+ * `wrangler types` narrows `process.env.WB_ENV` to the literal values the wrangler configuration
+ * declares (typically staging and production only), while local development, E2E, and scripts
+ * supply `development` and `test` through fnox (`wb gen-dev-vars` writes them into the gitignored
+ * `.dev.vars` that `wrangler dev` reads). This accessor widens the generated type back to the real
+ * runtime domain so environment detection stays in one place.
+ *
+ * Exposed as a function rather than a constant because Cloudflare Workers may not provide
+ * environment variables during module evaluation; callers choose when to read. Returns undefined
+ * where `process` does not exist (e.g. browsers).
+ */
+export function getAppEnv(): AppEnv | undefined {
+  return typeof process === 'undefined' ? undefined : (process.env.WB_ENV as AppEnv | undefined);
+}

--- a/packages/shared-lib/src/index.ts
+++ b/packages/shared-lib/src/index.ts
@@ -1,3 +1,4 @@
+export { getAppEnv } from './appEnv.js';
 export { ensureTruthy } from './assert.js';
 export { errorify, ignoreError, ignoreEnoent, ignoreErrorAsync, ignoreEnoentAsync, withRetry } from './error.js';
 export { humanizeNumber } from './humanize.js';
@@ -8,4 +9,5 @@ export { sleep } from './sleep.js';
 export { getConnectionLevelSqlitePragmas, getPersistentSqlitePragmas } from './sqlite.js';
 export { zenkakuAlphanumericalsToHankaku } from './zenkaku.js';
 
+export type { AppEnv } from './appEnv.js';
 export type { RetryOptions } from './error.js';


### PR DESCRIPTION
## Summary

- Add `getAppEnv(): AppEnv | undefined` and the `AppEnv` type (`'development' | 'test' | 'staging' | 'production'`) to `@willbooster/shared-lib`.

## Why

- Cloudflare Workers repositories (e.g. docoben, yutsugi) each carry an identical `src/lib/appEnv.ts` that widens the `wrangler types`-narrowed `process.env.WB_ENV` back to the real runtime domain. The value domain is the one wb standardizes (`standardWbEnvModes` in shared-lib-node), so the knowledge belongs in a shared runtime package.
- Exposed as a function because Workers may not provide environment variables during module evaluation; guarded with `typeof process` so browser bundles get `undefined` instead of a ReferenceError.

## Testing

- `bun verify` and `bun run build` in `packages/shared-lib` pass locally.
- Downstream migration will be verified in docoben / yutsugi with their full test suites.
