### PR TITLE
fix(wbfy): ignore local cache source checkouts

### DIFF
--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -98,6 +98,9 @@ async function buildWorkflowBadges(config: PackageConfig): Promise<string[]> {
   const badges: string[] = [];
   for (const fileName of fs.readdirSync(workflowsPath)) {
     if (!fileName.startsWith('test') && !fileName.startsWith('deploy')) continue;
+    // Workflow and README generation run concurrently. Do not retain a stale Rust badge while the
+    // workflow generator removes a caller created from a formerly misdetected local cache.
+    if (fileName === 'test-rust.yml' && config.cargoTomlDirPaths.length === 0) continue;
     // GitHub's badge endpoint returns 404 until the workflow has at least one run, so a badge for a
     // dispatch-only deploy workflow that has never run renders as a broken image. Test workflows run
     // on every PR, so only deploy badges need the guard.

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -269,6 +269,15 @@ export async function generateWorkflows(rootConfig: PackageConfig): Promise<void
     if (rootConfig.cargoTomlDirPaths.length > 0) {
       mandatoryKinds.push('test-rust');
     }
+    // A previous run may have mistaken a gitignored third-party checkout for repository Rust code.
+    // Remove only the generated-style caller: a same-named custom workflow with any other job stays.
+    if (rootConfig.cargoTomlDirPaths.length === 0) {
+      const testRustFileName = fileNamesByKind.get('test-rust');
+      if (testRustFileName && jobsAllCallReusableWorkflow(workflowsPath, testRustFileName, 'test-rust')) {
+        fileNamesByKind.delete('test-rust');
+        await fsUtil.removeConfined(path.join(workflowsPath, testRustFileName));
+      }
+    }
     // The self-applying nightly wbfy caller is retired: automated fleet maintenance is driven by
     // developers and agents running wbfy directly instead. An existing generated caller is
     // removed (only when the file solely calls the reusable wbfy workflow — a same-named custom
@@ -378,7 +387,7 @@ async function writeWorkflowYaml(
     ? 'deploy-production.yml'
     : undefined;
 
-  // A test-rust.yml in a repo without Rust code is a custom workflow that merely shares the name; leave it alone.
+  // A non-generated test-rust.yml in a repo without Rust code merely shares the name; leave it alone.
   if (kind === 'test-rust' && config.cargoTomlDirPaths.length === 0) return;
 
   let newSettings = structuredClone(kind in workflows ? workflows[kind as keyof typeof workflows] : {}) as Workflow;

--- a/packages/wbfy/src/utils/globUtil.ts
+++ b/packages/wbfy/src/utils/globUtil.ts
@@ -8,6 +8,9 @@ export const globIgnore = [
   // not influence language detection.
   '**/.tmp/**',
   '**/.tmp-*/**',
+  // Local caches can contain complete third-party source checkouts. Treating those as repository
+  // code generates workflows for paths that are gitignored and absent from fresh CI checkouts.
+  '**/.cache/**',
   '**/.venv/**',
   '**/test-fixtures/**',
   '**/test/fixtures/**',

--- a/packages/wbfy/test/unit/packageConfig.test.ts
+++ b/packages/wbfy/test/unit/packageConfig.test.ts
@@ -4,7 +4,9 @@ import path from 'node:path';
 
 import { expect, test } from 'vitest';
 
+import { generateWorkflows } from '../../src/generators/workflow.js';
 import { getPackageConfig } from '../../src/packageConfig.js';
+import { promisePool } from '../../src/utils/promisePool.js';
 
 // Regression test for the direct workspace-child invocation (`wbfy <repo>/packages/<app>`):
 // the entry keeps its child classification, but repository visibility must still be fetched
@@ -37,6 +39,37 @@ test('accepts Cargo-only Tauri projects without a package.json', async () => {
     expect(config).toBeDefined();
     expect(config?.doesContainTauriConfig).toBe(true);
     expect(config?.depending.tauri).toBe(true);
+  } finally {
+    fs.rmSync(tempDirPath, { recursive: true, force: true });
+  }
+});
+
+test('removes a generated Rust workflow based only on a cached Cargo project', async () => {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-package-config-'));
+  try {
+    fs.writeFileSync(path.join(tempDirPath, 'package.json'), '{}');
+    const packageDirPath = path.join(tempDirPath, 'packages', 'root');
+    const workflowsDirPath = path.join(packageDirPath, '.github', 'workflows');
+    fs.mkdirSync(path.join(packageDirPath, '.cache', 'clap-rs__clap'), { recursive: true });
+    fs.mkdirSync(workflowsDirPath, { recursive: true });
+    fs.writeFileSync(path.join(packageDirPath, 'package.json'), '{}');
+    fs.writeFileSync(path.join(packageDirPath, '.cache', 'clap-rs__clap', 'Cargo.toml'), '');
+    fs.writeFileSync(
+      path.join(workflowsDirPath, 'test-rust.yml'),
+      `name: Test Rust
+on: push
+jobs:
+  test-rust:
+    uses: WillBooster/reusable-workflows/.github/workflows/test-rust.yml@main
+`
+    );
+
+    const config = await getPackageConfig(packageDirPath);
+    if (!config) throw new Error('unreachable');
+    expect(config?.cargoTomlDirPaths).toEqual([]);
+    await generateWorkflows(config);
+    await promisePool.promiseAll();
+    expect(fs.existsSync(path.join(workflowsDirPath, 'test-rust.yml'))).toBe(false);
   } finally {
     fs.rmSync(tempDirPath, { recursive: true, force: true });
   }

--- a/packages/wbfy/test/unit/readme.test.ts
+++ b/packages/wbfy/test/unit/readme.test.ts
@@ -75,6 +75,26 @@ test('orders the block as workflows, semantic-release, then wbfy', async () => {
   });
 });
 
+test('drops a stale Rust workflow badge when the repository has no Rust code', async () => {
+  await withTempDir(async (dirPath) => {
+    const workflowsPath = path.resolve(dirPath, '.github', 'workflows');
+    fs.mkdirSync(workflowsPath, { recursive: true });
+    fs.writeFileSync(path.resolve(workflowsPath, 'test-rust.yml'), 'name: Test Rust\n');
+    fs.writeFileSync(
+      path.resolve(dirPath, 'README.md'),
+      `# Project
+
+[![Test rust](https://github.com/WillBooster/example/actions/workflows/test-rust.yml/badge.svg)](https://github.com/WillBooster/example/actions/workflows/test-rust.yml)
+${badgeOf('1.2.3')}
+`
+    );
+
+    const content = await runGenerateReadme(dirPath, '1.2.3');
+    expect(content).not.toContain('test-rust.yml');
+    expect(content).toContain(badgeOf('1.2.3'));
+  });
+});
+
 test.each([
   {
     name: 'no blank line after the heading',


### PR DESCRIPTION
## Summary

- ignore `.cache` trees during repository capability detection
- remove stale generated Rust workflows and badges when no repository Rust code remains
- cover the cache-detection and upgrade paths with regression tests

## Verification

- `bun verify-full`
- local `bun start "/Users/exkazuu/ghq/github.com/WillBooster/tokzip-corpus"`
