### PR TITLE
fix(wbfy): trust Zoom RTMS native install

### DIFF
--- a/packages/wbfy/src/generators/packageJson.ts
+++ b/packages/wbfy/src/generators/packageJson.ts
@@ -1185,6 +1185,10 @@ async function ensureTrustedDependencies(config: PackageConfig, jsonObj: Writabl
     // global-store entry even when the project installs them, so its server-side
     // `import 'zod'` fails from the store (observed in WillBooster/survey-system).
     ...(declaredDependencies.has('@hookform/resolvers') ? ['@hookform/resolvers'] : []),
+    // @zoom/rtms installs its native rtms.node binding in a lifecycle script. Without explicit
+    // trust, Bun skips that script and the package fails as soon as the Zoom bot imports it
+    // (observed in WillBooster/smartse-zoom-bot).
+    ...(declaredDependencies.has('@zoom/rtms') ? ['@zoom/rtms'] : []),
   ];
 
   // wbfy fully owns this field: a package whose lifecycle scripts must run gets added to wbfy
@@ -1231,6 +1235,7 @@ const wbfyManagedTrustedDependencies = new Set([
   '@hookform/resolvers',
   '@willbooster/judge',
   '@willbooster/llm-proxy',
+  '@zoom/rtms',
   'blitz',
   'drizzle-kit',
   lefthookDependency,

--- a/packages/wbfy/test/unit/packageJson.test.ts
+++ b/packages/wbfy/test/unit/packageJson.test.ts
@@ -886,6 +886,30 @@ test('manages trustedDependencies correctly when store-incompatible packages are
   expect(packageJson.trustedDependencies).toEqual([...(packageJson.trustedDependencies ?? [])].toSorted());
 });
 
+test('trusts @zoom/rtms so Bun installs its native binding', async () => {
+  const packageJson = await generatePackageJsonFrom(
+    {
+      workspaces: ['packages/*'],
+    },
+    {
+      isRoot: true,
+      doesContainSubPackageJsons: true,
+    },
+    {
+      files: {
+        'packages/server/package.json': JSON.stringify({
+          name: 'zoom-bot',
+          dependencies: {
+            '@zoom/rtms': '1.1.0',
+          },
+        }),
+      },
+    }
+  );
+
+  expect(packageJson.trustedDependencies).toContain('@zoom/rtms');
+});
+
 // wbfy fully owns trustedDependencies: packages whose lifecycle scripts must run get added to
 // wbfy itself, so unmanaged entries are removed and the field is deleted when wbfy needs nothing.
 test('removes custom trustedDependencies and deletes the field when wbfy needs no entries', async () => {


### PR DESCRIPTION
## Customer Summary

- Zoom bot repositories configured by wbfy can start successfully after dependency installation.
- No manual repository configuration or migration is required; re-running the released wbfy version applies the fix.

## Technical Summary

- Add `@zoom/rtms` to wbfy's managed root `trustedDependencies` whenever it is declared in the root or a workspace package.
- Keep the entry within wbfy's managed cleanup set so repeated configuration runs remain stable.
- Add regression coverage for a workspace package declaring `@zoom/rtms`.

## Why

wbfy fully owns `trustedDependencies`, but previously removed the target repository's `@zoom/rtms` entry. Bun then skipped the package's install lifecycle script, leaving the native `rtms.node` binding unavailable at runtime.

## Testing

- `bun verify-full`
- Ran local wbfy with `bun start /Users/exkazuu/ghq/github.com/WillBooster/smartse-zoom-bot` from `packages/wbfy`.
- Verified `bun -e "await import('@zoom/rtms')"` succeeds in the target server workspace.
