### PR TITLE
fix: drop node type references from generated CJS configs

### DIFF
--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -43,10 +43,12 @@ function getConfigContent(config: PackageConfig): string {
 
   // CommonJS packages need require/module.exports here: oxfmt config files are
   // only auto-discovered as .ts, and the shared config package is ESM-only.
+  // Reference "bun", not "node": @types/bun is the only type package wbfy installs, and
+  // Bun's isolated linker cannot resolve an undeclared @types/node (TS2688).
   if (!config.isEsmPackage) {
     return `${managedConfigBlocks.getBlock(
       'base',
-      `/// <reference types="node" />
+      `/// <reference types="bun" />
 import type { OxfmtConfig } from 'oxfmt';
 
 // oxlint-disable unicorn/prefer-module -- Oxfmt config files are only auto-discovered as .ts, and CommonJS avoids ESM package loading issues.

--- a/packages/wbfy/src/generators/oxfmtConfig.ts
+++ b/packages/wbfy/src/generators/oxfmtConfig.ts
@@ -43,13 +43,13 @@ function getConfigContent(config: PackageConfig): string {
 
   // CommonJS packages need require/module.exports here: oxfmt config files are
   // only auto-discovered as .ts, and the shared config package is ESM-only.
-  // Reference "bun", not "node": @types/bun is the only type package wbfy installs, and
-  // Bun's isolated linker cannot resolve an undeclared @types/node (TS2688).
+  // No /// <reference types> line: the wbfy-generated tsconfig already covers *.config.ts with
+  // types ["bun"], which types require/module.exports, while a "node" reference breaks under
+  // Bun's isolated linker where the undeclared @types/node is unresolvable (TS2688).
   if (!config.isEsmPackage) {
     return `${managedConfigBlocks.getBlock(
       'base',
-      `/// <reference types="bun" />
-import type { OxfmtConfig } from 'oxfmt';
+      `import type { OxfmtConfig } from 'oxfmt';
 
 // oxlint-disable unicorn/prefer-module -- Oxfmt config files are only auto-discovered as .ts, and CommonJS avoids ESM package loading issues.
 const oxfmtConfig = require('${oxfmtBaseConfigModule}');

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -81,13 +81,13 @@ function getConfigContent(config: PackageConfig): string {
   // type-check auto-discovered oxlint.config.ts as CommonJS, so importing the ESM
   // @willbooster/oxlint-config package triggers TS1479. Keep this in sync with
   // literacy-test's generated config pattern.
-  // Reference "bun", not "node": @types/bun is the only type package wbfy installs, and
-  // Bun's isolated linker cannot resolve an undeclared @types/node (TS2688).
+  // No /// <reference types> line: the wbfy-generated tsconfig already covers *.config.ts with
+  // types ["bun"], which types require/module.exports, while a "node" reference breaks under
+  // Bun's isolated linker where the undeclared @types/node is unresolvable (TS2688).
   if (!config.isEsmPackage) {
     return `${managedConfigBlocks.getBlock(
       'base',
-      `/// <reference types="bun" />
-import type { OxlintConfig } from 'oxlint';
+      `import type { OxlintConfig } from 'oxlint';
 
 // oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids ESM package loading issues.
 const oxlintBaseConfig = require('${oxlintBaseConfigModule}');

--- a/packages/wbfy/src/generators/oxlintConfig.ts
+++ b/packages/wbfy/src/generators/oxlintConfig.ts
@@ -81,10 +81,12 @@ function getConfigContent(config: PackageConfig): string {
   // type-check auto-discovered oxlint.config.ts as CommonJS, so importing the ESM
   // @willbooster/oxlint-config package triggers TS1479. Keep this in sync with
   // literacy-test's generated config pattern.
+  // Reference "bun", not "node": @types/bun is the only type package wbfy installs, and
+  // Bun's isolated linker cannot resolve an undeclared @types/node (TS2688).
   if (!config.isEsmPackage) {
     return `${managedConfigBlocks.getBlock(
       'base',
-      `/// <reference types="node" />
+      `/// <reference types="bun" />
 import type { OxlintConfig } from 'oxlint';
 
 // oxlint-disable unicorn/prefer-module -- Oxlint only auto-discovers .ts config files, and CommonJS avoids ESM package loading issues.


### PR DESCRIPTION
## Problem

Running `wbfy` on WillBooster/review-booster fails: its CommonJS sub-packages get generated `oxlint.config.ts` / `oxfmt.config.ts` containing `/// <reference types="node" />`, but wbfy only guarantees `@types/bun` as a devDependency. Under Bun's isolated linker, the undeclared `@types/node` is unresolvable, so oxlint's type check fails with `TS2688: Cannot find type definition file for 'node'` and wbfy's cleanup step exits 1.

## Fix

Drop the triple-slash reference entirely. The reference was added in #780 to type `require`/`module.exports` self-containedly, but wbfy also generates the tsconfig, which covers `*.config.ts` with `"types": ["bun"]` — so `require`/`module.exports` are already typed without any reference, and the `node` reference was the only thing breaking under the isolated linker.

Verified against review-booster's CJS `packages/app`: with the reference removed, both `bun run oxlint --type-aware --type-check .` and `bun run tsc --noEmit` pass; with the original `node` reference they fail with TS2688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
