### PR TITLE
fix: preserve custom Playwright web server commands

### DIFF
--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -219,7 +219,9 @@ function setWebServerCommand(object: ParsedObject): void {
 
 function isGeneratedWbStartTestCommand(command: ParsedValue): boolean {
   if (command.kind !== 'literal') return false;
-  return /^(['"`])(?:bun(?:[ \t]+--bun)?|yarn|npx)[ \t]+wb[ \t]+start[ \t]+--mode(?:=|[ \t]+)test\1$/u.test(
+  // Match only commands emitted by past wbfy versions. A broader command-shaped regex could
+  // overwrite a repository's deliberate wrapper while trying to recognize generated content.
+  return /^'(?:(?:bun|yarn) (?:wb start --mode test|start-test-server)|wb start --mode test)'$/u.test(
     command.value.trim()
   );
 }

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -208,10 +208,20 @@ function setWebServerCommand(object: ParsedObject): void {
   const webServer = object.properties.webServer;
   if (webServer?.kind !== 'object') return;
 
-  // wb owns the canonical test-server startup path; keep custom Playwright
-  // server settings while normalizing the command itself. Invoke wb through the
-  // package manager because target repos install wb as a package dependency.
+  const command = webServer.value.properties.command;
+  // Libraries can use Playwright's webServer to build and launch a fixture even though `wb start`
+  // intentionally has no test server for the library itself. Preserve those custom lifecycle
+  // commands; only add or migrate the command when wbfy already owns it.
+  if (command && !isGeneratedWbStartTestCommand(command)) return;
+
   webServer.value.properties.command = literal(getWbStartTestCommand());
+}
+
+function isGeneratedWbStartTestCommand(command: ParsedValue): boolean {
+  if (command.kind !== 'literal') return false;
+  return /^(['"`])(?:bun(?:[ \t]+--bun)?|yarn|npx)[ \t]+wb[ \t]+start[ \t]+--mode(?:=|[ \t]+)test\1$/u.test(
+    command.value.trim()
+  );
 }
 
 function getWbStartTestCommand(): string {

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -214,6 +214,8 @@ function setWebServerCommand(object: ParsedObject): void {
   // commands; only add or migrate the command when wbfy already owns it.
   if (command && !isGeneratedWbStartTestCommand(command)) return;
 
+  // Playwright requires `command` whenever `webServer` exists; an externally managed server should
+  // omit `webServer` instead. Keep filling this required field when a partial managed block lacks it.
   webServer.value.properties.command = literal(getWbStartTestCommand());
 }
 

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -21,16 +21,19 @@ test('preserves a custom Playwright web server lifecycle', async () => {
   expect(generated).toContain(`command: '${customCommand}'`);
 });
 
-test('migrates a legacy wbfy-managed Playwright web server command', async () => {
-  const generated = await fixConfig(`export default defineConfig({
+test.each(['wb start --mode test', 'yarn wb start --mode test', 'bun start-test-server', 'yarn start-test-server'])(
+  'migrates the legacy wbfy-managed Playwright web server command %s',
+  async (command) => {
+    const generated = await fixConfig(`export default defineConfig({
   webServer: {
-    command: 'yarn wb start --mode test',
+    command: '${command}',
     url: 'http://127.0.0.1:3010',
   },
 });`);
 
-  expect(generated).toContain(`command: 'bun wb start --mode test'`);
-});
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
+  }
+);
 
 async function fixConfig(content: string): Promise<string> {
   const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-playwright-config-'));

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { fixPlaywrightConfig } from '../../src/fixers/playwrightConfig.js';
+import { promisePool } from '../../src/utils/promisePool.js';
+
+import { createConfig } from '../helpers/testConfig.js';
+
+test('preserves a custom Playwright web server lifecycle', async () => {
+  const customCommand = 'bun run build && bun run next build test/e2e/next-app && bun run next start test/e2e/next-app';
+  const generated = await fixConfig(`export default defineConfig({
+  webServer: {
+    command: '${customCommand}',
+    url: 'http://127.0.0.1:3010',
+  },
+});`);
+
+  expect(generated).toContain(`command: '${customCommand}'`);
+});
+
+test('migrates a legacy wbfy-managed Playwright web server command', async () => {
+  const generated = await fixConfig(`export default defineConfig({
+  webServer: {
+    command: 'yarn wb start --mode test',
+    url: 'http://127.0.0.1:3010',
+  },
+});`);
+
+  expect(generated).toContain(`command: 'bun wb start --mode test'`);
+});
+
+async function fixConfig(content: string): Promise<string> {
+  const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-playwright-config-'));
+  try {
+    const filePath = path.join(dirPath, 'playwright.config.ts');
+    fs.writeFileSync(filePath, `import { defineConfig } from '@playwright/test';\n${content}\n`);
+    await fixPlaywrightConfig(createConfig({ dirPath, isRoot: true }));
+    await promisePool.promiseAll();
+    return fs.readFileSync(filePath, 'utf8');
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+}


### PR DESCRIPTION
## Customer Summary

- Keeps repository-specific Playwright fixture startup commands intact when wbfy updates configuration.
- Prevents library end-to-end tests from being redirected to a no-op `wb start --mode test` server command.
- Existing wbfy-managed commands continue to migrate automatically; no manual migration is required.

## Technical Summary

- Detects the exact Playwright `webServer.command` forms emitted by current and historical wbfy versions.
- Rewrites only those managed forms to `bun wb start --mode test` and preserves custom lifecycle commands.
- Adds coverage for custom commands and all historical managed command variants.
- Clarifies that Playwright requires `command` when a `webServer` block is present.

## Why

- wbfy unconditionally replaced custom Playwright fixture commands, breaking library E2E suites such as `monaco-loader` and `monaco-react`.
- Matching only known generated forms preserves wbfy's migrations without claiming arbitrary repository commands as managed content.

## Testing

- `bun verify-full`
- Local wbfy checkout applied to `WillBooster/monaco-loader`
- `bun verify-full` in `WillBooster/monaco-loader` (unit tests and all three Playwright tests passed)
- Multi-agent review-fix workflow
- GitHub Actions CI
