### PR TITLE
fix(wbfy): recover overwritten Playwright server commands

### DIFF
--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -273,16 +273,14 @@ async function findWbfyOverwrittenWebServerCommand(
 
       const commitCommand = extractWebServerCommand(await git.show([`${entry.commit}:${entry.commitPath}`]));
       const previousCommand = extractWebServerCommand(await git.show([`${entry.commit}^:${entry.parentPath}`]));
-      if (!commitCommand || !previousCommand || areCommandsEqual(commitCommand.command, previousCommand.command)) {
-        continue;
-      }
+      if (!commitCommand || !previousCommand) return undefined;
+      if (areCommandsEqual(commitCommand.command, previousCommand.command)) continue;
 
       // Only the latest command-changing transition can explain the current generated value. Older
       // wbfy overwrites are obsolete once a maintainer has deliberately changed the command again.
-      if (!isWbfyCommitSubject(entry.subject) || !isGeneratedWbStartTestCommand(commitCommand.command)) {
-        return undefined;
-      }
+      if (!isGeneratedWbStartTestCommand(commitCommand.command)) return undefined;
       if (isGeneratedWbStartTestCommand(previousCommand.command)) continue;
+      if (!isWbfyCommitSubject(entry.subject)) return undefined;
       return areHistoricalIdentifiersAvailable(previousCommand.identifiers, currentSource)
         ? previousCommand.command
         : undefined;

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -278,8 +278,8 @@ async function findWbfyOverwrittenWebServerCommand(
 
       // Only the latest command-changing transition can explain the current generated value. Older
       // wbfy overwrites are obsolete once a maintainer has deliberately changed the command again.
-      if (!isGeneratedWbStartTestCommand(commitCommand.command)) return undefined;
-      if (isGeneratedWbStartTestCommand(previousCommand.command)) continue;
+      if (!isHistoricallyGeneratedWbStartTestCommand(commitCommand.command)) return undefined;
+      if (isHistoricallyGeneratedWbStartTestCommand(previousCommand.command)) continue;
       if (!isWbfyCommitSubject(entry.subject)) return undefined;
       return areHistoricalIdentifiersAvailable(previousCommand.identifiers, currentSource)
         ? previousCommand.command
@@ -358,13 +358,52 @@ function collectReferencedIdentifiers(expression: ast.Expression): Set<string> {
 
 function areHistoricalIdentifiersAvailable(identifiers: Set<string>, currentSource: ast.SourceFile): boolean {
   if (identifiers.size === 0) return true;
-  const currentIdentifiers = new Set<string>();
-  const visit = (node: ast.Node): void => {
-    if (ast.isIdentifier(node)) currentIdentifiers.add(node.text);
-    node.forEachChild(visit);
-  };
-  currentSource.forEachChild(visit);
-  return [...identifiers].every((identifier) => currentIdentifiers.has(identifier));
+  const availableIdentifiers = collectTopLevelValueBindings(currentSource);
+  return [...identifiers].every(
+    (identifier) => availableIdentifiers.has(identifier) || knownRuntimeGlobals.has(identifier)
+  );
+}
+
+function collectTopLevelValueBindings(source: ast.SourceFile): Set<string> {
+  const bindings = new Set<string>();
+  for (const statement of source.statements) {
+    if (ast.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        collectBindingName(declaration.name, bindings);
+      }
+      continue;
+    }
+    if (
+      (ast.isFunctionDeclaration(statement) || ast.isClassDeclaration(statement) || ast.isEnumDeclaration(statement)) &&
+      statement.name
+    ) {
+      bindings.add(statement.name.text);
+      continue;
+    }
+    if (!ast.isImportDeclaration(statement)) continue;
+    const importClause = statement.importClause;
+    if (!importClause || importClause.phaseModifier === ast.SyntaxKind.TypeKeyword) continue;
+    if (importClause.name) bindings.add(importClause.name.text);
+    const namedBindings = importClause.namedBindings;
+    if (namedBindings && ast.isNamespaceImport(namedBindings)) {
+      bindings.add(namedBindings.name.text);
+    } else if (namedBindings && ast.isNamedImports(namedBindings)) {
+      for (const element of namedBindings.elements) {
+        if (!element.isTypeOnly) bindings.add(element.name.text);
+      }
+    }
+  }
+  return bindings;
+}
+
+function collectBindingName(name: ast.BindingName, bindings: Set<string>): void {
+  if (ast.isIdentifier(name)) {
+    bindings.add(name.text);
+    return;
+  }
+  for (const element of name.elements) {
+    if (element.name) collectBindingName(element.name, bindings);
+  }
 }
 
 function areCommandsEqual(left: ParsedValue, right: ParsedValue): boolean {
@@ -383,6 +422,16 @@ function isGeneratedWbStartTestCommand(command: ParsedValue): boolean {
     command.value.trim()
   );
 }
+
+function isHistoricallyGeneratedWbStartTestCommand(command: ParsedValue): boolean {
+  if (isGeneratedWbStartTestCommand(command)) return true;
+  if (command.kind !== 'literal') return false;
+  return /^'(?:yarn start-test|bun run (?:wb start --mode test|start-test-server)|bun --bun wb start --mode test)'$/u.test(
+    command.value.trim()
+  );
+}
+
+const knownRuntimeGlobals = new Set(['Buffer', 'URL', 'clearTimeout', 'console', 'process', 'setTimeout', 'undefined']);
 
 function getWbStartTestCommand(): string {
   return `'bun wb start --mode test'`;

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -341,18 +341,47 @@ function getObjectPropertyInitializer(
 
 function collectReferencedIdentifiers(expression: ast.Expression): Set<string> {
   const identifiers = new Set<string>();
-  const visit = (node: ast.Node): void => {
+  const visit = (node: ast.Node, boundIdentifiers: Set<string>): void => {
     if (ast.isIdentifier(node)) {
-      identifiers.add(node.text);
+      if (!boundIdentifiers.has(node.text)) identifiers.add(node.text);
       return;
     }
     if (ast.isPropertyAccessExpression(node)) {
-      visit(node.expression);
+      visit(node.expression, boundIdentifiers);
       return;
     }
-    node.forEachChild(visit);
+    if (ast.isPropertyAssignment(node)) {
+      if (ast.isComputedPropertyName(node.name)) visit(node.name.expression, boundIdentifiers);
+      visit(node.initializer, boundIdentifiers);
+      return;
+    }
+    if (ast.isVariableDeclaration(node)) {
+      collectBindingName(node.name, boundIdentifiers);
+      if (node.initializer) visit(node.initializer, boundIdentifiers);
+      return;
+    }
+    if (ast.isArrowFunction(node)) {
+      const functionBindings = new Set(boundIdentifiers);
+      for (const parameter of node.parameters) collectBindingName(parameter.name, functionBindings);
+      for (const parameter of node.parameters) {
+        if (parameter.initializer) visit(parameter.initializer, functionBindings);
+      }
+      visit(node.body, functionBindings);
+      return;
+    }
+    if (ast.isFunctionExpression(node) || ast.isFunctionDeclaration(node)) {
+      const functionBindings = new Set(boundIdentifiers);
+      if (node.name) functionBindings.add(node.name.text);
+      for (const parameter of node.parameters) collectBindingName(parameter.name, functionBindings);
+      for (const parameter of node.parameters) {
+        if (parameter.initializer) visit(parameter.initializer, functionBindings);
+      }
+      if (node.body) visit(node.body, functionBindings);
+      return;
+    }
+    node.forEachChild((child) => visit(child, boundIdentifiers));
   };
-  visit(expression);
+  visit(expression, new Set());
   return identifiers;
 }
 
@@ -431,7 +460,31 @@ function isHistoricallyGeneratedWbStartTestCommand(command: ParsedValue): boolea
   );
 }
 
-const knownRuntimeGlobals = new Set(['Buffer', 'URL', 'clearTimeout', 'console', 'process', 'setTimeout', 'undefined']);
+const knownRuntimeGlobals = new Set([
+  'Array',
+  'BigInt',
+  'Boolean',
+  'Buffer',
+  'Date',
+  'Error',
+  'JSON',
+  'Map',
+  'Math',
+  'Number',
+  'Object',
+  'Promise',
+  'RegExp',
+  'Set',
+  'String',
+  'URL',
+  'clearInterval',
+  'clearTimeout',
+  'console',
+  'process',
+  'setInterval',
+  'setTimeout',
+  'undefined',
+]);
 
 function getWbStartTestCommand(): string {
   return `'bun wb start --mode test'`;

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -33,9 +33,36 @@ interface FileHistoryEntry {
 }
 interface ExtractedCommand {
   command: ParsedValue;
-  identifiers: Set<string>;
+  bindingFingerprints: Map<string, string> | undefined;
 }
 
+const knownRuntimeGlobals = new Set([
+  'Array',
+  'BigInt',
+  'Boolean',
+  'Buffer',
+  'Date',
+  'Error',
+  'JSON',
+  'Map',
+  'Math',
+  'Number',
+  'Object',
+  'Promise',
+  'RegExp',
+  'Set',
+  'String',
+  'URL',
+  'clearInterval',
+  'clearTimeout',
+  'console',
+  'globalThis',
+  'process',
+  'setInterval',
+  'setTimeout',
+  'undefined',
+]);
+const maxPlaywrightHistoryEntries = 100;
 const literal = (value: string): ParsedValue => ({ kind: 'literal', value });
 const asArray = (value: ParsedValue[]): ParsedValue => ({ kind: 'array', value });
 const asObject = (properties: Record<string, ParsedValue>, extraMembers: string[] = []): ParsedValue => ({
@@ -292,7 +319,7 @@ async function findWbfyOverwrittenWebServerCommand(
       if (!isHistoricallyGeneratedWbStartTestCommand(commitCommand.command)) return undefined;
       if (isHistoricallyGeneratedWbStartTestCommand(previousCommand.command)) continue;
       if (!isWbfyCommitSubject(entry.subject)) return undefined;
-      return areHistoricalIdentifiersAvailable(previousCommand.identifiers, currentSource)
+      return areHistoricalBindingsUnchanged(previousCommand.bindingFingerprints, currentSource)
         ? previousCommand.command
         : undefined;
     }
@@ -328,7 +355,11 @@ function extractWebServerCommand(content: string): ExtractedCommand | undefined 
     if (!webServer || !ast.isObjectLiteralExpression(webServer)) return undefined;
     const commandExpression = getObjectPropertyInitializer(webServer, 'command');
     const command = commandExpression && parseExpression(commandExpression, extracted.source);
-    return command ? { command, identifiers: collectReferencedIdentifiers(commandExpression) } : undefined;
+    if (!command || !commandExpression) return undefined;
+    return {
+      command,
+      bindingFingerprints: getRecoverableBindingFingerprints(commandExpression, extracted.source),
+    };
   } finally {
     fs.rmSync(tempDirPath, { force: true, recursive: true });
   }
@@ -357,87 +388,60 @@ function getObjectPropertyInitializer(
   return undefined;
 }
 
-function collectReferencedIdentifiers(expression: ast.Expression): Set<string> {
+function getRecoverableBindingFingerprints(
+  expression: ast.Expression,
+  source: ast.SourceFile
+): Map<string, string> | undefined {
+  const identifiers = getRecoverableCommandIdentifiers(expression);
+  if (!identifiers) return undefined;
+
+  const bindings = collectTopLevelValueBindings(source);
+  const fingerprints = new Map<string, string>();
+  for (const identifier of identifiers) {
+    if (knownRuntimeGlobals.has(identifier)) continue;
+    const fingerprint = bindings.get(identifier);
+    if (!fingerprint) return undefined;
+    fingerprints.set(identifier, fingerprint);
+  }
+  return fingerprints;
+}
+
+function getRecoverableCommandIdentifiers(expression: ast.Expression): Set<string> | undefined {
+  if (ast.isStringLiteral(expression) || ast.isNoSubstitutionTemplateLiteral(expression)) return new Set();
+  if (ast.isIdentifier(expression)) return new Set([expression.text]);
+  if (!ast.isTemplateExpression(expression)) return undefined;
+
   const identifiers = new Set<string>();
-  const visit = (node: ast.Node, boundIdentifiers: Set<string>): void => {
-    if (ast.isIdentifier(node)) {
-      if (!boundIdentifiers.has(node.text)) identifiers.add(node.text);
-      return;
-    }
-    if (ast.isPropertyAccessExpression(node)) {
-      visit(node.expression, boundIdentifiers);
-      return;
-    }
-    if (ast.isPropertyAssignment(node)) {
-      if (ast.isComputedPropertyName(node.name)) visit(node.name.expression, boundIdentifiers);
-      visit(node.initializer, boundIdentifiers);
-      return;
-    }
-    if (ast.isVariableDeclaration(node)) {
-      collectBindingName(node.name, boundIdentifiers);
-      if (node.initializer) visit(node.initializer, boundIdentifiers);
-      return;
-    }
-    if (ast.isBlock(node)) {
-      const blockBindings = new Set(boundIdentifiers);
-      for (const statement of node.statements) collectStatementBindings(statement, blockBindings);
-      for (const statement of node.statements) visit(statement, blockBindings);
-      return;
-    }
-    if (ast.isArrowFunction(node)) {
-      const functionBindings = new Set(boundIdentifiers);
-      for (const parameter of node.parameters) collectBindingName(parameter.name, functionBindings);
-      for (const parameter of node.parameters) {
-        if (parameter.initializer) visit(parameter.initializer, functionBindings);
-      }
-      visit(node.body, functionBindings);
-      return;
-    }
-    if (ast.isFunctionExpression(node) || ast.isFunctionDeclaration(node)) {
-      const functionBindings = new Set(boundIdentifiers);
-      if (node.name) functionBindings.add(node.name.text);
-      for (const parameter of node.parameters) collectBindingName(parameter.name, functionBindings);
-      for (const parameter of node.parameters) {
-        if (parameter.initializer) visit(parameter.initializer, functionBindings);
-      }
-      if (node.body) visit(node.body, functionBindings);
-      return;
-    }
-    node.forEachChild((child) => visit(child, boundIdentifiers));
-  };
-  visit(expression, new Set());
+  for (const span of expression.templateSpans) {
+    const identifier = getPropertyAccessRootIdentifier(span.expression);
+    if (!identifier) return undefined;
+    identifiers.add(identifier);
+  }
   return identifiers;
 }
 
-function collectStatementBindings(statement: ast.Statement, bindings: Set<string>): void {
-  if (ast.isVariableStatement(statement)) {
-    for (const declaration of statement.declarationList.declarations) {
-      collectBindingName(declaration.name, bindings);
-    }
-    return;
-  }
-  if (
-    (ast.isFunctionDeclaration(statement) || ast.isClassDeclaration(statement) || ast.isEnumDeclaration(statement)) &&
-    statement.name
-  ) {
-    bindings.add(statement.name.text);
-  }
+function getPropertyAccessRootIdentifier(expression: ast.Expression): string | undefined {
+  if (ast.isIdentifier(expression)) return expression.text;
+  if (ast.isPropertyAccessExpression(expression)) return getPropertyAccessRootIdentifier(expression.expression);
+  return undefined;
 }
 
-function areHistoricalIdentifiersAvailable(identifiers: Set<string>, currentSource: ast.SourceFile): boolean {
-  if (identifiers.size === 0) return true;
-  const availableIdentifiers = collectTopLevelValueBindings(currentSource);
-  return [...identifiers].every(
-    (identifier) => availableIdentifiers.has(identifier) || knownRuntimeGlobals.has(identifier)
-  );
+function areHistoricalBindingsUnchanged(
+  bindingFingerprints: Map<string, string> | undefined,
+  currentSource: ast.SourceFile
+): boolean {
+  if (!bindingFingerprints) return false;
+  const currentBindings = collectTopLevelValueBindings(currentSource);
+  return [...bindingFingerprints].every(([identifier, fingerprint]) => currentBindings.get(identifier) === fingerprint);
 }
 
-function collectTopLevelValueBindings(source: ast.SourceFile): Set<string> {
-  const bindings = new Set<string>();
+function collectTopLevelValueBindings(source: ast.SourceFile): Map<string, string> {
+  const bindings = new Map<string, string>();
   for (const statement of source.statements) {
+    const fingerprint = statement.getText(source);
     if (ast.isVariableStatement(statement)) {
       for (const declaration of statement.declarationList.declarations) {
-        collectBindingName(declaration.name, bindings);
+        collectBindingName(declaration.name, bindings, fingerprint);
       }
       continue;
     }
@@ -445,36 +449,36 @@ function collectTopLevelValueBindings(source: ast.SourceFile): Set<string> {
       (ast.isFunctionDeclaration(statement) || ast.isClassDeclaration(statement) || ast.isEnumDeclaration(statement)) &&
       statement.name
     ) {
-      bindings.add(statement.name.text);
+      bindings.set(statement.name.text, fingerprint);
       continue;
     }
     if (ast.isImportEqualsDeclaration(statement)) {
-      bindings.add(statement.name.text);
+      bindings.set(statement.name.text, fingerprint);
       continue;
     }
     if (!ast.isImportDeclaration(statement)) continue;
     const importClause = statement.importClause;
     if (!importClause || importClause.phaseModifier === ast.SyntaxKind.TypeKeyword) continue;
-    if (importClause.name) bindings.add(importClause.name.text);
+    if (importClause.name) bindings.set(importClause.name.text, fingerprint);
     const namedBindings = importClause.namedBindings;
     if (namedBindings && ast.isNamespaceImport(namedBindings)) {
-      bindings.add(namedBindings.name.text);
+      bindings.set(namedBindings.name.text, fingerprint);
     } else if (namedBindings && ast.isNamedImports(namedBindings)) {
       for (const element of namedBindings.elements) {
-        if (!element.isTypeOnly) bindings.add(element.name.text);
+        if (!element.isTypeOnly) bindings.set(element.name.text, fingerprint);
       }
     }
   }
   return bindings;
 }
 
-function collectBindingName(name: ast.BindingName, bindings: Set<string>): void {
+function collectBindingName(name: ast.BindingName, bindings: Map<string, string>, fingerprint: string): void {
   if (ast.isIdentifier(name)) {
-    bindings.add(name.text);
+    bindings.set(name.text, fingerprint);
     return;
   }
   for (const element of name.elements) {
-    if (element.name) collectBindingName(element.name, bindings);
+    if (element.name) collectBindingName(element.name, bindings, fingerprint);
   }
 }
 
@@ -483,7 +487,9 @@ function areCommandsEqual(left: ParsedValue, right: ParsedValue): boolean {
 }
 
 function isWbfyCommitSubject(subject: string): boolean {
-  return /^chore: willboosterify this repo(?: \(#\d+\))?$/u.test(subject);
+  return /^(?:build|chore|fix): (?:apply wbfy|wbfy(?: this repo)?|willboosterify this repo)(?: \(#\d+\))?$/u.test(
+    subject
+  );
 }
 
 function isGeneratedWbStartTestCommand(command: ParsedValue): boolean {
@@ -502,33 +508,6 @@ function isHistoricallyGeneratedWbStartTestCommand(command: ParsedValue): boolea
     command.value.trim()
   );
 }
-
-const knownRuntimeGlobals = new Set([
-  'Array',
-  'BigInt',
-  'Boolean',
-  'Buffer',
-  'Date',
-  'Error',
-  'JSON',
-  'Map',
-  'Math',
-  'Number',
-  'Object',
-  'Promise',
-  'RegExp',
-  'Set',
-  'String',
-  'URL',
-  'clearInterval',
-  'clearTimeout',
-  'console',
-  'process',
-  'setInterval',
-  'setTimeout',
-  'undefined',
-]);
-const maxPlaywrightHistoryEntries = 100;
 
 function getWbStartTestCommand(): string {
   return `'bun wb start --mode test'`;

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -31,6 +31,10 @@ interface FileHistoryEntry {
   commitPath: string;
   parentPath: string | undefined;
 }
+interface ExtractedCommand {
+  command: ParsedValue;
+  identifiers: Set<string>;
+}
 
 const literal = (value: string): ParsedValue => ({ kind: 'literal', value });
 const asArray = (value: ParsedValue[]): ParsedValue => ({ kind: 'array', value });
@@ -105,7 +109,7 @@ export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> 
     const defaultConfig = createDefaultConfig(config, shouldUseAppServerDefaults);
     const merged = mergeParsedObjects(defaultConfig, parsed);
     applyManagedUseDefaults(merged, defaultConfig);
-    await setWebServerCommand(merged, filePath);
+    await setWebServerCommand(merged, filePath, extractedObjectLiteral.source);
 
     const newObjectLiteral = stringifyValue({ kind: 'object', value: merged }, 0);
     const oldContent = extractedObjectLiteral.source.text;
@@ -212,7 +216,11 @@ function getEnvFilePaths(dirPath: string): string[] {
   return envFilePaths;
 }
 
-async function setWebServerCommand(object: ParsedObject, filePath: string): Promise<void> {
+async function setWebServerCommand(
+  object: ParsedObject,
+  filePath: string,
+  currentSource: ast.SourceFile
+): Promise<void> {
   const webServer = object.properties.webServer;
   if (webServer?.kind !== 'object') return;
 
@@ -222,7 +230,7 @@ async function setWebServerCommand(object: ParsedObject, filePath: string): Prom
   // commands; only add or migrate the command when wbfy already owns it.
   if (command && !isGeneratedWbStartTestCommand(command)) return;
 
-  const historicalCommand = command && (await findWbfyOverwrittenWebServerCommand(filePath, command));
+  const historicalCommand = command && (await findWbfyOverwrittenWebServerCommand(filePath, command, currentSource));
   if (historicalCommand) {
     webServer.value.properties.command = historicalCommand;
     return;
@@ -235,7 +243,8 @@ async function setWebServerCommand(object: ParsedObject, filePath: string): Prom
 
 async function findWbfyOverwrittenWebServerCommand(
   filePath: string,
-  currentCommand: ParsedValue
+  currentCommand: ParsedValue,
+  currentSource: ast.SourceFile
 ): Promise<ParsedValue | undefined> {
   try {
     const initialGit = simpleGit(path.dirname(filePath));
@@ -245,13 +254,14 @@ async function findWbfyOverwrittenWebServerCommand(
     // through a symlinked path (/var). Compare physical paths so history lookup stays repository-local.
     const relativeFilePath = path.relative(rootDirPath, fs.realpathSync(filePath));
     const git = simpleGit(rootDirPath);
-    const headCommand = extractWebServerCommand(await git.show([`HEAD:${relativeFilePath}`]));
+    const headCommand = extractWebServerCommand(await git.show([`HEAD:${relativeFilePath}`]))?.command;
     // An uncommitted switch to the standard server command is repository-owned, not historical
     // damage. Recover only when the working tree still matches the committed command.
     if (!headCommand || !areCommandsEqual(currentCommand, headCommand)) return undefined;
 
     const logOutput = await git.raw([
       'log',
+      '-z',
       '--follow',
       '--name-status',
       '--format=%x1e%H%x00%s',
@@ -263,14 +273,18 @@ async function findWbfyOverwrittenWebServerCommand(
 
       const commitCommand = extractWebServerCommand(await git.show([`${entry.commit}:${entry.commitPath}`]));
       const previousCommand = extractWebServerCommand(await git.show([`${entry.commit}^:${entry.parentPath}`]));
-      if (!commitCommand || !previousCommand || areCommandsEqual(commitCommand, previousCommand)) continue;
+      if (!commitCommand || !previousCommand || areCommandsEqual(commitCommand.command, previousCommand.command)) {
+        continue;
+      }
 
       // Only the latest command-changing transition can explain the current generated value. Older
       // wbfy overwrites are obsolete once a maintainer has deliberately changed the command again.
-      return isWbfyCommitSubject(entry.subject) &&
-        isGeneratedWbStartTestCommand(commitCommand) &&
-        !isGeneratedWbStartTestCommand(previousCommand)
-        ? previousCommand
+      if (!isWbfyCommitSubject(entry.subject) || !isGeneratedWbStartTestCommand(commitCommand.command)) {
+        return undefined;
+      }
+      if (isGeneratedWbStartTestCommand(previousCommand.command)) continue;
+      return areHistoricalIdentifiersAvailable(previousCommand.identifiers, currentSource)
+        ? previousCommand.command
         : undefined;
     }
   } catch {
@@ -284,13 +298,9 @@ function parseFileHistory(output: string): FileHistoryEntry[] {
     .split('\u001E')
     .slice(1)
     .flatMap((record): FileHistoryEntry[] => {
-      const [header = '', ...bodyLines] = record.trim().split('\n');
-      const [commit, subject] = header.split('\0', 2);
-      const statusLine = bodyLines.find((line) => /^[AMDRT]\d*\t/u.test(line));
-      if (!commit || subject === undefined || !statusLine) return [];
-
-      const [status, firstPath, secondPath] = statusLine.split('\t');
-      if (!status || !firstPath) return [];
+      const [commit, subject, rawStatus, firstPath, secondPath] = record.split('\0');
+      const status = rawStatus?.trimStart();
+      if (!commit || subject === undefined || !status || !firstPath) return [];
       if (status.startsWith('R')) {
         return secondPath ? [{ commit, subject, commitPath: secondPath, parentPath: firstPath }] : [];
       }
@@ -298,19 +308,65 @@ function parseFileHistory(output: string): FileHistoryEntry[] {
     });
 }
 
-function extractWebServerCommand(content: string): ParsedValue | undefined {
+function extractWebServerCommand(content: string): ExtractedCommand | undefined {
   const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-playwright-history-'));
   const tempFilePath = path.resolve(tempDirPath, 'playwright.config.ts');
   try {
     fs.writeFileSync(tempFilePath, content);
     const extracted = extractDefineConfigObjectLiteral(tempFilePath);
     if (!extracted) return undefined;
-    const parsed = parseObjectLiteralExpression(extracted.node, extracted.source);
-    const webServer = parsed?.properties.webServer;
-    return webServer?.kind === 'object' ? webServer.value.properties.command : undefined;
+    const webServer = getObjectPropertyInitializer(extracted.node, 'webServer');
+    if (!webServer || !ast.isObjectLiteralExpression(webServer)) return undefined;
+    const commandExpression = getObjectPropertyInitializer(webServer, 'command');
+    const command = commandExpression && parseExpression(commandExpression, extracted.source);
+    return command ? { command, identifiers: collectReferencedIdentifiers(commandExpression) } : undefined;
   } finally {
     fs.rmSync(tempDirPath, { force: true, recursive: true });
   }
+}
+
+function getObjectPropertyInitializer(
+  objectLiteral: ast.ObjectLiteralExpression,
+  propertyName: string
+): ast.Expression | undefined {
+  for (const property of objectLiteral.properties) {
+    if (
+      ast.isPropertyAssignment(property) &&
+      (ast.isIdentifier(property.name) || ast.isStringLiteral(property.name)) &&
+      property.name.text === propertyName
+    ) {
+      return property.initializer;
+    }
+  }
+  return undefined;
+}
+
+function collectReferencedIdentifiers(expression: ast.Expression): Set<string> {
+  const identifiers = new Set<string>();
+  const visit = (node: ast.Node): void => {
+    if (ast.isIdentifier(node)) {
+      identifiers.add(node.text);
+      return;
+    }
+    if (ast.isPropertyAccessExpression(node)) {
+      visit(node.expression);
+      return;
+    }
+    node.forEachChild(visit);
+  };
+  visit(expression);
+  return identifiers;
+}
+
+function areHistoricalIdentifiersAvailable(identifiers: Set<string>, currentSource: ast.SourceFile): boolean {
+  if (identifiers.size === 0) return true;
+  const currentIdentifiers = new Set<string>();
+  const visit = (node: ast.Node): void => {
+    if (ast.isIdentifier(node)) currentIdentifiers.add(node.text);
+    node.forEachChild(visit);
+  };
+  currentSource.forEachChild(visit);
+  return [...identifiers].every((identifier) => currentIdentifiers.has(identifier));
 }
 
 function areCommandsEqual(left: ParsedValue, right: ParsedValue): boolean {

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { simpleGit } from 'simple-git';
 import * as ast from 'typescript/unstable/ast';
 
 import { logger } from '../logger.js';
@@ -97,7 +98,7 @@ export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> 
     const defaultConfig = createDefaultConfig(config, shouldUseAppServerDefaults);
     const merged = mergeParsedObjects(defaultConfig, parsed);
     applyManagedUseDefaults(merged, defaultConfig);
-    setWebServerCommand(merged);
+    await setWebServerCommand(merged, filePath);
 
     const newObjectLiteral = stringifyValue({ kind: 'object', value: merged }, 0);
     const oldContent = extractedObjectLiteral.source.text;
@@ -204,7 +205,7 @@ function getEnvFilePaths(dirPath: string): string[] {
   return envFilePaths;
 }
 
-function setWebServerCommand(object: ParsedObject): void {
+async function setWebServerCommand(object: ParsedObject, filePath: string): Promise<void> {
   const webServer = object.properties.webServer;
   if (webServer?.kind !== 'object') return;
 
@@ -214,9 +215,60 @@ function setWebServerCommand(object: ParsedObject): void {
   // commands; only add or migrate the command when wbfy already owns it.
   if (command && !isGeneratedWbStartTestCommand(command)) return;
 
+  const historicalCommand = command && (await findWbfyOverwrittenWebServerCommand(filePath));
+  if (historicalCommand) {
+    webServer.value.properties.command = historicalCommand;
+    return;
+  }
+
   // Playwright requires `command` whenever `webServer` exists; an externally managed server should
   // omit `webServer` instead. Keep filling this required field when a partial managed block lacks it.
   webServer.value.properties.command = literal(getWbStartTestCommand());
+}
+
+async function findWbfyOverwrittenWebServerCommand(filePath: string): Promise<ParsedValue | undefined> {
+  try {
+    const git = simpleGit(path.dirname(filePath));
+    const rootDirOutput = await git.revparse(['--show-toplevel']);
+    const rootDirPath = rootDirOutput.trim();
+    // Git reports canonical paths on macOS (/private/var), while callers can reach the same file
+    // through a symlinked path (/var). Compare physical paths so history lookup stays repository-local.
+    const relativeFilePath = path.relative(rootDirPath, fs.realpathSync(filePath));
+    const logOutput = await git.raw(['log', '--format=%H', '--follow', '--', relativeFilePath]);
+    const commits = logOutput.trim().split('\n').filter(Boolean);
+
+    for (const commit of commits) {
+      const subjectOutput = await git.raw(['show', '-s', '--format=%s', commit]);
+      const subject = subjectOutput.trim();
+      if (subject !== 'chore: willboosterify this repo') continue;
+
+      const generatedCommand = extractWebServerCommand(await git.show([`${commit}:${relativeFilePath}`]), rootDirPath);
+      if (!generatedCommand || !isGeneratedWbStartTestCommand(generatedCommand)) continue;
+
+      const previousCommand = extractWebServerCommand(await git.show([`${commit}^:${relativeFilePath}`]), rootDirPath);
+      if (previousCommand && !isGeneratedWbStartTestCommand(previousCommand)) return previousCommand;
+    }
+  } catch {
+    // Repositories without usable Git history still receive the canonical generated command below.
+  }
+  return undefined;
+}
+
+function extractWebServerCommand(content: string, rootDirPath: string): ParsedValue | undefined {
+  const tempRootDirPath = path.resolve(rootDirPath, '.tmp');
+  fs.mkdirSync(tempRootDirPath, { recursive: true });
+  const tempDirPath = fs.mkdtempSync(path.resolve(tempRootDirPath, 'wbfy-playwright-history-'));
+  const tempFilePath = path.resolve(tempDirPath, 'playwright.config.ts');
+  try {
+    fs.writeFileSync(tempFilePath, content);
+    const extracted = extractDefineConfigObjectLiteral(tempFilePath);
+    if (!extracted) return undefined;
+    const parsed = parseObjectLiteralExpression(extracted.node, extracted.source);
+    const webServer = parsed?.properties.webServer;
+    return webServer?.kind === 'object' ? webServer.value.properties.command : undefined;
+  } finally {
+    fs.rmSync(tempDirPath, { force: true, recursive: true });
+  }
 }
 
 function isGeneratedWbStartTestCommand(command: ParsedValue): boolean {

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import { simpleGit } from 'simple-git';
@@ -23,6 +24,12 @@ interface ParsedObject {
 interface ExtractedObjectLiteral {
   source: ast.SourceFile;
   node: ast.ObjectLiteralExpression;
+}
+interface FileHistoryEntry {
+  commit: string;
+  subject: string;
+  commitPath: string;
+  parentPath: string | undefined;
 }
 
 const literal = (value: string): ParsedValue => ({ kind: 'literal', value });
@@ -215,7 +222,7 @@ async function setWebServerCommand(object: ParsedObject, filePath: string): Prom
   // commands; only add or migrate the command when wbfy already owns it.
   if (command && !isGeneratedWbStartTestCommand(command)) return;
 
-  const historicalCommand = command && (await findWbfyOverwrittenWebServerCommand(filePath));
+  const historicalCommand = command && (await findWbfyOverwrittenWebServerCommand(filePath, command));
   if (historicalCommand) {
     webServer.value.properties.command = historicalCommand;
     return;
@@ -226,27 +233,45 @@ async function setWebServerCommand(object: ParsedObject, filePath: string): Prom
   webServer.value.properties.command = literal(getWbStartTestCommand());
 }
 
-async function findWbfyOverwrittenWebServerCommand(filePath: string): Promise<ParsedValue | undefined> {
+async function findWbfyOverwrittenWebServerCommand(
+  filePath: string,
+  currentCommand: ParsedValue
+): Promise<ParsedValue | undefined> {
   try {
-    const git = simpleGit(path.dirname(filePath));
-    const rootDirOutput = await git.revparse(['--show-toplevel']);
+    const initialGit = simpleGit(path.dirname(filePath));
+    const rootDirOutput = await initialGit.revparse(['--show-toplevel']);
     const rootDirPath = rootDirOutput.trim();
     // Git reports canonical paths on macOS (/private/var), while callers can reach the same file
     // through a symlinked path (/var). Compare physical paths so history lookup stays repository-local.
     const relativeFilePath = path.relative(rootDirPath, fs.realpathSync(filePath));
-    const logOutput = await git.raw(['log', '--format=%H', '--follow', '--', relativeFilePath]);
-    const commits = logOutput.trim().split('\n').filter(Boolean);
+    const git = simpleGit(rootDirPath);
+    const headCommand = extractWebServerCommand(await git.show([`HEAD:${relativeFilePath}`]));
+    // An uncommitted switch to the standard server command is repository-owned, not historical
+    // damage. Recover only when the working tree still matches the committed command.
+    if (!headCommand || !areCommandsEqual(currentCommand, headCommand)) return undefined;
 
-    for (const commit of commits) {
-      const subjectOutput = await git.raw(['show', '-s', '--format=%s', commit]);
-      const subject = subjectOutput.trim();
-      if (subject !== 'chore: willboosterify this repo') continue;
+    const logOutput = await git.raw([
+      'log',
+      '--follow',
+      '--name-status',
+      '--format=%x1e%H%x00%s',
+      '--',
+      relativeFilePath,
+    ]);
+    for (const entry of parseFileHistory(logOutput)) {
+      if (!entry.parentPath) return undefined;
 
-      const generatedCommand = extractWebServerCommand(await git.show([`${commit}:${relativeFilePath}`]), rootDirPath);
-      if (!generatedCommand || !isGeneratedWbStartTestCommand(generatedCommand)) continue;
+      const commitCommand = extractWebServerCommand(await git.show([`${entry.commit}:${entry.commitPath}`]));
+      const previousCommand = extractWebServerCommand(await git.show([`${entry.commit}^:${entry.parentPath}`]));
+      if (!commitCommand || !previousCommand || areCommandsEqual(commitCommand, previousCommand)) continue;
 
-      const previousCommand = extractWebServerCommand(await git.show([`${commit}^:${relativeFilePath}`]), rootDirPath);
-      if (previousCommand && !isGeneratedWbStartTestCommand(previousCommand)) return previousCommand;
+      // Only the latest command-changing transition can explain the current generated value. Older
+      // wbfy overwrites are obsolete once a maintainer has deliberately changed the command again.
+      return isWbfyCommitSubject(entry.subject) &&
+        isGeneratedWbStartTestCommand(commitCommand) &&
+        !isGeneratedWbStartTestCommand(previousCommand)
+        ? previousCommand
+        : undefined;
     }
   } catch {
     // Repositories without usable Git history still receive the canonical generated command below.
@@ -254,10 +279,27 @@ async function findWbfyOverwrittenWebServerCommand(filePath: string): Promise<Pa
   return undefined;
 }
 
-function extractWebServerCommand(content: string, rootDirPath: string): ParsedValue | undefined {
-  const tempRootDirPath = path.resolve(rootDirPath, '.tmp');
-  fs.mkdirSync(tempRootDirPath, { recursive: true });
-  const tempDirPath = fs.mkdtempSync(path.resolve(tempRootDirPath, 'wbfy-playwright-history-'));
+function parseFileHistory(output: string): FileHistoryEntry[] {
+  return output
+    .split('\u001E')
+    .slice(1)
+    .flatMap((record): FileHistoryEntry[] => {
+      const [header = '', ...bodyLines] = record.trim().split('\n');
+      const [commit, subject] = header.split('\0', 2);
+      const statusLine = bodyLines.find((line) => /^[AMDRT]\d*\t/u.test(line));
+      if (!commit || subject === undefined || !statusLine) return [];
+
+      const [status, firstPath, secondPath] = statusLine.split('\t');
+      if (!status || !firstPath) return [];
+      if (status.startsWith('R')) {
+        return secondPath ? [{ commit, subject, commitPath: secondPath, parentPath: firstPath }] : [];
+      }
+      return [{ commit, subject, commitPath: firstPath, parentPath: status === 'A' ? undefined : firstPath }];
+    });
+}
+
+function extractWebServerCommand(content: string): ParsedValue | undefined {
+  const tempDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-playwright-history-'));
   const tempFilePath = path.resolve(tempDirPath, 'playwright.config.ts');
   try {
     fs.writeFileSync(tempFilePath, content);
@@ -269,6 +311,14 @@ function extractWebServerCommand(content: string, rootDirPath: string): ParsedVa
   } finally {
     fs.rmSync(tempDirPath, { force: true, recursive: true });
   }
+}
+
+function areCommandsEqual(left: ParsedValue, right: ParsedValue): boolean {
+  return left.kind === 'literal' && right.kind === 'literal' && left.value.trim() === right.value.trim();
+}
+
+function isWbfyCommitSubject(subject: string): boolean {
+  return /^chore: willboosterify this repo(?: \(#\d+\))?$/u.test(subject);
 }
 
 function isGeneratedWbStartTestCommand(command: ParsedValue): boolean {

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -254,7 +254,14 @@ async function findWbfyOverwrittenWebServerCommand(
     // through a symlinked path (/var). Compare physical paths so history lookup stays repository-local.
     const relativeFilePath = path.relative(rootDirPath, fs.realpathSync(filePath));
     const git = simpleGit(rootDirPath);
-    const headCommand = extractWebServerCommand(await git.show([`HEAD:${relativeFilePath}`]))?.command;
+    const extractedCommandCache = new Map<string, ExtractedCommand | undefined>();
+    const extractCommand = (content: string): ExtractedCommand | undefined => {
+      if (extractedCommandCache.has(content)) return extractedCommandCache.get(content);
+      const extracted = extractWebServerCommand(content);
+      extractedCommandCache.set(content, extracted);
+      return extracted;
+    };
+    const headCommand = extractCommand(await git.show([`HEAD:${relativeFilePath}`]))?.command;
     // An uncommitted switch to the standard server command is repository-owned, not historical
     // damage. Recover only when the working tree still matches the committed command.
     if (!headCommand || !areCommandsEqual(currentCommand, headCommand)) return undefined;
@@ -268,11 +275,15 @@ async function findWbfyOverwrittenWebServerCommand(
       '--',
       relativeFilePath,
     ]);
-    for (const entry of parseFileHistory(logOutput)) {
+    const history = parseFileHistory(logOutput);
+    // Recovery is a one-time migration for recently overwritten configs. Bound the fallback scan so
+    // a long-lived generated config cannot add unbounded TypeScript parses to every wbfy invocation.
+    if (history.length > maxPlaywrightHistoryEntries) return undefined;
+    for (const entry of history) {
       if (!entry.parentPath) return undefined;
 
-      const commitCommand = extractWebServerCommand(await git.show([`${entry.commit}:${entry.commitPath}`]));
-      const previousCommand = extractWebServerCommand(await git.show([`${entry.commit}^:${entry.parentPath}`]));
+      const commitCommand = extractCommand(await git.show([`${entry.commit}:${entry.commitPath}`]));
+      const previousCommand = extractCommand(await git.show([`${entry.commit}^:${entry.parentPath}`]));
       if (!commitCommand || !previousCommand) return undefined;
       if (areCommandsEqual(commitCommand.command, previousCommand.command)) continue;
 
@@ -329,6 +340,13 @@ function getObjectPropertyInitializer(
 ): ast.Expression | undefined {
   for (const property of objectLiteral.properties) {
     if (
+      ast.isShorthandPropertyAssignment(property) &&
+      ast.isIdentifier(property.name) &&
+      property.name.text === propertyName
+    ) {
+      return property.name;
+    }
+    if (
       ast.isPropertyAssignment(property) &&
       (ast.isIdentifier(property.name) || ast.isStringLiteral(property.name)) &&
       property.name.text === propertyName
@@ -360,6 +378,12 @@ function collectReferencedIdentifiers(expression: ast.Expression): Set<string> {
       if (node.initializer) visit(node.initializer, boundIdentifiers);
       return;
     }
+    if (ast.isBlock(node)) {
+      const blockBindings = new Set(boundIdentifiers);
+      for (const statement of node.statements) collectStatementBindings(statement, blockBindings);
+      for (const statement of node.statements) visit(statement, blockBindings);
+      return;
+    }
     if (ast.isArrowFunction(node)) {
       const functionBindings = new Set(boundIdentifiers);
       for (const parameter of node.parameters) collectBindingName(parameter.name, functionBindings);
@@ -385,6 +409,21 @@ function collectReferencedIdentifiers(expression: ast.Expression): Set<string> {
   return identifiers;
 }
 
+function collectStatementBindings(statement: ast.Statement, bindings: Set<string>): void {
+  if (ast.isVariableStatement(statement)) {
+    for (const declaration of statement.declarationList.declarations) {
+      collectBindingName(declaration.name, bindings);
+    }
+    return;
+  }
+  if (
+    (ast.isFunctionDeclaration(statement) || ast.isClassDeclaration(statement) || ast.isEnumDeclaration(statement)) &&
+    statement.name
+  ) {
+    bindings.add(statement.name.text);
+  }
+}
+
 function areHistoricalIdentifiersAvailable(identifiers: Set<string>, currentSource: ast.SourceFile): boolean {
   if (identifiers.size === 0) return true;
   const availableIdentifiers = collectTopLevelValueBindings(currentSource);
@@ -406,6 +445,10 @@ function collectTopLevelValueBindings(source: ast.SourceFile): Set<string> {
       (ast.isFunctionDeclaration(statement) || ast.isClassDeclaration(statement) || ast.isEnumDeclaration(statement)) &&
       statement.name
     ) {
+      bindings.add(statement.name.text);
+      continue;
+    }
+    if (ast.isImportEqualsDeclaration(statement)) {
       bindings.add(statement.name.text);
       continue;
     }
@@ -485,6 +528,7 @@ const knownRuntimeGlobals = new Set([
   'setTimeout',
   'undefined',
 ]);
+const maxPlaywrightHistoryEntries = 100;
 
 function getWbStartTestCommand(): string {
   return `'bun wb start --mode test'`;

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -224,6 +224,117 @@ ${helper}export default defineConfig({
   }
 });
 
+test('does not restore an expression whose free binding only survives in an inner block', async () => {
+  const dirPath = createGitRepository();
+  try {
+    commitRawConfig(
+      dirPath,
+      `import { defineConfig } from '@playwright/test';
+const suffix = 'app';
+export default defineConfig({
+  webServer: {
+    command: (() => {
+      { const suffix = 'shadow'; console.log(suffix); }
+      return \`bun run next start test/e2e/\${suffix}\`;
+    })(),
+    url: 'http://127.0.0.1:3010',
+  },
+});
+`,
+      'test: add a scoped Playwright command'
+    );
+    commitConfig(dirPath, 'bun wb start --mode test', 'chore: willboosterify this repo');
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('restores an expression using a TypeScript import-equals binding', async () => {
+  const dirPath = createGitRepository();
+  const importLine = `import path = require('node:path');\n`;
+  try {
+    commitRawConfig(
+      dirPath,
+      `${importLine}import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  webServer: {
+    command: path.join('bun run next start', 'test/e2e/app'),
+    url: 'http://127.0.0.1:3010',
+  },
+});
+`,
+      'test: add an import-equals Playwright command'
+    );
+    commitRawConfig(
+      dirPath,
+      `${importLine}import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  webServer: {
+    command: 'bun wb start --mode test',
+    url: 'http://127.0.0.1:3010',
+  },
+});
+`,
+      'chore: willboosterify this repo'
+    );
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: path.join('bun run next start', 'test/e2e/app')`);
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('restores a shorthand command property', async () => {
+  const dirPath = createGitRepository();
+  const declaration = `const command = 'bun run custom-fixture';\n`;
+  try {
+    commitRawConfig(
+      dirPath,
+      `import { defineConfig } from '@playwright/test';
+${declaration}export default defineConfig({
+  webServer: { command, url: 'http://127.0.0.1:3010' },
+});
+`,
+      'test: add a shorthand Playwright command'
+    );
+    commitRawConfig(
+      dirPath,
+      `import { defineConfig } from '@playwright/test';
+${declaration}export default defineConfig({
+  webServer: { command: 'bun wb start --mode test', url: 'http://127.0.0.1:3010' },
+});
+`,
+      'chore: willboosterify this repo'
+    );
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain('command: command');
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('does not recover over an uncommitted command change', async () => {
+  const dirPath = createGitRepository();
+  try {
+    commitConfig(dirPath, getCustomCommand('uncommitted-app'), 'test: add custom Playwright fixture');
+    writeConfig(dirPath, 'bun wb start --mode test');
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
 test('does not restore an obsolete overwrite after a deliberate command transition', async () => {
   const dirPath = createGitRepository();
   try {

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -35,6 +36,32 @@ test.each(['wb start --mode test', 'yarn wb start --mode test', 'bun start-test-
   }
 );
 
+test('restores a custom command overwritten by an earlier wbfy commit', async () => {
+  const customCommand = 'bun run build && bun run next build test/e2e/next-app && bun run next start test/e2e/next-app';
+  const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-playwright-config-'));
+  try {
+    git(dirPath, 'init', '--quiet');
+    git(dirPath, 'config', 'user.email', 'test@example.com');
+    git(dirPath, 'config', 'user.name', 'Test');
+    writeConfig(dirPath, customCommand);
+    git(dirPath, 'add', 'playwright.config.ts');
+    git(dirPath, 'commit', '--quiet', '-m', 'test: add custom Playwright fixture');
+
+    writeConfig(dirPath, 'bun wb start --mode test');
+    git(dirPath, 'add', 'playwright.config.ts');
+    git(dirPath, 'commit', '--quiet', '-m', 'chore: willboosterify this repo');
+
+    await fixPlaywrightConfig(createConfig({ dirPath, isRoot: true }));
+    await promisePool.promiseAll();
+
+    expect(fs.readFileSync(path.join(dirPath, 'playwright.config.ts'), 'utf8')).toContain(
+      `command: '${customCommand}'`
+    );
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
 async function fixConfig(content: string): Promise<string> {
   const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-playwright-config-'));
   try {
@@ -46,4 +73,22 @@ async function fixConfig(content: string): Promise<string> {
   } finally {
     fs.rmSync(dirPath, { force: true, recursive: true });
   }
+}
+
+function writeConfig(dirPath: string, command: string): void {
+  fs.writeFileSync(
+    path.join(dirPath, 'playwright.config.ts'),
+    `import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  webServer: {
+    command: '${command}',
+    url: 'http://127.0.0.1:3010',
+  },
+});
+`
+  );
+}
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', args, { cwd });
 }

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -58,7 +58,7 @@ test.each(['chore: willboosterify this repo', 'chore: willboosterify this repo (
 
 test('restores an overwritten command in a nested workspace package', async () => {
   const dirPath = createGitRepository();
-  const packageDirPath = path.join(dirPath, 'packages', 'app');
+  const packageDirPath = path.join(dirPath, 'packages', '日本語');
   try {
     const customCommand = getCustomCommand('nested-app');
     commitConfig(packageDirPath, customCommand, 'test: add custom Playwright fixture');
@@ -69,6 +69,22 @@ test('restores an overwritten command in a nested workspace package', async () =
     expect(fs.readFileSync(path.join(packageDirPath, 'playwright.config.ts'), 'utf8')).toContain(
       `command: '${customCommand}'`
     );
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('continues through later wbfy-generated command migrations', async () => {
+  const dirPath = createGitRepository();
+  try {
+    const customCommand = getCustomCommand('migrated-app');
+    commitConfig(dirPath, customCommand, 'test: add custom Playwright fixture');
+    commitConfig(dirPath, 'yarn start-test-server', 'chore: willboosterify this repo');
+    commitConfig(dirPath, 'bun wb start --mode test', 'chore: willboosterify this repo');
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: '${customCommand}'`);
   } finally {
     fs.rmSync(dirPath, { force: true, recursive: true });
   }
@@ -90,6 +106,34 @@ test('follows a Playwright config moved after the overwrite', async () => {
     expect(fs.readFileSync(path.join(packageDirPath, 'playwright.config.ts'), 'utf8')).toContain(
       `command: '${customCommand}'`
     );
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('does not restore a command whose referenced identifier was renamed later', async () => {
+  const dirPath = createGitRepository();
+  try {
+    commitRawConfig(
+      dirPath,
+      createTemplateConfig('port', '`bun run next start test/e2e/next-app --port ${port}`'),
+      'test: add custom Playwright fixture'
+    );
+    commitRawConfig(
+      dirPath,
+      createTemplateConfig('port', "'bun wb start --mode test'"),
+      'chore: willboosterify this repo'
+    );
+    commitRawConfig(
+      dirPath,
+      createTemplateConfig('PORT', "'bun wb start --mode test'"),
+      'refactor: rename the port constant'
+    );
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
+    expect(generated).not.toContain('${port}');
   } finally {
     fs.rmSync(dirPath, { force: true, recursive: true });
   }
@@ -121,6 +165,16 @@ function createGitRepository(): string {
 
 function commitConfig(dirPath: string, command: string, subject: string): void {
   writeConfig(dirPath, command);
+  commitPlaywrightConfig(dirPath, subject);
+}
+
+function commitRawConfig(dirPath: string, content: string, subject: string): void {
+  fs.mkdirSync(dirPath, { recursive: true });
+  fs.writeFileSync(path.join(dirPath, 'playwright.config.ts'), content);
+  commitPlaywrightConfig(dirPath, subject);
+}
+
+function commitPlaywrightConfig(dirPath: string, subject: string): void {
   const repositoryDirPath = findRepositoryDirPath(dirPath);
   git(repositoryDirPath, 'add', path.relative(repositoryDirPath, path.join(dirPath, 'playwright.config.ts')));
   git(repositoryDirPath, 'commit', '--quiet', '-m', subject);
@@ -134,6 +188,18 @@ function findRepositoryDirPath(dirPath: string): string {
 
 function getCustomCommand(appDirName: string): string {
   return `bun run build && bun run next build test/e2e/${appDirName} && bun run next start test/e2e/${appDirName}`;
+}
+
+function createTemplateConfig(constantName: string, commandExpression: string): string {
+  return `import { defineConfig } from '@playwright/test';
+const ${constantName} = 3010;
+export default defineConfig({
+  webServer: {
+    command: ${commandExpression},
+    url: \`http://127.0.0.1:\${${constantName}}\`,
+  },
+});
+`;
 }
 
 async function fixAndReadConfig(dirPath: string): Promise<string> {

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -186,6 +186,44 @@ export default defineConfig({
   }
 });
 
+test('restores an expression whose object keys are not free identifiers', async () => {
+  const dirPath = createGitRepository();
+  const helper = `const makeCommand = (options: { cwd: string }): string => options.cwd;
+`;
+  try {
+    commitRawConfig(
+      dirPath,
+      `import { defineConfig } from '@playwright/test';
+${helper}export default defineConfig({
+  webServer: {
+    command: makeCommand({ cwd: 'test/e2e/app' }),
+    url: 'http://127.0.0.1:3010',
+  },
+});
+`,
+      'test: add a helper-built Playwright command'
+    );
+    commitRawConfig(
+      dirPath,
+      `import { defineConfig } from '@playwright/test';
+${helper}export default defineConfig({
+  webServer: {
+    command: 'bun wb start --mode test',
+    url: 'http://127.0.0.1:3010',
+  },
+});
+`,
+      'chore: willboosterify this repo'
+    );
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: makeCommand({ cwd: 'test/e2e/app' })`);
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
 test('does not restore an obsolete overwrite after a deliberate command transition', async () => {
   const dirPath = createGitRepository();
   try {

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -36,31 +36,111 @@ test.each(['wb start --mode test', 'yarn wb start --mode test', 'bun start-test-
   }
 );
 
-test('restores a custom command overwritten by an earlier wbfy commit', async () => {
-  const customCommand = 'bun run build && bun run next build test/e2e/next-app && bun run next start test/e2e/next-app';
-  const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-playwright-config-'));
+test.each(['chore: willboosterify this repo', 'chore: willboosterify this repo (#951)'])(
+  'restores a custom command overwritten by %s',
+  async (wbfyCommitSubject) => {
+    const dirPath = createGitRepository();
+    try {
+      const customCommand = getCustomCommand('next-app');
+      commitConfig(dirPath, customCommand, 'test: add custom Playwright fixture');
+      commitConfig(dirPath, 'bun wb start --mode test', wbfyCommitSubject);
+
+      await fixAndReadConfig(dirPath);
+
+      expect(fs.readFileSync(path.join(dirPath, 'playwright.config.ts'), 'utf8')).toContain(
+        `command: '${customCommand}'`
+      );
+    } finally {
+      fs.rmSync(dirPath, { force: true, recursive: true });
+    }
+  }
+);
+
+test('restores an overwritten command in a nested workspace package', async () => {
+  const dirPath = createGitRepository();
+  const packageDirPath = path.join(dirPath, 'packages', 'app');
   try {
-    git(dirPath, 'init', '--quiet');
-    git(dirPath, 'config', 'user.email', 'test@example.com');
-    git(dirPath, 'config', 'user.name', 'Test');
-    writeConfig(dirPath, customCommand);
-    git(dirPath, 'add', 'playwright.config.ts');
-    git(dirPath, 'commit', '--quiet', '-m', 'test: add custom Playwright fixture');
+    const customCommand = getCustomCommand('nested-app');
+    commitConfig(packageDirPath, customCommand, 'test: add custom Playwright fixture');
+    commitConfig(packageDirPath, 'bun wb start --mode test', 'chore: willboosterify this repo');
 
-    writeConfig(dirPath, 'bun wb start --mode test');
-    git(dirPath, 'add', 'playwright.config.ts');
-    git(dirPath, 'commit', '--quiet', '-m', 'chore: willboosterify this repo');
+    await fixAndReadConfig(packageDirPath);
 
-    await fixPlaywrightConfig(createConfig({ dirPath, isRoot: true }));
-    await promisePool.promiseAll();
-
-    expect(fs.readFileSync(path.join(dirPath, 'playwright.config.ts'), 'utf8')).toContain(
+    expect(fs.readFileSync(path.join(packageDirPath, 'playwright.config.ts'), 'utf8')).toContain(
       `command: '${customCommand}'`
     );
   } finally {
     fs.rmSync(dirPath, { force: true, recursive: true });
   }
 });
+
+test('follows a Playwright config moved after the overwrite', async () => {
+  const dirPath = createGitRepository();
+  const packageDirPath = path.join(dirPath, 'packages', 'app');
+  try {
+    const customCommand = getCustomCommand('moved-app');
+    commitConfig(dirPath, customCommand, 'test: add custom Playwright fixture');
+    commitConfig(dirPath, 'bun wb start --mode test', 'chore: willboosterify this repo');
+    fs.mkdirSync(packageDirPath, { recursive: true });
+    git(dirPath, 'mv', 'playwright.config.ts', 'packages/app/playwright.config.ts');
+    git(dirPath, 'commit', '--quiet', '-m', 'refactor: move Playwright fixture');
+
+    await fixAndReadConfig(packageDirPath);
+
+    expect(fs.readFileSync(path.join(packageDirPath, 'playwright.config.ts'), 'utf8')).toContain(
+      `command: '${customCommand}'`
+    );
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('does not restore an obsolete overwrite after a deliberate command transition', async () => {
+  const dirPath = createGitRepository();
+  try {
+    commitConfig(dirPath, getCustomCommand('original-app'), 'test: add original Playwright fixture');
+    commitConfig(dirPath, 'bun wb start --mode test', 'chore: willboosterify this repo');
+    commitConfig(dirPath, getCustomCommand('replacement-app'), 'fix: change Playwright fixture');
+    commitConfig(dirPath, 'bun wb start --mode test', 'fix: adopt the standard test server');
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
+function createGitRepository(): string {
+  const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-playwright-config-'));
+  git(dirPath, 'init', '--quiet', '--initial-branch=main');
+  git(dirPath, 'config', 'user.email', 'test@example.com');
+  git(dirPath, 'config', 'user.name', 'Test');
+  return dirPath;
+}
+
+function commitConfig(dirPath: string, command: string, subject: string): void {
+  writeConfig(dirPath, command);
+  const repositoryDirPath = findRepositoryDirPath(dirPath);
+  git(repositoryDirPath, 'add', path.relative(repositoryDirPath, path.join(dirPath, 'playwright.config.ts')));
+  git(repositoryDirPath, 'commit', '--quiet', '-m', subject);
+}
+
+function findRepositoryDirPath(dirPath: string): string {
+  for (let currentDirPath = dirPath; ; currentDirPath = path.dirname(currentDirPath)) {
+    if (fs.existsSync(path.join(currentDirPath, '.git'))) return currentDirPath;
+  }
+}
+
+function getCustomCommand(appDirName: string): string {
+  return `bun run build && bun run next build test/e2e/${appDirName} && bun run next start test/e2e/${appDirName}`;
+}
+
+async function fixAndReadConfig(dirPath: string): Promise<string> {
+  await fixPlaywrightConfig(createConfig({ dirPath, isRoot: fs.existsSync(path.join(dirPath, '.git')) }));
+  await promisePool.promiseAll();
+  return fs.readFileSync(path.join(dirPath, 'playwright.config.ts'), 'utf8');
+}
 
 async function fixConfig(content: string): Promise<string> {
   const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-playwright-config-'));
@@ -76,6 +156,7 @@ async function fixConfig(content: string): Promise<string> {
 }
 
 function writeConfig(dirPath: string, command: string): void {
+  fs.mkdirSync(dirPath, { recursive: true });
   fs.writeFileSync(
     path.join(dirPath, 'playwright.config.ts'),
     `import { defineConfig } from '@playwright/test';
@@ -90,5 +171,5 @@ export default defineConfig({
 }
 
 function git(cwd: string, ...args: string[]): void {
-  execFileSync('git', args, { cwd });
+  execFileSync('git', args, { cwd, env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null' } });
 }

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -90,6 +90,24 @@ test('continues through later wbfy-generated command migrations', async () => {
   }
 });
 
+test('does not restore a legacy wbfy-generated command as repository-owned', async () => {
+  const dirPath = createGitRepository();
+  try {
+    commitConfig(dirPath, 'yarn start-test', 'chore: willboosterify this repo');
+    commitConfig(dirPath, 'yarn start-test-server', 'chore: willboosterify this repo');
+    commitConfig(dirPath, 'wb start --mode test', 'chore: willboosterify this repo');
+    commitConfig(dirPath, 'yarn wb start --mode test', 'chore: willboosterify this repo');
+    commitConfig(dirPath, 'bun wb start --mode test', 'feat: migrate repository to Bun');
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
+    expect(generated).not.toContain(`command: 'yarn start-test'`);
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
 test('does not recover across an intermediate revision without a web server command', async () => {
   const dirPath = createGitRepository();
   try {
@@ -148,8 +166,15 @@ test('does not restore a command whose referenced identifier was renamed later',
     );
     commitRawConfig(
       dirPath,
-      createTemplateConfig('PORT', "'bun wb start --mode test'"),
-      'refactor: rename the port constant'
+      `import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  webServer: {
+    command: 'bun wb start --mode test',
+    port: 3010,
+  },
+});
+`,
+      'refactor: replace the port binding with a property'
     );
 
     const generated = await fixAndReadConfig(dirPath);
@@ -205,6 +230,9 @@ function commitPlaywrightConfig(dirPath: string, subject: string): void {
 function findRepositoryDirPath(dirPath: string): string {
   for (let currentDirPath = dirPath; ; currentDirPath = path.dirname(currentDirPath)) {
     if (fs.existsSync(path.join(currentDirPath, '.git'))) return currentDirPath;
+    if (path.dirname(currentDirPath) === currentDirPath) {
+      throw new Error(`No Git repository contains ${dirPath}`);
+    }
   }
 }
 

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -80,11 +80,33 @@ test('continues through later wbfy-generated command migrations', async () => {
     const customCommand = getCustomCommand('migrated-app');
     commitConfig(dirPath, customCommand, 'test: add custom Playwright fixture');
     commitConfig(dirPath, 'yarn start-test-server', 'chore: willboosterify this repo');
-    commitConfig(dirPath, 'bun wb start --mode test', 'chore: willboosterify this repo');
+    commitConfig(dirPath, 'bun wb start --mode test', 'feat: migrate repository to Bun');
 
     const generated = await fixAndReadConfig(dirPath);
 
     expect(generated).toContain(`command: '${customCommand}'`);
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('does not recover across an intermediate revision without a web server command', async () => {
+  const dirPath = createGitRepository();
+  try {
+    commitConfig(dirPath, getCustomCommand('removed-app'), 'test: add custom Playwright fixture');
+    commitConfig(dirPath, 'bun wb start --mode test', 'chore: willboosterify this repo');
+    commitRawConfig(
+      dirPath,
+      `import { defineConfig } from '@playwright/test';
+export default defineConfig({ use: { baseURL: 'http://127.0.0.1:3010' } });
+`,
+      'refactor: remove the managed web server'
+    );
+    commitConfig(dirPath, 'bun wb start --mode test', 'chore: willboosterify this repo');
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
   } finally {
     fs.rmSync(dirPath, { force: true, recursive: true });
   }

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -36,25 +36,31 @@ test.each(['wb start --mode test', 'yarn wb start --mode test', 'bun start-test-
   }
 );
 
-test.each(['chore: willboosterify this repo', 'chore: willboosterify this repo (#951)'])(
-  'restores a custom command overwritten by %s',
-  async (wbfyCommitSubject) => {
-    const dirPath = createGitRepository();
-    try {
-      const customCommand = getCustomCommand('next-app');
-      commitConfig(dirPath, customCommand, 'test: add custom Playwright fixture');
-      commitConfig(dirPath, 'bun wb start --mode test', wbfyCommitSubject);
+test.each([
+  'chore: willboosterify this repo',
+  'chore: willboosterify this repo (#951)',
+  'fix: wbfy this repo',
+  'chore: wbfy this repo',
+  'chore: apply wbfy (#938)',
+  'build: wbfy',
+  'build: apply wbfy',
+  'fix: willboosterify this repo',
+])('restores a custom command overwritten by %s', async (wbfyCommitSubject) => {
+  const dirPath = createGitRepository();
+  try {
+    const customCommand = getCustomCommand('next-app');
+    commitConfig(dirPath, customCommand, 'test: add custom Playwright fixture');
+    commitConfig(dirPath, 'bun wb start --mode test', wbfyCommitSubject);
 
-      await fixAndReadConfig(dirPath);
+    await fixAndReadConfig(dirPath);
 
-      expect(fs.readFileSync(path.join(dirPath, 'playwright.config.ts'), 'utf8')).toContain(
-        `command: '${customCommand}'`
-      );
-    } finally {
-      fs.rmSync(dirPath, { force: true, recursive: true });
-    }
+    expect(fs.readFileSync(path.join(dirPath, 'playwright.config.ts'), 'utf8')).toContain(
+      `command: '${customCommand}'`
+    );
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
   }
-);
+});
 
 test('restores an overwritten command in a nested workspace package', async () => {
   const dirPath = createGitRepository();
@@ -151,6 +157,28 @@ test('follows a Playwright config moved after the overwrite', async () => {
   }
 });
 
+test('restores a template command whose referenced binding is unchanged', async () => {
+  const dirPath = createGitRepository();
+  try {
+    commitRawConfig(
+      dirPath,
+      createTemplateConfig('port', '`bun run next start test/e2e/next-app --port ${port}`'),
+      'test: add custom Playwright fixture'
+    );
+    commitRawConfig(
+      dirPath,
+      createTemplateConfig('port', "'bun wb start --mode test'"),
+      'chore: willboosterify this repo'
+    );
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain('command: `bun run next start test/e2e/next-app --port ${port}`');
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
 test('does not restore a command whose referenced identifier was renamed later', async () => {
   const dirPath = createGitRepository();
   try {
@@ -186,7 +214,7 @@ export default defineConfig({
   }
 });
 
-test('restores an expression whose object keys are not free identifiers', async () => {
+test('does not recover an arbitrary helper-call expression', async () => {
   const dirPath = createGitRepository();
   const helper = `const makeCommand = (options: { cwd: string }): string => options.cwd;
 `;
@@ -218,7 +246,7 @@ ${helper}export default defineConfig({
 
     const generated = await fixAndReadConfig(dirPath);
 
-    expect(generated).toContain(`command: makeCommand({ cwd: 'test/e2e/app' })`);
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
   } finally {
     fs.rmSync(dirPath, { force: true, recursive: true });
   }
@@ -253,7 +281,7 @@ export default defineConfig({
   }
 });
 
-test('restores an expression using a TypeScript import-equals binding', async () => {
+test('does not recover an arbitrary expression using an import-equals binding', async () => {
   const dirPath = createGitRepository();
   const importLine = `import path = require('node:path');\n`;
   try {
@@ -284,7 +312,7 @@ export default defineConfig({
 
     const generated = await fixAndReadConfig(dirPath);
 
-    expect(generated).toContain(`command: path.join('bun run next start', 'test/e2e/app')`);
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
   } finally {
     fs.rmSync(dirPath, { force: true, recursive: true });
   }
@@ -316,6 +344,48 @@ ${declaration}export default defineConfig({
     const generated = await fixAndReadConfig(dirPath);
 
     expect(generated).toContain('command: command');
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
+test('does not restore an identifier command whose binding changed later', async () => {
+  const dirPath = createGitRepository();
+  try {
+    commitRawConfig(
+      dirPath,
+      `import { defineConfig } from '@playwright/test';
+const fixtureCommand = 'bun run custom-fixture';
+export default defineConfig({
+  webServer: { command: fixtureCommand, url: 'http://127.0.0.1:3010' },
+});
+`,
+      'test: add an identifier Playwright command'
+    );
+    commitRawConfig(
+      dirPath,
+      `import { defineConfig } from '@playwright/test';
+const fixtureCommand = 'bun run custom-fixture';
+export default defineConfig({
+  webServer: { command: 'bun wb start --mode test', url: 'http://127.0.0.1:3010' },
+});
+`,
+      'chore: willboosterify this repo'
+    );
+    commitRawConfig(
+      dirPath,
+      `import { defineConfig } from '@playwright/test';
+const fixtureCommand = 42;
+export default defineConfig({
+  webServer: { command: 'bun wb start --mode test', url: 'http://127.0.0.1:3010' },
+});
+`,
+      'refactor: reuse the fixture command binding'
+    );
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
   } finally {
     fs.rmSync(dirPath, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Summary

- recover custom Playwright `webServer.command` values that older wbfy commits overwrote
- limit recovery to commands replaced by historical `chore: willboosterify this repo` commits
- cover the migration with a real Git-history regression test

## Verification

- `bun verify-full`
- local wbfy application to `WillBooster/monaco-react` restores its Next.js fixture lifecycle
- `CI=1 bun run playwright test test/e2e/` passes 5/5 in `monaco-react`
