### PR TITLE
test: speed up prisma script tests and merge --bun script tests

### DIFF
--- a/packages/wb/test/unit/scripts/prismaScripts.test.ts
+++ b/packages/wb/test/unit/scripts/prismaScripts.test.ts
@@ -2,6 +2,7 @@ import child_process from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -10,7 +11,9 @@ import { cleanUpSqliteDbIfNeeded, prismaScripts } from '../../../src/scripts/pri
 
 const createdDirs: string[] = [];
 // This package does not depend on Prisma, so the test pins a CLI version explicitly instead of relying on ambient tools.
-const PRISMA_TEST_COMMAND = 'npx --yes prisma@6.10.1';
+const PRISMA_TEST_COMMAND = 'bunx prisma@6.10.1';
+// CHECKPOINT_DISABLE skips the Prisma CLI's telemetry network call, which dominates its startup time.
+const PRISMA_TEST_ENV = { ...process.env, CHECKPOINT_DISABLE: '1' };
 
 afterEach(() => {
   for (const dirPath of createdDirs.splice(0)) {
@@ -49,7 +52,7 @@ describe('prismaScripts.reset', () => {
     expect(fs.existsSync(walPath)).toBe(false);
     expect(fs.existsSync(absoluteDbPath)).toBe(false);
     expect(fs.existsSync(`${absoluteDbPath}-shm`)).toBe(false);
-  }, 120_000);
+  });
 
   it('does not add sqlite cleanup when DATABASE_URL is not file scheme', () => {
     const project = {
@@ -85,6 +88,7 @@ describe('prismaScripts.reset', () => {
 
     child_process.execSync(command.replaceAll('PRISMA ', `${PRISMA_TEST_COMMAND} `), {
       cwd: dirPath,
+      env: PRISMA_TEST_ENV,
       stdio: 'inherit',
     });
 
@@ -95,13 +99,11 @@ describe('prismaScripts.reset', () => {
     expect(fs.existsSync(`${dbPath}-litestream`)).toBe(false);
     expect(fs.existsSync(path.resolve(dirPath, 'prisma', 'mount', '.prod.sqlite3-shadow'))).toBe(false);
 
-    const introspectedSchema = child_process.execSync(`${PRISMA_TEST_COMMAND} db pull --print --url "file:${dbPath}"`, {
-      cwd: dirPath,
-      encoding: 'utf8',
-      env: { ...process.env, DATABASE_URL: `file:${dbPath}` },
-      stdio: ['ignore', 'pipe', 'inherit'],
-    });
-    expect(introspectedSchema).toContain('model t');
+    // The checkpointed database must remain readable with its data intact.
+    const db = new DatabaseSync(dbPath);
+    const row = db.prepare('SELECT count(*) AS count FROM t').get() as { count: number };
+    db.close();
+    expect(row.count).toBeGreaterThan(0);
   }, 120_000);
 
   it('resolves database paths under db/ for the Blitz layout (db/schema.prisma)', () => {
@@ -163,13 +165,12 @@ function createProjectDir(options?: { blitzLayout?: boolean }): string {
 }
 
 function createDatabaseWithWal(dbPath: string): void {
-  child_process.execSync(`${PRISMA_TEST_COMMAND} db execute --stdin --url "file:${dbPath}"`, {
-    encoding: 'utf8',
-    input:
-      'PRAGMA journal_mode=WAL; CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY); INSERT INTO t DEFAULT VALUES;',
-    stdio: ['pipe', 'pipe', 'inherit'],
-  });
-  // Prisma CLI does not keep SQLite sidecar files around after the command exits, so we create them to exercise cleanup paths.
+  const db = new DatabaseSync(dbPath);
+  db.exec(
+    'PRAGMA journal_mode=WAL; CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY); INSERT INTO t DEFAULT VALUES;'
+  );
+  db.close();
+  // Closing the connection checkpoints and removes the SQLite sidecar files, so we create them to exercise cleanup paths.
   fs.writeFileSync(`${dbPath}-wal`, 'wal');
   fs.writeFileSync(`${dbPath}-shm`, 'shm');
 }

--- a/packages/wb/test/unit/scripts/prismaScripts.test.ts
+++ b/packages/wb/test/unit/scripts/prismaScripts.test.ts
@@ -101,9 +101,12 @@ describe('prismaScripts.reset', () => {
 
     // The checkpointed database must remain readable with its data intact.
     const db = new DatabaseSync(dbPath);
-    const row = db.prepare('SELECT count(*) AS count FROM t').get() as { count: number };
-    db.close();
-    expect(row.count).toBeGreaterThan(0);
+    try {
+      const row = db.prepare('SELECT count(*) AS count FROM t').get() as { count: number };
+      expect(row.count).toBeGreaterThan(0);
+    } finally {
+      db.close();
+    }
   }, 120_000);
 
   it('resolves database paths under db/ for the Blitz layout (db/schema.prisma)', () => {
@@ -166,10 +169,13 @@ function createProjectDir(options?: { blitzLayout?: boolean }): string {
 
 function createDatabaseWithWal(dbPath: string): void {
   const db = new DatabaseSync(dbPath);
-  db.exec(
-    'PRAGMA journal_mode=WAL; CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY); INSERT INTO t DEFAULT VALUES;'
-  );
-  db.close();
+  try {
+    db.exec(
+      'PRAGMA journal_mode=WAL; CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY); INSERT INTO t DEFAULT VALUES;'
+    );
+  } finally {
+    db.close();
+  }
   // Closing the connection checkpoints and removes the SQLite sidecar files, so we create them to exercise cleanup paths.
   fs.writeFileSync(`${dbPath}-wal`, 'wal');
   fs.writeFileSync(`${dbPath}-shm`, 'shm');

--- a/packages/wbfy/test/unit/packageJson.test.ts
+++ b/packages/wbfy/test/unit/packageJson.test.ts
@@ -1087,10 +1087,11 @@ test('adds no publishConfig in a private repository', async () => {
   expect(packageJson.publishConfig).toBeUndefined();
 });
 
-test('strips `bun --bun` from user-authored scripts invoking Node-based tools', async () => {
+test('strips `bun --bun` only from command-position invocations of Node-based tools', async () => {
   const packageJson = await generatePackageJsonFrom(
     {
       scripts: {
+        // Node-based tool invocations lose `--bun`.
         build: 'bun --bun next build',
         dev: 'bun --bun next dev',
         start: 'bun --bun next start && bun --bun wrangler tail',
@@ -1099,6 +1100,23 @@ test('strips `bun --bun` from user-authored scripts invoking Node-based tools', 
         'quoted-executable': '"bun" --bun next build',
         multiline: 'bun --bun next build\nbun --bun wrangler tail',
         'env-prefix': 'NODE_ENV=production bun --bun next build',
+        // Direct script-file executions keep `--bun`.
+        'file-exec': 'exec bun --bun src/index.ts',
+        'file-chained': 'bun --bun src/index.ts;echo done',
+        'file-quoted': 'bun --bun "src/index.ts"',
+        'file-spaced-path': 'bun --bun "src/my script.ts"',
+        'file-runtime-flags': 'bun --bun --smol src/index.ts',
+        'file-variable': 'bun --bun "$ENTRYPOINT"',
+        'file-run-file': 'bun --bun run ./src/index.ts',
+        'file-extensionless': 'bun --bun ./scripts/server',
+        'file-bare-file': 'bun --bun server',
+        'file-run-missing': 'bun --bun run server',
+        'file-quoted-flag': 'bun --bun run "--preload" ./setup.ts',
+        'file-flag-value': 'bun --bun --cwd packages/app src/index.ts',
+        // `bun --bun` outside a command position is data, not a command.
+        'echo-literal': 'echo "bun --bun next build"',
+        'nested-literal': `node -e 'console.log("use bun --bun next")'`,
+        'other-tool': 'my-bun --bun next build',
       },
     },
     {}
@@ -1113,59 +1131,18 @@ test('strips `bun --bun` from user-authored scripts invoking Node-based tools', 
     'quoted-executable': '"bun" next build',
     multiline: 'bun next build\nbun wrangler tail',
     'env-prefix': 'NODE_ENV=production bun next build',
-  });
-});
-
-test('keeps `bun --bun` on direct script-file executions', async () => {
-  const packageJson = await generatePackageJsonFrom(
-    {
-      scripts: {
-        start: 'exec bun --bun src/index.ts',
-        'start-chained': 'bun --bun src/index.ts;echo done',
-        'start-quoted': 'bun --bun "src/index.ts"',
-        'start-spaced-path': 'bun --bun "src/my script.ts"',
-        'start-runtime-flags': 'bun --bun --smol src/index.ts',
-        'start-variable': 'bun --bun "$ENTRYPOINT"',
-        'start-run-file': 'bun --bun run ./src/index.ts',
-        'start-extensionless': 'bun --bun ./scripts/server',
-        'start-bare-file': 'bun --bun server',
-        'start-run-missing': 'bun --bun run server',
-        'start-quoted-flag': 'bun --bun run "--preload" ./setup.ts',
-        'start-flag-value': 'bun --bun --cwd packages/app src/index.ts',
-      },
-    },
-    {}
-  );
-
-  expect(packageJson.scripts).toMatchObject({
-    start: 'exec bun --bun src/index.ts',
-    'start-chained': 'bun --bun src/index.ts;echo done',
-    'start-quoted': 'bun --bun "src/index.ts"',
-    'start-spaced-path': 'bun --bun "src/my script.ts"',
-    'start-runtime-flags': 'bun --bun --smol src/index.ts',
-    'start-variable': 'bun --bun "$ENTRYPOINT"',
-    'start-run-file': 'bun --bun run ./src/index.ts',
-    'start-extensionless': 'bun --bun ./scripts/server',
-    'start-bare-file': 'bun --bun server',
-    'start-run-missing': 'bun --bun run server',
-    'start-quoted-flag': 'bun --bun run "--preload" ./setup.ts',
-    'start-flag-value': 'bun --bun --cwd packages/app src/index.ts',
-  });
-});
-
-test('does not rewrite `bun --bun` outside a command position', async () => {
-  const packageJson = await generatePackageJsonFrom(
-    {
-      scripts: {
-        'echo-literal': 'echo "bun --bun next build"',
-        'nested-literal': `node -e 'console.log("use bun --bun next")'`,
-        'other-tool': 'my-bun --bun next build',
-      },
-    },
-    {}
-  );
-
-  expect(packageJson.scripts).toMatchObject({
+    'file-exec': 'exec bun --bun src/index.ts',
+    'file-chained': 'bun --bun src/index.ts;echo done',
+    'file-quoted': 'bun --bun "src/index.ts"',
+    'file-spaced-path': 'bun --bun "src/my script.ts"',
+    'file-runtime-flags': 'bun --bun --smol src/index.ts',
+    'file-variable': 'bun --bun "$ENTRYPOINT"',
+    'file-run-file': 'bun --bun run ./src/index.ts',
+    'file-extensionless': 'bun --bun ./scripts/server',
+    'file-bare-file': 'bun --bun server',
+    'file-run-missing': 'bun --bun run server',
+    'file-quoted-flag': 'bun --bun run "--preload" ./setup.ts',
+    'file-flag-value': 'bun --bun --cwd packages/app src/index.ts',
     'echo-literal': 'echo "bun --bun next build"',
     'nested-literal': `node -e 'console.log("use bun --bun next")'`,
     'other-tool': 'my-bun --bun next build',


### PR DESCRIPTION
## Customer Summary

- No user-visible behavior changes: this only speeds up the automated test suite.
- CI and local verification runs finish faster, shortening feedback for every future change.

## Technical Summary

- `packages/wb/test/unit/scripts/prismaScripts.test.ts` (~29s → ~3s under vitest):
  - Create SQLite fixtures with `node:sqlite` (`DatabaseSync`, still a real WAL-mode database) instead of spawning `npx prisma db execute` per fixture, closing connections via `try...finally`.
  - Verify the checkpointed database directly with `node:sqlite` instead of a `prisma db pull` introspection.
  - The one remaining real Prisma invocation (executing the generated `cleanUpLitestream` command, the behavior under test) now runs via `bunx` with `CHECKPOINT_DISABLE=1`, skipping the telemetry network call that dominated CLI startup (~12s → ~4s per spawn locally).
- `packages/wbfy/test/unit/packageJson.test.ts`: merged the three `bun --bun` rewrite tests (identical config, disjoint script names) into a single `generatePackageJson` call; the `run`-target/script-name relationships the tests rely on (`build` exists → alias, `server` absent → file) are preserved.

## Why

- The prismaScripts test file dominated the `wb` package's test time, and almost all of it was Prisma CLI startup and telemetry overhead rather than the behavior under test.
- Measured per-file timings across all packages first; the remaining slow file (`wbfy/test/unit/packageJson.test.ts`, ~40s) is dominated by one-time synchronous `npm show <dep> version` registry lookups in the generator (warm `generatePackageJson` calls take ~10ms), so further test merging there would not reduce runtime. Speeding that up would need parallelized/batched version lookups in `wbfy` itself — left as a possible follow-up.
- Other slow tests (`cleanupIdempotency`, `maintenanceCommand`, `typecheck`, `setup`) are genuine E2E flows and were left untouched.

## Testing

- `bun verify-full` passed (typecheck + lint + all tests; tests 1m 1s).
- `bun vitest run test/unit/scripts/prismaScripts.test.ts` in `packages/wb`: 5 passed in ~3s.
- `bun vitest run test/unit/packageJson.test.ts` in `packages/wbfy`: 81 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
