### PR TITLE
fix(wb): warn about bun-node shims only when they win node resolution

### DIFF
--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -97,7 +97,8 @@ function findFirstNodeOnPath(): string | undefined {
     const nodePath = path.join(dir, 'node');
     try {
       fs.accessSync(nodePath, fs.constants.X_OK);
-      return nodePath;
+      // X_OK also passes for searchable directories, which execvp skips.
+      if (fs.statSync(nodePath).isFile()) return nodePath;
     } catch {
       // Not present or not executable in this directory; keep searching.
     }
@@ -109,7 +110,8 @@ function isBunNodeShim(nodePath: string): boolean {
   // `bun --bun` and bunfig's `run.bun` prepend a bun-node-<version> directory whose `node` links
   // to bun, and oven/bun images symlink node -> bun in bun-node-fallback-bin, so the giveaway is
   // either a bun-node- path segment or a resolution to the bun binary itself.
-  if (nodePath.includes('/bun-node-')) return true;
+  // A segment check rather than an `includes('/bun-node-')` so relative PATH entries match too.
+  if (nodePath.split(path.sep).some((segment) => segment.startsWith('bun-node-'))) return true;
   try {
     return path.basename(fs.realpathSync(nodePath)) === 'bun';
   } catch {

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -110,8 +110,10 @@ function isBunNodeShim(nodePath: string): boolean {
   // `bun --bun` and bunfig's `run.bun` prepend a bun-node-<version> directory whose `node` links
   // to bun, and oven/bun images symlink node -> bun in bun-node-fallback-bin, so the giveaway is
   // either a bun-node- path segment or a resolution to the bun binary itself.
-  // A segment check rather than an `includes('/bun-node-')` so relative PATH entries match too.
-  if (nodePath.split(path.sep).some((segment) => segment.startsWith('bun-node-'))) return true;
+  // Shims live directly in a bun-node-<version> directory, so check only the immediate parent
+  // (relative PATH entries included): matching ancestors would false-positive on e.g. a real node
+  // inside a bun-node-workspace checkout.
+  if (path.basename(path.dirname(nodePath)).startsWith('bun-node-')) return true;
   try {
     return path.basename(fs.realpathSync(nodePath)) === 'bun';
   } catch {

--- a/packages/wb/src/index.ts
+++ b/packages/wb/src/index.ts
@@ -44,11 +44,15 @@ await yargs(hideBin(process.argv))
       process.chdir(dirPath);
     }
 
-    if (process.env.PATH?.includes('/bun-node-')) {
+    // Warn only when a shim actually wins `node` resolution: oven/bun images append a harmless
+    // /usr/local/bun-node-fallback-bin (node -> bun) at the END of PATH, so a PATH substring
+    // check false-positives whenever a real node precedes it.
+    const nodeOnPath = findFirstNodeOnPath();
+    if (nodeOnPath && isBunNodeShim(nodeOnPath)) {
       // Not fixed up here: tools requiring real Node.js (Playwright, wrangler, vinext) may hang or
       // crash under the shim, and some (wrangler dev) fail silently, so surface the cause upfront.
       console.warn(
-        "Warning: PATH contains a bun-node shim (from `bun --bun` or bunfig's `run.bun`); " +
+        `Warning: \`node\` on PATH is a Bun shim (${nodeOnPath}); ` +
           'run wb without `--bun` and remove `[run] bun` from bunfig.toml.'
       );
     }
@@ -84,6 +88,34 @@ await yargs(hideBin(process.argv))
   .strict()
   .version(getVersion())
   .help().argv;
+
+/** The first executable `node` on PATH, i.e. the one child processes will run. */
+function findFirstNodeOnPath(): string | undefined {
+  for (const dir of (process.env.PATH ?? '').split(path.delimiter)) {
+    if (!dir) continue;
+
+    const nodePath = path.join(dir, 'node');
+    try {
+      fs.accessSync(nodePath, fs.constants.X_OK);
+      return nodePath;
+    } catch {
+      // Not present or not executable in this directory; keep searching.
+    }
+  }
+  return undefined;
+}
+
+function isBunNodeShim(nodePath: string): boolean {
+  // `bun --bun` and bunfig's `run.bun` prepend a bun-node-<version> directory whose `node` links
+  // to bun, and oven/bun images symlink node -> bun in bun-node-fallback-bin, so the giveaway is
+  // either a bun-node- path segment or a resolution to the bun binary itself.
+  if (nodePath.includes('/bun-node-')) return true;
+  try {
+    return path.basename(fs.realpathSync(nodePath)) === 'bun';
+  } catch {
+    return false;
+  }
+}
 
 function getVersion(): string {
   let packageJsonDir = path.dirname(new URL(import.meta.url).pathname);

--- a/packages/wb/test/unit/binDotenv.test.ts
+++ b/packages/wb/test/unit/binDotenv.test.ts
@@ -451,15 +451,43 @@ describe('bin/index.js run command', () => {
     expect(result.status).toBe(0);
   });
 
-  it('warns when a Bun node shim is present on PATH', async () => {
+  it('warns when a bun-node shim wins node resolution on PATH', async () => {
     await fs.writeFile(path.join(projectDirPath, 'probe.js'), "console.log('executed');\n");
+    // The shim delegates to the current runtime so child processes still work under the test.
+    const shimDirPath = path.join(projectDirPath, 'bun-node-review');
+    await fs.mkdir(shimDirPath);
+    await fs.writeFile(path.join(shimDirPath, 'node'), `#!/bin/sh\nexec "${process.execPath}" "$@"\n`, { mode: 0o755 });
 
     const result = childProcess.spawnSync(process.execPath, [binIndexPath, 'run', '--quiet-env', 'probe.js'], {
       cwd: projectDirPath,
       encoding: 'utf8',
-      env: { PATH: `/tmp/bun-node-review:${process.env.PATH}` },
+      env: { PATH: `${shimDirPath}:${process.env.PATH}` },
     });
-    expect(result.stderr).toContain('Warning: PATH contains a bun-node shim');
+    expect(result.stderr).toContain('is a Bun shim');
+    expect(result.stdout).toContain('executed');
+    expect(result.status).toBe(0);
+  });
+
+  it('does not warn about a trailing bun-node fallback that loses node resolution', async () => {
+    // oven/bun images append bun-node-fallback-bin (node -> bun) at the END of PATH; while a real
+    // node precedes it, wb must stay silent instead of telling users to remove a `[run] bun`
+    // setting they do not have.
+    await fs.writeFile(path.join(projectDirPath, 'probe.js'), "console.log('executed');\n");
+    const realNodeDirPath = path.join(projectDirPath, 'real-node-bin');
+    await fs.mkdir(realNodeDirPath);
+    await fs.writeFile(path.join(realNodeDirPath, 'node'), `#!/bin/sh\nexec "${process.execPath}" "$@"\n`, {
+      mode: 0o755,
+    });
+    const fallbackDirPath = path.join(projectDirPath, 'bun-node-fallback-bin');
+    await fs.mkdir(fallbackDirPath);
+    await fs.symlink(process.execPath, path.join(fallbackDirPath, 'node'));
+
+    const result = childProcess.spawnSync(process.execPath, [binIndexPath, 'run', '--quiet-env', 'probe.js'], {
+      cwd: projectDirPath,
+      encoding: 'utf8',
+      env: { PATH: `${realNodeDirPath}:${process.env.PATH}:${fallbackDirPath}` },
+    });
+    expect(result.stderr).not.toContain('Bun shim');
     expect(result.stdout).toContain('executed');
     expect(result.status).toBe(0);
   });


### PR DESCRIPTION
## Customer Summary

- The `wb` startup warning "PATH contains a bun-node shim" no longer appears spuriously in containers built from official `oven/bun` Docker images (e.g. chofu-walking's production server printed it on every boot while running correctly).
- When the warning does appear, it now names the offending `node` path, making the cause easier to diagnose.
- No behavior changes besides the warning: genuinely broken setups (`bun --bun` / bunfig `[run] bun`) still warn as before.

## Technical Summary

- `packages/wb/src/index.ts`: replaced the `PATH.includes('/bun-node-')` substring check with resolution-based detection — find the first executable `node` on PATH (skipping searchable directories via `statSync().isFile()`, since `X_OK` passes for them) and warn only when that winning entry is a Bun shim: its immediate parent directory starts with `bun-node-` (works for relative PATH entries too), or it resolves to the `bun` binary via `realpathSync`.
- `packages/wb/test/unit/binDotenv.test.ts`: updated the warning test to use a shim that actually wins resolution, and added a regression test for the trailing `oven/bun` fallback that must stay silent while a real node precedes it.

## Why

- `oven/bun` images append `/usr/local/bun-node-fallback-bin` (`node -> bun`) at the END of PATH as a last-resort fallback. The substring check fired on it even when a real node (e.g. mise shims) wins resolution, telling users to remove a `[run] bun` setting they do not have.
- Checking what `node` actually resolves to matches the warning's intent (tools like Playwright/wrangler need real Node) and was verified to still catch `bun --bun` / bunfig `[run] bun`, which prepend their shim at PATH index 0.

## Testing

- `packages/wb`: `bun run verify-full` passed (install, lint, typecheck, all unit tests).
- Manually reproduced the false-positive scenario (real node first, bun-node fallback last → silent) and the true-positive scenarios (shim first on PATH, including a directory named `node` preceding it → warns) against the built CLI.
- Multi-agent review (Codex, Claude Code, Antigravity) ran to convergence; all raised findings fixed.
