### PR TITLE
fix(wbfy): scan Playwright command history only for non-web-app packages

### DIFF
--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -136,7 +136,7 @@ export async function fixPlaywrightConfig(config: PackageConfig): Promise<void> 
     const defaultConfig = createDefaultConfig(config, shouldUseAppServerDefaults);
     const merged = mergeParsedObjects(defaultConfig, parsed);
     applyManagedUseDefaults(merged, defaultConfig);
-    await setWebServerCommand(merged, filePath, extractedObjectLiteral.source);
+    await setWebServerCommand(merged, filePath, extractedObjectLiteral.source, shouldUseAppServerDefaults);
 
     const newObjectLiteral = stringifyValue({ kind: 'object', value: merged }, 0);
     const oldContent = extractedObjectLiteral.source.text;
@@ -246,7 +246,8 @@ function getEnvFilePaths(dirPath: string): string[] {
 async function setWebServerCommand(
   object: ParsedObject,
   filePath: string,
-  currentSource: ast.SourceFile
+  currentSource: ast.SourceFile,
+  isWebApp: boolean
 ): Promise<void> {
   const webServer = object.properties.webServer;
   if (webServer?.kind !== 'object') return;
@@ -257,10 +258,17 @@ async function setWebServerCommand(
   // commands; only add or migrate the command when wbfy already owns it.
   if (command && !isGeneratedWbStartTestCommand(command)) return;
 
-  const historicalCommand = command && (await findWbfyOverwrittenWebServerCommand(filePath, command, currentSource));
-  if (historicalCommand) {
-    webServer.value.properties.command = historicalCommand;
-    return;
+  // A web app (it defines NEXT_PUBLIC_BASE_URL) standardizes on the generated server command, so a
+  // generated command there is intended, not overwrite damage. Only a non-web-app package (e.g. a
+  // React library serving a demo fixture) carrying the generated command can be a victim of the
+  // past overwrite bug — `wb start --mode test` has nothing to serve for a library — so the Git
+  // history recovery scan runs just for that small set instead of taxing every repository.
+  if (!isWebApp) {
+    const historicalCommand = command && (await findWbfyOverwrittenWebServerCommand(filePath, command, currentSource));
+    if (historicalCommand) {
+      webServer.value.properties.command = historicalCommand;
+      return;
+    }
   }
 
   // Playwright requires `command` whenever `webServer` exists; an externally managed server should

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -405,6 +405,23 @@ test('does not recover over an uncommitted command change', async () => {
   }
 });
 
+test('keeps the generated command in a web app without scanning history', async () => {
+  const dirPath = createGitRepository();
+  try {
+    // NEXT_PUBLIC_BASE_URL in an env file marks the package as a web app, which standardizes on
+    // the generated server command; a past overwrite must NOT be restored there.
+    fs.writeFileSync(path.join(dirPath, 'mise.toml'), `[env]\nNEXT_PUBLIC_BASE_URL = 'http://127.0.0.1:3010'\n`);
+    commitConfig(dirPath, getCustomCommand('web-app'), 'test: add custom Playwright fixture');
+    commitConfig(dirPath, 'bun wb start --mode test', 'chore: willboosterify this repo');
+
+    const generated = await fixAndReadConfig(dirPath);
+
+    expect(generated).toContain(`command: 'bun wb start --mode test'`);
+  } finally {
+    fs.rmSync(dirPath, { force: true, recursive: true });
+  }
+});
+
 test('does not restore an obsolete overwrite after a deliberate command transition', async () => {
   const dirPath = createGitRepository();
   try {


### PR DESCRIPTION
## Summary

Follow-up to #1149. The Git-history recovery scan for overwritten Playwright `webServer.command` values currently runs for every repository whose config carries the generated command — which includes every web app — on every wbfy invocation. That is a permanent per-run tax on most managed repositories, and it can misread a deliberate adoption of the standard command (a human-driven wbfy run over a custom command) as overwrite damage.

This PR gates the recovery on the existing web-app signal (`NEXT_PUBLIC_BASE_URL` defined in fnox/mise env files, i.e. `shouldUseAppServerDefaults`):

- **Web app** → the generated `bun wb start --mode test` is the intended standard; keep/emit it without any history scan.
- **Non-web-app package** (e.g. a React library like monaco-react serving a demo fixture, where `wb start --mode test` has nothing to serve) → a generated command is evidence of the past overwrite bug, so the recovery scan runs — now only for this small set.

Custom (non-generated) commands are preserved unchanged in both cases, exactly as before.

## Verification

- All 27 existing `playwrightConfig` tests pass unchanged (their temp repos define no `NEXT_PUBLIC_BASE_URL`, so they exercise the non-web-app recovery path).
- New test: a repo with `NEXT_PUBLIC_BASE_URL` in `mise.toml` and a custom→generated overwrite in history keeps the generated command (no restoration).
- Full wbfy unit suite: 374 tests pass.
