### PR TITLE
fix(wbfy): migrate every historical Playwright command form and keep custom test-rust badges

### DIFF
--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -507,7 +507,7 @@ function isGeneratedWbStartTestCommand(command: ParsedValue): boolean {
   // regex could overwrite a repository's deliberate wrapper while recognizing generated content.
   // Single quotes only: every generated form is single-quoted (as is org formatting), and an
   // unrecognized quoting style fails safe — the command is preserved, never overwritten.
-  return /^'(?:(?:bun(?: run)?|yarn) (?:wb start --mode test|start-test-server)|wb start --mode test|yarn start-test|bun --bun wb start --mode test)'$/u.test(
+  return /^'(?:(?:(?:bun(?: --bun| run)?|yarn) )?wb start --mode test|(?:bun(?: run)?|yarn) start-test-server|yarn start-test)'$/u.test(
     command.value.trim()
   );
 }

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -324,8 +324,8 @@ async function findWbfyOverwrittenWebServerCommand(
 
       // Only the latest command-changing transition can explain the current generated value. Older
       // wbfy overwrites are obsolete once a maintainer has deliberately changed the command again.
-      if (!isHistoricallyGeneratedWbStartTestCommand(commitCommand.command)) return undefined;
-      if (isHistoricallyGeneratedWbStartTestCommand(previousCommand.command)) continue;
+      if (!isGeneratedWbStartTestCommand(commitCommand.command)) return undefined;
+      if (isGeneratedWbStartTestCommand(previousCommand.command)) continue;
       if (!isWbfyCommitSubject(entry.subject)) return undefined;
       return areHistoricalBindingsUnchanged(previousCommand.bindingFingerprints, currentSource)
         ? previousCommand.command
@@ -502,17 +502,10 @@ function isWbfyCommitSubject(subject: string): boolean {
 
 function isGeneratedWbStartTestCommand(command: ParsedValue): boolean {
   if (command.kind !== 'literal') return false;
-  // Match only commands emitted by past wbfy versions. A broader command-shaped regex could
-  // overwrite a repository's deliberate wrapper while trying to recognize generated content.
-  return /^'(?:(?:bun|yarn) (?:wb start --mode test|start-test-server)|wb start --mode test)'$/u.test(
-    command.value.trim()
-  );
-}
-
-function isHistoricallyGeneratedWbStartTestCommand(command: ParsedValue): boolean {
-  if (isGeneratedWbStartTestCommand(command)) return true;
-  if (command.kind !== 'literal') return false;
-  return /^'(?:yarn start-test|bun run (?:wb start --mode test|start-test-server)|bun --bun wb start --mode test)'$/u.test(
+  // Match only commands emitted by past wbfy versions (every historical form, so none of them is
+  // preserved as "custom" pointing at a script wbfy has since removed). A broader command-shaped
+  // regex could overwrite a repository's deliberate wrapper while recognizing generated content.
+  return /^'(?:(?:bun|yarn|bun run) (?:wb start --mode test|start-test-server)|wb start --mode test|yarn start-test|bun --bun wb start --mode test)'$/u.test(
     command.value.trim()
   );
 }

--- a/packages/wbfy/src/fixers/playwrightConfig.ts
+++ b/packages/wbfy/src/fixers/playwrightConfig.ts
@@ -505,7 +505,9 @@ function isGeneratedWbStartTestCommand(command: ParsedValue): boolean {
   // Match only commands emitted by past wbfy versions (every historical form, so none of them is
   // preserved as "custom" pointing at a script wbfy has since removed). A broader command-shaped
   // regex could overwrite a repository's deliberate wrapper while recognizing generated content.
-  return /^'(?:(?:bun|yarn|bun run) (?:wb start --mode test|start-test-server)|wb start --mode test|yarn start-test|bun --bun wb start --mode test)'$/u.test(
+  // Single quotes only: every generated form is single-quoted (as is org formatting), and an
+  // unrecognized quoting style fails safe — the command is preserved, never overwritten.
+  return /^'(?:(?:bun(?: run)?|yarn) (?:wb start --mode test|start-test-server)|wb start --mode test|yarn start-test|bun --bun wb start --mode test)'$/u.test(
     command.value.trim()
   );
 }

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -96,19 +96,18 @@ async function buildWorkflowBadges(config: PackageConfig): Promise<string[]> {
   const workflowsPath = path.resolve(config.dirPath, '.github', 'workflows');
   if (!repository || !fs.existsSync(workflowsPath)) return [];
 
+  // Workflow and README generation run concurrently. Do not retain a stale Rust badge while the
+  // workflow generator removes a caller created from a formerly misdetected local cache — but
+  // mirror its ownership check: a custom same-named workflow survives, so its badge must too.
+  // Decided synchronously before the loop's first await: the generator's delete can only land at
+  // an await point, and a post-delete read would misreport the wbfy-owned caller as custom.
+  const dropsTestRustBadge =
+    config.cargoTomlDirPaths.length === 0 && jobsAllCallReusableWorkflow(workflowsPath, 'test-rust.yml', 'test-rust');
+
   const badges: string[] = [];
   for (const fileName of fs.readdirSync(workflowsPath)) {
     if (!fileName.startsWith('test') && !fileName.startsWith('deploy')) continue;
-    // Workflow and README generation run concurrently. Do not retain a stale Rust badge while the
-    // workflow generator removes a caller created from a formerly misdetected local cache — but
-    // mirror its ownership check: a custom same-named workflow survives, so its badge must too.
-    if (
-      fileName === 'test-rust.yml' &&
-      config.cargoTomlDirPaths.length === 0 &&
-      jobsAllCallReusableWorkflow(workflowsPath, fileName, 'test-rust')
-    ) {
-      continue;
-    }
+    if (fileName === 'test-rust.yml' && dropsTestRustBadge) continue;
     // GitHub's badge endpoint returns 404 until the workflow has at least one run, so a badge for a
     // dispatch-only deploy workflow that has never run renders as a broken image. Test workflows run
     // on every PR, so only deploy badges need the guard.

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -101,6 +101,8 @@ async function buildWorkflowBadges(config: PackageConfig): Promise<string[]> {
   // mirror its ownership check: a custom same-named workflow survives, so its badge must too.
   // Decided synchronously before the loop's first await: the generator's delete can only land at
   // an await point, and a post-delete read would misreport the wbfy-owned caller as custom.
+  // No existsSync pre-check: the helper already treats a missing file as not owned, and this runs
+  // once per repository, so the exceptional ENOENT read costs nothing worth a redundant stat.
   const dropsTestRustBadge =
     config.cargoTomlDirPaths.length === 0 && jobsAllCallReusableWorkflow(workflowsPath, 'test-rust.yml', 'test-rust');
 

--- a/packages/wbfy/src/generators/readme.ts
+++ b/packages/wbfy/src/generators/readme.ts
@@ -5,6 +5,7 @@ import type { Image, Link, Paragraph, PhrasingContent, RootContent } from 'mdast
 import { fromMarkdown } from 'mdast-util-from-markdown';
 
 import { logger } from '../logger.js';
+import { jobsAllCallReusableWorkflow } from './workflow.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { getOctokit } from '../utils/githubUtil.js';
@@ -99,8 +100,15 @@ async function buildWorkflowBadges(config: PackageConfig): Promise<string[]> {
   for (const fileName of fs.readdirSync(workflowsPath)) {
     if (!fileName.startsWith('test') && !fileName.startsWith('deploy')) continue;
     // Workflow and README generation run concurrently. Do not retain a stale Rust badge while the
-    // workflow generator removes a caller created from a formerly misdetected local cache.
-    if (fileName === 'test-rust.yml' && config.cargoTomlDirPaths.length === 0) continue;
+    // workflow generator removes a caller created from a formerly misdetected local cache — but
+    // mirror its ownership check: a custom same-named workflow survives, so its badge must too.
+    if (
+      fileName === 'test-rust.yml' &&
+      config.cargoTomlDirPaths.length === 0 &&
+      jobsAllCallReusableWorkflow(workflowsPath, fileName, 'test-rust')
+    ) {
+      continue;
+    }
     // GitHub's badge endpoint returns 404 until the workflow has at least one run, so a badge for a
     // dispatch-only deploy workflow that has never run renders as a broken image. Test workflows run
     // on every PR, so only deploy badges need the guard.

--- a/packages/wbfy/src/generators/workflow.ts
+++ b/packages/wbfy/src/generators/workflow.ts
@@ -354,7 +354,7 @@ export function isObsoleteGenPrWorkflow(workflowsPath: string, fileName: string)
  * delete it: unparsable files and files with any other job return false — deleting a whole
  * workflow on a loose match would be too aggressive.
  */
-function jobsAllCallReusableWorkflow(workflowsPath: string, fileName: string, workflowName: string): boolean {
+export function jobsAllCallReusableWorkflow(workflowsPath: string, fileName: string, workflowName: string): boolean {
   if (!fileName.endsWith('.yml')) return false;
   let content: string;
   try {

--- a/packages/wbfy/test/unit/playwrightConfig.test.ts
+++ b/packages/wbfy/test/unit/playwrightConfig.test.ts
@@ -22,19 +22,25 @@ test('preserves a custom Playwright web server lifecycle', async () => {
   expect(generated).toContain(`command: '${customCommand}'`);
 });
 
-test.each(['wb start --mode test', 'yarn wb start --mode test', 'bun start-test-server', 'yarn start-test-server'])(
-  'migrates the legacy wbfy-managed Playwright web server command %s',
-  async (command) => {
-    const generated = await fixConfig(`export default defineConfig({
+test.each([
+  'wb start --mode test',
+  'yarn wb start --mode test',
+  'bun start-test-server',
+  'yarn start-test-server',
+  'yarn start-test',
+  'bun run wb start --mode test',
+  'bun run start-test-server',
+  'bun --bun wb start --mode test',
+])('migrates the legacy wbfy-managed Playwright web server command %s', async (command) => {
+  const generated = await fixConfig(`export default defineConfig({
   webServer: {
     command: '${command}',
     url: 'http://127.0.0.1:3010',
   },
 });`);
 
-    expect(generated).toContain(`command: 'bun wb start --mode test'`);
-  }
-);
+  expect(generated).toContain(`command: 'bun wb start --mode test'`);
+});
 
 test.each([
   'chore: willboosterify this repo',

--- a/packages/wbfy/test/unit/readme.test.ts
+++ b/packages/wbfy/test/unit/readme.test.ts
@@ -79,7 +79,15 @@ test('drops a stale Rust workflow badge when the repository has no Rust code', a
   await withTempDir(async (dirPath) => {
     const workflowsPath = path.resolve(dirPath, '.github', 'workflows');
     fs.mkdirSync(workflowsPath, { recursive: true });
-    fs.writeFileSync(path.resolve(workflowsPath, 'test-rust.yml'), 'name: Test Rust\n');
+    fs.writeFileSync(
+      path.resolve(workflowsPath, 'test-rust.yml'),
+      `name: Test Rust
+on: push
+jobs:
+  test-rust:
+    uses: WillBooster/reusable-workflows/.github/workflows/test-rust.yml@main
+`
+    );
     fs.writeFileSync(
       path.resolve(dirPath, 'README.md'),
       `# Project
@@ -92,6 +100,30 @@ ${badgeOf('1.2.3')}
     const content = await runGenerateReadme(dirPath, '1.2.3');
     expect(content).not.toContain('test-rust.yml');
     expect(content).toContain(badgeOf('1.2.3'));
+  });
+});
+
+test('keeps the badge of a custom test-rust workflow the workflow generator preserves', async () => {
+  await withTempDir(async (dirPath) => {
+    const workflowsPath = path.resolve(dirPath, '.github', 'workflows');
+    fs.mkdirSync(workflowsPath, { recursive: true });
+    // A non-generated test-rust.yml merely shares the name; the workflow generator leaves it
+    // alone, so the README must keep its badge as well.
+    fs.writeFileSync(
+      path.resolve(workflowsPath, 'test-rust.yml'),
+      `name: Test Rust
+on: push
+jobs:
+  custom:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo --version
+`
+    );
+    fs.writeFileSync(path.resolve(dirPath, 'README.md'), `# Project\n\n${badgeOf('1.2.3')}\n`);
+
+    const content = await runGenerateReadme(dirPath, '1.2.3');
+    expect(content).toContain('test-rust.yml/badge.svg');
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-ups from the review of the recent autonomous wbfy fixes:

1. **Playwright webServer migration allowlist gap** (follow-up to #1148/#1149): the migration allowlist missed historical generated forms (`yarn start-test`, `bun run wb start --mode test`, `bun run start-test-server`, `bun --bun wb start --mode test`), so a repository still carrying one of them was preserved as "custom" forever — possibly pointing at a script wbfy has since removed. The historical forms are now folded into the single allowlist used for both migration and history analysis (the two previously separate predicates were identical in purpose and are merged), and the regex is grouped by command with an optional runner prefix per review feedback (same 9 accepted forms).

2. **test-rust badge asymmetry** (follow-up to #1141): the README generator dropped the test-rust badge for ANY `test-rust.yml` in a repository without Rust code, while the workflow generator deliberately preserves a custom (non-generated) workflow of that name. The badge drop now mirrors the same ownership check (`jobsAllCallReusableWorkflow`), so a preserved custom workflow keeps its badge. Per multi-agent review, the ownership decision is made synchronously before the badge loop's first await: README and workflow generation run concurrently, and a post-delete read inside the loop would misreport the wbfy-owned caller as custom and retain a badge for a workflow removed in the same run.

A third review note (suppressing `globalStore = true` under the hoisted linker) was investigated and intentionally NOT applied: `readBunGlobalStore` reads the setting back to detect linker/store migrations and trigger the `node_modules` reinstall, so the value is persisted state, not dead output (an existing test pins this behavior).

## Review

- Multi-agent review (codex, Claude, antigravity): one confirmed finding (the badge/deletion race above) — fixed; converged at "no concern" from all three agents.
- Gemini suggestions: regex regrouping adopted; double-quote support and an existsSync pre-check rejected as out of contract / redundant, with code comments documenting the reasons.

## Verification

- New migration test cases for all four historical command forms (32 playwrightConfig tests).
- README tests: generated-style caller badge dropped; custom `test-rust.yml` badge kept.
- Full wbfy unit suite: 379 tests pass.
