### PR TITLE
feat(wbfy)!: retire the hoisted Bun linker

### DIFF
--- a/packages/wbfy/src/generators/agents.ts
+++ b/packages/wbfy/src/generators/agents.ts
@@ -6,7 +6,6 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
 import { generatesWorkerTypes } from '../packageConfig.js';
-import { readBunLinker } from './bunfig.js';
 import { hasCloudflareDeployWorkflow, invokesWbDeploy } from './workflow.js';
 
 export async function generateAgentInstructions(rootConfig: PackageConfig, allConfigs: PackageConfig[]): Promise<void> {
@@ -72,14 +71,11 @@ function generateAgentInstruction(
   const miseInstruction = fs.existsSync(path.resolve(rootConfig.dirPath, 'mise.toml'))
     ? '\n- Tool versions (node, bun, and others) are pinned in `mise.toml`; run `mise install` after changing it, and never install those tools globally instead.'
     : '';
-  // Isolated installs are the org standard and the most agent-hostile part of the stack: a package
-  // that is only reachable because a dependency hoisted it no longer resolves, and the reflex fix
-  // (switching the linker back) silently reintroduces the phantom dependencies the layout exists to
-  // catch.
-  const isolatedInstallInstruction =
-    readBunLinker(rootConfig.dirPath) === 'isolated'
-      ? `\n- \`bunfig.toml\` uses Bun's isolated linker, so only declared dependencies resolve. If an import fails to resolve, declare that package in the \`package.json\` that imports it; never switch \`linker\` to \`hoisted\` or add to \`publicHoistPattern\` to work around it.`
-      : '';
+  // Isolated installs are the org standard (wbfy generates no other linker) and the most
+  // agent-hostile part of the stack: a package that is only reachable because a dependency hoisted
+  // it no longer resolves, and the reflex fix (switching the linker back) silently reintroduces
+  // the phantom dependencies the layout exists to catch.
+  const isolatedInstallInstruction = `\n- \`bunfig.toml\` uses Bun's isolated linker, so only declared dependencies resolve. If an import fails to resolve, declare that package in the \`package.json\` that imports it; never switch \`linker\` to \`hoisted\` or add to \`publicHoistPattern\` to work around it.`;
   // Every clause states only a verified fact, reusing the workflow generator's own detectors: the
   // wrangler-config clause needs an actual config file (isCloudflare also matches a mere wrangler
   // mention in a script or workflow), the workflow clause needs a live reusable-deploy caller

--- a/packages/wbfy/src/generators/bunfig.ts
+++ b/packages/wbfy/src/generators/bunfig.ts
@@ -154,14 +154,12 @@ export const bunMinimumReleaseAgeExcludes = [
   'react-server-dom-webpack',
 ];
 
-export type BunLinker = 'isolated' | 'hoisted';
-
 /**
  * Reads the linker explicitly declared in the repository's bunfig.toml. Returns undefined when
  * none is declared: Bun's default is context-dependent (isolated for new workspace projects with
  * `configVersion = 1` lockfiles, hoisted otherwise), so absence must not be read as hoisted.
  */
-export function readBunLinker(rootDirPath: string): BunLinker | undefined {
+export function readBunLinker(rootDirPath: string): 'isolated' | 'hoisted' | undefined {
   const filePath = path.resolve(rootDirPath, 'bunfig.toml');
   if (!fs.existsSync(filePath)) return undefined;
   const linker = parseBunfigToml(fs.readFileSync(filePath, 'utf8'))?.install?.linker;
@@ -182,21 +180,19 @@ export function shouldUseBunGlobalStore(configs: PackageConfig[]): boolean {
 
 export async function generateBunfigToml(
   config: PackageConfig,
-  linker: BunLinker,
   yarnMinimumReleaseAgeSeconds: number | undefined,
   useGlobalStore: boolean
 ): Promise<void> {
   return logger.functionIgnoringException('generateBunfigToml', async () => {
     const filePath = path.resolve(config.dirPath, 'bunfig.toml');
     const existingContent = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
-    const content = newContent(existingContent, linker, config, yarnMinimumReleaseAgeSeconds, useGlobalStore);
+    const content = newContent(existingContent, config, yarnMinimumReleaseAgeSeconds, useGlobalStore);
     await promisePool.run(() => fsUtil.generateFile(filePath, content));
   });
 }
 
 const newContent = (
   existingContent: string | undefined,
-  linker: BunLinker,
   config: PackageConfig,
   yarnMinimumReleaseAgeSeconds: number | undefined,
   useGlobalStore: boolean
@@ -226,22 +222,19 @@ const newContent = (
     : '# Keep Turbopack dependencies inside the project root.\nglobalStore = false';
   // No `[run] bun = true`: its node->bun PATH shim leaks into every child process and breaks
   // tools requiring real Node.js (Playwright, wrangler, vinext); any existing setting is dropped.
+  // publicHoistPattern — tsx: build-ts under Node.js spawns `node --import tsx`, which resolves
+  // tsx from the consumer package's directory, not from build-ts's own dependencies.
+  // undici-types: bun-types references it without declaring it as a dependency (oven-sh/bun#22805);
+  // generated tsconfigs also map undici-types to the hoisted copy (see tsconfig.ts) because the
+  // global store realpaths bun-types outside the repository.
   return `env = false
 telemetry = false
 
 ${extractRawTestSections(existingContent)}[install]
 exact = ${bunfigToml?.install?.exact === false ? 'false' : 'true'}
 ${globalStoreLine}
-${
-  linker === 'isolated'
-    ? // tsx: build-ts under Node.js spawns `node --import tsx`, which resolves tsx from the
-      // consumer package's directory, not from build-ts's own dependencies.
-      // undici-types: bun-types references it without declaring it as a dependency
-      // (oven-sh/bun#22805); generated tsconfigs also map undici-types to the hoisted copy
-      // (see tsconfig.ts) because the global store realpaths bun-types outside the repository.
-      'linker = "isolated"\npublicHoistPattern = ["tsx", "undici-types"]'
-    : 'linker = "hoisted"'
-}
+linker = "isolated"
+publicHoistPattern = ["tsx", "undici-types"]
 minimumReleaseAge = ${minimumReleaseAgeSeconds}${minimumReleaseAgeSeconds === bunMinimumReleaseAgeSeconds ? ' # 5 days' : ` # repository-specific override (org default: ${bunMinimumReleaseAgeSeconds} = 5 days)`}
 # minimumReleaseAgeExcludes is managed by wbfy — repository-specific entries are prohibited and
 # removed on every run (the minimumReleaseAge above may still be repository-specific). To exclude

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -17,7 +17,6 @@ import { removeEnvExample } from './fixers/envExample.js';
 import { removeEnvFiles } from './fixers/envFiles.js';
 import { untrackWorkerTypes } from './fixers/workerTypes.js';
 import { generateAgentInstructions } from './generators/agents.js';
-import type { BunLinker } from './generators/bunfig.js';
 import { generateBunfigToml, readBunGlobalStore, readBunLinker, shouldUseBunGlobalStore } from './generators/bunfig.js';
 import { generateDockerignore } from './generators/dockerignore.js';
 import { generateEditorconfig } from './generators/editorconfig.js';
@@ -246,8 +245,9 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
     for (const config of allPackageConfigs) await removeEnvExample(config);
 
     // Managed repositories use Bun with mise (and optionally fnox); Yarn artifacts are removed.
-    // Deciding the linker requires running installs, so --skip-deps keeps the previous linker
-    // and skips the probe (and its node_modules cleanup) entirely.
+    // The isolated linker is the only supported layout (hoisted was retired org-wide); the
+    // previous linker is read solely so the install probe knows a layout switch needs a clean
+    // tree. --skip-deps skips the probe (and its node_modules cleanup) entirely.
     const previousBunLinker = readBunLinker(rootDirPath);
     const previousBunGlobalStore = readBunGlobalStore(rootDirPath);
     // Root-level install layout must cover workspace apps too: Next.js commonly lives under
@@ -259,12 +259,7 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
     // minimumReleaseAgeExcludes is org policy managed solely by bunMinimumReleaseAgeExcludes.
     const yarnMinimumReleaseAgeSeconds = readYarnrcMinimumReleaseAgeSeconds(rootDirPath);
     await removeYarnFiles(rootConfig);
-    await generateBunfigToml(
-      rootConfig,
-      skipDeps ? (previousBunLinker ?? 'isolated') : 'isolated',
-      yarnMinimumReleaseAgeSeconds,
-      useGlobalStore
-    );
+    await generateBunfigToml(rootConfig, yarnMinimumReleaseAgeSeconds, useGlobalStore);
     await generateMiseToml(rootConfig, bunVersion);
     await generateFnoxToml(rootConfig);
     // After generateFnoxToml so the insertion can never race the transactional recipient
@@ -277,25 +272,18 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
     // guaranteed to be on disk yet; the probe below must not validate a stale configuration.
     await promisePool.promiseAll();
 
-    // The linker must be decided BEFORE any `bun add` mutates package.json files: per-package
-    // installs tolerate failures (spawnSync discards their status), so a layout that cannot
-    // install would silently drop every managed dependency update for the rest of the run.
+    // The layout must be verified installable BEFORE any `bun add` mutates package.json files:
+    // per-package installs tolerate failures (spawnSync discards their status), so a layout that
+    // cannot install would silently drop every managed dependency update for the rest of the run.
     if (
       !skipDeps &&
-      !(await ensureInstallableBunLinker(
-        rootDirPath,
-        rootConfig,
-        previousBunLinker,
-        previousBunGlobalStore,
-        yarnMinimumReleaseAgeSeconds,
-        useGlobalStore
-      ))
+      !probeIsolatedBunInstall(rootDirPath, rootConfig, previousBunLinker, previousBunGlobalStore, useGlobalStore)
     ) {
       // Do not fail the run here: the probe observes the pre-migration lifecycle scripts (e.g.
-      // still-Yarn-based postinstall commands that generatePackageJson converts later), so both
-      // layouts can fail spuriously. refreshBunLock runs after the conversion and is the single
-      // authority on whether the final install — and therefore the run — failed.
-      console.warn(`bun install currently fails in ${rootDirPath} under both the isolated and hoisted linkers.`);
+      // still-Yarn-based postinstall commands that generatePackageJson converts later), so it can
+      // fail spuriously. refreshBunLock runs after the conversion and is the single authority on
+      // whether the final install — and therefore the run — failed.
+      console.warn(`bun install currently fails in ${rootDirPath} under the isolated linker.`);
     }
 
     const shouldRunWorkflows =
@@ -404,7 +392,7 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
     // Refresh lock files
     let didRefreshBunLock = false;
     try {
-      await refreshBunLock(rootDirPath, rootConfig, yarnMinimumReleaseAgeSeconds, useGlobalStore);
+      refreshBunLock(rootDirPath);
       didRefreshBunLock = true;
     } catch (error) {
       // A failed install must fail the CLI: exiting 0 with a stale or missing Bun lockfile would
@@ -439,20 +427,18 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
 }
 
 /**
- * Probes `bun install` under the isolated linker (the default bunfig.toml wbfy generates) and
- * falls back to the hoisted linker when the isolated layout cannot install — it breaks projects
- * relying on hoisted (phantom) dependencies or on install scripts incompatible with the layout.
- * Returns false when neither linker can install. The probe reruns on every wbfy run, so a
- * repository automatically moves back to the isolated linker once its incompatibility is fixed.
+ * Probes `bun install` under the isolated linker — the only layout wbfy generates since the
+ * hoisted linker was retired org-wide. An incompatibility (e.g. a phantom dependency an isolated
+ * layout refuses to resolve) must be fixed in the repository or in wbfy's managed lists, never by
+ * switching the linker back. Returns false when the install fails.
  */
-async function ensureInstallableBunLinker(
+function probeIsolatedBunInstall(
   rootDirPath: string,
   rootConfig: PackageConfig,
-  previousLinker: BunLinker | undefined,
+  previousLinker: 'isolated' | 'hoisted' | undefined,
   previousGlobalStore: boolean | undefined,
-  yarnMinimumReleaseAgeSeconds: number | undefined,
   useGlobalStore: boolean
-): Promise<boolean> {
+): boolean {
   // A layout switch must probe from a clean tree: `bun install` does not remove packages the
   // previous layout left behind, so e.g. still-hoisted phantom dependencies can make the isolated
   // probe succeed although a fresh checkout could not install.
@@ -463,20 +449,7 @@ async function ensureInstallableBunLinker(
   // masquerade as a layout incompatibility.
   if (spawnSyncAndReturnStatus('bun', ['install'], rootDirPath, 1) === 0) return true;
 
-  console.warn('bun install failed with the isolated linker; falling back to the hoisted linker.');
-  await generateBunfigToml(rootConfig, 'hoisted', yarnMinimumReleaseAgeSeconds, useGlobalStore);
-  await promisePool.promiseAll();
-  // The failed isolated attempt may have left a partial isolated tree behind.
-  removeNodeModules(rootDirPath, rootConfig);
-  // Retry here too: a transient failure would otherwise discard the correct hoisted answer and
-  // restore the isolated configuration this function just proved cannot install.
-  if (spawnSyncAndReturnStatus('bun', ['install'], rootDirPath, 1) === 0) return true;
-
-  // Both layouts failed, so the failure is not linker-specific; keep the default isolated
-  // configuration instead of persisting a downgrade that the failed install never justified.
-  // Clean up the failed hoisted attempt too, so later installs do not run on a polluted tree.
-  await generateBunfigToml(rootConfig, 'isolated', yarnMinimumReleaseAgeSeconds, useGlobalStore);
-  await promisePool.promiseAll();
+  // Clean up the failed attempt so later installs do not run on a polluted tree.
   removeNodeModules(rootDirPath, rootConfig);
   return false;
 }
@@ -505,34 +478,12 @@ function removeNodeModules(rootDirPath: string, rootConfig: PackageConfig): void
   }
 }
 
-async function refreshBunLock(
-  rootDirPath: string,
-  rootConfig: PackageConfig,
-  yarnMinimumReleaseAgeSeconds: number | undefined,
-  useGlobalStore: boolean
-): Promise<void> {
+function refreshBunLock(rootDirPath: string): void {
   // wbfy should update only the packages it explicitly manages through bun add.
   // Running bun update here refreshes unrelated application dependencies and
   // can change product behavior, so keep the existing lock and reconcile it.
-  let status = spawnSyncAndReturnStatus('bun', ['install'], rootDirPath, 1);
+  const status = spawnSyncAndReturnStatus('bun', ['install'], rootDirPath, 1);
   if (status === 0) return;
-
-  // The pre-conversion probe can be inconclusive (legacy lifecycle scripts fail under both
-  // linkers), so the converted repository gets one more chance on the hoisted linker before the
-  // run fails — e.g. a converted script may exercise a phantom dependency only hoisting provides.
-  if (readBunLinker(rootDirPath) === 'isolated') {
-    console.warn('bun install failed with the isolated linker after migration; retrying with the hoisted linker.');
-    await generateBunfigToml(rootConfig, 'hoisted', yarnMinimumReleaseAgeSeconds, useGlobalStore);
-    await promisePool.promiseAll();
-    removeNodeModules(rootDirPath, rootConfig);
-    status = spawnSyncAndReturnStatus('bun', ['install'], rootDirPath, 1);
-    if (status === 0) return;
-    // Both layouts failed after conversion; restore the default isolated configuration and clean
-    // up the failed hoisted attempt so the next run does not probe on a polluted tree.
-    await generateBunfigToml(rootConfig, 'isolated', yarnMinimumReleaseAgeSeconds, useGlobalStore);
-    await promisePool.promiseAll();
-    removeNodeModules(rootDirPath, rootConfig);
-  }
   throw new Error(`Failed to refresh Bun lockfile: bun install exited with status ${status}`);
 }
 

--- a/packages/wbfy/test/unit/bunfig.test.ts
+++ b/packages/wbfy/test/unit/bunfig.test.ts
@@ -58,19 +58,12 @@ test('keeps Next.js dependencies inside the Turbopack filesystem root', async ()
     // The root package need not depend on Next.js when a workspace app does; the repository-wide
     // decision is passed separately from the root PackageConfig.
     const config = createConfig({ dirPath: tempDirPath });
-    await generateBunfigToml(config, 'isolated', undefined, false);
+    await generateBunfigToml(config, undefined, false);
     await promisePool.promiseAll();
 
     const content = fs.readFileSync(path.join(tempDirPath, 'bunfig.toml'), 'utf8');
     expect(content).toContain('# Keep Turbopack dependencies inside the project root.\nglobalStore = false');
     expect(content).toContain('linker = "isolated"');
-    expect(readBunGlobalStore(tempDirPath)).toBe(false);
-
-    await generateBunfigToml(config, 'hoisted', undefined, false);
-    await promisePool.promiseAll();
-    expect(fs.readFileSync(path.join(tempDirPath, 'bunfig.toml'), 'utf8')).toContain(
-      'globalStore = false\nlinker = "hoisted"'
-    );
     expect(readBunGlobalStore(tempDirPath)).toBe(false);
   } finally {
     fs.rmSync(tempDirPath, { force: true, recursive: true });
@@ -80,14 +73,14 @@ test('keeps Next.js dependencies inside the Turbopack filesystem root', async ()
 test('keeps a migrated .yarnrc.yml npmMinimalAgeGate across regenerations', async () => {
   const tempDirPath = await fs.promises.realpath(fs.mkdtempSync(path.join(os.tmpdir(), 'wbfy-bunfig-')));
   try {
-    await generateBunfigToml(createConfig({ dirPath: tempDirPath }), 'isolated', 172_800, true);
+    await generateBunfigToml(createConfig({ dirPath: tempDirPath }), 172_800, true);
     await promisePool.promiseAll();
     const content = fs.readFileSync(path.join(tempDirPath, 'bunfig.toml'), 'utf8');
     expect(content).toContain('minimumReleaseAge = 172800');
 
     // A later run has no .yarnrc.yml to read anymore (removeYarnFiles deleted it), so the
     // repository's gate must survive via the existing bunfig.toml.
-    await generateBunfigToml(createConfig({ dirPath: tempDirPath }), 'isolated', undefined, true);
+    await generateBunfigToml(createConfig({ dirPath: tempDirPath }), undefined, true);
     await promisePool.promiseAll();
     const regenerated = fs.readFileSync(path.join(tempDirPath, 'bunfig.toml'), 'utf8');
     expect(regenerated).toContain('minimumReleaseAge = 172800');
@@ -115,7 +108,7 @@ minimumReleaseAgeExcludes = [
 ]
 `
     );
-    await generateBunfigToml(createConfig({ dirPath: tempDirPath }), 'isolated', undefined, true);
+    await generateBunfigToml(createConfig({ dirPath: tempDirPath }), undefined, true);
     await promisePool.promiseAll();
     const content = fs.readFileSync(path.join(tempDirPath, 'bunfig.toml'), 'utf8');
     expect(content).not.toContain('@next/eslint-plugin-next');

--- a/packages/wbfy/test/unit/prettierMigration.test.ts
+++ b/packages/wbfy/test/unit/prettierMigration.test.ts
@@ -90,17 +90,12 @@ test('deletes .idea/prettier.xml except in Java repositories', async () => {
 
 test('omits @willbooster/prettier-config from bunfig excludes except in Java repositories', async () => {
   await withTempDir(async (tempDirPath) => {
-    await generateBunfigToml(createConfig({ dirPath: tempDirPath }), 'isolated', undefined, true);
+    await generateBunfigToml(createConfig({ dirPath: tempDirPath }), undefined, true);
     await promisePool.promiseAll();
     const bunfigPath = path.join(tempDirPath, 'bunfig.toml');
     expect(fs.readFileSync(bunfigPath, 'utf8')).not.toContain('@willbooster/prettier-config');
 
-    await generateBunfigToml(
-      createConfig({ dirPath: tempDirPath, doesContainJava: true }),
-      'isolated',
-      undefined,
-      true
-    );
+    await generateBunfigToml(createConfig({ dirPath: tempDirPath, doesContainJava: true }), undefined, true);
     await promisePool.promiseAll();
     expect(fs.readFileSync(bunfigPath, 'utf8')).toContain('@willbooster/prettier-config');
   });


### PR DESCRIPTION
## Summary

Only two repositories in the WillBooster / WillBoosterLab organizations still had `linker = "hoisted"` in `bunfig.toml`, and both were stale artifacts generated before wbfy defaulted to the isolated linker (#962) — not results of the probe's hoisted fallback. Both install cleanly under the isolated layout and are migrating in WillBooster/qa-support#76 and WillBoosterLab/exercode-sakamoto-smartse-courses#11. With no repository depending on hoisting, wbfy drops every path that writes `linker = "hoisted"`:

- `generateBunfigToml` loses its `linker` parameter and always emits the isolated configuration — including under `--skip-deps`, which previously carried a declared hoisted linker forward forever.
- The pre-conversion install probe (`ensureInstallableBunLinker` → `probeIsolatedBunInstall`) no longer demotes the bunfig to hoisted when the isolated install fails; it only verifies the isolated layout from a clean tree (the clean-tree check still reads the previous linker/globalStore) and warns, leaving `refreshBunLock` as the single authority on the final install.
- `refreshBunLock` no longer retries with the hoisted linker; a failed final install fails the run as before.
- The isolated-linker instruction in generated agent instruction files is now unconditional (`agents.ts` no longer reads the linker).

A repository that cannot install under the isolated layout now surfaces as a failed run to be fixed in that repository (or in wbfy's managed lists), per the org policy that deviations from wbfy-generated output are fixed at the source instead of accommodated.

## Verification

- `bun verify-full` passes (all unit tests, including the updated `generateBunfigToml` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
