### PR TITLE
fix: centralize Renovate private registry config

### DIFF
--- a/packages/wbfy/src/generators/renovateJsonc.ts
+++ b/packages/wbfy/src/generators/renovateJsonc.ts
@@ -9,11 +9,15 @@ import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { jsoncUtil } from '../utils/jsoncUtil.js';
 import { overwriteMerge } from '../utils/mergeUtil.js';
+import { repoResolvesPrivatePackages } from '../utils/privatePackages.js';
 import { promisePool } from '../utils/promisePool.js';
 
 // The shared preset every WillBooster / WillBoosterLab repository extends. willbooster-configs IS
 // this preset, so injecting it there would make the preset extend itself.
 const sharedPreset = 'github>WillBooster/willbooster-configs:renovate.jsonc';
+const privatePackagesPreset = 'github>WillBooster/willbooster-configs:renovate-private-packages.jsonc';
+const privateRegistryHost = 'verdaccio-production-e389.up.railway.app';
+const privateRegistryScopeMapping = `@willbooster-private:registry=https://${privateRegistryHost}/`;
 
 const jsonObj = {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
@@ -26,6 +30,9 @@ const legacyPresets = new Set(['@willbooster', 'github>WillBooster/willbooster-c
 
 // $schema is optional: an existing config need not declare it.
 type Settings = Partial<typeof jsonObj> & {
+  hostRules?: { matchHost?: string }[];
+  npmrc?: string;
+  npmrcMerge?: boolean;
   packageRules?: { matchPackageNames: string[]; enabled?: boolean }[];
 };
 
@@ -169,8 +176,49 @@ function buildSettings(config: PackageConfig, liveSettings: Settings | undefined
         arrayMerge: overwriteMerge,
       }) as Settings)
     : generatedSettings;
-  newSettings.extends = mergeRenovateExtends(config, jsonObj.extends, liveSettings?.extends);
+  const generatedExtends = repoResolvesPrivatePackages(config)
+    ? [...jsonObj.extends, privatePackagesPreset]
+    : jsonObj.extends;
+  newSettings.extends = mergeRenovateExtends(config, generatedExtends, liveSettings?.extends);
+  if (generatedExtends.includes(privatePackagesPreset)) removeInlinePrivateRegistrySettings(newSettings);
   return newSettings;
+}
+
+/** The shared private-package preset and Mend organization host rule own all Verdaccio settings. */
+function removeInlinePrivateRegistrySettings(settings: Settings): void {
+  if (settings.hostRules) {
+    settings.hostRules = settings.hostRules.filter((rule) => !isPrivateRegistryHost(rule.matchHost));
+    // Keep an own property with an undefined value: jsonc-parser interprets it as a deliberate
+    // deletion while JSON.stringify omits it when generating a new file from scratch.
+    if (settings.hostRules.length === 0) settings.hostRules = undefined;
+  }
+
+  if (!settings.npmrc) return;
+  const remainingLines = settings.npmrc
+    .split(/\r?\n/u)
+    .filter((line) => line.trim() !== privateRegistryScopeMapping)
+    .filter((line) => !isPrivateRegistryTokenLine(line));
+  const remainingNpmrc = remainingLines.join('\n').trim();
+  if (remainingNpmrc) {
+    settings.npmrc = remainingNpmrc;
+  } else {
+    settings.npmrc = undefined;
+    settings.npmrcMerge = undefined;
+  }
+}
+
+function isPrivateRegistryHost(matchHost: string | undefined): boolean {
+  if (!matchHost) return false;
+  try {
+    return new URL(matchHost.includes('://') ? matchHost : `https://${matchHost}`).hostname === privateRegistryHost;
+  } catch {
+    return false;
+  }
+}
+
+function isPrivateRegistryTokenLine(line: string): boolean {
+  const trimmedLine = line.trim();
+  return trimmedLine.startsWith(`//${privateRegistryHost}/:_authToken=`);
 }
 
 interface ExistingConfig {
@@ -252,18 +300,26 @@ function mergeRenovateExtends(
   const presetsToAdd = config.isWillBoosterConfigs ? [] : generatedExtends;
   const presetsToDrop = config.isWillBoosterConfigs ? new Set(legacyPresets).add(sharedPreset) : legacyPresets;
 
-  // Only prepend the presets that are missing. Moving one that is already listed would reorder the
-  // array, and a later preset overrides an earlier one in Renovate — so re-sorting silently flips
-  // which config wins (and, being a reorder rather than an addition, also costs the array's
-  // comments, which can only be preserved by insertion).
+  // Only insert the presets that are missing. The private-package preset belongs immediately after
+  // the shared defaults so it can complement them; every other generated preset is prepended.
+  // Moving one that is already listed would reorder the array, and a later preset overrides an
+  // earlier one in Renovate — so re-sorting silently flips which config wins (and, being a reorder
+  // rather than an addition, also costs the array's comments, which can only be preserved by insertion).
   // Compared case-insensitively: GitHub owner and repository names are case-insensitive, so a differently-spelled
   // copy of the same preset would otherwise be duplicated, and a lowercase legacy preset would survive migration.
-  const missingExtends = presetsToAdd.filter(
-    (preset) => !existingExtends.some((existing) => isSamePreset(existing, preset))
-  );
-  return [...missingExtends, ...existingExtends].filter(
+  const mergedExtends = existingExtends.filter(
     (item) => ![...presetsToDrop].some((dropped) => isSamePreset(dropped, item))
   );
+  for (const preset of presetsToAdd) {
+    if (mergedExtends.some((existing) => isSamePreset(existing, preset))) continue;
+    if (isSamePreset(preset, privatePackagesPreset)) {
+      const sharedPresetIndex = mergedExtends.findIndex((existing) => isSamePreset(existing, sharedPreset));
+      mergedExtends.splice(sharedPresetIndex + 1, 0, preset);
+    } else {
+      mergedExtends.unshift(preset);
+    }
+  }
+  return mergedExtends;
 }
 
 function normalize(content: string): string {

--- a/packages/wbfy/test/unit/renovateJsonc.test.ts
+++ b/packages/wbfy/test/unit/renovateJsonc.test.ts
@@ -29,6 +29,7 @@ async function withRepo(files: Record<string, string>, run: (dirPath: string) =>
 }
 
 const preset = 'github>WillBooster/willbooster-configs:renovate.jsonc';
+const privatePackagesPreset = 'github>WillBooster/willbooster-configs:renovate-private-packages.jsonc';
 const legacyPreset = 'github>WillBooster/willbooster-configs:renovate.json5';
 
 test('never makes willbooster-configs extend its own preset', async () => {
@@ -54,6 +55,78 @@ test('generates renovate.jsonc in a repository without any Renovate config', asy
     const content = fs.readFileSync(path.join(dirPath, 'renovate.jsonc'), 'utf8');
     expect(parseSettings(content).extends).toEqual([preset]);
   });
+});
+
+test.each([
+  {
+    name: 'dependency',
+    packageJson: { name: 'private-consumer', dependencies: { '@willbooster-private/llm-proxy': '1.0.0' } },
+  },
+  {
+    name: 'publisher',
+    packageJson: { name: '@willbooster-private/private-publisher' },
+  },
+])('adds the private-package preset for a private-package $name', async ({ packageJson }) => {
+  await withRepo({ 'package.json': JSON.stringify(packageJson) }, async (dirPath) => {
+    const settings = parseSettings(fs.readFileSync(path.join(dirPath, 'renovate.jsonc'), 'utf8'));
+    expect(settings.extends).toEqual([preset, privatePackagesPreset]);
+  });
+});
+
+test('replaces inline Verdaccio authentication and npmrc with the shared preset', async () => {
+  await withRepo(
+    {
+      'package.json': JSON.stringify({
+        name: 'private-consumer',
+        dependencies: { '@willbooster-private/llm-proxy': '1.0.0' },
+      }),
+      'renovate.jsonc': `{
+  "extends": ["${preset}"],
+  "hostRules": [
+    {
+      "matchHost": "https://verdaccio-production-e389.up.railway.app/",
+      "token": "{{ secrets.VerdaccioBasicAuth }}"
+    }
+  ],
+  // Scope mapping only; authentication used to come from the inline host rule.
+  "npmrc": "@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/\\n//verdaccio-production-e389.up.railway.app/:_authToken=\${NPM_TOKEN}",
+  "npmrcMerge": true
+}
+`,
+    },
+    async (dirPath) => {
+      const settings = parseSettings(fs.readFileSync(path.join(dirPath, 'renovate.jsonc'), 'utf8'));
+      expect(settings.extends).toEqual([preset, privatePackagesPreset]);
+      expect(settings.hostRules).toBeUndefined();
+      expect(settings.npmrc).toBeUndefined();
+      expect(settings.npmrcMerge).toBeUndefined();
+      expect(fs.readFileSync(path.join(dirPath, 'renovate.jsonc'), 'utf8')).not.toContain('Scope mapping only');
+    }
+  );
+});
+
+test('preserves unrelated inline npm and host settings while removing Verdaccio entries', async () => {
+  await withRepo(
+    {
+      'package.json': JSON.stringify({ name: '@willbooster-private/private-publisher' }),
+      'renovate.jsonc': JSON.stringify({
+        hostRules: [
+          { matchHost: 'verdaccio-production-e389.up.railway.app', token: 'remove-me' },
+          { matchHost: 'npm.example.test', token: 'keep-me' },
+        ],
+        npmrc:
+          '@willbooster-private:registry=https://verdaccio-production-e389.up.railway.app/\n' +
+          '@example:registry=https://npm.example.test/',
+        npmrcMerge: true,
+      }),
+    },
+    async (dirPath) => {
+      const settings = parseSettings(fs.readFileSync(path.join(dirPath, 'renovate.jsonc'), 'utf8'));
+      expect(settings.hostRules).toEqual([{ matchHost: 'npm.example.test', token: 'keep-me' }]);
+      expect(settings.npmrc).toBe('@example:registry=https://npm.example.test/');
+      expect(settings.npmrcMerge).toBe(true);
+    }
+  );
 });
 
 test('migrates renovate.json and deletes it so it stops outranking renovate.jsonc', async () => {


### PR DESCRIPTION
## Customer Summary

- Automatically configures Renovate private-package access for every repository that consumes or publishes `@willbooster-private/*` packages.
- Removes repository-specific Verdaccio credentials and npmrc fragments in favor of the shared preset and Mend organization host rule.
- Keeps developer installs dependent only on the user-level `~/.npmrc`; no repository-level `.npmrc` is generated.

## Technical Summary

- Reuses `repoResolvesPrivatePackages` to add `renovate-private-packages.jsonc` after the shared Renovate preset.
- Removes only Verdaccio-specific inline host rules, scope mappings, and token placeholders while preserving unrelated registry settings.
- Preserves existing preset order and adds regression coverage for consumers, publishers, migrations, and unrelated host/npm settings.

## Why

- Private-package Renovate authentication was manually duplicated across repositories and could reference secrets removed from Mend.
- Central ownership lets one read-only organization credential serve every applicable repository without committed credentials or environment-variable placeholders.

## Testing

- `bun test packages/wbfy/test/unit/renovateJsonc.test.ts`
- `bun verify-full`
- GitHub Actions: all workflows passed

## Notes

- Gemini review was unavailable because its daily review quota was exhausted.
