### PR TITLE
fix: enforce user npmrc for local private packages

### DIFF
--- a/packages/wb/src/commands/setupPrivatePackages.ts
+++ b/packages/wb/src/commands/setupPrivatePackages.ts
@@ -188,7 +188,7 @@ export async function materializePrivatePackages(
   if (downloadedPackages.length > 0 && !auth) {
     throw new Error(
       `Cannot download ${downloadedPackages.map((p) => p.name).join(', ')}: no registry configured for the ${PRIVATE_REGISTRY_SCOPE} scope; ` +
-        `add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to .npmrc or ~/.npmrc. Only installed copies satisfying an exact version or ` +
+        `add "${PRIVATE_REGISTRY_SCOPE}:registry=..." to ~/.npmrc. Only installed copies satisfying an exact version or ` +
         'semver range are reused without registry access; dist-tag specifiers (e.g. `latest`) always require it.'
     );
   }

--- a/packages/wb/src/utils/privateRegistry.ts
+++ b/packages/wb/src/utils/privateRegistry.ts
@@ -7,8 +7,8 @@ import semver from 'semver';
 
 /**
  * Materialization of `@willbooster-private/*` registry (Verdaccio) dependencies for Docker builds:
- * the packages are downloaded on the host (auth via .npmrc / ~/.npmrc locally, or VERDACCIO_TOKEN
- * on CI) and extracted next to the repository so image builds need no registry credentials
+ * the packages are downloaded on the host (auth via ~/.npmrc locally, or a temporary .npmrc plus
+ * VERDACCIO_TOKEN on CI) and extracted next to the repository so image builds need no registry credentials
  * (https://github.com/WillBooster/shared/issues/964).
  */
 export const PRIVATE_REGISTRY_SCOPE = '@willbooster-private';
@@ -57,14 +57,14 @@ export interface PrivateRegistryAuth {
 }
 
 /**
- * Resolve the registry URL and auth token for the private scope from the project's .npmrc and
- * ~/.npmrc (nearer file wins), expanding `${VAR}` references from the environment. On CI the
- * VERDACCIO_TOKEN environment variable serves as the fallback token.
+ * Resolve the registry URL and auth token for the private scope from ~/.npmrc locally. CI may also
+ * supply a temporary project .npmrc; VERDACCIO_TOKEN serves as its fallback token.
  */
 export function resolvePrivateRegistryAuth(rootDirPath: string): PrivateRegistryAuth | undefined {
   const entries: Record<string, string> = {};
-  // Reverse order so nearer files overwrite the home-directory defaults.
-  for (const npmrcPath of [path.join(os.homedir(), '.npmrc'), path.join(rootDirPath, '.npmrc')]) {
+  const npmrcPaths = [path.join(os.homedir(), '.npmrc')];
+  if (process.env.CI) npmrcPaths.push(path.join(rootDirPath, '.npmrc'));
+  for (const npmrcPath of npmrcPaths) {
     try {
       Object.assign(entries, parseNpmrc(fs.readFileSync(npmrcPath, 'utf8')));
     } catch {

--- a/packages/wb/test/unit/privateRegistry.test.ts
+++ b/packages/wb/test/unit/privateRegistry.test.ts
@@ -1,12 +1,25 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   isPrivateRegistryDependency,
   materializedVersionSatisfies,
   parseNpmrc,
+  resolvePrivateRegistryAuth,
   selectVersionFromPackument,
   specifierSubset,
 } from '../../src/utils/privateRegistry.js';
+
+const tempDirPaths: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  delete process.env.CI;
+  await Promise.all(tempDirPaths.splice(0).map((dirPath) => fs.promises.rm(dirPath, { recursive: true, force: true })));
+});
 
 describe('isPrivateRegistryDependency', () => {
   it('accepts registry ranges for the private scope only', () => {
@@ -109,3 +122,45 @@ legacy-peer-deps=true
     });
   });
 });
+
+describe('resolvePrivateRegistryAuth', () => {
+  it('ignores a project npmrc during local development', async () => {
+    const { homeDirPath, rootDirPath } = await makeNpmrcFixture();
+    vi.spyOn(os, 'homedir').mockReturnValue(homeDirPath);
+
+    expect(resolvePrivateRegistryAuth(rootDirPath)).toEqual({
+      registryUrl: 'https://home.example.test',
+      authToken: 'home-token',
+    });
+  });
+
+  it('allows the temporary project npmrc to override the home file on CI', async () => {
+    const { homeDirPath, rootDirPath } = await makeNpmrcFixture();
+    vi.spyOn(os, 'homedir').mockReturnValue(homeDirPath);
+    process.env.CI = 'true';
+
+    expect(resolvePrivateRegistryAuth(rootDirPath)).toEqual({
+      registryUrl: 'https://project.example.test',
+      authToken: 'project-token',
+    });
+  });
+});
+
+async function makeNpmrcFixture(): Promise<{ homeDirPath: string; rootDirPath: string }> {
+  const parentDirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wb-private-registry-'));
+  tempDirPaths.push(parentDirPath);
+  const homeDirPath = path.join(parentDirPath, 'home');
+  const rootDirPath = path.join(parentDirPath, 'repo');
+  await Promise.all([fs.promises.mkdir(homeDirPath), fs.promises.mkdir(rootDirPath)]);
+  await Promise.all([
+    fs.promises.writeFile(
+      path.join(homeDirPath, '.npmrc'),
+      '@willbooster-private:registry=https://home.example.test/\n//home.example.test/:_authToken=home-token\n'
+    ),
+    fs.promises.writeFile(
+      path.join(rootDirPath, '.npmrc'),
+      '@willbooster-private:registry=https://project.example.test/\n//project.example.test/:_authToken=project-token\n'
+    ),
+  ]);
+  return { homeDirPath, rootDirPath };
+}

--- a/packages/wbfy/src/generators/npmrc.ts
+++ b/packages/wbfy/src/generators/npmrc.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { PackageConfig } from '../packageConfig.js';
+import { fsUtil } from '../utils/fsUtil.js';
+
+/**
+ * Organization repositories authenticate local package-manager commands exclusively through the
+ * developer's ~/.npmrc. CI may create a temporary repository .npmrc, but it must never become
+ * persistent repository configuration.
+ */
+export async function removeRepositoryNpmrcFiles(configs: PackageConfig[]): Promise<void> {
+  const rootConfig = configs.find((config) => config.isRoot) ?? configs[0];
+  if (rootConfig?.repoAuthor !== 'WillBooster' && rootConfig?.repoAuthor !== 'WillBoosterLab') return;
+
+  for (const npmrcPath of new Set(configs.map((config) => path.resolve(config.dirPath, '.npmrc')))) {
+    if (!(await fs.promises.lstat(npmrcPath).catch(() => {}))) continue;
+    if (await fsUtil.removeConfined(npmrcPath)) {
+      console.info(`Removed repository npmrc ${npmrcPath}; local authentication belongs in ~/.npmrc.`);
+    }
+  }
+}

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -40,6 +40,7 @@ import { ensureWbEnvDefinitions } from './generators/wbEnv.js';
 import { generateSelfContainedWorkflows } from './generators/selfContainedWorkflow.js';
 import { generateWorkflows, isReusableWorkflowsRepo } from './generators/workflow.js';
 import { generateMiseToml, minimumBunVersion } from './generators/miseToml.js';
+import { removeRepositoryNpmrcFiles } from './generators/npmrc.js';
 import { setupLabels } from './github/label.js';
 import { setupRepositoryRulesets } from './github/ruleset.js';
 import { setupGitHubSettings } from './github/settings.js';
@@ -208,6 +209,8 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
     );
     const subPackageConfigs = nullableSubPackageConfigs.filter((config) => !!config);
     const allPackageConfigs = [rootConfig, ...subPackageConfigs];
+
+    await removeRepositoryNpmrcFiles(allPackageConfigs);
 
     if (options.isVerbose) {
       for (const config of allPackageConfigs) {

--- a/packages/wbfy/test/unit/npmrc.test.ts
+++ b/packages/wbfy/test/unit/npmrc.test.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { removeRepositoryNpmrcFiles } from '../../src/generators/npmrc.js';
+import type { PackageConfig } from '../../src/packageConfig.js';
+import { fsUtil } from '../../src/utils/fsUtil.js';
+
+const tempDirPaths: string[] = [];
+
+afterEach(async () => {
+  fsUtil.setRootDirPath(undefined);
+  await Promise.all(tempDirPaths.splice(0).map((dirPath) => fs.promises.rm(dirPath, { recursive: true, force: true })));
+});
+
+describe('removeRepositoryNpmrcFiles', () => {
+  it.each(['WillBooster', 'WillBoosterLab'])('removes root and workspace npmrc files for %s', async (repoAuthor) => {
+    const rootDirPath = await makeTempDir();
+    const workspaceDirPath = path.join(rootDirPath, 'packages', 'app');
+    await fs.promises.mkdir(workspaceDirPath, { recursive: true });
+    await fs.promises.writeFile(path.join(rootDirPath, '.npmrc'), 'root=true\n');
+    await fs.promises.symlink('../../.npmrc', path.join(workspaceDirPath, '.npmrc'));
+    fsUtil.setRootDirPath(rootDirPath);
+
+    await removeRepositoryNpmrcFiles([
+      packageConfig(rootDirPath, repoAuthor, true),
+      packageConfig(workspaceDirPath, repoAuthor, false),
+    ]);
+
+    await expect(fs.promises.lstat(path.join(rootDirPath, '.npmrc'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.promises.lstat(path.join(workspaceDirPath, '.npmrc'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('preserves repository npmrc files outside the organizations', async () => {
+    const rootDirPath = await makeTempDir();
+    const npmrcPath = path.join(rootDirPath, '.npmrc');
+    await fs.promises.writeFile(npmrcPath, 'registry=https://example.test/\n');
+    fsUtil.setRootDirPath(rootDirPath);
+
+    await removeRepositoryNpmrcFiles([packageConfig(rootDirPath, 'example', true)]);
+
+    await expect(fs.promises.readFile(npmrcPath, 'utf8')).resolves.toBe('registry=https://example.test/\n');
+  });
+});
+
+async function makeTempDir(): Promise<string> {
+  const dirPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'wbfy-npmrc-'));
+  tempDirPaths.push(dirPath);
+  return dirPath;
+}
+
+function packageConfig(dirPath: string, repoAuthor: string, isRoot: boolean): PackageConfig {
+  return { dirPath, repoAuthor, isRoot } as PackageConfig;
+}


### PR DESCRIPTION
## Summary
- remove repository-level `.npmrc` files from WillBooster and WillBoosterLab roots and workspaces during wbfy
- use only `~/.npmrc` for local private registry authentication
- keep temporary project `.npmrc` support restricted to CI

## Verification
- `bun verify`
- 46 focused tests for npmrc cleanup, private registry auth, and Renovate config
- `bun verify-full` reached 346 passing tests; 3 unrelated package metadata tests exceeded their 60-second timeout during npm registry latency
