### PR TITLE
fix(wbfy): make Chakra toaster types portable

### DIFF
--- a/packages/wbfy/src/fixers/chakraToaster.ts
+++ b/packages/wbfy/src/fixers/chakraToaster.ts
@@ -1,0 +1,36 @@
+import fs from 'node:fs/promises';
+
+import fg from 'fast-glob';
+
+import { logger } from '../logger.js';
+import type { PackageConfig } from '../packageConfig.js';
+import { fsUtil } from '../utils/fsUtil.js';
+
+export async function fixChakraToaster(config: PackageConfig): Promise<void> {
+  return logger.functionIgnoringException('fixChakraToaster', async () => {
+    if (!config.depending.chakra) return;
+
+    const filePaths = await fg.glob('**/toaster.{ts,tsx}', {
+      absolute: true,
+      cwd: config.dirPath,
+      ignore: ['**/.*/**', '**/node_modules/**'],
+    });
+    for (const filePath of filePaths) {
+      const content = await fs.readFile(filePath, 'utf8');
+      if (
+        content.includes('CreateToasterReturn') ||
+        !content.includes("from '@chakra-ui/react'") ||
+        !content.includes('export const toaster = createToaster(')
+      ) {
+        continue;
+      }
+      const updatedContent = content
+        .replace(
+          /^import .* from '@chakra-ui\/react';$/mu,
+          "$&\nimport type { CreateToasterReturn } from '@chakra-ui/react';"
+        )
+        .replace('export const toaster = createToaster(', 'export const toaster: CreateToasterReturn = createToaster(');
+      if (updatedContent !== content) await fsUtil.generateFile(filePath, updatedContent);
+    }
+  });
+}

--- a/packages/wbfy/src/index.ts
+++ b/packages/wbfy/src/index.ts
@@ -7,6 +7,7 @@ import semver from 'semver';
 import yargs from 'yargs';
 
 import { fixNextConfigJson } from './fixers/nextConfig.js';
+import { fixChakraToaster } from './fixers/chakraToaster.js';
 import { fixPlaywrightConfig } from './fixers/playwrightConfig.js';
 import { fixTestDirectoriesUpdatingPackageJson } from './fixers/testDirectory.js';
 import { fixTypeDefinitions } from './fixers/typeDefinition.js';
@@ -295,6 +296,9 @@ async function willboosterifyPaths(paths: string[], skipDeps: boolean, force: bo
       }
       if (config.depending.next) {
         promises.push(fixNextConfigJson(config));
+      }
+      if (config.depending.chakra) {
+        promises.push(fixChakraToaster(config));
       }
       await generateGitignore(config, rootConfig);
       await promisePool.promiseAll();

--- a/packages/wbfy/test/unit/chakraToaster.test.ts
+++ b/packages/wbfy/test/unit/chakraToaster.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { fixChakraToaster } from '../../src/fixers/chakraToaster.js';
+import { fsUtil } from '../../src/utils/fsUtil.js';
+import { createConfig } from '../helpers/testConfig.js';
+
+test('makes the Chakra toaster inferred type portable under Bun isolated installs', async () => {
+  const dirPath = await fs.mkdtemp(path.join(os.tmpdir(), 'wbfy-chakra-toaster-'));
+  const filePath = path.join(dirPath, 'src', 'components', 'ui', 'toaster.tsx');
+  try {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(
+      filePath,
+      `import { createToaster } from '@chakra-ui/react';
+
+export const toaster = createToaster({ placement: 'bottom-end' });
+`
+    );
+    fsUtil.setRootDirPath(dirPath);
+
+    await fixChakraToaster(createConfig({ dirPath, depending: { ...createConfig().depending, chakra: true } }));
+    await fixChakraToaster(createConfig({ dirPath, depending: { ...createConfig().depending, chakra: true } }));
+
+    await expect(fs.readFile(filePath, 'utf8')).resolves.toBe(`import { createToaster } from '@chakra-ui/react';
+import type { CreateToasterReturn } from '@chakra-ui/react';
+
+export const toaster: CreateToasterReturn = createToaster({ placement: 'bottom-end' });
+`);
+  } finally {
+    fsUtil.setRootDirPath(undefined);
+    await fs.rm(dirPath, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a wbfy fixer that gives Chakra UI toaster exports an explicit portable type
- keep the transformation idempotent
- prevent generated declarations from depending on Bun's nested package paths when the isolated linker is enabled

## Verification
- `bun test packages/wbfy/test/unit/chakraToaster.test.ts`
- `bun verify`
