### PR TITLE
fix(wb): accept redirecting test servers

### DIFF
--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -273,15 +273,13 @@ export abstract class BaseScripts {
 }
 
 /**
- * Builds a wait-on boot check polling `http-get://localhost:<port>`. `localhost` (not `127.0.0.1`)
- * lets Node's Happy Eyeballs try both address families: on macOS, dev servers without an explicit
- * host (e.g. vinext/Vite) can bind IPv6-only (`::1`), so an IPv4-only poll would hang until timeout
- * even though the server is up. The `NO_PROXY`/`no_proxy` prefix keeps the loopback poll off HTTP
- * proxies: wait-on's axios applies `HTTP(S)_PROXY` env vars unless `NO_PROXY` matches the polled
- * host, and existing `NO_PROXY` conventions may list `127.0.0.1` without `localhost`.
+ * Builds a wait-on boot check for a listening loopback port. A TCP check treats redirects and
+ * authentication responses as a successfully started server; an HTTP status check would keep
+ * waiting even though Playwright can already use the app. `localhost` lets Node try both address
+ * families when a dev server binds only IPv4 or IPv6.
  */
 export function buildWaitOnLoopbackCommand(port: string | number | undefined, waitOnArgs?: string): string {
-  return `NO_PROXY=localhost no_proxy=localhost wait-on ${waitOnArgs ? `${waitOnArgs} ` : ''}http-get://localhost:${port}`;
+  return `wait-on ${waitOnArgs ? `${waitOnArgs} ` : ''}tcp:localhost:${port}`;
 }
 
 function findCustomProductionStartScriptPath(project: Project): string | undefined {

--- a/packages/wb/src/scripts/execution/baseScripts.ts
+++ b/packages/wb/src/scripts/execution/baseScripts.ts
@@ -279,6 +279,7 @@ export abstract class BaseScripts {
  * families when a dev server binds only IPv4 or IPv6.
  */
 export function buildWaitOnLoopbackCommand(port: string | number | undefined, waitOnArgs?: string): string {
+  if (port === undefined || port === '') throw new Error('Port is required for the loopback readiness check.');
   return `wait-on ${waitOnArgs ? `${waitOnArgs} ` : ''}tcp:localhost:${port}`;
 }
 

--- a/packages/wb/test/unit/scripts/execution/baseScripts.test.ts
+++ b/packages/wb/test/unit/scripts/execution/baseScripts.test.ts
@@ -5,13 +5,20 @@ import type { TestArgv } from '../../../../src/commands/test.js';
 import type { Project } from '../../../../src/project.js';
 import type { ScriptArgv } from '../../../../src/scripts/builder.js';
 import { normalizeArgs } from '../../../../src/scripts/builder.js';
-import { BaseScripts } from '../../../../src/scripts/execution/baseScripts.js';
+import { BaseScripts, buildWaitOnLoopbackCommand } from '../../../../src/scripts/execution/baseScripts.js';
 import { buildEnvReaderOptionArgs, sharedOptionsBuilder } from '../../../../src/sharedOptionsBuilder.js';
 import { buildShellCommand, buildShellEnvironmentAssignment } from '../../../../src/utils/shell.js';
 
 vi.mock('../../../../src/utils/port.js', () => ({
   checkAndKillPortProcess: vi.fn().mockResolvedValue(3000),
 }));
+
+describe('buildWaitOnLoopbackCommand', () => {
+  it('fails before generating an invalid command when the port is missing', () => {
+    expect(() => buildWaitOnLoopbackCommand(undefined)).toThrow('Port is required');
+    expect(() => buildWaitOnLoopbackCommand('')).toThrow('Port is required');
+  });
+});
 
 class TestScripts extends BaseScripts {
   constructor() {

--- a/packages/wb/test/unit/scripts/execution/httpServerScripts.test.ts
+++ b/packages/wb/test/unit/scripts/execution/httpServerScripts.test.ts
@@ -75,18 +75,16 @@ describe('HttpServerScripts.testE2E', () => {
         '--success',
         'first',
         'echo "no build" && node dist/index.js && exit 1',
-        `NO_PROXY=localhost no_proxy=localhost wait-on -t 600000 -i 2000 http-get://localhost:3000 && ${buildShellCommand(
-          [
-            'YARN',
-            'vitest',
-            'run',
-            `test/e2e/quo'te.spec.ts`,
-            'test/e2e/space path.spec.ts',
-            '--passWithNoTests',
-            '--allowOnly',
-            '--watch=false',
-          ]
-        )}`,
+        `wait-on -t 600000 -i 2000 tcp:localhost:3000 && ${buildShellCommand([
+          'YARN',
+          'vitest',
+          'run',
+          `test/e2e/quo'te.spec.ts`,
+          'test/e2e/space path.spec.ts',
+          '--passWithNoTests',
+          '--allowOnly',
+          '--watch=false',
+        ])}`,
       ])
     );
   });


### PR DESCRIPTION
## Summary
- detect test server readiness by listening TCP port instead of requiring a 2xx response from `/`
- allow authenticated or redirecting applications to start their E2E tests normally
- preserve localhost IPv4/IPv6 support

## Verification
- `bun test packages/wb/test/unit/scripts/execution/httpServerScripts.test.ts packages/wb/test/unit/scripts/execution/baseScripts.test.ts`
- `bun verify`
- reproduced the prior false negative in WillBooster/ai-game-builder#746: the server was serving repeated 307 responses while wb reported a startup timeout
